### PR TITLE
Refactor matricule generation to use recent inscription data

### DIFF
--- a/app/Http/Controllers/ESBTPEtudiantController.php
+++ b/app/Http/Controllers/ESBTPEtudiantController.php
@@ -454,6 +454,42 @@ class ESBTPEtudiantController extends Controller
         $classes = ESBTPClasse::where('is_active', true)->get();
         $annees = ESBTPAnneeUniversitaire::orderBy('start_date', 'desc')->get();
 
+        // Récupérer l'inscription la plus récente pour la génération du matricule
+        // Priorité : inscription de l'année courante active > inscription la plus récente
+        $inscriptionRecente = $etudiant->inscriptions()
+            ->with(['niveau', 'filiere', 'classe.niveau'])
+            ->whereHas('anneeUniversitaire', function($query) {
+                $query->where('is_current', true);
+            })
+            ->where('status', 'active')
+            ->first();
+
+        // Si pas d'inscription active cette année, prendre la plus récente
+        if (!$inscriptionRecente) {
+            $inscriptionRecente = $etudiant->inscriptions()
+                ->with(['niveau', 'filiere', 'classe.niveau'])
+                ->orderByDesc('created_at')
+                ->first();
+        }
+
+        // Extraire les infos pour la génération du matricule
+        $niveauEtudeCode = null;
+        $filiereIdForMatricule = null;
+
+        if ($inscriptionRecente) {
+            // Essayer d'abord depuis la classe (plus fiable)
+            if ($inscriptionRecente->classe && $inscriptionRecente->classe->niveau) {
+                $niveauEtudeCode = $inscriptionRecente->classe->niveau->code;
+            }
+            // Sinon depuis l'inscription directement
+            elseif ($inscriptionRecente->niveau) {
+                $niveauEtudeCode = $inscriptionRecente->niveau->code;
+            }
+
+            // Filière depuis l'inscription
+            $filiereIdForMatricule = $inscriptionRecente->filiere_id;
+        }
+
         // Logging pour debug
         \Log::info('Étudiant chargé pour édition', [
             'id' => $etudiant->id,
@@ -463,6 +499,9 @@ class ESBTPEtudiantController extends Controller
             'sexeArray' => $etudiant['sexe'] ?? null,
             'genre' => $etudiant->genre,
             'all_attributes' => $etudiant->getAttributes(),
+            'inscription_recente_id' => $inscriptionRecente?->id,
+            'niveau_etude_code' => $niveauEtudeCode,
+            'filiere_id_matricule' => $filiereIdForMatricule,
         ]);
 
         return view('esbtp.etudiants.edit', compact(
@@ -470,7 +509,10 @@ class ESBTPEtudiantController extends Controller
             'filieres',
             'niveaux',
             'classes',
-            'annees'
+            'annees',
+            'niveauEtudeCode',
+            'filiereIdForMatricule',
+            'inscriptionRecente'
         ));
     }
 

--- a/resources/views/esbtp/etudiants/partials/edit-form-scripts.blade.php
+++ b/resources/views/esbtp/etudiants/partials/edit-form-scripts.blade.php
@@ -458,13 +458,17 @@
         const matriculeMode = document.getElementById('matriculeMode');
         const matriculeHelp = document.getElementById('matriculeHelp');
         const genreSelect = document.getElementById('sexe');
-        const classeSelect = document.getElementById('classe_id');
         const initialGenre = genreSelect ? genreSelect.value : null;
-        const initialClasse = classeSelect ? classeSelect.value : null;
 
         // Charger le mode de génération des matricules
         let currentMatriculeMode = 'automatique'; // Par défaut
