### PR TITLE
fix(bulletins): propriété code optionnelle sur objets période

### DIFF
--- a/resources/views/components/student-results/results-overview-card.blade.php
+++ b/resources/views/components/student-results/results-overview-card.blade.php
@@ -17,7 +17,7 @@
                 $periodeNom = $periodeKey === 'semestre1' ? 'Semestre 1' : 'Semestre 2';
                 if (isset($periodes)) {
                     foreach ($periodes as $p) {
-                        if ((string) $p->id === (string) $periode || $p->code === $periodeKey) {
+                        if ((string) $p->id === (string) $periode || (isset($p->code) && $p->code === $periodeKey)) {
                             $periodeNom = $p->nom;
                             break;
                         }


### PR DESCRIPTION
## Problème

`Undefined property: stdClass::$code` dans `results-overview-card.blade.php` — les objets `$periodes` ne disposent pas tous d'une propriété `code`.

## Fix

Protège l'accès avec `isset($p->code)` avant la comparaison.

## Test

- [ ] Page résultats étudiant s'affiche sans erreur
- [ ] Label période correct (Semestre 1 / Semestre 2)