### PR TITLE
fix(classes/matieres): correct toggleCombination API payload format

### DIFF
--- a/resources/views/esbtp/classes/matieres.blade.php
+++ b/resources/views/esbtp/classes/matieres.blade.php
@@ -193,19 +193,21 @@ async function toggleCombination(matiereId, action, button) {
             throw new Error(liaisonData.message || 'Impossible de récupérer les liaisons.');
         }
 
-        let filieres = liaisonData.filieres || [];
-        let niveaux = liaisonData.niveaux || [];
+        // liaisonData.liaisons = [{filiere_id, niveau_id}, ...]
+        let liaisons = (liaisonData.liaisons || []).map(l => ({
+            filiere_id: l.filiere_id,
+            niveau_id: l.niveau_id
+        }));
+
+        const comboKey = l => `${l.filiere_id}-${l.niveau_id}`;
+        const thisKey = `${CLASSE_FILIERE_ID}-${CLASSE_NIVEAU_ID}`;
 
         if (action === 'add') {
-            if (!filieres.includes(CLASSE_FILIERE_ID)) {
-                filieres.push(CLASSE_FILIERE_ID);
-            }
-            if (!niveaux.includes(CLASSE_NIVEAU_ID)) {
-                niveaux.push(CLASSE_NIVEAU_ID);
+            if (!liaisons.some(l => comboKey(l) === thisKey)) {
+                liaisons.push({ filiere_id: CLASSE_FILIERE_ID, niveau_id: CLASSE_NIVEAU_ID });
             }
         } else if (action === 'remove') {
-            filieres = filieres.filter(id => id !== CLASSE_FILIERE_ID);
-            niveaux = niveaux.filter(id => id !== CLASSE_NIVEAU_ID);
+            liaisons = liaisons.filter(l => comboKey(l) !== thisKey);
         }
 
         const updateResponse = await fetch(`/esbtp/matieres/${matiereId}/update-liaisons`, {
@@ -216,7 +218,7 @@ async function toggleCombination(matiereId, action, button) {
                 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
                 'Accept': 'application/json'
             },
-            body: JSON.stringify({ filieres, niveaux })
+            body: JSON.stringify({ liaisons })
         });
 
         if (!updateResponse.ok) {


### PR DESCRIPTION
## Summary
- Corrige les boutons **Ajouter à la classe** / **Retirer de la classe** qui ne fonctionnaient pas sur `/esbtp/classes/{id}/matieres`

## Root cause
La fonction JS `toggleCombination` lisait `liaisonData.filieres` et `liaisonData.niveaux` mais l'API `getLiaisons` retourne `liaisonData.liaisons` (tableau de `{filiere_id, niveau_id}`).  
Résultat : tableaux vides → POST `{filieres:[],niveaux:[]}` → suppression de toutes les liaisons sur "Retirer", rien sur "Ajouter".

## Changes
- `resources/views/esbtp/classes/matieres.blade.php` — lit `liaisonData.liaisons`, ajoute/retire le combo `{filiere_id, niveau_id}` de la classe, poste `{liaisons:[...]}` (format attendu par `updateLiaisons`)

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tester "Ajouter à la classe" sur une matière "Disponible dans le catalogue" → doit apparaître dans les combinaisons de la matière
- [ ] Tester "Retirer de la classe" → doit retirer uniquement la combinaison filière/niveau de cette classe, pas toutes les liaisons
- [ ] Tester sur esbtp-abidjan.klassci.com après deploy

## Checklist
- [x] No secrets or sensitive data committed
- [x] Single file modified, diff minimal

Closes #39