-        let niveauConfig = null;
+
+        // Récupérer les infos de niveau/filière depuis l'inscription la plus récente (passées par le controller)
+        const niveauEtudeCodeFromInscription = @json($niveauEtudeCode ?? null);
+        const filiereIdFromInscription = @json($filiereIdForMatricule ?? null);
+
+        // Initialiser niveauConfig directement si on a les infos
+        let niveauConfig = niveauEtudeCodeFromInscription ? { code: niveauEtudeCodeFromInscription } : null;
 
         fetch('/esbtp/matricule-config/mode-info', {
             method: 'GET',
@@ -477,10 +481,13 @@
         .then(data => {
             currentMatriculeMode = data.mode || 'automatique';
             updateMatriculeUI();
+            // Vérifier le statut du niveau config après avoir mis à jour l'UI
+            checkNiveauConfigStatus();
         })
         .catch(error => {
             console.error('Erreur lors du chargement du mode matricule:', error);
             updateMatriculeUI();
+            checkNiveauConfigStatus();
         });
 
         function updateMatriculeUI() {
@@ -645,54 +652,20 @@
             matriculeStatus.innerHTML = `<small class="alert ${alertClass} p-1 m-0">${message}</small>`;
         }
 
-        // Détecter le niveau d'études depuis la classe sélectionnée
-        // Pour les étudiants, on devrait déjà avoir une classe associée
-        // Mais pour la génération, on peut récupérer le niveau config de la classe
-        function loadNiveauConfigFromClasse(onLoaded) {
-            if (!classeSelect || !classeSelect.value) {
-                niveauConfig = null;
-                if (typeof onLoaded === 'function') {
-                    onLoaded(null);
-                }
-                return;
+        // Vérifier si le niveau est configuré pour la génération automatique
+        // (niveauConfig est déjà initialisé depuis les données Blade de l'inscription récente)
+        function checkNiveauConfigStatus() {
+            if (!niveauConfig && currentMatriculeMode === 'automatique' && authUserIsSuperAdmin) {
+                showMatriculeStatus('⚠️ Aucune inscription trouvée - génération automatique impossible', 'warning');
+                if (generateBtn) generateBtn.disabled = true;
+            } else if (niveauConfig) {
+                showMatriculeStatus('', '');
+                if (generateBtn && authUserIsSuperAdmin) generateBtn.disabled = false;
             }
-
-            const classeId = classeSelect.value;
-
-            fetch(`/esbtp/api/classes/${classeId}/niveau-config`, {
-                method: 'GET',
-                headers: {
-                    'Accept': 'application/json',
-                    'X-Requested-With': 'XMLHttpRequest'
-                }
-            })
-            .then(response => response.json())
-            .then(data => {
-                niveauConfig = data.niveau_config;
-
-                if (!niveauConfig && currentMatriculeMode === 'automatique' && authUserIsSuperAdmin) {
-                    showMatriculeStatus('⚠️ Niveau non configuré pour génération automatique', 'warning');
-                    if (generateBtn) generateBtn.disabled = true;
-                } else {
-                    showMatriculeStatus('', '');
-                    if (generateBtn && authUserIsSuperAdmin) generateBtn.disabled = false;
-                }
-
-                if (typeof onLoaded === 'function') {
-                    onLoaded(niveauConfig);
-                }
-            })
-            .catch(error => {
-                console.error('Erreur:', error);
-                niveauConfig = null;
-                if (typeof onLoaded === 'function') {
-                    onLoaded(null);
-                }
-            });
         }
 
-        // Charger la config du niveau au démarrage
-        loadNiveauConfigFromClasse();
+        // Vérifier le statut au démarrage (après le chargement du mode)
+        // Note: On appelle cette fonction après avoir récupéré le mode matricule
 
         function maybeAutoRegenerateMatricule(force) {
             if (!authUserIsSuperAdmin) {
@@ -718,25 +691,14 @@
             }
         }
 
-        // Écouter les changements de classe
-        if (classeSelect && authUserIsSuperAdmin) {
-            classeSelect.addEventListener('change', function() {
-                loadNiveauConfigFromClasse(() => {
-                    const genreChanged = genreSelect && genreSelect.value !== initialGenre;
-                    const classeChanged = classeSelect.value !== initialClasse;
-                    if (genreChanged || classeChanged) {
-                        maybeAutoRegenerateMatricule(true);
-                    }
-                });
-            });
-        }
-
         // Écouter les changements de genre pour le mode auto
+        // (pas besoin d'écouter la classe car on utilise les infos de l'inscription récente)
         if (genreSelect && authUserIsSuperAdmin) {
             genreSelect.addEventListener('change', function() {
-                loadNiveauConfigFromClasse(() => {
+                // Vérifier si le genre a changé et régénérer si nécessaire
+                if (genreSelect.value !== initialGenre) {
                     maybeAutoRegenerateMatricule(true);
-                });
+                }
             });
         }
 
@@ -788,17 +750,16 @@
         }
 
         // Si mode auto et genre déjà sélectionné, générer le matricule au chargement
+        // Note: niveauConfig est déjà initialisé depuis les données Blade de l'inscription récente
         $(document).ready(function() {
             if (currentMatriculeMode === 'automatique' && authUserIsSuperAdmin) {
-                if (genreSelect && genreSelect.value && !matriculeInput.value) {
+                // Vérifier le statut du niveau config
+                checkNiveauConfigStatus();
+
+                // Si on a les infos nécessaires et pas de matricule, générer automatiquement
+                if (genreSelect && genreSelect.value && !matriculeInput.value && niveauConfig) {
                     setTimeout(() => {
-                        loadNiveauConfigFromClasse();
-                        // Attendre un peu pour la récupération de la config du niveau
-                        setTimeout(() => {
-                            if (niveauConfig) {
-                                generateMatriculeAuto();
-                            }
-                        }, 500);
+                        generateMatriculeAuto();
                     }, 100);
                 }
             }


### PR DESCRIPTION
## Summary
Refactored the matricule generation logic to retrieve and use the student's most recent inscription data directly from the controller, eliminating the need for dynamic class-based lookups in the frontend.

## Key Changes

- **Controller Enhancement**: Added logic in `ESBTPEtudiantController::edit()` to fetch the student's most recent inscription with priority given to active inscriptions from the current academic year
  - Extracts `niveauEtudeCode` and `filiereIdForMatricule` from the inscription's related niveau and filière
  - Passes this data to the view for use in matricule generation

- **Frontend Simplification**: Removed dynamic `loadNiveauConfigFromClasse()` function and class change event listeners
  - `niveauConfig` is now initialized directly from Blade template data (`$niveauEtudeCode`)
  - Eliminated unnecessary API calls to fetch niveau configuration on class selection changes
  - Simplified the matricule status check with new `checkNiveauConfigStatus()` function

- **Improved User Experience**: 
  - Matricule generation now works with the student's actual enrollment data rather than relying on class selection
  - Clearer warning messages when no inscription is found
  - Automatic matricule generation on page load (when applicable) is now more reliable

## Implementation Details

- The inscription lookup prioritizes the current academic year's active inscription, falling back to the most recent inscription if none exists
- The niveau code is extracted preferentially from the classe's niveau relationship (more reliable) before falling back to the inscription's direct niveau relationship
- Removed the `initialClasse` tracking since class changes no longer trigger matricule regeneration
- The `checkNiveauConfigStatus()` function is called both after loading the matricule mode and on document ready to ensure proper UI state

https://claude.ai/code/session_01N7k8A98qTn1igMfPxFmpsC