### PR TITLE
feat(periodes): migrer emplois-temps et planning-general vers labels dynamiques

### DIFF
--- a/app/Models/ESBTPPeriode.php
+++ b/app/Models/ESBTPPeriode.php
@@ -1,0 +1,233 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Class ESBTPPeriode
+ *
+ * Modèle pour les périodes académiques génériques (semestres, trimestres, etc.)
+ *
+ * Relations:
+ * - belongsTo: ESBTPAnneeUniversitaire
+ * - hasMany: ESBTPPlanificationAcademique, ESBTPEmploiTemps, ESBTPEvaluation, ESBTPNote,
+ *            ESBTPResultat, ESBTPBulletin, ESBTPConfigMatiere, ESBTPConfigMatiereTypeFormation
+ *
+ * @property int $id
+ * @property int $annee_universitaire_id
+ * @property string $nom
+ * @property int $ordre
+ * @property \Carbon\Carbon $date_debut
+ * @property \Carbon\Carbon $date_fin
+ * @property int $poids
+ * @property bool $is_active
+ * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon $updated_at
+ *
+ * @property-read ESBTPAnneeUniversitaire $anneeUniversitaire
+ */
+class ESBTPPeriode extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'esbtp_periodes';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<string>
+     */
+    protected $fillable = [
+        'annee_universitaire_id',
+        'nom',
+        'ordre',
+        'date_debut',
+        'date_fin',
+        'poids',
+        'is_active',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'date_debut' => 'date',
+        'date_fin' => 'date',
+        'poids' => 'integer',
+        'is_active' => 'boolean',
+        'ordre' => 'integer',
+    ];
+
+    /**
+     * Get the année universitaire that owns the période.
+     *
+     * @return BelongsTo
+     */
+    public function anneeUniversitaire(): BelongsTo
+    {
+        return $this->belongsTo(ESBTPAnneeUniversitaire::class, 'annee_universitaire_id');
+    }
+
+    /**
+     * Get the planifications académiques for the période.
+     *
+     * @return HasMany
+     */
+    public function planificationsAcademiques(): HasMany
+    {
+        return $this->hasMany(ESBTPPlanificationAcademique::class, 'periode_id');
+    }
+
+    /**
+     * Get the emplois du temps for the période.
+     *
+     * @return HasMany
+     */
+    public function emploisTemps(): HasMany
+    {
+        return $this->hasMany(ESBTPEmploiTemps::class, 'periode_id');
+    }
+
+    /**
+     * Get the évaluations for the période.
+     *
+     * @return HasMany
+     */
+    public function evaluations(): HasMany
+    {
+        return $this->hasMany(ESBTPEvaluation::class, 'periode_id');
+    }
+
+    /**
+     * Get the notes for the période.
+     *
+     * @return HasMany
+     */
+    public function notes(): HasMany
+    {
+        return $this->hasMany(ESBTPNote::class, 'periode_id');
+    }
+
+    /**
+     * Get the résultats for the période.
+     *
+     * @return HasMany
+     */
+    public function resultats(): HasMany
+    {
+        return $this->hasMany(ESBTPResultat::class, 'periode_id');
+    }
+
+    /**
+     * Get the bulletins for the période.
+     *
+     * @return HasMany
+     */
+    public function bulletins(): HasMany
+    {
+        return $this->hasMany(ESBTPBulletin::class, 'periode_id');
+    }
+
+    /**
+     * Get the config matières for the période.
+     *
+     * @return HasMany
+     */
+    public function configMatieres(): HasMany
+    {
+        return $this->hasMany(ESBTPConfigMatiere::class, 'periode_id');
+    }
+
+    /**
+     * Get the config matière type formations for the période.
+     *
+     * @return HasMany
+     */
+    public function configMatiereTypeFormations(): HasMany
+    {
+        return $this->hasMany(ESBTPConfigMatiereTypeFormation::class, 'periode_id');
+    }
+
+    /**
+     * Scope a query to only include active périodes.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+
+    /**
+     * Scope a query to order périodes by ordre.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeOrdered($query)
+    {
+        return $query->orderBy('ordre', 'asc');
+    }
+
+    /**
+     * Scope a query to only include périodes for a specific année universitaire.
+     *
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @param  int  $anneeUniversitaireId
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public function scopeForAnneeUniversitaire($query, $anneeUniversitaireId)
+    {
+        return $query->where('annee_universitaire_id', $anneeUniversitaireId);
+    }
+
+    /**
+     * Get the durée (durée en jours) de la période.
+     *
+     * @return int
+     */
+    public function getDureeAttribute(): int
+    {
+        return $this->date_debut->diffInDays($this->date_fin);
+    }
+
+    /**
+     * Check if the période est en cours (date du jour entre date_debut et date_fin).
+     *
+     * @return bool
+     */
+    public function isEnCours(): bool
+    {
+        $today = today();
+        return $today->between($this->date_debut, $this->date_fin);
+    }
+
+    /**
+     * Check if the période est passée (date_fin < aujourd'hui).
+     *
+     * @return bool
+     */
+    public function isPassee(): bool
+    {
+        return $this->date_fin->isPast();
+    }
+
+    /**
+     * Check if the période est à venir (date_debut > aujourd'hui).
+     *
+     * @return bool
+     */
+    public function isAVenir(): bool
+    {
+        return $this->date_debut->isFuture();
+    }
+}

--- a/database/migrations/2026_02_05_200850_create_esbtp_periodes_table.php
+++ b/database/migrations/2026_02_05_200850_create_esbtp_periodes_table.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Cette migration crée la table centrale esbtp_periodes pour le système de périodes académiques génériques.
+     *
+     * Objectif: Remplacer les semestre/periode hardcodés (INT, VARCHAR, ENUM) par un système flexible
+     * supportant N périodes par année universitaire (2 semestres, 3 trimestres, etc.).
+     *
+     * Ancrage: annee_universitaire_id (PAS etablissement_id - chaque tenant = BDD séparée)
+     *
+     * Champs:
+     * - annee_universitaire_id: Année académique (FK)
+     * - nom: Nom de la période (ex: "Semestre 1", "Trimestre 1", "Quadrimestre 1")
+     * - ordre: Position dans l'année (1, 2, 3, ...) pour tri/affichage
+     * - date_debut: Date de début de la période
+     * - date_fin: Date de fin de la période
+     * - poids: Coefficient pour calcul moyenne annuelle (défaut: 1 = équipondéré)
+     * - is_active: Permet de désactiver une période (ex: année incomplète)
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('esbtp_periodes', function (Blueprint $table) {
+            $table->id();
+
+            // Ancrage sur l'année universitaire (multi-tenant via BDD séparées)
+            $table->unsignedBigInteger('annee_universitaire_id');
+            $table->foreign('annee_universitaire_id')
+                  ->references('id')
+                  ->on('esbtp_annees_universitaires')
+                  ->onDelete('cascade');
+
+            // Informations de la période
+            $table->string('nom', 50); // "Semestre 1", "Trimestre 2", etc.
+            $table->tinyInteger('ordre')->unsigned(); // 1, 2, 3, ...
+
+            // Dates de début/fin
+            $table->date('date_debut');
+            $table->date('date_fin');
+
+            // Poids pour calcul moyenne annuelle
+            $table->tinyInteger('poids')->unsigned()->default(1);
+
+            // Statut
+            $table->boolean('is_active')->default(true);
+
+            // Timestamps standard
+            $table->timestamps();
+
+            // Index pour performance
+            $table->index('annee_universitaire_id');
+            $table->index('ordre');
+            $table->index(['annee_universitaire_id', 'ordre']);
+
+            // Contrainte UNIQUE: Pas de doublon ordre pour une même année
+            $table->unique(['annee_universitaire_id', 'ordre'], 'unique_periode_ordre_par_annee');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('esbtp_periodes');
+    }
+};

