### PR TITLE
fix(matricule): éliminer doublon lors de la génération automatique sur inscription.create

### DIFF
--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -605,8 +605,9 @@ class ESBTPInscriptionController extends Controller
             "ville" => "nullable|string|max:100",
             "commune" => "nullable|string|max:100",
             "photo" => "nullable|image|mimes:jpeg,png,jpg,gif|max:2048",
-            "matricule" =>
-                "required|string|max:20|unique:esbtp_etudiants,matricule",
+            "matricule" => empty(trim((string) $request->matricule))
+                ? "nullable"
+                : "required|string|max:20|unique:esbtp_etudiants,matricule",
         ];
         $messages = [
             "classe_id.required" => "Veuillez sélectionner une classe",

--- a/app/Http/Controllers/ESBTPMatriculeConfigController.php
+++ b/app/Http/Controllers/ESBTPMatriculeConfigController.php
@@ -167,7 +167,10 @@ class ESBTPMatriculeConfigController extends Controller
         ]);
 
         try {
-            $config = ESBTPMatriculeConfig::where('niveau_etude_code', $request->niveau_etude_code)
+            $etablissementId = ESBTPSystemSetting::getCurrentEtablissementId();
+
+            $config = ESBTPMatriculeConfig::where('etablissement_id', $etablissementId)
+                ->where('niveau_etude_code', $request->niveau_etude_code)
                 ->where('is_active', true)
                 ->first();
 

--- a/app/Models/ESBTPMatriculeConfig.php
+++ b/app/Models/ESBTPMatriculeConfig.php
@@ -83,9 +83,9 @@ class ESBTPMatriculeConfig extends Model
                   $this->etablissement_code .
                   $anneeFormatee . '-%';
 
-        // Chercher le dernier matricule avec ce pattern (excluant soft deleted)
-        $dernierEtudiant = ESBTPEtudiant::where('matricule', 'LIKE', $pattern)
-            ->whereNull('deleted_at')
+        // Chercher le dernier matricule avec ce pattern (inclut soft deleted — matricules jamais réutilisés)
+        $dernierEtudiant = ESBTPEtudiant::withTrashed()
+            ->where('matricule', 'LIKE', $pattern)
             ->orderByRaw("CAST(SUBSTRING_INDEX(matricule, '-', -1) AS UNSIGNED) DESC")
             ->first();
 
@@ -109,9 +109,9 @@ class ESBTPMatriculeConfig extends Model
                             $anneeFormatee . '-' .
                             $numeroFormate;
 
-            // Vérifier si ce matricule existe (requête EXISTS rapide)
-            $exists = ESBTPEtudiant::where('matricule', $testMatricule)
-                ->whereNull('deleted_at')
+            // Vérifier si ce matricule existe (inclut soft deleted — jamais réutilisés)
+            $exists = ESBTPEtudiant::withTrashed()
+                ->where('matricule', $testMatricule)
                 ->exists();
 
             if (!$exists) {
@@ -186,6 +186,6 @@ class ESBTPMatriculeConfig extends Model
      */
     public static function matriculeExists($matricule)
     {
-        return ESBTPEtudiant::where('matricule', $matricule)->exists();
+        return ESBTPEtudiant::withTrashed()->where('matricule', $matricule)->exists();
     }
 }

--- a/app/Support/MatriculeGenerator.php
+++ b/app/Support/MatriculeGenerator.php
@@ -30,11 +30,7 @@ class MatriculeGenerator
             $config = $this->resolveConfiguration($niveauId);
             if ($config) {
                 $annee = $this->resolveAnnee($anneeUniversitaireId);
-                $matricule = $config->genererMatricule($genre, $annee);
-
-                if (!ESBTPEtudiant::where('matricule', $matricule)->exists()) {
-                    return $matricule;
-                }
+                return $config->genererMatricule($genre, $annee);
             }
         }
 
@@ -172,9 +168,9 @@ class MatriculeGenerator
 
         $matriculePrefix = Str::upper($filiereCode . $niveauCode . $anneeCode);
 
