### PR TITLE
fix(bulletins): éviter RouteNotFoundException au chargement normal de la page

### DIFF
--- a/resources/views/esbtp/resultats/etudiant.blade.php
+++ b/resources/views/esbtp/resultats/etudiant.blade.php
@@ -14,9 +14,14 @@
     $classeName = $coeffContext['classe']['name'] ?? null;
     $filiereName = $coeffContext['classe']['filiere_name'] ?? null;
     $niveauName = $coeffContext['classe']['niveau_name'] ?? null;
-    $configUrl = $coeffContext['config_url'] ?? route('esbtp.evaluations.index', ['open_coefficients' => 1]);
-    $classeMatieresUrl = $coeffContext['classe_matieres_url'] ?? (isset($classe) && $classe ? route('classes.matieres', ['classe' => $classe->id]) : null);
-    $evaluationsUrl = $coeffContext['evaluations_url'] ?? route('esbtp.evaluations.index');
+    $configUrl = null;
+    $classeMatieresUrl = null;
+    $evaluationsUrl = null;
+    if ($coeffContext) {
+        $configUrl = $coeffContext['config_url'] ?? route('esbtp.evaluations.index', ['open_coefficients' => 1]);
+        $classeMatieresUrl = $coeffContext['classe_matieres_url'] ?? (isset($classe) && $classe ? route('classes.matieres', ['classe' => $classe->id]) : null);
+        $evaluationsUrl = $coeffContext['evaluations_url'] ?? route('esbtp.evaluations.index');
+    }
 @endphp
 
 @section('content')


### PR DESCRIPTION
## Problème

Après le merge de la PR #43, la page résultats étudiant lève une `RouteNotFoundException` au chargement normal :

> Route [classes.matieres] not defined.

## Cause

Le bloc `@php` dans `etudiant.blade.php` appelait `route('classes.matieres', ...)` à chaque chargement de page, même quand `$coeffContext` est `null` (cas normal sans erreur de coefficient).

## Fix

Les appels `route()` pour les URLs du modal d'erreur sont maintenant protégés dans un `if ($coeffContext)` — ils ne s'évaluent que quand le contexte d'erreur est présent en session.

## Test

- [ ] Charger `/esbtp/resultats/etudiant/{id}` → page s'affiche normalement sans erreur
- [ ] Déclencher une erreur de coefficient → modal s'ouvre avec les bons liens