--- a/database/migrations/2026_02_05_200940_migrate_planifications_periode.php
+++ b/database/migrations/2026_02_05_200940_migrate_planifications_periode.php
@@ -1,0 +1,139 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Migration esbtp_planifications_academiques: semestre (INT) → periode_id (FK)
+     *
+     * État actuel (après CleanPeriodeDataSeeder):
+     * - Colonne semestre: INT (1, 2)
+     * - Colonne semestre_str: VARCHAR ('semestre1', 'semestre2')
+     *
+     * Objectif:
+     * - Ajouter colonne periode_id (FK vers esbtp_periodes)
+     * - Backfill periode_id depuis semestre_str + annee_universitaire_id
+     * - Supprimer colonnes semestre et semestre_str
+     * - Recréer contrainte UNIQUE avec periode_id
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Étape 1: Ajouter colonne periode_id (nullable temporairement)
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable()->after('annee_universitaire_id');
+            $table->index('periode_id');
+        });
+
+        // Étape 2: Backfill periode_id depuis semestre_str + annee_universitaire_id
+        $planifications = DB::table('esbtp_planifications_academiques')
+            ->whereNotNull('semestre_str')
+            ->get();
+
+        foreach ($planifications as $planif) {
+            // Déterminer l'ordre de la période (semestre1 = 1, semestre2 = 2)
+            $ordre = ($planif->semestre_str === 'semestre1') ? 1 : 2;
+
+            // Trouver la période correspondante
+            $periode = DB::table('esbtp_periodes')
+                ->where('annee_universitaire_id', $planif->annee_universitaire_id)
+                ->where('ordre', $ordre)
+                ->first();
+
+            if ($periode) {
+                DB::table('esbtp_planifications_academiques')
+                    ->where('id', $planif->id)
+                    ->update(['periode_id' => $periode->id]);
+            } else {
+                \Log::warning("Période introuvable pour planification ID {$planif->id} (annee_universitaire_id={$planif->annee_universitaire_id}, ordre={$ordre})");
+            }
+        }
+
+        // Étape 3: Rendre periode_id NOT NULL
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable(false)->change();
+            $table->foreign('periode_id')
+                  ->references('id')
+                  ->on('esbtp_periodes')
+                  ->onDelete('cascade');
+        });
+
+        // Étape 4: Supprimer ancienne contrainte UNIQUE (si elle existe)
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            // Récupérer le nom de la contrainte UNIQUE existante
+            $indexName = DB::select("SHOW INDEX FROM esbtp_planifications_academiques WHERE Column_name = 'matiere_id' AND Non_unique = 0");
+
+            if (!empty($indexName)) {
+                $table->dropUnique($indexName[0]->Key_name ?? 'esbtp_planifications_academiques_matiere_id_unique');
+            }
+        });
+
+        // Étape 5: Créer nouvelle contrainte UNIQUE avec periode_id
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            $table->unique(
+                ['matiere_id', 'annee_universitaire_id', 'periode_id'],
+                'unique_planif_matiere_annee_periode'
+            );
+        });
+
+        // Étape 6: Supprimer colonnes semestre et semestre_str
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            $table->dropColumn(['semestre', 'semestre_str']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Recréer colonnes semestre et semestre_str
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            $table->tinyInteger('semestre')->unsigned()->nullable()->after('annee_universitaire_id');
+            $table->string('semestre_str', 20)->nullable()->after('semestre');
+        });
+
+        // Backfill depuis periode_id
+        $planifications = DB::table('esbtp_planifications_academiques')
+            ->join('esbtp_periodes', 'esbtp_planifications_academiques.periode_id', '=', 'esbtp_periodes.id')
+            ->select('esbtp_planifications_academiques.id', 'esbtp_periodes.ordre')
+            ->get();
+
+        foreach ($planifications as $planif) {
+            $semestre = $planif->ordre;
+            $semestreStr = "semestre{$semestre}";
+
+            DB::table('esbtp_planifications_academiques')
+                ->where('id', $planif->id)
+                ->update([
+                    'semestre' => $semestre,
+                    'semestre_str' => $semestreStr
+                ]);
+        }
+
+        // Supprimer nouvelle contrainte UNIQUE
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            $table->dropUnique('unique_planif_matiere_annee_periode');
+        });
+
+        // Recréer ancienne contrainte UNIQUE (approximative)
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            $table->unique(['matiere_id', 'annee_universitaire_id', 'semestre']);
+        });
+
+        // Supprimer colonne periode_id
+        Schema::table('esbtp_planifications_academiques', function (Blueprint $table) {
+            $table->dropForeign(['periode_id']);
+            $table->dropColumn('periode_id');
+        });
+    }
+};

--- a/database/migrations/2026_02_05_200941_migrate_emploi_temps_periode.php
+++ b/database/migrations/2026_02_05_200941_migrate_emploi_temps_periode.php
@@ -1,0 +1,106 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Migration esbtp_emploi_temps: semestre (VARCHAR) → periode_id (FK)
+     *
+     * État actuel (après CleanPeriodeDataSeeder):
+     * - Colonne semestre: VARCHAR ('semestre1', 'semestre2')
+     *
+     * Objectif:
+     * - Ajouter colonne periode_id (FK vers esbtp_periodes)
+     * - Backfill periode_id depuis semestre + annee_universitaire_id
+     * - Supprimer colonne semestre
+     *
+     * Note: Pas de contrainte UNIQUE à reconstruire sur cette table.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Étape 1: Ajouter colonne periode_id (nullable temporairement)
+        Schema::table('esbtp_emploi_temps', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable()->after('annee_universitaire_id');
+            $table->index('periode_id');
+        });
+
+        // Étape 2: Backfill periode_id depuis semestre + annee_universitaire_id
+        $emploisTemps = DB::table('esbtp_emploi_temps')
+            ->whereNotNull('semestre')
+            ->get();
+
+        foreach ($emploisTemps as $emploi) {
+            // Déterminer l'ordre de la période (semestre1 = 1, semestre2 = 2)
+            $ordre = ($emploi->semestre === 'semestre1') ? 1 : 2;
+
+            // Trouver la période correspondante
+            $periode = DB::table('esbtp_periodes')
+                ->where('annee_universitaire_id', $emploi->annee_universitaire_id)
+                ->where('ordre', $ordre)
+                ->first();
+
+            if ($periode) {
+                DB::table('esbtp_emploi_temps')
+                    ->where('id', $emploi->id)
+                    ->update(['periode_id' => $periode->id]);
+            } else {
+                \Log::warning("Période introuvable pour emploi_temps ID {$emploi->id} (annee_universitaire_id={$emploi->annee_universitaire_id}, ordre={$ordre})");
+            }
+        }
+
+        // Étape 3: Rendre periode_id NOT NULL
+        Schema::table('esbtp_emploi_temps', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable(false)->change();
+            $table->foreign('periode_id')
+                  ->references('id')
+                  ->on('esbtp_periodes')
+                  ->onDelete('cascade');
+        });
+
+        // Étape 4: Supprimer colonne semestre
+        Schema::table('esbtp_emploi_temps', function (Blueprint $table) {
+            $table->dropColumn('semestre');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Recréer colonne semestre
+        Schema::table('esbtp_emploi_temps', function (Blueprint $table) {
+            $table->string('semestre', 20)->nullable()->after('annee_universitaire_id');
+        });
+
+        // Backfill depuis periode_id
+        $emploisTemps = DB::table('esbtp_emploi_temps')
+            ->join('esbtp_periodes', 'esbtp_emploi_temps.periode_id', '=', 'esbtp_periodes.id')
+            ->select('esbtp_emploi_temps.id', 'esbtp_periodes.ordre')
+            ->get();
+
+        foreach ($emploisTemps as $emploi) {
+            $semestreStr = "semestre{$emploi->ordre}";
+
+            DB::table('esbtp_emploi_temps')
+                ->where('id', $emploi->id)
+                ->update(['semestre' => $semestreStr]);
+        }
+
+        // Supprimer colonne periode_id
+        Schema::table('esbtp_emploi_temps', function (Blueprint $table) {
+            $table->dropForeign(['periode_id']);
+            $table->dropColumn('periode_id');
+        });
+    }
+};

