### PR TITLE
fix: Améliorer détection inscription pour génération matricule

### DIFF
--- a/app/Http/Controllers/ESBTPEtudiantController.php
+++ b/app/Http/Controllers/ESBTPEtudiantController.php
@@ -455,16 +455,26 @@ class ESBTPEtudiantController extends Controller
         $annees = ESBTPAnneeUniversitaire::orderBy('start_date', 'desc')->get();
 
         // Récupérer l'inscription la plus récente pour la génération du matricule
-        // Priorité : inscription de l'année courante active > inscription la plus récente
+        // Priorité : inscription de l'année courante active > inscription la plus récente (any status)
         $inscriptionRecente = $etudiant->inscriptions()
             ->with(['niveau', 'filiere', 'classe.niveau'])
             ->whereHas('anneeUniversitaire', function($query) {
                 $query->where('is_current', true);
             })
-            ->where('status', 'active')
+            ->whereRaw('LOWER(status) = ?', ['active'])
             ->first();
 
-        // Si pas d'inscription active cette année, prendre la plus récente
+        // Si pas d'inscription active cette année, prendre n'importe quelle inscription de l'année courante
+        if (!$inscriptionRecente) {
+            $inscriptionRecente = $etudiant->inscriptions()
+                ->with(['niveau', 'filiere', 'classe.niveau'])
+                ->whereHas('anneeUniversitaire', function($query) {
+                    $query->where('is_current', true);
+                })
+                ->first();
+        }
+
+        // Si toujours rien, prendre la plus récente toutes années confondues
         if (!$inscriptionRecente) {
             $inscriptionRecente = $etudiant->inscriptions()
                 ->with(['niveau', 'filiere', 'classe.niveau'])
@@ -489,6 +499,22 @@ class ESBTPEtudiantController extends Controller
             // Filière depuis l'inscription
             $filiereIdForMatricule = $inscriptionRecente->filiere_id;
         }
+
+        // Debug détaillé pour diagnostic
+        \Log::debug('Matricule generation - inscription lookup', [
+            'etudiant_id' => $etudiant->id,
+            'etudiant_matricule' => $etudiant->matricule,
+            'inscription_found' => $inscriptionRecente ? true : false,
+            'inscription_id' => $inscriptionRecente?->id,
+            'inscription_status' => $inscriptionRecente?->status,
+            'classe_id' => $inscriptionRecente?->classe_id,
+            'classe_niveau_id' => $inscriptionRecente?->classe?->niveau_etude_id,
+            'classe_niveau_code' => $inscriptionRecente?->classe?->niveau?->code,
+            'inscription_niveau_id' => $inscriptionRecente?->niveau_id,
+            'inscription_niveau_code' => $inscriptionRecente?->niveau?->code,
+            'final_niveau_code' => $niveauEtudeCode,
+            'filiere_id' => $filiereIdForMatricule,
+        ]);
 
         // Logging pour debug
         \Log::info('Étudiant chargé pour édition', [

--- a/resources/views/esbtp/etudiants/partials/edit-form-scripts.blade.php
+++ b/resources/views/esbtp/etudiants/partials/edit-form-scripts.blade.php
@@ -655,9 +655,18 @@
         // Vérifier si le niveau est configuré pour la génération automatique
         // (niveauConfig est déjà initialisé depuis les données Blade de l'inscription récente)
         function checkNiveauConfigStatus() {
+            // Si l'étudiant a déjà un matricule, pas besoin de warning
+            const hasExistingMatricule = matriculeInput && matriculeInput.value && matriculeInput.value.trim() !== '';
+
             if (!niveauConfig && currentMatriculeMode === 'automatique' && authUserIsSuperAdmin) {
-                showMatriculeStatus('⚠️ Aucune inscription trouvée - génération automatique impossible', 'warning');
-                if (generateBtn) generateBtn.disabled = true;
+                if (hasExistingMatricule) {
+                    // L'étudiant a déjà un matricule, on peut le régénérer manuellement si besoin
+                    showMatriculeStatus('ℹ️ Matricule existant. Cliquez sur "Générer" pour en créer un nouveau.', 'info');
+                } else {
+                    // Pas de matricule et pas d'inscription trouvée
+                    showMatriculeStatus('⚠️ Aucune inscription trouvée - génération automatique impossible', 'warning');
+                }
+                if (generateBtn) generateBtn.disabled = !hasExistingMatricule; // Permettre si matricule existe
             } else if (niveauConfig) {
                 showMatriculeStatus('', '');
                 if (generateBtn && authUserIsSuperAdmin) generateBtn.disabled = false;


### PR DESCRIPTION
- Ajouter fallbacks multiples pour trouver l'inscription:
  1. Année courante + status 'active' (case insensitive)
  2. Année courante (any status)
  3. Plus récente toutes années confondues
- Ajouter logs détaillés pour diagnostic
- Ne pas afficher warning si l'étudiant a déjà un matricule
- Permettre régénération même sans niveauConfig si matricule existe

https://claude.ai/code/session_01N7k8A98qTn1igMfPxFmpsC