### PR TITLE
fix(migration): shorten unique index name to avoid MySQL 64-char limit

### DIFF
--- a/database/migrations/2026_02_19_000001_create_esbtp_matiere_filiere_niveau_table.php
+++ b/database/migrations/2026_02_19_000001_create_esbtp_matiere_filiere_niveau_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->unsignedBigInteger('niveau_etude_id');
             $table->timestamps();
 
-            $table->unique(['matiere_id', 'filiere_id', 'niveau_etude_id']);
+            $table->unique(['matiere_id', 'filiere_id', 'niveau_etude_id'], 'uq_mat_fil_niv');
 
             $table->foreign('matiere_id')->references('id')->on('esbtp_matieres')->onDelete('cascade');
             $table->foreign('filiere_id')->references('id')->on('esbtp_filieres')->onDelete('cascade');


### PR DESCRIPTION
## Summary

- Corrige l'erreur MySQL lors de la migration : le nom d'index auto-genere depassait 64 caracteres
- Renomme l'index unique en `uq_mat_fil_niv` (nom court explicite)

## What was changed

- `database/migrations/2026_02_19_000001_create_esbtp_matiere_filiere_niveau_table.php` — ajout du parametre de nom court pour l'index unique composite

## Test plan

- [ ] `php artisan migrate` s'execute sans erreur
- [ ] La table `esbtp_matiere_filiere_niveau` est creee avec la contrainte unique `uq_mat_fil_niv`

Closes #34
