### PR TITLE
Fix modal centering CSS to prevent hidden modals from blocking clicks

### DIFF
--- a/resources/views/esbtp/frais/index.blade.php
+++ b/resources/views/esbtp/frais/index.blade.php
@@ -188,7 +188,9 @@
 }
 
 /* Modal centering fix - ensures modals are centered regardless of scroll position */
-.modal {
+/* NOTE: Must target .modal.show only — targeting .modal causes hidden modals to become
+   invisible fullscreen overlays (position:fixed 100vw/100vh) that block all clicks */
+.modal.show {
     display: flex !important;
     align-items: center;
     justify-content: center;
@@ -198,10 +200,6 @@
     width: 100vw !important;
     height: 100vh !important;
     z-index: 1050;
-}
-
-.modal.show {
-    display: flex !important;
 }
 
 .modal-dialog {


### PR DESCRIPTION
## Summary
Fixed a CSS issue where modal styling was being applied to all `.modal` elements, including hidden ones, causing them to become invisible fullscreen overlays that blocked user interactions.

## Changes
- **Consolidated modal centering styles**: Moved all centering properties (flexbox, alignment, positioning) from the generic `.modal` selector to `.modal.show` selector only
- **Removed redundant rule**: Deleted the duplicate `.modal.show { display: flex !important; }` rule that was previously separate
- **Added explanatory comment**: Included a note documenting why the selector must be `.modal.show` to prevent hidden modals from becoming click-blocking overlays

## Implementation Details
The issue occurred because targeting `.modal` applied `position: fixed` with `100vw/100vh` dimensions to all modals, even those not currently displayed. By restricting these styles to `.modal.show` (which is only present on active modals), hidden modals no longer interfere with page interactions while maintaining proper centering for visible modals.

https://claude.ai/code/session_013a6gjMvyuTEW4YyvWCSbZb