### PR TITLE
fix(bulletins): corriger ouverture auto du modal coefficients

### DIFF
--- a/resources/views/esbtp/resultats/etudiant.blade.php
+++ b/resources/views/esbtp/resultats/etudiant.blade.php
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
-@if($coeffContext)
+@if(session('coefficient_missing_context'))
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         const modalElement = document.getElementById('studentCoeffModal');


### PR DESCRIPTION
## Problème

Le modal `studentCoeffModal` ne s'ouvrait pas automatiquement après la redirection suite à une `CoefficientMissingException`.

La session `coefficient_missing_context` était bien présente (la bannière rouge s'affichait dans le modal), mais le script d'auto-ouverture n'était jamais rendu.

## Cause

Problème de portée Blade : la variable `$coeffContext` définie dans le bloc `@php` n'est **pas accessible** dans `@section('scripts')` lors du rendu via `@yield('scripts')` dans le layout parent.

```blade
{{-- @php block (body scope) --}}
$coeffContext = session('coefficient_missing_context');

{{-- @section('scripts') — $coeffContext est NULL ici --}}
@if($coeffContext)  ← toujours false
```

## Fix

Remplacer `@if($coeffContext)` par `@if(session('coefficient_missing_context'))` pour lire directement depuis la session, contournant le problème de portée.

## Fichier modifié

- `resources/views/esbtp/resultats/etudiant.blade.php` — 1 ligne