### PR TITLE
Fix notes.index: AJAX save, absence toggle, and modal backdrop

### DIFF
--- a/app/Http/Controllers/ESBTPNoteController.php
+++ b/app/Http/Controllers/ESBTPNoteController.php
@@ -493,6 +493,89 @@ class ESBTPNoteController extends Controller
     }
 
     /**
+     * Sauvegarde (création ou mise à jour) d'une note via AJAX depuis notes.index.
+     * Retourne toujours du JSON. Utilise un UPSERT pour éviter le "already exists".
+     */
+    public function saveNoteAjax(Request $request)
+    {
+        $request->validate([
+            'etudiant_id'   => 'required|exists:esbtp_etudiants,id',
+            'evaluation_id' => 'required|exists:esbtp_evaluations,id',
+            'note'          => 'nullable|numeric|min:0',
+            'is_absent'     => 'nullable|string',
+        ]);
+
+        try {
+            $isAbsent = in_array($request->is_absent, ['on', '1', 'true', true], true);
+
+            $evaluation = ESBTPEvaluation::findOrFail($request->evaluation_id);
+
+            // Vérification publication évaluation
+            if (! $evaluation->is_published) {
+                return response()->json([
+                    'success' => false,
+                    'message' => "Cette évaluation n'est pas publiée. Activez-la avant de saisir les notes.",
+                ], 422);
+            }
+
+            // UPSERT : trouver la note existante ou en créer une nouvelle
+            $note = ESBTPNote::where('etudiant_id', $request->etudiant_id)
+                ->where('evaluation_id', $request->evaluation_id)
+                ->first();
+
+            // Vérification permission coordinateur : ne peut pas modifier une note existante
+            if ($note && Auth::user()->hasRole('coordinateur')) {
+                return response()->json([
+                    'success' => false,
+                    'message' => "Vous ne pouvez pas modifier les notes déjà enregistrées.",
+                ], 403);
+            }
+
+            if (! $note) {
+                $note = new ESBTPNote;
+                $note->etudiant_id        = $request->etudiant_id;
+                $note->evaluation_id      = $request->evaluation_id;
+                $note->classe_id          = $evaluation->classe_id;
+                $note->matiere_id         = $evaluation->matiere_id;
+                $note->semestre           = $evaluation->periode;
+                $note->annee_universitaire = $evaluation->anneeUniversitaire
+                    ? $evaluation->anneeUniversitaire->name : 'N/A';
+                $note->type_evaluation    = $evaluation->type;
+                $note->created_by         = Auth::id();
+            } else {
+                $note->semestre = $evaluation->periode;
+            }
+
+            // Valeur de la note : 0 si absent, valeur saisie sinon
+            $note->note       = $isAbsent ? 0 : (float) ($request->note ?? 0);
+            $note->is_absent  = $isAbsent ? 1 : 0;
+            $note->commentaire = $request->commentaire;
+            $note->updated_by  = Auth::id();
+            $note->save();
+
+            // Notification d'absence si nécessaire
+            if ($isAbsent && $note->wasRecentlyCreated) {
+                $this->sendAbsenceNotificationForNote($note, $evaluation);
+            }
+
+            return response()->json([
+                'success'  => true,
+                'message'  => 'Note enregistrée avec succès.',
+                'note_id'  => $note->id,
+                'is_absent' => (bool) $note->is_absent,
+                'note'     => $note->note,
+            ]);
+
+        } catch (\Exception $e) {
+            \Log::error('saveNoteAjax error: ' . $e->getMessage());
+            return response()->json([
+                'success' => false,
+                'message' => 'Erreur serveur : ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
      * Supprime une note spécifique.
      *
      * @return \Illuminate\Http\Response

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,63 @@
+# Plan - Fix notes.index : absent toggle + backdrop
+
+## Diagnostic des 3 bugs
+
+### Bug 1 & 2 : Erreur 422 + input bloqué au décocher "absent"
+
+**Séquence problématique :**
+1. Cocher "absent" → `toggleAbsence()` → input disabled, `saveNote()` envoie `note:0, is_absent:'on'` → `store()` crée la note (OK)
+2. Décocher "absent" → `toggleAbsence()` → input enabled, `val('')`, puis `saveNote()` envoie `note:'', is_absent:''`
+3. Validation Laravel : `required_unless:is_absent,on` → note est vide ET is_absent n'est pas 'on' → **422**
+4. Alerte générique "Erreur lors de la sauvegarde des notes"
+
+**Causes profondes :**
+- `store()` ne fait qu'un INSERT (pas UPSERT) et retourne des redirects (pas JSON)
+- `toggleAbsence()` auto-sauvegarde avec note vide lors du décocher
+- `saveNote()` ne gère pas correctement les réponses d'erreur 422
+
+### Bug 3 : Backdrop reste après fermeture du modal
+
+**Cause :** `#classSelectionModal` n'a pas de handler `hidden.bs.modal` pour nettoyer les backdrops. Bootstrap les retire normalement mais le code existant pour `evaluationCreateModal` peut interférer.
+
+---
+
+## Fichiers à modifier (3 fichiers)
+
+### 1. `app/Http/Controllers/ESBTPNoteController.php`
+Ajouter méthode `saveNoteAjax()` :
+- Retourne toujours du JSON (`response()->json()`)
+- Logique UPSERT : si note existe → UPDATE, sinon → CREATE
+- Validation adaptée : `note` nullable (peut être 0 ou valeur réelle)
+- Respecte les permissions coordinateur
+
+### 2. `routes/web.php`
+Ajouter avant le `Route::resource('notes', ...)` :
+```php
+Route::post('notes/save-ajax', [ESBTPNoteController::class, 'saveNoteAjax'])
+    ->name('esbtp.notes.save-ajax');
+```
+(avant le resource pour éviter le conflit de routes)
+
+### 3. `resources/views/esbtp/notes/index.blade.php`
+Trois corrections JS :
+
+**a) `saveNote()` :**
+- Changer l'URL vers `esbtp.notes.save-ajax`
+- Garder la guard : si non-absent ET note vide → ne pas sauvegarder
+- Améliorer le handler d'erreur pour afficher le message JSON
+
+**b) `toggleAbsence()` :**
+- Quand cochage (isAbsent=true) : comportement actuel conservé + auto-save
+- Quand décochage (isAbsent=false) : réactiver l'input, vider la valeur, **NE PAS auto-sauvegarder** (attendre la saisie d'une vraie note). L'input reçoit un placeholder visuel.
+
+**c) Handler `hidden.bs.modal` pour `#classSelectionModal` :**
+```javascript
+$('#classSelectionModal').on('hidden.bs.modal', function() {
+    setTimeout(() => {
+        document.querySelectorAll('.modal-backdrop').forEach(b => b.remove());
+        document.body.classList.remove('modal-open');
+        document.body.style.overflow = '';
+        document.body.style.paddingRight = '';
+    }, 150);
+});
+```

