### PR TITLE
fix(evaluations): refonte design modal coefficients + fix overflow labels

### DIFF
--- a/resources/views/esbtp/evaluations/index.blade.php
+++ b/resources/views/esbtp/evaluations/index.blade.php
@@ -612,111 +612,7 @@
     margin-bottom: 0;
 }
 
-.coeff-modal .modal-content {
-    border-radius: 16px;
-    border: none;
-    overflow: hidden;
-}
-
-.coeff-modal .modal-header {
-    background: linear-gradient(135deg, #0f3f87 0%, #0453cb 100%);
-    color: #fff;
-    border-bottom: none;
-}
-
-.coeff-modal .modal-body {
-    background: #f8fafc;
-}
-
-.coeff-modal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
-}
-
-.coeff-cards {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    gap: 1rem;
-}
-
-.coeff-card {
-    background: #fff;
-    border-radius: 14px;
-    border: 1px solid rgba(148, 163, 184, 0.2);
-    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
-    padding: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-}
-
-.coeff-card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 0.75rem;
-}
-
-.coeff-combo {
-    display: flex;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-}
-
-.coeff-status {
-    font-size: 0.75rem;
-    font-weight: 700;
-    padding: 0.25rem 0.6rem;
-    border-radius: 999px;
-}
-
-.status-complete {
-    background: rgba(16, 185, 129, 0.15);
-    color: #047857;
-}
-
-.status-partial {
-    background: rgba(245, 158, 11, 0.15);
-    color: #b45309;
-}
-
-.status-missing {
-    background: rgba(239, 68, 68, 0.15);
-    color: #b91c1c;
-}
-
-.status-empty {
-    background: rgba(148, 163, 184, 0.2);
-    color: #475569;
-}
-
-.coeff-grid {
-    display: grid;
-    gap: 0.6rem;
-}
-
-.coeff-row {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.6rem 0.75rem;
-    border-radius: 10px;
-    background: rgba(4, 83, 203, 0.06);
-    border: 1px solid rgba(4, 83, 203, 0.12);
-}
-
-.coeff-input {
-    max-width: 90px;
-}
-
-.coeff-card-footer {
-    display: flex;
-    justify-content: flex-end;
-}
-
+/* ── Modal coefficients ── */
 .coeff-modal .modal-content {
     border-radius: 18px;
     overflow: hidden;
@@ -730,14 +626,21 @@
     color: var(--text-primary);
 }
 
+.coeff-modal .modal-body {
+    background: #f8fafc;
+    padding: 1.5rem;
+}
+
+/* ── En-tête du partial ── */
 .coeff-modal-header {
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 1rem;
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
 }
 
+/* ── Intro info-box ── */
 .coeff-modal-intro {
     display: flex;
     gap: 0.85rem;
@@ -746,7 +649,7 @@
     border-radius: 14px;
     background: rgba(4, 83, 203, 0.08);
     border: 1px solid rgba(4, 83, 203, 0.16);
-    margin-bottom: 1.25rem;
+    margin-bottom: 1.5rem;
 }
 
 .coeff-modal-intro .intro-icon {
@@ -771,13 +674,99 @@
     font-size: 0.85rem;
 }
 
