### PR TITLE
fix(matieres): afficher liaisons exactes filiere+niveau dans les tables

### DIFF
--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -1042,6 +1042,8 @@ class ESBTPClasseController extends Controller
         $matieres = ESBTPMatiere::with([
             "filieres:id,name,code",
             "niveaux:id,name,code",
+            "liaisonsFilieresNiveaux.filiere:id,name,code",
+            "liaisonsFilieresNiveaux.niveauEtude:id,name,code",
         ])
             ->where("is_active", true)
             ->orderBy("name")
@@ -1053,10 +1055,10 @@ class ESBTPClasseController extends Controller
                 if (!$classeFiliereId || !$classeNiveauId) {
                     return false;
                 }
-                return $matiere->filieres
-                    ->pluck("id")
-                    ->contains($classeFiliereId) &&
-                    $matiere->niveaux->pluck("id")->contains($classeNiveauId);
+                return $matiere->liaisonsFilieresNiveaux
+                    ->where('filiere_id', $classeFiliereId)
+                    ->where('niveau_etude_id', $classeNiveauId)
+                    ->isNotEmpty();
             })
             ->values()
             ->map(function (ESBTPMatiere $matiere) {
@@ -1072,6 +1074,8 @@ class ESBTPClasseController extends Controller
         $availableMatieres = ESBTPMatiere::with([
             "filieres:id,name,code",
             "niveaux:id,name,code",
+            "liaisonsFilieresNiveaux.filiere:id,name,code",
+            "liaisonsFilieresNiveaux.niveauEtude:id,name,code",
         ])
             ->where("is_active", true)
             ->orderBy("name")
@@ -1084,14 +1088,10 @@ class ESBTPClasseController extends Controller
                     return false;
                 }
 
-                $hasFiliere = $matiere->filieres
-                    ->pluck("id")
-                    ->contains($classeFiliereId);
-                $hasNiveau = $matiere->niveaux
-                    ->pluck("id")
-                    ->contains($classeNiveauId);
-
-                return !($hasFiliere && $hasNiveau);
+                return $matiere->liaisonsFilieresNiveaux
+                    ->where('filiere_id', $classeFiliereId)
+                    ->where('niveau_etude_id', $classeNiveauId)
+                    ->isEmpty();
             })
             ->values()
             ->map(function (ESBTPMatiere $matiere) {

--- a/app/Http/Controllers/ESBTPMatiereController.php
+++ b/app/Http/Controllers/ESBTPMatiereController.php
@@ -79,7 +79,12 @@ class ESBTPMatiereController extends Controller
     public function refreshLigne(ESBTPMatiere $matiere)
     {
         try {
-            $matiere->load(['filieres:id,name,code', 'niveaux:id,name,code']);
+            $matiere->load([
+                'filieres:id,name,code',
+                'niveaux:id,name,code',
+                'liaisonsFilieresNiveaux.filiere:id,name,code',
+                'liaisonsFilieresNiveaux.niveauEtude:id,name,code',
+            ]);
 
             return response()->json([
                 'success' => true,
@@ -121,7 +126,12 @@ class ESBTPMatiereController extends Controller
         $totalHeuresExpression = 'COALESCE(heures_cm, 0) + COALESCE(heures_td, 0) + COALESCE(heures_tp, 0) + COALESCE(heures_stage, 0) + COALESCE(heures_perso, 0)';
 
         $query = ESBTPMatiere::query()
-            ->with(['filieres:id,name,code', 'niveaux:id,name,code'])
+            ->with([
+                'filieres:id,name,code',
+                'niveaux:id,name,code',
+                'liaisonsFilieresNiveaux.filiere:id,name,code',
+                'liaisonsFilieresNiveaux.niveauEtude:id,name,code',
+            ])
             ->orderBy('name');
 
         if ($filiere) {

--- a/app/Models/ESBTPMatiereFilierNiveau.php
+++ b/app/Models/ESBTPMatiereFilierNiveau.php
@@ -13,4 +13,19 @@ class ESBTPMatiereFilierNiveau extends Model
         'filiere_id',
         'niveau_etude_id',
     ];
+
+    public function filiere()
+    {
+        return $this->belongsTo(ESBTPFiliere::class, 'filiere_id');
+    }
+
+    public function niveauEtude()
+    {
+        return $this->belongsTo(ESBTPNiveauEtude::class, 'niveau_etude_id');
+    }
+
+    public function matiere()
+    {
+        return $this->belongsTo(ESBTPMatiere::class, 'matiere_id');
+    }
 }

--- a/resources/views/esbtp/classes/matieres/partials/matiere-row.blade.php
+++ b/resources/views/esbtp/classes/matieres/partials/matiere-row.blade.php
@@ -4,24 +4,16 @@
     $isLinked = (bool) ($matiere->matches_combination ?? false);
     $isActiveGlobal = (bool) ($matiere->is_active ?? true);
 
-    $combos = collect($matiere->filieres)
-        ->flatMap(function ($filiere) use ($matiere) {
-            return collect($matiere->niveaux)->map(function ($niveau) use ($filiere) {
-                return [
-                    'filiere_id' => $filiere->id,
-                    'niveau_id' => $niveau->id,
-                    'label' => (
-                        ($filiere->code ?? Str::limit($filiere->name, 6))
-                    ) . ' · ' . (
-                        ($niveau->code ?? Str::limit($niveau->name, 6))
-                    ),
-                ];
-            });
-        })
-        ->unique(function ($combo) {
-            return $combo['filiere_id'] . '-' . $combo['niveau_id'];
-        })
-        ->values();
+    $liaisons = $matiere->liaisonsFilieresNiveaux ?? collect();
+    $combos = $liaisons->map(function ($liaison) {
+        $fCode = $liaison->filiere->code ?? Str::limit($liaison->filiere->name ?? '?', 6);
+        $nCode = $liaison->niveauEtude->code ?? Str::limit($liaison->niveauEtude->name ?? '?', 4);
+        return [
+            'filiere_id' => $liaison->filiere_id,
+            'niveau_id'  => $liaison->niveau_etude_id,
+            'label'      => $fCode . ' · ' . $nCode,
+        ];
+    })->values();
 @endphp
 
 <tr data-matiere-id="{{ $matiere->id }}"
@@ -38,7 +30,27 @@
         @endif
     </td>
     <td class="align-middle">
-        <div class="combo-badges" data-combos='@json($combos)'></div>
+        @if($combos->isNotEmpty())
+            <div class="d-flex flex-wrap gap-1">
+                @foreach($combos->take(3) as $combo)
+                    <span class="badge d-inline-flex align-items-center gap-1 px-2 py-1"
+                          style="background: linear-gradient(135deg,#e8f0fe 0%,#d2e3fc 100%); color:#1a56db; font-size:.72rem; font-weight:600; border:1px solid #c2d4f8; border-radius:999px;">
+                        {{ $combo['label'] }}
+                    </span>
+                @endforeach
+                @if($combos->count() > 3)
+                    <span class="badge d-inline-flex align-items-center px-2 py-1"
+                          style="background:#f1f5f9; color:#64748b; font-size:.72rem; border:1px solid #e2e8f0; border-radius:999px;"
+                          title="{{ $combos->count() }} combinaisons au total">
+                        +{{ $combos->count() - 3 }}
+                    </span>
+                @endif
+            </div>
+        @else
+            <span class="badge bg-light text-muted border" style="border-color:#e2e8f0 !important; font-size:.72rem;">
+                <i class="fas fa-unlink me-1 opacity-50"></i>Non configuré
+            </span>
+        @endif
     </td>
     <td class="align-middle">
         <span class="badge {{ $isLinked ? 'bg-primary' : 'bg-secondary text-dark' }}" data-role="class-status">

--- a/resources/views/esbtp/matieres/partials/matiere-row.blade.php
+++ b/resources/views/esbtp/matieres/partials/matiere-row.blade.php
@@ -1,6 +1,10 @@
 @php
     $filieres = $matiere->filieres ?? collect();
     $niveaux = $matiere->niveaux ?? collect();
+    $liaisons = $matiere->liaisonsFilieresNiveaux ?? collect();
+    $liaisonCount = $liaisons->count();
+    $liaisonsVisible = $liaisons->take(3);
+    $liaisonsExtra = max(0, $liaisonCount - 3);
 @endphp
 
 <tr data-matiere-id="{{ $matiere->id }}" class="position-relative">
@@ -18,9 +22,9 @@
         @if($matiere->description)
             <small class="text-muted d-block">{{ \Illuminate\Support\Str::limit($matiere->description, 80) }}</small>
         @endif
-        @if($filieres->count() && $niveaux->count())
+        @if($liaisonCount > 0)
             <small class="text-muted">
-                <i class="fas fa-link me-1"></i>{{ $filieres->count() * $niveaux->count() }} combinaison(s)
+                <i class="fas fa-link me-1"></i>{{ $liaisonCount }} combinaison(s)
             </small>
         @endif
     </td>
@@ -30,43 +34,35 @@
     <td>
         <span class="font-bold color-primary">{{ $matiere->total_heures_default ?? 0 }}h</span>
     </td>
+    {{-- Colonne Liaisons : pills filière · niveau exactes --}}
     <td>
-        @if($filieres->isNotEmpty())
+        @if($liaisonCount > 0)
             <div class="d-flex flex-wrap gap-1">
-                @foreach($filieres->take(3) as $filiere)
-                    <span class="badge bg-primary text-white" title="{{ $filiere->name }}">
-                        {{ $filiere->code ?? \Illuminate\Support\Str::limit($filiere->name, 8) }}
+                @foreach($liaisonsVisible as $liaison)
+                    @php
+                        $fCode = $liaison->filiere->code ?? \Illuminate\Support\Str::limit($liaison->filiere->name ?? '?', 8);
+                        $nCode = $liaison->niveauEtude->code ?? \Illuminate\Support\Str::limit($liaison->niveauEtude->name ?? '?', 4);
+                        $tooltip = ($liaison->filiere->name ?? $fCode) . ' — ' . ($liaison->niveauEtude->name ?? $nCode);
+                    @endphp
+                    <span class="badge d-inline-flex align-items-center gap-1 px-2 py-1"
+                          style="background: linear-gradient(135deg,#e8f0fe 0%,#d2e3fc 100%); color:#1a56db; font-size:.72rem; font-weight:600; border:1px solid #c2d4f8; border-radius:999px;"
+                          title="{{ $tooltip }}">
+                        <span style="color:#1a56db;">{{ $fCode }}</span>
+                        <span style="color:#94a3b8; font-weight:400;">·</span>
+                        <span style="color:#0f3fa6;">{{ $nCode }}</span>
                     </span>
                 @endforeach
-                @if($filieres->count() > 3)
-                    <span class="badge bg-info text-white" title="{{ $filieres->count() }} filières au total">
-                        +{{ $filieres->count() - 3 }}
+                @if($liaisonsExtra > 0)
+                    <span class="badge d-inline-flex align-items-center px-2 py-1"
+                          style="background:#f1f5f9; color:#64748b; font-size:.72rem; border:1px solid #e2e8f0; border-radius:999px;"
+                          title="{{ $liaisonCount }} combinaisons au total">
+                        +{{ $liaisonsExtra }}
                     </span>
                 @endif
             </div>
         @else
-            <span class="badge bg-secondary">
-                <i class="fas fa-minus me-1"></i>Aucune
-            </span>
-        @endif
-    </td>
-    <td>
-        @if($niveaux->isNotEmpty())
-            <div class="d-flex flex-wrap gap-1">
-                @foreach($niveaux->take(3) as $niveau)
-                    <span class="badge bg-info text-white" title="{{ $niveau->name }}">
-                        {{ $niveau->code ?? \Illuminate\Support\Str::limit($niveau->name, 8) }}
-                    </span>
-                @endforeach
-                @if($niveaux->count() > 3)
-                    <span class="badge bg-warning text-dark" title="{{ $niveaux->count() }} niveaux au total">
-                        +{{ $niveaux->count() - 3 }}
-                    </span>
-                @endif
-            </div>
-        @else
-            <span class="badge bg-secondary">
-                <i class="fas fa-minus me-1"></i>Aucun
+            <span class="badge bg-light text-muted border" style="border-color:#e2e8f0 !important; font-size:.72rem;">
+                <i class="fas fa-unlink me-1 opacity-50"></i>Non configuré
             </span>
         @endif
     </td>

--- a/resources/views/esbtp/matieres/partials/results.blade.php
+++ b/resources/views/esbtp/matieres/partials/results.blade.php
@@ -26,8 +26,7 @@
                         <th>Nom</th>
                         <th>Coefficient</th>
                         <th>Total heures</th>
-                        <th>Filières</th>
-                        <th>Niveaux</th>
+                        <th>Liaisons</th>
                         <th>Statut</th>
                         <th style="width: 180px;">Actions</th>
                     </tr>
@@ -37,7 +36,7 @@
                         @include('esbtp.matieres.partials.matiere-row', ['matiere' => $matiere])
                     @empty
                         <tr>
-                            <td colspan="9" class="py-5 text-center">
+                            <td colspan="8" class="py-5 text-center">
                                 <div class="d-flex flex-column align-items-center gap-2 text-muted">
                                     <i class="fas fa-inbox fa-2x"></i>
                                     <span>Aucune matière trouvée avec ces critères.</span>


### PR DESCRIPTION
## Summary
- Remplace les colonnes Filières/Niveaux séparées par une colonne **Liaisons** unifiée avec des pills `FILIERE · NIVEAU` exactes dans la liste globale des matières
- Corrige le filtre de la page `classes/{id}/matieres` : utilise désormais `esbtp_matiere_filiere_niveau` au lieu du produit cartésien filieres×niveaux
- Corrige l'affichage des combinaisons catalogue dans la même page

## What was changed
- `app/Models/ESBTPMatiereFilierNiveau.php` — ajout des relations `filiere()`, `niveauEtude()`, `matiere()`
- `app/Http/Controllers/ESBTPMatiereController.php` — eager loading de `liaisonsFilieresNiveaux` dans listing et refreshLigne
- `app/Http/Controllers/ESBTPClasseController.php` — filtre matieres/availableMatieres via `liaisonsFilieresNiveaux` + eager loading
- `resources/views/esbtp/matieres/partials/results.blade.php` — colonnes Filières+Niveaux → colonne Liaisons
- `resources/views/esbtp/matieres/partials/matiere-row.blade.php` — pills `FILIERE · NIVEAU` avec design gradient bleu
- `resources/views/esbtp/classes/matieres/partials/matiere-row.blade.php` — remplace produit cartésien par vraies liaisons

## Test plan
- [ ] Page `/esbtp/matieres` : colonne Liaisons affiche pills `FILIERE · NIVEAU` exactes (ex: `BATIMENT · 1A`)
- [ ] Page `/esbtp/classes/2/matieres` : colonne Combinaisons catalogue affiche les bonnes combos
- [ ] Après save d'une liaison dans le modal, refreshLigne met bien à jour les pills
- [ ] Tooltip sur les pills affiche le nom complet

Closes #37