### PR TITLE
fix(routes): corriger doublon préfixe nom route notes.save-ajax

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -914,7 +914,7 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             // Routes API utilisées par les formulaires
 
             // Routes pour les notes
-            Route::post('notes/save-ajax', [ESBTPNoteController::class, 'saveNoteAjax'])->name('esbtp.notes.save-ajax');
+            Route::post('notes/save-ajax', [ESBTPNoteController::class, 'saveNoteAjax'])->name('notes.save-ajax');
             Route::resource('notes', \App\Http\Controllers\ESBTPNoteController::class)
                 ->names([
                     'index' => 'esbtp.notes.index',


### PR DESCRIPTION
La route POST notes/save-ajax était dans le groupe `Route::prefix('esbtp')->name('esbtp.')->group(...)`. Les routes individuelles avec ->name() héritent du préfixe du groupe, donc ->name('esbtp.notes.save-ajax') produisait le nom enregistré 'esbtp.esbtp.notes.save-ajax' au lieu de 'esbtp.notes.save-ajax'.

Fix : utiliser ->name('notes.save-ajax') pour que le groupe ajoute automatiquement 'esbtp.' et obtenir le nom final 'esbtp.notes.save-ajax' attendu par la vue.

Note : les routes Resource avec ->names([...]) ne sont pas affectées car cette méthode remplace le nom complet sans tenir compte du préfixe groupe.

https://claude.ai/code/session_012NChhEgpLXBZKVhsPPv87k