### PR TITLE
fix(classes): fix DataTables crash and add workflow_step constraint

### DIFF
--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -440,6 +440,7 @@ class ESBTPClasseController extends Controller
                                     $anneeCourante->id,
                                 )
                                 ->where("status", "active")
+                                ->where("workflow_step", "etudiant_cree")
                                 ->where("classe_id", $classe->id);
                         });
                 },
@@ -2275,11 +2276,12 @@ class ESBTPClasseController extends Controller
 
             $search = $request->input('q', '');
 
-            // Étudiants ayant une inscription active pour l'année courante mais PAS dans cette classe
+            // Étudiants ayant une inscription active + workflow étudiant créé pour l'année courante mais PAS dans cette classe
             $query = ESBTPEtudiant::query()
                 ->whereHas('inscriptions', function ($q) use ($anneeCourante, $classe) {
                     $q->where('annee_universitaire_id', $anneeCourante->id)
                       ->where('status', 'active')
+                      ->where('workflow_step', 'etudiant_cree')
                       ->where(function ($sub) use ($classe) {
                           $sub->where('classe_id', '!=', $classe->id)
                               ->orWhereNull('classe_id');
@@ -2307,6 +2309,7 @@ class ESBTPClasseController extends Controller
                 ->with(['inscriptions' => function ($q) use ($anneeCourante) {
                     $q->where('annee_universitaire_id', $anneeCourante->id)
                       ->where('status', 'active')
+                      ->where('workflow_step', 'etudiant_cree')
                       ->with('classe:id,name,code');
                 }])
                 ->orderBy('nom')
@@ -2530,6 +2533,7 @@ class ESBTPClasseController extends Controller
                                 $inscriptionQuery
                                     ->where('annee_universitaire_id', $anneeCourante->id)
                                     ->where('status', 'active')
+                                    ->where('workflow_step', 'etudiant_cree')
                                     ->where('classe_id', $classe->id);
                             });
                     },

--- a/resources/views/esbtp/classes/show.blade.php
+++ b/resources/views/esbtp/classes/show.blade.php
@@ -714,8 +714,9 @@ document.addEventListener('DOMContentLoaded', () => {
 @push('scripts')
 <script>
     $(document).ready(function() {
-        // Initialiser DataTables sur la table étudiants
+        // Initialiser DataTables sur la table étudiants (si la librairie est chargée)
         function initStudentDataTable() {
+            if (typeof $.fn.DataTable === 'undefined') return;
             if ($.fn.DataTable.isDataTable('#studentsDataTable')) {
                 $('#studentsDataTable').DataTable().destroy();
             }


### PR DESCRIPTION
- Guard $.fn.DataTable calls with typeof check to prevent crash when DataTables library is not loaded (was killing all subsequent JS)
- Add workflow_step='etudiant_cree' constraint to searchAvailableStudents, show() student loading, and studentTableHtml AJAX refresh
- Ensures only fully validated students appear in class and modals

https://claude.ai/code/session_014GmmKW5mJADJgzTVVeXtfR