### PR TITLE
fix(bulletins): coefficient manquant — modal actionnable + fixes UX résultats

### DIFF
--- a/app/Exceptions/CoefficientMissingException.php
+++ b/app/Exceptions/CoefficientMissingException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+class CoefficientMissingException extends RuntimeException
+{
+    private array $context;
+
+    public function __construct(string $message, array $context = [], int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->context = $context;
+    }
+
+    public function getContext(): array
+    {
+        return $this->context;
+    }
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -42,6 +42,36 @@ class Handler extends ExceptionHandler
 
     public function render($request, Throwable $e)
     {
+        if ($e instanceof CoefficientMissingException) {
+            $context = $e->getContext();
+            $classeId = $context['classe']['id'] ?? null;
+            $matiereId = $context['matiere']['id'] ?? null;
+
+            $context['config_url'] = route('esbtp.evaluations.index', ['open_coefficients' => 1]);
+            if ($classeId) {
+                $context['classe_matieres_url'] = route('classes.matieres', ['classe' => $classeId]);
+            }
+            if ($classeId || $matiereId) {
+                $query = array_filter([
+                    'classe_id' => $classeId,
+                    'matiere_id' => $matiereId,
+                ], fn ($value) => ! is_null($value) && $value !== '');
+                $context['evaluations_url'] = route('esbtp.evaluations.index', $query);
+            }
+
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => $e->getMessage(),
+                    'context' => $context,
+                ], 422);
+            }
+
+            return redirect()->back()
+                ->with('error', $e->getMessage())
+                ->with('coefficient_missing_context', $context);
+        }
+
         if ($e instanceof RuntimeException) {
             $message = $e->getMessage();
 

--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\CoefficientMissingException;
 use App\Helpers\SettingsHelper;
 use App\Models\Classe;
 use App\Models\ESBTPAbsence;
@@ -4250,6 +4251,13 @@ class ESBTPBulletinController extends Controller
 
             return view($this->getBulletinTemplateView(), $donnees);
 
+        } catch (CoefficientMissingException $e) {
+            $context = $this->buildCoefficientIssueContext($e->getContext(), $request);
+            $message = $this->formatCoefficientIssueMessage($context);
+
+            return redirect()->back()
+                ->with('error', $message)
+                ->with('coefficient_missing_context', $context);
         } catch (\Exception $e) {
             if (str_contains($e->getMessage(), 'Configuration bulletin manquante')) {
                 $bulletin = ESBTPBulletin::where('etudiant_id', $etudiantId)
@@ -4823,6 +4831,13 @@ class ESBTPBulletinController extends Controller
 
             return $pdf->download($filename);
 
+        } catch (CoefficientMissingException $e) {
+            $context = $this->buildCoefficientIssueContext($e->getContext(), $request);
+            $message = $this->formatCoefficientIssueMessage($context);
+
+            return redirect()->back()
+                ->with('error', $message)
+                ->with('coefficient_missing_context', $context);
         } catch (\Exception $e) {
             // Gestion des erreurs de configuration
             if (str_contains($e->getMessage(), 'Configuration bulletin manquante')) {
@@ -8014,5 +8029,50 @@ class ESBTPBulletinController extends Controller
         return $style === 'abidjan'
             ? 'esbtp.bulletins.preview-abidjan'
             : 'esbtp.bulletins.preview';
+    }
+
+    private function buildCoefficientIssueContext(array $context, Request $request): array
+    {
+        $classeId = $context['classe']['id'] ?? $request->input('classe_id');
+        $matiereId = $context['matiere']['id'] ?? null;
+
+        $context['config_url'] = $context['config_url']
+            ?? route('esbtp.evaluations.index', ['open_coefficients' => 1]);
+
+        if ($classeId) {
+            $context['classe_matieres_url'] = $context['classe_matieres_url']
+                ?? route('classes.matieres', ['classe' => $classeId]);
+        }
+
+        $query = array_filter([
+            'classe_id' => $classeId,
+            'matiere_id' => $matiereId,
+        ], fn ($value) => ! is_null($value) && $value !== '');
+
+        if (! empty($query)) {
+            $context['evaluations_url'] = $context['evaluations_url']
+                ?? route('esbtp.evaluations.index', $query);
+        }
+
+        return $context;
+    }
+
+    private function formatCoefficientIssueMessage(array $context): string
+    {
+        $reason = $context['reason'] ?? 'coefficient_missing';
+        $matiereName = $context['matiere']['name'] ?? 'la matière sélectionnée';
+        $classeName = $context['classe']['name'] ?? 'la classe';
+        $filiereName = $context['classe']['filiere_name'] ?? 'la filière';
+        $niveauName = $context['classe']['niveau_name'] ?? 'le niveau';
+
+        if ($reason === 'matiere_hors_combinaison') {
+            return "La matière {$matiereName} n'est pas rattachée à la combinaison {$filiereName} / {$niveauName} de {$classeName}.";
+        }
+
+        if ($reason === 'matiere_introuvable') {
+            return 'Matière introuvable. Veuillez vérifier la configuration des évaluations.';
+        }
+
+        return "Coefficient manquant pour {$matiereName}. Configurez les coefficients avant de continuer.";
     }
 }

--- a/app/Services/BulletinService.php
+++ b/app/Services/BulletinService.php
@@ -2,11 +2,13 @@
 
 namespace App\Services;
 
+use App\Exceptions\CoefficientMissingException;
 use App\Helpers\SettingsHelper;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPBulletin;
 use App\Models\ESBTPClasse;
 use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPMatiere;
 use App\Models\ESBTPMatiereCoefficient;
 use App\Models\ESBTPNote;
 use App\Models\ESBTPResultat;
@@ -423,6 +425,7 @@ class BulletinService
         }
 
         $classeCourante = $this->classeCache[$classe->id];