--- a/database/migrations/2026_02_05_200942_migrate_evaluations_periode.php
+++ b/database/migrations/2026_02_05_200942_migrate_evaluations_periode.php
@@ -1,0 +1,106 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Migration esbtp_evaluations: periode (VARCHAR) → periode_id (FK NULLABLE)
+     *
+     * État actuel (après CleanPeriodeDataSeeder):
+     * - Colonne periode: VARCHAR ('semestre1', 'semestre2', NULL)
+     *
+     * Objectif:
+     * - Ajouter colonne periode_id (FK vers esbtp_periodes, NULLABLE)
+     * - Backfill periode_id depuis periode + annee_universitaire_id
+     * - Supprimer colonne periode
+     *
+     * Note: periode_id reste NULLABLE pour supporter les évaluations continues (pas liées à une période).
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Étape 1: Ajouter colonne periode_id (nullable)
+        Schema::table('esbtp_evaluations', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable()->after('annee_universitaire_id');
+            $table->index('periode_id');
+        });
+
+        // Étape 2: Backfill periode_id depuis periode + annee_universitaire_id
+        $evaluations = DB::table('esbtp_evaluations')
+            ->whereNotNull('periode')
+            ->get();
+
+        foreach ($evaluations as $evaluation) {
+            // Déterminer l'ordre de la période (semestre1 = 1, semestre2 = 2)
+            $ordre = ($evaluation->periode === 'semestre1') ? 1 : 2;
+
+            // Trouver la période correspondante
+            $periode = DB::table('esbtp_periodes')
+                ->where('annee_universitaire_id', $evaluation->annee_universitaire_id)
+                ->where('ordre', $ordre)
+                ->first();
+
+            if ($periode) {
+                DB::table('esbtp_evaluations')
+                    ->where('id', $evaluation->id)
+                    ->update(['periode_id' => $periode->id]);
+            } else {
+                \Log::warning("Période introuvable pour evaluation ID {$evaluation->id} (annee_universitaire_id={$evaluation->annee_universitaire_id}, ordre={$ordre})");
+            }
+        }
+
+        // Étape 3: Ajouter contrainte FK (periode_id reste NULLABLE)
+        Schema::table('esbtp_evaluations', function (Blueprint $table) {
+            $table->foreign('periode_id')
+                  ->references('id')
+                  ->on('esbtp_periodes')
+                  ->onDelete('set null'); // Si période supprimée, évaluation devient "continue"
+        });
+
+        // Étape 4: Supprimer colonne periode
+        Schema::table('esbtp_evaluations', function (Blueprint $table) {
+            $table->dropColumn('periode');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Recréer colonne periode
+        Schema::table('esbtp_evaluations', function (Blueprint $table) {
+            $table->string('periode', 20)->nullable()->after('annee_universitaire_id');
+        });
+
+        // Backfill depuis periode_id
+        $evaluations = DB::table('esbtp_evaluations')
+            ->whereNotNull('periode_id')
+            ->join('esbtp_periodes', 'esbtp_evaluations.periode_id', '=', 'esbtp_periodes.id')
+            ->select('esbtp_evaluations.id', 'esbtp_periodes.ordre')
+            ->get();
+
+        foreach ($evaluations as $evaluation) {
+            $periodeStr = "semestre{$evaluation->ordre}";
+
+            DB::table('esbtp_evaluations')
+                ->where('id', $evaluation->id)
+                ->update(['periode' => $periodeStr]);
+        }
+
+        // Supprimer colonne periode_id
+        Schema::table('esbtp_evaluations', function (Blueprint $table) {
+            $table->dropForeign(['periode_id']);
+            $table->dropColumn('periode_id');
+        });
+    }
+};

--- a/database/migrations/2026_02_05_200943_migrate_notes_periode.php
+++ b/database/migrations/2026_02_05_200943_migrate_notes_periode.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Migration esbtp_notes: semestre (VARCHAR) → periode_id (FK NULLABLE)
+     *
+     * État actuel (après CleanPeriodeDataSeeder):
+     * - Colonne semestre: VARCHAR ('semestre1', 'semestre2', NULL)
+     *
+     * Objectif:
+     * - Ajouter colonne periode_id (FK vers esbtp_periodes, NULLABLE)
+     * - Backfill periode_id depuis semestre + evaluation.annee_universitaire_id
+     * - Supprimer colonne semestre
+     *
+     * Note: periode_id reste NULLABLE car les notes héritent de leur evaluation.periode_id.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Étape 1: Ajouter colonne periode_id (nullable)
+        Schema::table('esbtp_notes', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable()->after('evaluation_id');
+            $table->index('periode_id');
+        });
+
+        // Étape 2: Backfill periode_id depuis semestre + evaluation.annee_universitaire_id
+        $notes = DB::table('esbtp_notes')
+            ->join('esbtp_evaluations', 'esbtp_notes.evaluation_id', '=', 'esbtp_evaluations.id')
+            ->whereNotNull('esbtp_notes.semestre')
+            ->select('esbtp_notes.id', 'esbtp_notes.semestre', 'esbtp_evaluations.annee_universitaire_id')
+            ->get();
+
+        foreach ($notes as $note) {
+            // Déterminer l'ordre de la période (semestre1 = 1, semestre2 = 2)
+            $ordre = ($note->semestre === 'semestre1') ? 1 : 2;
+
+            // Trouver la période correspondante
+            $periode = DB::table('esbtp_periodes')
+                ->where('annee_universitaire_id', $note->annee_universitaire_id)
+                ->where('ordre', $ordre)
+                ->first();
+
+            if ($periode) {
+                DB::table('esbtp_notes')
+                    ->where('id', $note->id)
+                    ->update(['periode_id' => $periode->id]);
+            } else {
+                \Log::warning("Période introuvable pour note ID {$note->id} (annee_universitaire_id={$note->annee_universitaire_id}, ordre={$ordre})");
+            }
+        }
+
+        // Étape 3: Ajouter contrainte FK (periode_id reste NULLABLE)
+        Schema::table('esbtp_notes', function (Blueprint $table) {
+            $table->foreign('periode_id')
+                  ->references('id')
+                  ->on('esbtp_periodes')
+                  ->onDelete('set null');
+        });
+
+        // Étape 4: Supprimer colonne semestre
+        Schema::table('esbtp_notes', function (Blueprint $table) {
+            $table->dropColumn('semestre');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Recréer colonne semestre
+        Schema::table('esbtp_notes', function (Blueprint $table) {
+            $table->string('semestre', 20)->nullable()->after('evaluation_id');
+        });
+
+        // Backfill depuis periode_id
+        $notes = DB::table('esbtp_notes')
+            ->whereNotNull('periode_id')
+            ->join('esbtp_periodes', 'esbtp_notes.periode_id', '=', 'esbtp_periodes.id')
+            ->select('esbtp_notes.id', 'esbtp_periodes.ordre')
+            ->get();
+
+        foreach ($notes as $note) {
+            $semestreStr = "semestre{$note->ordre}";
+
+            DB::table('esbtp_notes')
+                ->where('id', $note->id)
+                ->update(['semestre' => $semestreStr]);
+        }
+
+        // Supprimer colonne periode_id
+        Schema::table('esbtp_notes', function (Blueprint $table) {
+            $table->dropForeign(['periode_id']);
+            $table->dropColumn('periode_id');
+        });
+    }
+};

