### PR TITLE
fix(classes): fix modal backdrop error - use @push instead of @section

### DIFF
--- a/resources/views/esbtp/classes/show.blade.php
+++ b/resources/views/esbtp/classes/show.blade.php
@@ -711,7 +711,7 @@ document.addEventListener('DOMContentLoaded', () => {
 </div>
 @endsection
 
-@section('scripts')
+@push('scripts')
 <script>
     $(document).ready(function() {
         // Initialiser DataTables sur la table étudiants
@@ -918,7 +918,8 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(function(data) {
                 if (data.success) {
                     // Fermer le modal
-                    bootstrap.Modal.getInstance(document.getElementById('addStudentsModal')).hide();
+                    var addModal = bootstrap.Modal.getInstance(document.getElementById('addStudentsModal'));
+                    if (addModal) addModal.hide();
                     // Réinitialiser
                     addSelectedStudents = {};
                     updateAddSelectedCount();
@@ -1052,7 +1053,8 @@ document.addEventListener('DOMContentLoaded', () => {
             .then(function(data) {
                 if (data.success) {
                     // Fermer le modal
-                    bootstrap.Modal.getInstance(document.getElementById('removeStudentsModal')).hide();
+                    var removeModal = bootstrap.Modal.getInstance(document.getElementById('removeStudentsModal'));
+                    if (removeModal) removeModal.hide();
                     // Réinitialiser
                     document.getElementById('removeSelectAll').checked = false;
                     document.getElementById('removeSearchInput').value = '';
@@ -1095,7 +1097,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Fonction pour afficher le modal d'information sur le changement d'année
     function showYearChangeInfo() {
-        $('#yearChangeModal').modal('show');
+        var el = document.getElementById('yearChangeModal');
+        if (el) {
+            bootstrap.Modal.getOrCreateInstance(el).show();
+        }
     }
 </script>
 
@@ -1252,4 +1257,4 @@ document.addEventListener('DOMContentLoaded', () => {
     </div>
 </div>
 
-@endsection
+@endpush


### PR DESCRIPTION
The layout uses @stack('scripts') but the modals code used @section('scripts'), which meant the JavaScript and modal HTML were never rendered in the page. This caused Bootstrap to throw 'Cannot read properties of undefined (backdrop)' when clicking the add/remove student buttons.

- Change @section('scripts') to @push('scripts') / @endpush
- Add null checks on bootstrap.Modal.getInstance() before calling .hide()
- Replace jQuery .modal('show') with Bootstrap 5 native API

https://claude.ai/code/session_014GmmKW5mJADJgzTVVeXtfR