+/* ── État vide ── */
+.coeff-empty-state {
+    text-align: center;
+    padding: 2.5rem 1rem;
+    color: var(--text-secondary);
+}
+
+/* ── Grille de cards ── */
+.coeff-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+    gap: 1.25rem;
+}
+
+/* ── Card individuelle ── */
+.coeff-card {
+    background: #fff;
+    border-radius: 16px;
+    border: 1px solid rgba(148, 163, 184, 0.22);
+    box-shadow: 0 4px 16px rgba(15, 23, 42, 0.06);
+    padding: 1.1rem 1.2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    transition: box-shadow 0.2s;
+}
+
+.coeff-card:hover {
+    box-shadow: 0 8px 28px rgba(15, 23, 42, 0.1);
+}
+
+/* Bordure colorée selon statut */
+.complete-card  { border-left: 4px solid #10b981; }
+.partial-card   { border-left: 4px solid #f59e0b; }
+.missing-card   { border-left: 4px solid #ef4444; }
+.empty-card     { border-left: 4px solid #94a3b8; }
+
+/* ── En-tête card ── */
+.coeff-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.coeff-card-title {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.coeff-ordinal {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: rgba(4, 83, 203, 0.12);
+    color: var(--primary);
+    font-size: 0.75rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.coeff-combo-info {
+    min-width: 0;
+}
+
+.coeff-combo {
+    display: flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.3rem;
+}
+
+.coeff-progress-text {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+/* ── Badge statut ── */
 .coeff-status {
     padding: 0.3rem 0.7rem;
     border-radius: 999px;
     font-size: 0.7rem;
     font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
+    letter-spacing: 0.06em;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 
 .coeff-status.status-complete {
@@ -804,23 +793,137 @@
     border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
+/* ── Barre de progression ── */
+.coeff-progress-bar-wrap {
+    height: 4px;
+    border-radius: 99px;
+    background: rgba(148, 163, 184, 0.2);
+    overflow: hidden;
+}
+
+.coeff-progress-bar {
+    height: 100%;
+    border-radius: 99px;
+    transition: width 0.4s ease;
+}
+
+.coeff-progress-bar[data-status="complete"] { background: #10b981; }
+.coeff-progress-bar[data-status="partial"]  { background: #f59e0b; }
+.coeff-progress-bar[data-status="missing"]  { background: #ef4444; }
+.coeff-progress-bar[data-status="empty"]    { background: #94a3b8; }
+
+/* ── Corps card ── */
+.coeff-card-body {
+    display: flex;
+    flex-direction: column;
+}
+
+/* ── Alertes ── */
 .coeff-alert {
     padding: 0.65rem 0.85rem;
     border-radius: 10px;
-    font-size: 0.85rem;
+    font-size: 0.83rem;
     margin-bottom: 0.85rem;
 }
 
 .coeff-alert-warning {
-    background: rgba(245, 158, 11, 0.14);
-    border: 1px solid rgba(245, 158, 11, 0.35);
+    background: rgba(245, 158, 11, 0.1);
+    border: 1px solid rgba(245, 158, 11, 0.3);
     color: #92400e;
 }
 
 .coeff-alert-empty {
-    background: rgba(148, 163, 184, 0.18);
-    border: 1px dashed rgba(148, 163, 184, 0.5);
+    background: rgba(148, 163, 184, 0.12);
+    border: 1px dashed rgba(148, 163, 184, 0.4);
     color: #475569;
+}
+
+/* ── Grille matières ── */
+.coeff-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.coeff-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.55rem 0.75rem;
+    border-radius: 10px;
+    background: rgba(4, 83, 203, 0.04);
+    border: 1px solid rgba(4, 83, 203, 0.1);
+    transition: background 0.15s;
+}
+
+.coeff-row.has-value {
+    background: rgba(16, 185, 129, 0.04);
+    border-color: rgba(16, 185, 129, 0.18);
+}
+
+.coeff-row.missing-value {
+    background: rgba(239, 68, 68, 0.04);
+    border-color: rgba(239, 68, 68, 0.14);
+}
+
+.coeff-matiere-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.coeff-matiere-name {
+    font-weight: 600;
+    font-size: 0.87rem;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.coeff-matiere-code {
+    font-size: 0.72rem;
+    color: var(--text-secondary);
+    margin-top: 1px;
+}
+
+.coeff-input-wrap {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-shrink: 0;
+}
+
+.coeff-current-badge {
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 0.15rem 0.45rem;
+    border-radius: 6px;
+    background: rgba(16, 185, 129, 0.14);
+    color: #047857;
+    border: 1px solid rgba(16, 185, 129, 0.3);
+    white-space: nowrap;
+}
+
+.coeff-input {
+    width: 80px;
+    min-width: 80px;
+    text-align: center;
+}
+
+/* ── Pied card ── */
+.coeff-card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    padding-top: 0.25rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.coeff-save-feedback {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
 }
 </style>
 @endpush
@@ -1555,6 +1658,10 @@ document.addEventListener('DOMContentLoaded', () => {
         formData.append('niveau_etude_id', form.dataset.niveauId || '');
         formData.append('annee_universitaire_id', coeffYearId || '');
 
+        const saveBtn = form.querySelector('.coeff-save-btn');
+        const saveFeedback = form.querySelector('.coeff-save-feedback');
+        if (saveBtn) { saveBtn.disabled = true; saveBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Enregistrement...'; }
+
         fetch(coeffUpdateUrl, {
             method: 'POST',
             headers: {
@@ -1569,18 +1676,21 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (!data.success) {
                     throw new Error(data.message || 'Enregistrement impossible');
                 }
-                const toast = document.createElement('div');
-                toast.className = 'alert alert-success mt-3';
-                toast.textContent = data.message || 'Coefficients enregistrés.';
-                form.prepend(toast);
-                setTimeout(() => toast.remove(), 2500);
+                if (saveFeedback) {
+                    saveFeedback.classList.remove('d-none');
+                    setTimeout(() => saveFeedback.classList.add('d-none'), 2500);
+                }
             })
             .catch(error => {
                 const toast = document.createElement('div');
-                toast.className = 'alert alert-danger mt-3';
+                toast.className = 'alert alert-danger mt-2 mb-0';
+                toast.style.cssText = 'font-size:0.83rem;padding:0.5rem 0.75rem';
                 toast.textContent = error.message;
-                form.prepend(toast);
+                form.querySelector('.coeff-card-footer')?.before(toast);
                 setTimeout(() => toast.remove(), 3500);
+            })
+            .finally(() => {
+                if (saveBtn) { saveBtn.disabled = false; saveBtn.innerHTML = '<i class="fas fa-save me-1"></i>Enregistrer'; }
             });
     });
 

--- a/resources/views/esbtp/evaluations/partials/coefficients-modal.blade.php
+++ b/resources/views/esbtp/evaluations/partials/coefficients-modal.blade.php
@@ -1,9 +1,17 @@
+{{--
+    Partial : modal coefficients (chargé en AJAX depuis evaluations/index)
+    Variables attendues : $cards (Collection), $anneeUniversitaire (model|null)
+--}}
 <div class="coeff-modal-header">
     <div>
         <h5 class="mb-1"><i class="fas fa-sliders-h me-2"></i>Coefficients par combinaison</h5>
-        <div class="text-muted">Année {{ $anneeUniversitaire->name ?? 'courante' }}</div>
+        <div class="text-muted small">
+            <i class="fas fa-calendar-alt me-1"></i>Année universitaire courante
+        </div>
     </div>
-    <span class="badge bg-light text-dark">{{ $cards->count() }} combinaisons</span>
+    <span class="badge bg-primary rounded-pill px-3 py-2">
+        <i class="fas fa-layer-group me-1"></i>{{ $cards->count() }} combinaison{{ $cards->count() > 1 ? 's' : '' }}
+    </span>
 </div>
 
 <div class="coeff-modal-intro">
@@ -17,73 +25,126 @@
 </div>
 
 @if($cards->isEmpty())
-    <div class="alert alert-warning">Aucune combinaison filière/niveau trouvée.</div>
+    <div class="coeff-empty-state">
+        <i class="fas fa-inbox fa-2x mb-2 text-muted"></i>
+        <div class="fw-semibold">Aucune combinaison filière/niveau trouvée.</div>
+        <div class="text-muted small mt-1">Créez d'abord des classes avec une filière et un niveau associés.</div>
+    </div>
 @else
     <div class="coeff-cards">
-        @foreach($cards as $card)
+        @foreach($cards as $cardIndex => $card)
             @php
                 $statusClass = match($card['status']) {
                     'complete' => 'status-complete',
-                    'partial' => 'status-partial',
-                    'missing' => 'status-missing',
-                    default => 'status-empty',
+                    'partial'  => 'status-partial',
+                    'missing'  => 'status-missing',
+                    default    => 'status-empty',
                 };
                 $statusLabel = match($card['status']) {
                     'complete' => 'Complet',
-                    'partial' => 'Incomplet',
-                    'missing' => 'Non configuré',
-                    'empty' => 'Sans matières',
-                    default => 'Inconnu',
+                    'partial'  => 'Incomplet',
+                    'missing'  => 'Non configuré',
+                    'empty'    => 'Sans matières',
+                    default    => 'Inconnu',
+                };
+                $statusIcon = match($card['status']) {
+                    'complete' => 'fas fa-check-circle',
+                    'partial'  => 'fas fa-exclamation-circle',
+                    'missing'  => 'fas fa-times-circle',
+                    default    => 'fas fa-minus-circle',
                 };
             @endphp
-            <form class="coeff-card" data-filiere-id="{{ $card['filiere']->id }}" data-niveau-id="{{ $card['niveau']->id }}">
+            <form class="coeff-card {{ $statusClass }}-card"
+                  data-filiere-id="{{ $card['filiere']->id }}"
+                  data-niveau-id="{{ $card['niveau']->id }}">
+
+                {{-- En-tête card --}}
                 <div class="coeff-card-header">
-                    <div>
-                        <div class="coeff-combo">
-                            <span class="badge bg-primary">{{ $card['filiere']->name }}</span>
-                            <span class="badge bg-secondary">{{ $card['niveau']->name }}</span>
+                    <div class="coeff-card-title">
+                        <div class="coeff-ordinal">{{ $cardIndex + 1 }}</div>
+                        <div class="coeff-combo-info">
+                            <div class="coeff-combo">
+                                <span class="badge bg-primary">{{ $card['filiere']->name }}</span>
+                                <span class="badge bg-secondary">{{ $card['niveau']->name }}</span>
+                            </div>
+                            <div class="coeff-progress-text">
+                                <i class="fas fa-tasks me-1"></i>
+                                {{ $card['configured'] }}/{{ $card['total'] }} matière{{ $card['total'] > 1 ? 's' : '' }} configurée{{ $card['configured'] > 1 ? 's' : '' }}
+                            </div>
                         </div>
-                        <div class="text-muted small">{{ $card['configured'] }}/{{ $card['total'] }} matières configurées</div>
                     </div>
                     <span class="coeff-status {{ $statusClass }}">
-                        {{ $statusLabel }}
+                        <i class="{{ $statusIcon }} me-1"></i>{{ $statusLabel }}
                     </span>
                 </div>
+
+                {{-- Barre de progression --}}
+                @if($card['total'] > 0)
+                    @php $pct = round(($card['configured'] / $card['total']) * 100); @endphp
+                    <div class="coeff-progress-bar-wrap">
+                        <div class="coeff-progress-bar" style="width: {{ $pct }}%"
+                             data-status="{{ $card['status'] }}"></div>
+                    </div>
+                @endif
+
+                {{-- Corps card --}}
                 <div class="coeff-card-body">
                     @if($card['total'] === 0)
                         <div class="coeff-alert coeff-alert-empty">
+                            <i class="fas fa-info-circle me-2"></i>
                             Aucune matière liée à cette combinaison. Ajoutez d'abord les matières dans la classe.
                         </div>
                     @else
                         @if(in_array($card['status'], ['missing', 'partial'], true))
                             <div class="coeff-alert coeff-alert-warning">
+                                <i class="fas fa-exclamation-triangle me-2"></i>
                                 Complétez les coefficients manquants pour activer la génération des bulletins.
                             </div>
                         @endif
+
                         <div class="coeff-grid">
                             @foreach($card['matieres'] as $matiere)
-                                <div class="coeff-row">
-                                    <div>
-                                        <div class="fw-semibold">{{ $matiere['name'] }}</div>
-                                        <div class="text-muted small">{{ $matiere['code'] ?? '—' }}</div>
+                                @php $hasValue = !is_null($matiere['coefficient']) && $matiere['coefficient'] !== ''; @endphp
+                                <div class="coeff-row {{ $hasValue ? 'has-value' : 'missing-value' }}">
+                                    <div class="coeff-matiere-info">
+                                        <div class="coeff-matiere-name" title="{{ $matiere['name'] }}">
+                                            {{ $matiere['name'] }}
+                                        </div>
+                                        @if(!empty($matiere['code']))
+                                            <div class="coeff-matiere-code">{{ $matiere['code'] }}</div>
+                                        @endif
                                     </div>
-                                    <input type="number"
-                                           name="coefficients[{{ $matiere['id'] }}]"
-                                           value="{{ $matiere['coefficient'] }}"
-                                           step="0.1"
-                                           min="0.1"
-                                           placeholder="—"
-                                           class="form-control coeff-input">
+                                    <div class="coeff-input-wrap">
+                                        @if($hasValue)
+                                            <span class="coeff-current-badge">{{ $matiere['coefficient'] }}</span>
+                                        @endif
+                                        <input type="number"
+                                               name="coefficients[{{ $matiere['id'] }}]"
+                                               value="{{ $matiere['coefficient'] }}"
+                                               step="0.1"
+                                               min="0.1"
+                                               placeholder="—"
+                                               class="form-control coeff-input"
+                                               aria-label="Coefficient {{ $matiere['name'] }}">
+                                    </div>
                                 </div>
                             @endforeach
                         </div>
                     @endif
                 </div>
-                <div class="coeff-card-footer">
-                    <button type="submit" class="btn btn-primary btn-sm">
-                        <i class="fas fa-save me-1"></i>Enregistrer
-                    </button>
-                </div>
+
+                {{-- Pied card --}}
+                @if($card['total'] > 0)
+                    <div class="coeff-card-footer">
+                        <div class="coeff-save-feedback d-none">
+                            <i class="fas fa-check-circle text-success me-1"></i>
+                            <span class="text-success small fw-semibold">Enregistré</span>
+                        </div>
+                        <button type="submit" class="btn btn-primary btn-sm coeff-save-btn">
+                            <i class="fas fa-save me-1"></i>Enregistrer
+                        </button>
+                    </div>
+                @endif
             </form>
         @endforeach
     </div>


### PR DESCRIPTION
## Summary
- Refonte complète du design du modal de configuration des coefficients dans `evaluations/index`
- Correction du débordement des labels de matières (text-overflow ellipsis)
- Suppression du double bloc CSS dupliqué et de l'affichage inutile de l'année

## Changes
- `resources/views/esbtp/evaluations/index.blade.php` — Suppression CSS dupliqué, nouveau CSS pour les classes ajoutées (ordinal, barre de progression, badge valeur, coloration contextuelle), JS submit mis à jour avec spinner + feedback inline
- `resources/views/esbtp/evaluations/partials/coefficients-modal.blade.php` — Nouveau layout : numéro ordinal circulaire, barre de progression colorée, bordure gauche par statut, `text-overflow: ellipsis` sur les noms, badge vert valeur actuelle, ligne verte/rouge selon renseignement, "Année universitaire courante" au lieu du nom de l'année

## Type of change
- [x] fix — bug fix
- [x] refactor — no behavior change

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (php -l) on all modified PHP files

Closes #52