### PR TITLE
fix(bulletins): éviter RouteNotFoundException dans buildCoefficientIssueContext et Handler

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -49,7 +49,9 @@ class Handler extends ExceptionHandler
 
             $context['config_url'] = route('esbtp.evaluations.index', ['open_coefficients' => 1]);
             if ($classeId) {
-                $context['classe_matieres_url'] = route('classes.matieres', ['classe' => $classeId]);
+                $context['classe_matieres_url'] = \Illuminate\Support\Facades\Route::has('classes.matieres')
+                    ? route('classes.matieres', ['classe' => $classeId])
+                    : route('esbtp.evaluations.index', ['open_coefficients' => 1]);
             }
             if ($classeId || $matiereId) {
                 $query = array_filter([

--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -8041,7 +8041,9 @@ class ESBTPBulletinController extends Controller
 
         if ($classeId) {
             $context['classe_matieres_url'] = $context['classe_matieres_url']
-                ?? route('classes.matieres', ['classe' => $classeId]);
+                ?? (\Illuminate\Support\Facades\Route::has('classes.matieres')
+                    ? route('classes.matieres', ['classe' => $classeId])
+                    : route('esbtp.evaluations.index', ['open_coefficients' => 1]));
         }
 
         $query = array_filter([


### PR DESCRIPTION
## Résumé

- Corrige `Route [classes.matieres] not defined` dans `buildCoefficientIssueContext()` et `Handler.php`
- La route `classes.matieres` n'existe pas sur tous les tenants (yakro)
- Utilise `Route::has()` avant d'appeler `route()` pour éviter le crash lors du preview bulletin

## Plan de test

- [ ] Tester le preview bulletin d'un étudiant avec coefficient manquant → plus de RouteNotFoundException
- [ ] Vérifier que le nouveau modal `studentCoeffModal` s'ouvre correctement
- [ ] Tester sur esbtp-yakro où la route `classes.matieres` n'existe pas

Closes #46