--- a/database/migrations/2026_02_05_200944_migrate_resultats_periode.php
+++ b/database/migrations/2026_02_05_200944_migrate_resultats_periode.php
@@ -1,0 +1,133 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Migration esbtp_resultats: periode (VARCHAR) → periode_id (FK NULLABLE)
+     *
+     * État actuel (après CleanPeriodeDataSeeder):
+     * - Colonne periode: VARCHAR ('semestre1', 'semestre2', NULL)
+     * - Table vide en production (structure seulement)
+     *
+     * Objectif:
+     * - Ajouter colonne periode_id (FK vers esbtp_periodes, NULLABLE)
+     * - Backfill periode_id si données existantes
+     * - Supprimer colonne periode
+     * - Recréer contrainte UNIQUE avec periode_id
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Étape 1: Ajouter colonne periode_id (nullable)
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable()->after('annee_universitaire_id');
+            $table->index('periode_id');
+        });
+
+        // Étape 2: Backfill periode_id depuis periode + annee_universitaire_id (si données existantes)
+        $resultats = DB::table('esbtp_resultats')
+            ->whereNotNull('periode')
+            ->get();
+
+        foreach ($resultats as $resultat) {
+            // Déterminer l'ordre de la période (semestre1 = 1, semestre2 = 2)
+            $ordre = ($resultat->periode === 'semestre1') ? 1 : 2;
+
+            // Trouver la période correspondante
+            $periode = DB::table('esbtp_periodes')
+                ->where('annee_universitaire_id', $resultat->annee_universitaire_id)
+                ->where('ordre', $ordre)
+                ->first();
+
+            if ($periode) {
+                DB::table('esbtp_resultats')
+                    ->where('id', $resultat->id)
+                    ->update(['periode_id' => $periode->id]);
+            } else {
+                \Log::warning("Période introuvable pour resultat ID {$resultat->id} (annee_universitaire_id={$resultat->annee_universitaire_id}, ordre={$ordre})");
+            }
+        }
+
+        // Étape 3: Ajouter contrainte FK (periode_id reste NULLABLE)
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $table->foreign('periode_id')
+                  ->references('id')
+                  ->on('esbtp_periodes')
+                  ->onDelete('set null');
+        });
+
+        // Étape 4: Supprimer ancienne contrainte UNIQUE (si elle existe)
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $indexName = DB::select("SHOW INDEX FROM esbtp_resultats WHERE Column_name = 'periode' AND Non_unique = 0");
+
+            if (!empty($indexName)) {
+                $table->dropUnique($indexName[0]->Key_name);
+            }
+        });
+
+        // Étape 5: Créer nouvelle contrainte UNIQUE avec periode_id
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $table->unique(
+                ['etudiant_id', 'matiere_id', 'annee_universitaire_id', 'periode_id'],
+                'unique_resultat_etudiant_matiere_annee_periode'
+            );
+        });
+
+        // Étape 6: Supprimer colonne periode
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $table->dropColumn('periode');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Recréer colonne periode
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $table->string('periode', 20)->nullable()->after('annee_universitaire_id');
+        });
+
+        // Backfill depuis periode_id
+        $resultats = DB::table('esbtp_resultats')
+            ->whereNotNull('periode_id')
+            ->join('esbtp_periodes', 'esbtp_resultats.periode_id', '=', 'esbtp_periodes.id')
+            ->select('esbtp_resultats.id', 'esbtp_periodes.ordre')
+            ->get();
+
+        foreach ($resultats as $resultat) {
+            $periodeStr = "semestre{$resultat->ordre}";
+
+            DB::table('esbtp_resultats')
+                ->where('id', $resultat->id)
+                ->update(['periode' => $periodeStr]);
+        }
+
+        // Supprimer nouvelle contrainte UNIQUE
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $table->dropUnique('unique_resultat_etudiant_matiere_annee_periode');
+        });
+
+        // Recréer ancienne contrainte UNIQUE
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $table->unique(['etudiant_id', 'matiere_id', 'annee_universitaire_id', 'periode']);
+        });
+
+        // Supprimer colonne periode_id
+        Schema::table('esbtp_resultats', function (Blueprint $table) {
+            $table->dropForeign(['periode_id']);
+            $table->dropColumn('periode_id');
+        });
+    }
+};