--- a/resources/views/esbtp/notes/index.blade.php
+++ b/resources/views/esbtp/notes/index.blade.php
@@ -547,6 +547,16 @@ $(document).ready(function() {
         }
     });
 
+    // Nettoyage backdrop après fermeture du modal principal notes
+    $('#classSelectionModal').on('hidden.bs.modal', function() {
+        setTimeout(function() {
+            document.querySelectorAll('.modal-backdrop').forEach(function(b) { b.remove(); });
+            document.body.classList.remove('modal-open');
+            document.body.style.overflow = '';
+            document.body.style.paddingRight = '';
+        }, 150);
+    });
+
     $(document).on('click', '#exportBlankPdfBtn.disabled', function(event) {
         event.preventDefault();
     });
@@ -879,10 +889,16 @@ function createEvaluation() {
 // Fonction pour sauvegarder une note
 function saveNote(studentId, evaluationId, noteValue) {
     const isAbsent = $(`#absent-${studentId}-${evaluationId}`).is(':checked');
-    
+
+    // Si non absent et note vide, ne pas envoyer (attendre que l'utilisateur saisisse une note)
+    if (!isAbsent && (noteValue === '' || noteValue === null || noteValue === undefined)) {
+        return;
+    }
+
     $.ajax({
-        url: '{{ route("esbtp.notes.store") }}',
+        url: '{{ route("esbtp.notes.save-ajax") }}',
         method: 'POST',
+        dataType: 'json',
         data: {
             _token: '{{ csrf_token() }}',
             etudiant_id: studentId,
@@ -891,21 +907,30 @@ function saveNote(studentId, evaluationId, noteValue) {
             is_absent: isAbsent ? 'on' : ''
         },
         success: function(response) {
+            if (!response.success) {
+                alert(response.message || 'Erreur lors de la sauvegarde de la note.');
+                return;
+            }
             // Animation de succès
             triggerRowHighlight(studentId);
-            
+
             // Mettre à jour les données locales
             if (!notesData[studentId]) notesData[studentId] = {};
             notesData[studentId][evaluationId] = isAbsent ? 0 : noteValue;
             notesData[studentId][evaluationId + '_absent'] = isAbsent;
-            
+
             // Recalculer les moyennes
             calculateStudentAverage(studentId);
             calculateClassAverages();
         },
         error: function(xhr) {
-            console.error('Erreur lors de la sauvegarde:', xhr);
-            alert('Erreur lors de la sauvegarde de la note.');
+            console.error('Erreur lors de la sauvegarde:', xhr.responseJSON || xhr);
+            const msg = (xhr.responseJSON && xhr.responseJSON.message)
+                ? xhr.responseJSON.message
+                : (xhr.responseJSON && xhr.responseJSON.errors)
+                    ? Object.values(xhr.responseJSON.errors).flat().join('\n')
+                    : 'Erreur lors de la sauvegarde de la note.';
+            alert(msg);
         }
     });
 }
@@ -913,15 +938,16 @@ function saveNote(studentId, evaluationId, noteValue) {
 // Fonction pour basculer l'état d'absence
 function toggleAbsence(studentId, evaluationId, isAbsent) {
     const input = $(`input[data-student-id="${studentId}"][data-eval-id="${evaluationId}"]`);
-    
+
     if (isAbsent) {
+        // Cochage : désactiver l'input et sauvegarder l'absence
         input.val('0').prop('disabled', true);
+        saveNote(studentId, evaluationId, 0);
     } else {
-        input.val('').prop('disabled', false);
+        // Décochage : réactiver l'input et le vider
+        // NE PAS sauvegarder immédiatement : attendre que l'utilisateur saisisse une note
+        input.val('').prop('disabled', false).attr('placeholder', 'Note...').focus();
     }
-    
-    // Sauvegarder automatiquement
-    saveNote(studentId, evaluationId, input.val());
 }
 
 // Fonction pour calculer toutes les moyennes

--- a/routes/web.php
+++ b/routes/web.php
@@ -914,6 +914,7 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             // Routes API utilisées par les formulaires
 
             // Routes pour les notes
+            Route::post('notes/save-ajax', [ESBTPNoteController::class, 'saveNoteAjax'])->name('esbtp.notes.save-ajax');
             Route::resource('notes', \App\Http\Controllers\ESBTPNoteController::class)
                 ->names([
                     'index' => 'esbtp.notes.index',


### PR DESCRIPTION
## Summary
This PR fixes three critical bugs in the notes management interface:
1. **422 validation error** when unchecking the "absent" checkbox
2. **Blocked input field** after toggling absence off
3. **Persistent modal backdrop** after closing the class selection modal

## Key Changes

### Backend (`ESBTPNoteController.php`)
- Added new `saveNoteAjax()` method that always returns JSON responses
- Implements UPSERT logic: updates existing notes or creates new ones
- Validates that evaluations are published before allowing note entry
- Enforces permission checks: coordinators cannot modify existing notes
- Sends absence notifications only for newly created absent records

### Frontend (`resources/views/esbtp/notes/index.blade.php`)
- **`saveNote()` function:**
  - Changed endpoint from `store` to new `save-ajax` route
  - Added guard: prevents sending empty notes when student is not marked absent
  - Improved error handling to display JSON error messages and validation details
  
- **`toggleAbsence()` function:**
  - On check: disables input, sets value to 0, and auto-saves the absence
  - On uncheck: re-enables input, clears value, and waits for user to enter a note (no auto-save)
  - Adds visual placeholder to guide user input
  
- **Modal cleanup:**
  - Added `hidden.bs.modal` event handler for `#classSelectionModal`
  - Removes orphaned backdrop elements and resets body styles after modal closes

### Routing (`routes/web.php`)
- Added `POST notes/save-ajax` route pointing to new controller method
- Placed before resource route to avoid route conflicts

## Implementation Details
- The UPSERT approach prevents "already exists" errors when updating notes
- Validation is nullable for the note field, allowing 0 or absence-only entries
- Error responses now include detailed messages from both validation and business logic
- Modal backdrop cleanup uses a small delay to ensure Bootstrap's cleanup completes first

https://claude.ai/code/session_012NChhEgpLXBZKVhsPPv87k