### PR TITLE
fix(bulletins): utiliser $coeffContext pour l'auto-ouverture du modal

### DIFF
--- a/resources/views/esbtp/resultats/etudiant.blade.php
+++ b/resources/views/esbtp/resultats/etudiant.blade.php
@@ -145,7 +145,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 </script>
 
-@if(session('coefficient_missing_context'))
+@if($coeffContext)
     <script>
     document.addEventListener('DOMContentLoaded', function() {
         const modalElement = document.getElementById('studentCoeffModal');


### PR DESCRIPTION
## Problème

Le modal `studentCoeffModal` ne s'ouvrait toujours pas automatiquement malgré le fix précédent (PR #49).

## Cause réelle

`session('coefficient_missing_context')` est une fonction qui **consomme** la valeur flash lors du **premier appel** — ligne 10 du bloc `@php` :

```php
$coeffContext = session('coefficient_missing_context'); // ← consomme la session
```

Au moment où `@section('scripts')` est évalué, un deuxième appel à `session(...)` retourne `null`. La PR #49 avait donc introduit une régression en remplaçant `$coeffContext` par `session(...)`.

## Fix

Revenir à `@if($coeffContext)` — la variable capturée dans le `@php` garde la valeur correcte.

```blade
{{-- AVANT (PR #49 — incorrect) --}}
@if(session('coefficient_missing_context'))

{{-- APRÈS (correct) --}}
@if($coeffContext)
```