--- a/database/migrations/2026_02_05_200945_migrate_bulletins_periode.php
+++ b/database/migrations/2026_02_05_200945_migrate_bulletins_periode.php
@@ -1,0 +1,128 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Migration esbtp_bulletins: periode (VARCHAR) → periode_id (FK NULLABLE) + type_bulletin (ENUM)
+     *
+     * État actuel (après CleanPeriodeDataSeeder):
+     * - Colonne periode: VARCHAR ('semestre1', 'semestre2', NULL)
+     *
+     * Objectif:
+     * - Ajouter colonne periode_id (FK vers esbtp_periodes, NULLABLE)
+     * - Ajouter colonne type_bulletin ENUM('periode', 'annuel')
+     * - Backfill periode_id et type_bulletin depuis periode + annee_universitaire_id
+     * - Supprimer colonne periode
+     *
+     * Note:
+     * - periode_id NULL = Bulletin annuel (type_bulletin='annuel')
+     * - periode_id NOT NULL = Bulletin de période (type_bulletin='periode')
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Étape 1: Ajouter colonnes periode_id et type_bulletin
+        Schema::table('esbtp_bulletins', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable()->after('annee_universitaire_id');
+            $table->enum('type_bulletin', ['periode', 'annuel'])->default('periode')->after('periode_id');
+            $table->index('periode_id');
+            $table->index('type_bulletin');
+        });
+
+        // Étape 2: Backfill periode_id et type_bulletin depuis periode + annee_universitaire_id
+        // Bulletins de période (periode NOT NULL)
+        $bulletinsPeriode = DB::table('esbtp_bulletins')
+            ->whereNotNull('periode')
+            ->get();
+
+        foreach ($bulletinsPeriode as $bulletin) {
+            // Déterminer l'ordre de la période (semestre1 = 1, semestre2 = 2)
+            $ordre = ($bulletin->periode === 'semestre1') ? 1 : 2;
+
+            // Trouver la période correspondante
+            $periode = DB::table('esbtp_periodes')
+                ->where('annee_universitaire_id', $bulletin->annee_universitaire_id)
+                ->where('ordre', $ordre)
+                ->first();
+
+            if ($periode) {
+                DB::table('esbtp_bulletins')
+                    ->where('id', $bulletin->id)
+                    ->update([
+                        'periode_id' => $periode->id,
+                        'type_bulletin' => 'periode'
+                    ]);
+            } else {
+                \Log::warning("Période introuvable pour bulletin ID {$bulletin->id} (annee_universitaire_id={$bulletin->annee_universitaire_id}, ordre={$ordre})");
+            }
+        }
+
+        // Bulletins annuels (periode NULL)
+        DB::table('esbtp_bulletins')
+            ->whereNull('periode')
+            ->update([
+                'periode_id' => null,
+                'type_bulletin' => 'annuel'
+            ]);
+
+        // Étape 3: Ajouter contrainte FK (periode_id reste NULLABLE)
+        Schema::table('esbtp_bulletins', function (Blueprint $table) {
+            $table->foreign('periode_id')
+                  ->references('id')
+                  ->on('esbtp_periodes')
+                  ->onDelete('set null');
+        });
+
+        // Étape 4: Supprimer colonne periode
+        Schema::table('esbtp_bulletins', function (Blueprint $table) {
+            $table->dropColumn('periode');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Recréer colonne periode
+        Schema::table('esbtp_bulletins', function (Blueprint $table) {
+            $table->string('periode', 20)->nullable()->after('annee_universitaire_id');
+        });
+
+        // Backfill depuis periode_id et type_bulletin
+        // Bulletins de période
+        $bulletinsPeriode = DB::table('esbtp_bulletins')
+            ->where('type_bulletin', 'periode')
+            ->whereNotNull('periode_id')
+            ->join('esbtp_periodes', 'esbtp_bulletins.periode_id', '=', 'esbtp_periodes.id')
+            ->select('esbtp_bulletins.id', 'esbtp_periodes.ordre')
+            ->get();
+
+        foreach ($bulletinsPeriode as $bulletin) {
+            $periodeStr = "semestre{$bulletin->ordre}";
+
+            DB::table('esbtp_bulletins')
+                ->where('id', $bulletin->id)
+                ->update(['periode' => $periodeStr]);
+        }
+
+        // Bulletins annuels (periode reste NULL)
+        // Rien à faire, periode = NULL par défaut
+
+        // Supprimer colonnes periode_id et type_bulletin
+        Schema::table('esbtp_bulletins', function (Blueprint $table) {
+            $table->dropForeign(['periode_id']);
+            $table->dropColumn(['periode_id', 'type_bulletin']);
+        });
+    }
+};

--- a/database/migrations/2026_02_05_200946_migrate_config_matieres_periode.php
+++ b/database/migrations/2026_02_05_200946_migrate_config_matieres_periode.php
@@ -1,0 +1,140 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Migration esbtp_config_matieres: semestre (INT) → periode_id (FK NULLABLE)
+     *
+     * État actuel (après CleanPeriodeDataSeeder):
+     * - Colonne semestre: INT (1, 2, NULL)
+     * - Colonne semestre_str: VARCHAR ('semestre1', 'semestre2', NULL)
+     *
+     * Objectif:
+     * - Ajouter colonne periode_id (FK vers esbtp_periodes, NULLABLE)
+     * - Backfill periode_id depuis semestre_str + annee_universitaire_id
+     * - Supprimer colonnes semestre et semestre_str
+     * - Recréer contrainte UNIQUE avec periode_id
+     *
+     * Note: periode_id peut être NULL pour les matières annuelles.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Étape 1: Ajouter colonne periode_id (nullable)
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable()->after('annee_universitaire_id');
+            $table->index('periode_id');
+        });
+
+        // Étape 2: Backfill periode_id depuis semestre_str + annee_universitaire_id
+        $configMatieres = DB::table('esbtp_config_matieres')
+            ->whereNotNull('semestre_str')
+            ->get();
+
+        foreach ($configMatieres as $config) {
+            // Déterminer l'ordre de la période (semestre1 = 1, semestre2 = 2)
+            $ordre = ($config->semestre_str === 'semestre1') ? 1 : 2;
+
+            // Trouver la période correspondante
+            $periode = DB::table('esbtp_periodes')
+                ->where('annee_universitaire_id', $config->annee_universitaire_id)
+                ->where('ordre', $ordre)
+                ->first();
+
+            if ($periode) {
+                DB::table('esbtp_config_matieres')
+                    ->where('id', $config->id)
+                    ->update(['periode_id' => $periode->id]);
+            } else {
+                \Log::warning("Période introuvable pour config_matiere ID {$config->id} (annee_universitaire_id={$config->annee_universitaire_id}, ordre={$ordre})");
+            }
+        }
+
+        // Étape 3: Ajouter contrainte FK (periode_id reste NULLABLE)
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $table->foreign('periode_id')
+                  ->references('id')
+                  ->on('esbtp_periodes')
+                  ->onDelete('set null');
+        });
+
+        // Étape 4: Supprimer ancienne contrainte UNIQUE (si elle existe)
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $indexName = DB::select("SHOW INDEX FROM esbtp_config_matieres WHERE Column_name = 'matiere_id' AND Non_unique = 0");
+
+            if (!empty($indexName)) {
+                $table->dropUnique($indexName[0]->Key_name ?? 'esbtp_config_matieres_unique');
+            }
+        });
+
+        // Étape 5: Créer nouvelle contrainte UNIQUE avec periode_id
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $table->unique(
+                ['classe_id', 'annee_universitaire_id', 'periode_id', 'matiere_id'],
+                'unique_config_matiere_classe_annee_periode'
+            );
+        });
+
+        // Étape 6: Supprimer colonnes semestre et semestre_str
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $table->dropColumn(['semestre', 'semestre_str']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Recréer colonnes semestre et semestre_str
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $table->tinyInteger('semestre')->unsigned()->nullable()->after('annee_universitaire_id');
+            $table->string('semestre_str', 20)->nullable()->after('semestre');
+        });
+
+        // Backfill depuis periode_id
+        $configMatieres = DB::table('esbtp_config_matieres')
+            ->whereNotNull('periode_id')
+            ->join('esbtp_periodes', 'esbtp_config_matieres.periode_id', '=', 'esbtp_periodes.id')
+            ->select('esbtp_config_matieres.id', 'esbtp_periodes.ordre')
+            ->get();
+
+        foreach ($configMatieres as $config) {
+            $semestre = $config->ordre;
+            $semestreStr = "semestre{$semestre}";
+
+            DB::table('esbtp_config_matieres')
+                ->where('id', $config->id)
+                ->update([
+                    'semestre' => $semestre,
+                    'semestre_str' => $semestreStr
+                ]);
+        }
+
+        // Supprimer nouvelle contrainte UNIQUE
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $table->dropUnique('unique_config_matiere_classe_annee_periode');
+        });
+
+        // Recréer ancienne contrainte UNIQUE
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $table->unique(['classe_id', 'annee_universitaire_id', 'semestre', 'matiere_id']);
+        });
+
+        // Supprimer colonne periode_id
+        Schema::table('esbtp_config_matieres', function (Blueprint $table) {
+            $table->dropForeign(['periode_id']);
+            $table->dropColumn('periode_id');
+        });
+    }
+};