+        $classeCourante->loadMissing(['filiere', 'niveauEtude']);
 
         if (! $classeCourante || ! $classeCourante->filiere_id || ! $classeCourante->niveau_etude_id) {
             throw new \RuntimeException('Classe invalide pour le calcul du coefficient.');
@@ -435,7 +438,56 @@ class BulletinService
             ->value('coefficient');
 
         if ($coefficient === null) {
-            throw new \RuntimeException('Coefficient manquant pour la matière sélectionnée.');
+            $matiere = ESBTPMatiere::find($matiereId);
+            $inFiliere = false;
+            $inNiveau = false;
+
+            if ($matiere) {
+                $inFiliere = $matiere->filieres()
+                    ->where('esbtp_filieres.id', $classeCourante->filiere_id)
+                    ->exists();
+                $inNiveau = $matiere->niveaux()
+                    ->where('esbtp_niveau_etudes.id', $classeCourante->niveau_etude_id)
+                    ->exists();
+
+                if (! $inFiliere && $matiere->filiere_id) {
+                    $inFiliere = (int) $matiere->filiere_id === (int) $classeCourante->filiere_id;
+                }
+                if (! $inNiveau && $matiere->niveau_etude_id) {
+                    $inNiveau = (int) $matiere->niveau_etude_id === (int) $classeCourante->niveau_etude_id;
+                }
+            }
+
+            $reason = 'coefficient_missing';
+            if (! $matiere) {
+                $reason = 'matiere_introuvable';
+            } elseif (! $inFiliere || ! $inNiveau) {
+                $reason = 'matiere_hors_combinaison';
+            }
+
+            $context = [
+                'reason' => $reason,
+                'matiere' => $matiere
+                    ? [
+                        'id' => $matiere->id,
+                        'name' => $matiere->name,
+                        'code' => $matiere->code,
+                    ]
+                    : [
+                        'id' => $matiereId,
+                    ],
+                'classe' => [
+                    'id' => $classeCourante->id,
+                    'name' => $classeCourante->name,
+                    'filiere_id' => $classeCourante->filiere_id,
+                    'niveau_etude_id' => $classeCourante->niveau_etude_id,
+                    'filiere_name' => $classeCourante->filiere->name ?? null,
+                    'niveau_name' => $classeCourante->niveauEtude->name ?? null,
+                ],
+                'annee_universitaire_id' => $anneeUniversitaireId,
+            ];
+
+            throw new CoefficientMissingException('Coefficient manquant pour la matière sélectionnée.', $context);
         }
 
         $this->coefficientCache[$cacheKey] = (float) $coefficient;

--- a/resources/views/components/student-results/action-buttons.blade.php
+++ b/resources/views/components/student-results/action-buttons.blade.php
@@ -70,10 +70,15 @@
                         <i class="fas fa-file-pdf"></i>
                         Génération
                     </h6>
-                    <a href="#" class="btn-acasi danger featured"
-                       onclick="window.open('{{ route('esbtp.bulletins.pdf-params', ['bulletin' => $etudiant->id, 'classe_id' => $classe->id, 'periode' => $periode, 'annee_universitaire_id' => $annee_id]) }}', '_blank')">
-                        <i class="fas fa-file-pdf"></i>Générer le bulletin PDF
-                    </a>
+                    <div class="info-notice">
+                        <div class="notice-content">
+                            <i class="fas fa-file-pdf"></i>
+                            <div>
+                                <h6>Téléchargement</h6>
+                                <p>Utilisez le bouton principal en haut de page pour générer le PDF du bulletin.</p>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             @else
                 <div class="action-section">

--- a/resources/views/components/student-results/results-overview-card.blade.php
+++ b/resources/views/components/student-results/results-overview-card.blade.php
@@ -7,10 +7,17 @@
         </div>
         <div class="main-card-subtitle">
             @php
-                $periodeNom = $periode == 1 ? 'Semestre 1' : 'Semestre 2';
+                $periodeKey = (string) $periode;
+                if ($periodeKey === '1') {
+                    $periodeKey = 'semestre1';
+                } elseif ($periodeKey === '2') {
+                    $periodeKey = 'semestre2';
+                }
+
+                $periodeNom = $periodeKey === 'semestre1' ? 'Semestre 1' : 'Semestre 2';
                 if (isset($periodes)) {
                     foreach ($periodes as $p) {
-                        if ($p->id == $periode) {
+                        if ((string) $p->id === (string) $periode || $p->code === $periodeKey) {
                             $periodeNom = $p->nom;
                             break;
                         }

--- a/resources/views/esbtp/evaluations/index.blade.php
+++ b/resources/views/esbtp/evaluations/index.blade.php
@@ -716,6 +716,112 @@
     display: flex;
     justify-content: flex-end;
 }
+
+.coeff-modal .modal-content {
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid rgba(4, 83, 203, 0.2);
+    box-shadow: 0 22px 50px rgba(15, 23, 42, 0.25);
+}
+
+.coeff-modal .modal-header {
+    background: linear-gradient(135deg, rgba(4, 83, 203, 0.14), rgba(94, 145, 222, 0.2));
+    border-bottom: 1px solid rgba(4, 83, 203, 0.2);
+    color: var(--text-primary);
+}
+
+.coeff-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.coeff-modal-intro {
+    display: flex;
+    gap: 0.85rem;
+    align-items: flex-start;
+    padding: 0.85rem 1rem;
+    border-radius: 14px;
+    background: rgba(4, 83, 203, 0.08);
+    border: 1px solid rgba(4, 83, 203, 0.16);
+    margin-bottom: 1.25rem;
+}
+
+.coeff-modal-intro .intro-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: rgba(4, 83, 203, 0.18);
+    color: var(--primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.coeff-modal-intro .intro-title {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.coeff-modal-intro .intro-text {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.coeff-status {
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.coeff-status.status-complete {
+    background: rgba(16, 185, 129, 0.16);
+    color: #047857;
+    border: 1px solid rgba(16, 185, 129, 0.35);
+}
+
+.coeff-status.status-partial {
+    background: rgba(245, 158, 11, 0.16);
+    color: #b45309;
+    border: 1px solid rgba(245, 158, 11, 0.35);
+}
+
+.coeff-status.status-missing {
+    background: rgba(239, 68, 68, 0.14);
+    color: #b91c1c;
+    border: 1px solid rgba(239, 68, 68, 0.35);
+}
+
+.coeff-status.status-empty {
+    background: rgba(148, 163, 184, 0.18);
+    color: #475569;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.coeff-alert {
+    padding: 0.65rem 0.85rem;
+    border-radius: 10px;
+    font-size: 0.85rem;
+    margin-bottom: 0.85rem;
+}
+
+.coeff-alert-warning {
+    background: rgba(245, 158, 11, 0.14);
+    border: 1px solid rgba(245, 158, 11, 0.35);
+    color: #92400e;
+}
+
+.coeff-alert-empty {
+    background: rgba(148, 163, 184, 0.18);
+    border: 1px dashed rgba(148, 163, 184, 0.5);
+    color: #475569;
+}
 </style>
 @endpush
 

--- a/resources/views/esbtp/evaluations/partials/coefficients-modal.blade.php
+++ b/resources/views/esbtp/evaluations/partials/coefficients-modal.blade.php
@@ -6,6 +6,16 @@
     <span class="badge bg-light text-dark">{{ $cards->count() }} combinaisons</span>
 </div>
 
+<div class="coeff-modal-intro">
+    <div class="intro-icon">
+        <i class="fas fa-lightbulb"></i>
+    </div>
+    <div>
+        <div class="intro-title">Ces coefficients sont utilisés pour les bulletins</div>
+        <div class="intro-text">Complétez chaque combinaison filière / niveau pour éviter les blocages lors des previews et PDFs.</div>
+    </div>
+</div>
+
 @if($cards->isEmpty())
     <div class="alert alert-warning">Aucune combinaison filière/niveau trouvée.</div>
 @else
@@ -18,6 +28,13 @@
                     'missing' => 'status-missing',
                     default => 'status-empty',
                 };
+                $statusLabel = match($card['status']) {
+                    'complete' => 'Complet',
+                    'partial' => 'Incomplet',
+                    'missing' => 'Non configuré',
+                    'empty' => 'Sans matières',
+                    default => 'Inconnu',
+                };
             @endphp
             <form class="coeff-card" data-filiere-id="{{ $card['filiere']->id }}" data-niveau-id="{{ $card['niveau']->id }}">
                 <div class="coeff-card-header">
@@ -29,13 +46,20 @@
                         <div class="text-muted small">{{ $card['configured'] }}/{{ $card['total'] }} matières configurées</div>
                     </div>
                     <span class="coeff-status {{ $statusClass }}">
-                        {{ strtoupper($card['status']) }}
+                        {{ $statusLabel }}
                     </span>
                 </div>
                 <div class="coeff-card-body">
                     @if($card['total'] === 0)
-                        <div class="text-muted">Aucune matière liée à cette combinaison.</div>
+                        <div class="coeff-alert coeff-alert-empty">
+                            Aucune matière liée à cette combinaison. Ajoutez d'abord les matières dans la classe.
+                        </div>
                     @else
+                        @if(in_array($card['status'], ['missing', 'partial'], true))
+                            <div class="coeff-alert coeff-alert-warning">
+                                Complétez les coefficients manquants pour activer la génération des bulletins.
+                            </div>
+                        @endif
                         <div class="coeff-grid">
                             @foreach($card['matieres'] as $matiere)
                                 <div class="coeff-row">

--- a/resources/views/esbtp/resultats/etudiant.blade.php
+++ b/resources/views/esbtp/resultats/etudiant.blade.php
@@ -6,6 +6,19 @@
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 @endsection
 
+@php
+    $coeffContext = session('coefficient_missing_context');
+    $reason = $coeffContext['reason'] ?? null;
+    $matiereName = $coeffContext['matiere']['name'] ?? null;
+    $matiereCode = $coeffContext['matiere']['code'] ?? null;
+    $classeName = $coeffContext['classe']['name'] ?? null;
+    $filiereName = $coeffContext['classe']['filiere_name'] ?? null;
+    $niveauName = $coeffContext['classe']['niveau_name'] ?? null;
+    $configUrl = $coeffContext['config_url'] ?? route('esbtp.evaluations.index', ['open_coefficients' => 1]);
+    $classeMatieresUrl = $coeffContext['classe_matieres_url'] ?? (isset($classe) && $classe ? route('classes.matieres', ['classe' => $classe->id]) : null);
+    $evaluationsUrl = $coeffContext['evaluations_url'] ?? route('esbtp.evaluations.index');
+@endphp
+
 @section('content')
 <div class="dashboard-acasi">
     <div class="main-content">
@@ -30,30 +43,12 @@
                        class="btn-acasi primary">
                         <i class="fas fa-eye"></i>Prévisualiser bulletin
                     </a>
-                    <a href="#" class="btn-acasi danger"
-                       onclick="window.open('{{ route('esbtp.bulletins.pdf-params', ['bulletin' => $etudiant->id, 'classe_id' => $classe->id, 'periode' => $periode, 'annee_universitaire_id' => $annee_id]) }}', '_blank')">
+                    <a href="{{ route('esbtp.bulletins.pdf-params', ['bulletin' => $etudiant->id, 'classe_id' => $classe->id, 'periode' => $periode, 'annee_universitaire_id' => $annee_id]) }}" class="btn-acasi danger">
                         <i class="fas fa-file-pdf"></i>Télécharger PDF
                     </a>
                 @endif
             </div>
         </div>
-        
-        <!-- Messages Flash -->
-        @if(session('success'))
-            <div class="alert alert-success alert-dismissible fade show" role="alert">
-                <i class="fas fa-check-circle me-2"></i>
-                {{ session('success') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
-        @endif
-
-        @if(session('error'))
-            <div class="alert alert-danger alert-dismissible fade show" role="alert">
-                <i class="fas fa-exclamation-circle me-2"></i>
-                {{ session('error') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
-        @endif
 
         <!-- Filtres -->
         @include('components.student-results.filters-section')
@@ -76,6 +71,100 @@
 
         <!-- Actions et navigation -->
         @include('components.student-results.action-buttons')
+
+        @if($coeffContext)
+            <div class="modal fade" id="bulletinIssueModal" tabindex="-1" aria-hidden="true">
+                <div class="modal-dialog modal-lg modal-dialog-centered">
+                    <div class="modal-content bulletin-issue-modal">
+                        <div class="modal-header">
+                            <div class="issue-header">
+                                <div class="issue-badge">
+                                    <i class="fas fa-triangle-exclamation"></i>
+                                </div>
+                                <div>
+                                    <h5 class="modal-title">Bulletin bloqué</h5>
+                                    <div class="issue-subtitle">Une configuration est nécessaire pour continuer.</div>
+                                </div>
+                            </div>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="issue-card">
+                                @if($reason === 'matiere_hors_combinaison')
+                                    <div class="issue-title">Matière hors combinaison filière / niveau</div>
+                                    <p class="issue-text">
+                                        La matière <strong>{{ $matiereName ?? 'sélectionnée' }}</strong>
+                                        n'est pas rattachée à la combinaison <strong>{{ $filiereName ?? 'filière' }}</strong> /
+                                        <strong>{{ $niveauName ?? 'niveau' }}</strong> de la classe
+                                        <strong>{{ $classeName ?? 'sélectionnée' }}</strong>.
+                                    </p>
+                                    <div class="issue-note">
+                                        Les coefficients se configurent uniquement sur les matières liées à cette combinaison.
+                                    </div>
+                                @elseif($reason === 'matiere_introuvable')
+                                    <div class="issue-title">Matière introuvable</div>
+                                    <p class="issue-text">
+                                        La matière associée aux notes n'a pas été retrouvée. Veuillez vérifier la configuration des évaluations.
+                                    </p>
+                                @else
+                                    <div class="issue-title">Coefficient manquant</div>
+                                    <p class="issue-text">
+                                        Aucun coefficient n'est défini pour
+                                        <strong>{{ $matiereName ?? 'cette matière' }}</strong> sur
+                                        <strong>{{ $classeName ?? 'cette classe' }}</strong>.
+                                    </p>
+                                    <div class="issue-note">
+                                        Configurez les coefficients pour générer la preview et le PDF.
+                                    </div>
+                                @endif
+
+                                <div class="issue-grid">
+                                    <div class="issue-item">
+                                        <span>Matière</span>
+                                        <strong>{{ $matiereName ?? 'Non renseignée' }}{{ $matiereCode ? ' · '.$matiereCode : '' }}</strong>
+                                    </div>
+                                    <div class="issue-item">
+                                        <span>Classe</span>
+                                        <strong>{{ $classeName ?? 'Non renseignée' }}</strong>
+                                    </div>
+                                    <div class="issue-item">
+                                        <span>Combinaison</span>
+                                        <strong>{{ $filiereName ?? '—' }} · {{ $niveauName ?? '—' }}</strong>
+                                    </div>
+                                </div>
+
+                                <div class="issue-actions">
+                                    @if($reason === 'matiere_hors_combinaison' && $classeMatieresUrl)
+                                        <a href="{{ $classeMatieresUrl }}" class="btn-acasi primary">
+                                            <i class="fas fa-list-check"></i>Gérer matières de la classe
+                                        </a>
+                                        <a href="{{ $configUrl }}" class="btn-acasi secondary">
+                                            <i class="fas fa-sliders-h"></i>Configurer coefficients
+                                        </a>
+                                    @else
+                                        <a href="{{ $configUrl }}" class="btn-acasi primary">
+                                            <i class="fas fa-sliders-h"></i>Configurer coefficients
+                                        </a>
+                                        @if($classeMatieresUrl)
+                                            <a href="{{ $classeMatieresUrl }}" class="btn-acasi secondary">
+                                                <i class="fas fa-list-check"></i>Matières de la classe
+                                            </a>
+                                        @endif
+                                    @endif
+                                    <a href="{{ $evaluationsUrl }}" class="btn-acasi info">
+                                        <i class="fas fa-clipboard-list"></i>Vérifier évaluations
+                                    </a>
+                                </div>
+
+                                <div class="issue-footnote">
+                                    Besoin d'aide ? Vérifiez que les évaluations utilisent des matières rattachées à la classe.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endif
 
     </div>
 </div>
@@ -117,4 +206,129 @@ document.addEventListener('DOMContentLoaded', function() {
     });
 });
 </script>
+
+@if($coeffContext)
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const modalElement = document.getElementById('bulletinIssueModal');
+        if (modalElement && typeof bootstrap !== 'undefined') {
+            const modalInstance = new bootstrap.Modal(modalElement);
+            modalInstance.show();
+        }
+    });
+    </script>
+@endif
 @endsection
+
+@push('styles')
+<style>
+.bulletin-issue-modal .modal-content {
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid rgba(4, 83, 203, 0.15);
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.25);
+}
+
+.bulletin-issue-modal .modal-header {
+    background: linear-gradient(135deg, rgba(4, 83, 203, 0.12), rgba(94, 145, 222, 0.18));
+    border-bottom: 1px solid rgba(4, 83, 203, 0.18);
+}
+
+.issue-header {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+}
+
+.issue-badge {
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 14px;
+    background: rgba(239, 68, 68, 0.12);
+    color: #dc2626;
+    font-size: 1.25rem;
+}
+
+.issue-subtitle {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.issue-card {
+    background: #fff;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    padding: 1.5rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.issue-title {
+    font-weight: 700;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+}
+
+.issue-text {
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+.issue-note {
+    background: rgba(4, 83, 203, 0.08);
+    border-left: 4px solid var(--primary);
+    padding: 0.75rem 1rem;
+    border-radius: 10px;
+    color: var(--text-primary);
+    font-size: 0.9rem;
+}
+
+.issue-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+}
+
+.issue-item {
+    background: var(--background-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 0.75rem 0.9rem;
+    display: grid;
+    gap: 0.25rem;
+}
+
+.issue-item span {
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    color: var(--text-secondary);
+}
+
+.issue-item strong {
+    font-size: 0.9rem;
+    color: var(--text-primary);
+}
+
+.issue-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.issue-footnote {
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 576px) {
+    .issue-actions .btn-acasi {
+        width: 100%;
+        justify-content: center;
+    }
+}
+</style>
+@endpush


### PR DESCRIPTION
## Résumé

Résolution de deux problèmes bloquants sur la page résultats étudiant.

### Issue #41 — Erreurs coefficient manquant

- **`CoefficientMissingException`** (nouveau) : exception dédiée avec `getContext()` retournant raison, matière, classe et URLs d'action
- **`BulletinService`** : classification de 3 cas (`matiere_hors_combinaison`, `coefficient_missing`, `matiere_introuvable`) au lieu d'une exception générique
- **`ESBTPBulletinController`** : catch `CoefficientMissingException` dans preview et PDF → session flash `coefficient_missing_context`
- **`Handler.php`** : handler global avec URLs de configuration directes (JSON + redirect)
- **`etudiant.blade.php`** : modal Bootstrap auto-ouvert au chargement avec instructions adaptées par cas + boutons d'action ciblés
- **`evaluations/index.blade.php`** : auto-ouverture du modal coefficients via `?open_coefficients=1`
- **`coefficients-modal.blade.php`** : amélioration UX du modal de configuration

### Issue #42 — Fixes UX résultats

- **Bouton PDF** : remplacé `href="#" onclick="window.open()"` par lien direct `href="{{ route(...) }}"` — corrige la redirect incorrecte vers `/navbar/notifications`
- **Label période** : normalisation `'1'` → `'semestre1'` / `'2'` → `'semestre2'` dans `results-overview-card` avant affichage du nom
- **Doublon bouton PDF** : section "Génération" dans `action-buttons` remplacée par une notice info pointant vers le bouton principal

## Plan de test

- [ ] Sur la page résultats étudiant, cliquer "Prévisualiser bulletin" avec un coefficient manquant → modal explicatif s'ouvre automatiquement
- [ ] Le modal distingue les 3 cas (hors combinaison / introuvable / manquant) avec instructions adaptées
- [ ] Bouton "Configurer" dans le modal → redirige vers evaluations/index et ouvre le modal coefficients
- [ ] Cliquer "Télécharger PDF" → génère le PDF sans redirect vers /navbar/notifications
- [ ] Sélectionner Semestre 1 → la carte aperçu affiche "Semestre 1" (non "Semestre 2")
- [ ] Section "Actions disponibles" → pas de doublon bouton PDF