-        // ⚡ Optimisation : récupérer toutes les séquences existantes en une seule requête
-        $existing = ESBTPEtudiant::where('matricule', 'like', "{$matriculePrefix}%")
-            ->whereNull('deleted_at')
+        // ⚡ Optimisation : récupérer toutes les séquences existantes en une seule requête (inclut soft deleted)
+        $existing = ESBTPEtudiant::withTrashed()
+            ->where('matricule', 'like', "{$matriculePrefix}%")
             ->pluck('matricule')
             ->map(function ($m) {
                 // Récupérer la partie après le tiret
@@ -204,8 +200,8 @@ class MatriculeGenerator
         $seqFormatted = str_pad($seq, 6, '0', STR_PAD_LEFT);
         $matricule = $matriculePrefix . $seqFormatted;
 
-        // 🔒 Double vérification finale pour éviter toute collision
-        if (ESBTPEtudiant::where('matricule', $matricule)->exists()) {
+        // 🔒 Double vérification finale pour éviter toute collision (inclut soft deleted)
+        if (ESBTPEtudiant::withTrashed()->where('matricule', $matricule)->exists()) {
             // Si collision, on incrémente automatiquement
             $seq = $existing->isNotEmpty() ? $existing->last() + 1 : 1;
             $seqFormatted = str_pad($seq, 6, '0', STR_PAD_LEFT);

--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -2627,38 +2627,25 @@ document.addEventListener('DOMContentLoaded', function() {
             // MODE AUTOMATIQUE
             // ====================================
             if (currentMatriculeMode === 'automatique') {
-                e.preventDefault(); // Bloquer le submit pour générer le matricule
-
                 // Vérifications pré-requis
                 if (!genreSelect || !genreSelect.value) {
+                    e.preventDefault();
                     alert('⚠️ Veuillez sélectionner le genre/sexe avant de soumettre le formulaire.');
                     if (genreSelect) genreSelect.focus();
                     return;
                 }
 
                 if (!niveauConfig) {
+                    e.preventDefault();
                     alert('⚠️ La classe sélectionnée n\'a pas de configuration de matricule.\n\nContactez l\'équipe technique ou sélectionnez une autre classe.');
                     if (classeSelect) classeSelect.focus();
                     return;
                 }
 
-                // Générer le matricule automatiquement
-                debugLog('⏳ Génération automatique du matricule...');
-                const matricule = await generateMatriculeAuto();
-
-                if (matricule) {
-                    // ✅ Matricule généré avec succès
-                    matriculeInput.value = matricule;
-                    debugLog('✅ Matricule généré et assigné:', matricule);
-
-                    // Soumettre RÉELLEMENT le formulaire
-                    debugLog('📤 Soumission réelle du formulaire...');
-                    inscriptionForm.submit();
-                } else {
-                    // ❌ Erreur de génération
-                    alert('❌ Impossible de générer le matricule automatiquement.\n\nVeuillez vérifier que:\n• Le genre/sexe est sélectionné\n• La classe a une configuration de matricule valide\n\nSi le problème persiste, contactez l\'équipe technique.');
-                    debugError('Échec de la génération du matricule');
-                }
+                // Vider le champ matricule — le serveur génère avec logique de retry
+                matriculeInput.value = '';
+                debugLog('📤 Mode AUTO : matricule laissé vide, génération serverside avec retry');
+                // Laisser le submit se poursuivre naturellement
             }
 
             // ====================================


### PR DESCRIPTION
Trois causes racines résolues :

1. TOCTOU client→serveur : le mode AUTO généraient le matricule via AJAX
   puis le soumettait dans le formulaire. Entre la génération et l'INSERT
   un autre requête pouvait prendre le même numéro, et la règle `unique`
   Laravel bloquait avant même d'atteindre la boucle de retry.
   → Le champ matricule est désormais laissé vide en mode AUTO ; le serveur
     génère via MatriculeGenerator avec la boucle retry (3 tentatives) et
     la contrainte UNIQUE en BDD comme filet de sécurité.

2. Validation inconditionnelle : la règle `required|unique` s'appliquait
   même quand le matricule allait être auto-généré, bloquant le chemin
   de génération serverside.
   → La règle devient `nullable` dès que le champ est vide à la réception.

3. Soft-deleted réutilisés : getProchainNumero() excluait les étudiants
   soft-deleted (whereNull deleted_at), les traitant comme des « trous »
   dans la séquence. Une réinscription après suppression pouvait donc
   regénérer un matricule déjà utilisé.
   → Toutes les requêtes de séquence utilisent withTrashed() pour traiter
     les matricules des étudiants supprimés comme « occupés », conformément
     à la règle documentée « soft-deleted matricules jamais réutilisés ».

Bonus : l'endpoint de prévisualisation /matricule-config/generate filtre
désormais par etablissement_id pour éviter les collisions cross-tenant.

https://claude.ai/code/session_01D51k7YYFhq1K5ECtkS3prw