--- a/database/migrations/2026_02_05_200947_migrate_config_matiere_type_formations_periode.php
+++ b/database/migrations/2026_02_05_200947_migrate_config_matiere_type_formations_periode.php
@@ -1,0 +1,143 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Migration esbtp_config_matiere_type_formations: semestre (INT) → periode_id (FK NULLABLE)
+     *
+     * État actuel (après CleanPeriodeDataSeeder):
+     * - Colonne semestre: INT (1, 2, NULL)
+     * - Colonne semestre_str: VARCHAR ('semestre1', 'semestre2', NULL)
+     *
+     * Objectif:
+     * - Ajouter colonne periode_id (FK vers esbtp_periodes, NULLABLE)
+     * - Backfill periode_id depuis semestre_str + annee_universitaire_id (via matiere)
+     * - Supprimer colonnes semestre et semestre_str
+     * - Recréer contrainte UNIQUE avec periode_id
+     *
+     * Note: periode_id peut être NULL pour les matières annuelles.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // Étape 1: Ajouter colonne periode_id (nullable)
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $table->unsignedBigInteger('periode_id')->nullable()->after('type_formation_id');
+            $table->index('periode_id');
+        });
+
+        // Étape 2: Backfill periode_id depuis semestre_str + annee via matiere
+        // Note: Cette table n'a pas directement annee_universitaire_id, elle passe par matiere
+        $configs = DB::table('esbtp_config_matiere_type_formations as cmtf')
+            ->join('esbtp_matieres as m', 'cmtf.matiere_id', '=', 'm.id')
+            ->whereNotNull('cmtf.semestre_str')
+            ->select('cmtf.id', 'cmtf.semestre_str', 'm.annee_universitaire_id')
+            ->get();
+
+        foreach ($configs as $config) {
+            // Déterminer l'ordre de la période (semestre1 = 1, semestre2 = 2)
+            $ordre = ($config->semestre_str === 'semestre1') ? 1 : 2;
+
+            // Trouver la période correspondante
+            $periode = DB::table('esbtp_periodes')
+                ->where('annee_universitaire_id', $config->annee_universitaire_id)
+                ->where('ordre', $ordre)
+                ->first();
+
+            if ($periode) {
+                DB::table('esbtp_config_matiere_type_formations')
+                    ->where('id', $config->id)
+                    ->update(['periode_id' => $periode->id]);
+            } else {
+                \Log::warning("Période introuvable pour config_matiere_type_formation ID {$config->id} (annee_universitaire_id={$config->annee_universitaire_id}, ordre={$ordre})");
+            }
+        }
+
+        // Étape 3: Ajouter contrainte FK (periode_id reste NULLABLE)
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $table->foreign('periode_id')
+                  ->references('id')
+                  ->on('esbtp_periodes')
+                  ->onDelete('set null');
+        });
+
+        // Étape 4: Supprimer ancienne contrainte UNIQUE (si elle existe)
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $indexName = DB::select("SHOW INDEX FROM esbtp_config_matiere_type_formations WHERE Column_name = 'matiere_id' AND Non_unique = 0");
+
+            if (!empty($indexName)) {
+                $table->dropUnique($indexName[0]->Key_name ?? 'esbtp_config_matiere_type_formations_unique');
+            }
+        });
+
+        // Étape 5: Créer nouvelle contrainte UNIQUE avec periode_id
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $table->unique(
+                ['matiere_id', 'type_formation_id', 'periode_id'],
+                'unique_config_mtf_periode'
+            );
+        });
+
+        // Étape 6: Supprimer colonnes semestre et semestre_str
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $table->dropColumn(['semestre', 'semestre_str']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // Recréer colonnes semestre et semestre_str
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $table->tinyInteger('semestre')->unsigned()->nullable()->after('type_formation_id');
+            $table->string('semestre_str', 20)->nullable()->after('semestre');
+        });
+
+        // Backfill depuis periode_id
+        $configs = DB::table('esbtp_config_matiere_type_formations')
+            ->whereNotNull('periode_id')
+            ->join('esbtp_periodes', 'esbtp_config_matiere_type_formations.periode_id', '=', 'esbtp_periodes.id')
+            ->select('esbtp_config_matiere_type_formations.id', 'esbtp_periodes.ordre')
+            ->get();
+
+        foreach ($configs as $config) {
+            $semestre = $config->ordre;
+            $semestreStr = "semestre{$semestre}";
+
+            DB::table('esbtp_config_matiere_type_formations')
+                ->where('id', $config->id)
+                ->update([
+                    'semestre' => $semestre,
+                    'semestre_str' => $semestreStr
+                ]);
+        }
+
+        // Supprimer nouvelle contrainte UNIQUE
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $table->dropUnique('unique_config_mtf_periode');
+        });
+
+        // Recréer ancienne contrainte UNIQUE
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $table->unique(['matiere_id', 'type_formation_id', 'semestre']);
+        });
+
+        // Supprimer colonne periode_id
+        Schema::table('esbtp_config_matiere_type_formations', function (Blueprint $table) {
+            $table->dropForeign(['periode_id']);
+            $table->dropColumn('periode_id');
+        });
+    }
+};

--- a/database/seeders/CleanPeriodeDataSeeder.php
+++ b/database/seeders/CleanPeriodeDataSeeder.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * CleanPeriodeDataSeeder
+ *
+ * Nettoie et normalise les données de périodes/semestres AVANT la migration vers periode_id.
+ *
+ * Objectif: Uniformiser tous les formats (INT, VARCHAR avec variantes) vers 'semestre1'/'semestre2'
+ * pour garantir une migration propre sans perte de données.
+ *
+ * Formats détectés en production (dumps esbtp-abidjan + esbtp-yakro):
+ * - esbtp_emploi_temps.semestre: 'Semestre 1', 'Semestre 2' (VARCHAR)
+ * - esbtp_evaluations.periode: 'semestre1', 'semestre2' (VARCHAR)
+ * - esbtp_notes.semestre: '1', '2' (VARCHAR - converti par auto-sync bug)
+ * - esbtp_planifications_academiques.semestre: 1, 2 (INT)
+ * - esbtp_config_matieres.semestre: 1, 2 (INT)
+ * - esbtp_config_matiere_type_formations.semestre: 1, 2 (INT)
+ * - esbtp_resultats.periode: Format inconnu (table vide en prod)
+ * - esbtp_bulletins.periode: Format inconnu (vérification nécessaire)
+ *
+ * Normalisation cible:
+ * - 'Semestre 1' → 'semestre1'
+ * - 'Semestre 2' → 'semestre2'
+ * - '1' → 'semestre1'
+ * - '2' → 'semestre2'
+ * - 1 (INT) → 'semestre1'
+ * - 2 (INT) → 'semestre2'
+ */
+class CleanPeriodeDataSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Log::info('🧹 Démarrage du nettoyage des données de périodes...');
+
+        $this->checkEmploiTemps();
+        $this->checkEvaluations();
+        $this->checkNotes();
+        $this->checkPlanificationsAcademiques();
+        $this->checkConfigMatieres();
+        $this->checkConfigMatiereTypeFormations();
+        $this->checkResultats();
+        $this->checkBulletins();
+
+        Log::info('✅ Nettoyage des données de périodes terminé avec succès.');
+    }
+
+    /**
+     * Normaliser esbtp_emploi_temps.semestre (VARCHAR)
+     * Format détecté: 'Semestre 1', 'Semestre 2'
+     */
+    private function checkEmploiTemps(): void
+    {
+        Log::info('📋 Vérification esbtp_emploi_temps...');
+
+        // Semestre 1
+        $updatedS1 = DB::table('esbtp_emploi_temps')
+            ->where('semestre', 'Semestre 1')
+            ->update(['semestre' => 'semestre1']);
+
+        // Semestre 2
+        $updatedS2 = DB::table('esbtp_emploi_temps')
+            ->where('semestre', 'Semestre 2')
+            ->update(['semestre' => 'semestre2']);
+
+        Log::info("  → Semestre 1: {$updatedS1} lignes normalisées");
+        Log::info("  → Semestre 2: {$updatedS2} lignes normalisées");
+    }
+
+    /**
+     * Normaliser esbtp_evaluations.periode (VARCHAR)
+     * Format détecté: 'semestre1', 'semestre2' (déjà OK normalement)
+     */
+    private function checkEvaluations(): void
+    {
+        Log::info('📋 Vérification esbtp_evaluations...');
+
+        // Vérifier s'il y a des formats non standards
+        $nonStandard = DB::table('esbtp_evaluations')
+            ->whereNotNull('periode')
+            ->whereNotIn('periode', ['semestre1', 'semestre2'])
+            ->get();
+
+        if ($nonStandard->count() > 0) {
+            Log::warning("  ⚠️  {$nonStandard->count()} évaluations avec format non standard détectées:");
+            foreach ($nonStandard as $eval) {
+                Log::warning("     - ID {$eval->id}: periode='{$eval->periode}'");
+            }
+
+            // Tentative de normalisation (1 → semestre1, 2 → semestre2)
+            $updated1 = DB::table('esbtp_evaluations')
+                ->where('periode', '1')
+                ->update(['periode' => 'semestre1']);
+
+            $updated2 = DB::table('esbtp_evaluations')
+                ->where('periode', '2')
+                ->update(['periode' => 'semestre2']);
+
+            Log::info("  → '1': {$updated1} lignes normalisées");
+            Log::info("  → '2': {$updated2} lignes normalisées");
+        } else {
+            Log::info('  ✅ Toutes les évaluations sont déjà au format standard.');
+        }
+    }
+
+    /**
+     * Normaliser esbtp_notes.semestre (VARCHAR)
+     * Format détecté: '1', '2' (généré par auto-sync bug dans ESBTPNote::booted())
+     */
+    private function checkNotes(): void
+    {
+        Log::info('📋 Vérification esbtp_notes...');
+
+        // '1' → 'semestre1'
+        $updated1 = DB::table('esbtp_notes')
+            ->where('semestre', '1')
+            ->update(['semestre' => 'semestre1']);
+
+        // '2' → 'semestre2'
+        $updated2 = DB::table('esbtp_notes')
+            ->where('semestre', '2')
+            ->update(['semestre' => 'semestre2']);
+
+        Log::info("  → '1': {$updated1} lignes normalisées");
+        Log::info("  → '2': {$updated2} lignes normalisées");
+    }
+
+    /**
+     * Normaliser esbtp_planifications_academiques.semestre (INT)
+     * Format détecté: 1, 2
+     *
+     * Note: Cette table utilise un INT, donc on va créer une colonne VARCHAR temporaire
+     * pour la normalisation, puis la migration finale remplacera par periode_id.
+     */
+    private function checkPlanificationsAcademiques(): void
+    {
+        Log::info('📋 Vérification esbtp_planifications_academiques...');
+
+        // Vérifier si la colonne semestre_str existe déjà
+        $columnExists = DB::getSchemaBuilder()->hasColumn('esbtp_planifications_academiques', 'semestre_str');
+
+        if (!$columnExists) {
+            // Créer colonne temporaire VARCHAR
+            DB::statement('ALTER TABLE esbtp_planifications_academiques ADD COLUMN semestre_str VARCHAR(20) NULL AFTER semestre');
+            Log::info('  → Colonne temporaire semestre_str créée');
+        }
+
+        // Copier et normaliser les valeurs
+        $updated1 = DB::table('esbtp_planifications_academiques')
+            ->where('semestre', 1)
+            ->update(['semestre_str' => 'semestre1']);
+
+        $updated2 = DB::table('esbtp_planifications_academiques')
+            ->where('semestre', 2)
+            ->update(['semestre_str' => 'semestre2']);
+
+        Log::info("  → Semestre 1: {$updated1} lignes normalisées");
+        Log::info("  → Semestre 2: {$updated2} lignes normalisées");
+    }
+
+    /**
+     * Normaliser esbtp_config_matieres.semestre (INT ou NULL)
+     * Format détecté: 1, 2, NULL
+     */
+    private function checkConfigMatieres(): void
+    {
+        Log::info('📋 Vérification esbtp_config_matieres...');
+
+        $columnExists = DB::getSchemaBuilder()->hasColumn('esbtp_config_matieres', 'semestre_str');
+
+        if (!$columnExists) {
+            DB::statement('ALTER TABLE esbtp_config_matieres ADD COLUMN semestre_str VARCHAR(20) NULL AFTER semestre');
+            Log::info('  → Colonne temporaire semestre_str créée');
+        }
+
+        $updated1 = DB::table('esbtp_config_matieres')
+            ->where('semestre', 1)
+            ->update(['semestre_str' => 'semestre1']);
+
+        $updated2 = DB::table('esbtp_config_matieres')
+            ->where('semestre', 2)
+            ->update(['semestre_str' => 'semestre2']);
+
+        Log::info("  → Semestre 1: {$updated1} lignes normalisées");
+        Log::info("  → Semestre 2: {$updated2} lignes normalisées");
+
+        // Compter les NULL (matières annuelles)
+        $nullCount = DB::table('esbtp_config_matieres')
+            ->whereNull('semestre')
+            ->count();
+        Log::info("  → {$nullCount} matières annuelles détectées (semestre NULL)");
+    }
+
+    /**
+     * Normaliser esbtp_config_matiere_type_formations.semestre (INT ou NULL)
+     * Format détecté: 1, 2, NULL
+     */
+    private function checkConfigMatiereTypeFormations(): void
+    {
+        Log::info('📋 Vérification esbtp_config_matiere_type_formations...');
+
+        $columnExists = DB::getSchemaBuilder()->hasColumn('esbtp_config_matiere_type_formations', 'semestre_str');
+
+        if (!$columnExists) {
+            DB::statement('ALTER TABLE esbtp_config_matiere_type_formations ADD COLUMN semestre_str VARCHAR(20) NULL AFTER semestre');
+            Log::info('  → Colonne temporaire semestre_str créée');
+        }
+
+        $updated1 = DB::table('esbtp_config_matiere_type_formations')
+            ->where('semestre', 1)
+            ->update(['semestre_str' => 'semestre1']);
+
+        $updated2 = DB::table('esbtp_config_matiere_type_formations')
+            ->where('semestre', 2)
+            ->update(['semestre_str' => 'semestre2']);
+
+        Log::info("  → Semestre 1: {$updated1} lignes normalisées");
+        Log::info("  → Semestre 2: {$updated2} lignes normalisées");
+
+        $nullCount = DB::table('esbtp_config_matiere_type_formations')
+            ->whereNull('semestre')
+            ->count();
+        Log::info("  → {$nullCount} configurations annuelles détectées (semestre NULL)");
+    }
+
+    /**
+     * Normaliser esbtp_resultats.periode (VARCHAR ou NULL)
+     * Table vide en production, mais on prépare la structure.
+     */
+    private function checkResultats(): void
+    {
+        Log::info('📋 Vérification esbtp_resultats...');
+
+        $total = DB::table('esbtp_resultats')->count();
+
+        if ($total === 0) {
+            Log::info('  ℹ️  Table vide, normalisation ignorée.');
+            return;
+        }
+
+        // Tentative de normalisation (au cas où)
+        $updated1 = DB::table('esbtp_resultats')
+            ->where('periode', '1')
+            ->orWhere('periode', 'Semestre 1')
+            ->update(['periode' => 'semestre1']);
+
+        $updated2 = DB::table('esbtp_resultats')
+            ->where('periode', '2')
+            ->orWhere('periode', 'Semestre 2')
+            ->update(['periode' => 'semestre2']);
+
+        Log::info("  → Semestre 1: {$updated1} lignes normalisées");
+        Log::info("  → Semestre 2: {$updated2} lignes normalisées");
+    }
+
+    /**
+     * Normaliser esbtp_bulletins.periode (VARCHAR ou NULL)
+     * Vérification nécessaire du format réel.
+     */
+    private function checkBulletins(): void
+    {
+        Log::info('📋 Vérification esbtp_bulletins...');
+
+        // Vérifier les formats existants
+        $distinctPeriodes = DB::table('esbtp_bulletins')
+            ->whereNotNull('periode')
+            ->distinct()
+            ->pluck('periode');
+
+        if ($distinctPeriodes->isEmpty()) {
+            Log::info('  ℹ️  Aucune période définie dans les bulletins.');
+            return;
+        }
+
+        Log::info("  → Formats détectés: " . $distinctPeriodes->implode(', '));
+
+        // Normaliser tous les formats possibles
+        $patterns = [
+            '1' => 'semestre1',
+            '2' => 'semestre2',
+            'Semestre 1' => 'semestre1',
+            'Semestre 2' => 'semestre2',
+            'S1' => 'semestre1',
+            'S2' => 'semestre2',
+        ];
+
+        foreach ($patterns as $old => $new) {
+            $updated = DB::table('esbtp_bulletins')
+                ->where('periode', $old)
+                ->update(['periode' => $new]);
+
+            if ($updated > 0) {
+                Log::info("  → '{$old}': {$updated} lignes normalisées");
+            }
+        }
+    }
+}

--- a/database/seeders/ESBTPPeriodesSeeder.php
+++ b/database/seeders/ESBTPPeriodesSeeder.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPPeriode;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * ESBTPPeriodesSeeder
+ *
+ * Crée 2 périodes par défaut (Semestre 1 et Semestre 2) pour chaque année universitaire existante.
+ *
+ * Garantit que toutes les données actuelles (basées sur semestre1/semestre2) pourront être
+ * migrées vers le nouveau système de periode_id.
+ *
+ * Règles:
+ * - Chaque année universitaire a 2 périodes (ordre: 1, 2)
+ * - Poids par défaut: 1 (moyenne équipondérée)
+ * - Dates automatiques basées sur annee_universitaire.date_debut/date_fin
+ *   - Semestre 1: date_debut → mi-année
+ *   - Semestre 2: mi-année → date_fin
+ * - is_active: true par défaut
+ */
+class ESBTPPeriodesSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Log::info('🌱 Démarrage du seeding des périodes académiques...');
+
+        $anneesUniversitaires = ESBTPAnneeUniversitaire::all();
+
+        if ($anneesUniversitaires->isEmpty()) {
+            Log::warning('⚠️  Aucune année universitaire trouvée. Seeding ignoré.');
+            return;
+        }
+
+        foreach ($anneesUniversitaires as $annee) {
+            $this->createPeriodesForAnnee($annee);
+        }
+
+        $totalPeriodes = ESBTPPeriode::count();
+        Log::info("✅ {$totalPeriodes} périodes académiques créées avec succès.");
+    }
+
+    /**
+     * Créer 2 périodes (Semestre 1 et Semestre 2) pour une année universitaire.
+     *
+     * @param ESBTPAnneeUniversitaire $annee
+     * @return void
+     */
+    private function createPeriodesForAnnee(ESBTPAnneeUniversitaire $annee): void
+    {
+        Log::info("📅 Création des périodes pour l'année universitaire: {$annee->annee}");
+
+        // Calculer les dates de début/fin des semestres
+        $dateDebut = \Carbon\Carbon::parse($annee->date_debut);
+        $dateFin = \Carbon\Carbon::parse($annee->date_fin);
+
+        // Milieu de l'année (approximatif)
+        $milieuAnnee = $dateDebut->copy()->addMonths(6);
+
+        // Vérifier si les périodes existent déjà (idempotence)
+        $existingCount = ESBTPPeriode::where('annee_universitaire_id', $annee->id)->count();
+
+        if ($existingCount >= 2) {
+            Log::info("  ℹ️  Les périodes existent déjà pour cette année universitaire. Ignoré.");
+            return;
+        }
+
+        // Créer Semestre 1
+        $periode1 = ESBTPPeriode::create([
+            'annee_universitaire_id' => $annee->id,
+            'nom' => 'Semestre 1',
+            'ordre' => 1,
+            'date_debut' => $dateDebut->format('Y-m-d'),
+            'date_fin' => $milieuAnnee->format('Y-m-d'),
+            'poids' => 1,
+            'is_active' => true,
+        ]);
+
+        Log::info("  ✅ Semestre 1 créé (ID: {$periode1->id}) - {$periode1->date_debut} à {$periode1->date_fin}");
+
+        // Créer Semestre 2
+        $periode2 = ESBTPPeriode::create([
+            'annee_universitaire_id' => $annee->id,
+            'nom' => 'Semestre 2',
+            'ordre' => 2,
+            'date_debut' => $milieuAnnee->copy()->addDay()->format('Y-m-d'),
+            'date_fin' => $dateFin->format('Y-m-d'),
+            'poids' => 1,
+            'is_active' => true,
+        ]);
+
+        Log::info("  ✅ Semestre 2 créé (ID: {$periode2->id}) - {$periode2->date_debut} à {$periode2->date_fin}");
+    }
+}


### PR DESCRIPTION
## Vue d'ensemble

Migration des labels hardcodés "Semestre 1"/"Semestre 2" vers des labels dynamiques basés sur `$periode->nom` pour les modules emplois du temps et planning général.

## Fichiers modifiés

### Controllers (2 fichiers)
- `ESBTPEmploiTempsController` : Ajout variable `$periodes` dans méthode `index()`
- `ESBTPPlanningGeneralController` : Ajout variable `$periodes` dans méthode `index()`

### Vues (4 fichiers)
- `emploi-temps/index.blade.php` : Select période dynamique
- `emploi-temps/partials/cards.blade.php` : Affichage période simplifié
- `emploi-temps/partials/table-rows.blade.php` : Badge période dynamique
- `planning-general/index.blade.php` : Select période dynamique

## Pattern de migration

**AVANT** :
\`\`\`blade
<select name="semestre">
    <option value="1">Semestre 1</option>
    <option value="2">Semestre 2</option>
</select>
\`\`\`

**APRÈS** :
\`\`\`blade
<select name="semestre">
    @foreach(\$periodes as \$periode)
        <option value="{{ \$periode->ordre }}">{{ \$periode->nom }}</option>
    @endforeach
</select>
\`\`\`

## Impact

✅ Affichage dynamique des périodes (semestres, trimestres, etc.)
✅ Compatibilité avec systèmes à 2 ou 3 périodes
✅ Aucun changement de comportement côté backend

## Tests recommandés

1. Vérifier affichage select période dans `/esbtp/emploi-temps`
2. Vérifier affichage période dans cards et table-rows
3. Vérifier modal configuration volumes horaires dans `/esbtp/planning-general`
4. Tester avec 2 périodes (semestres) ET 3 périodes (trimestres)