### PR TITLE
fix(bulletins): rediriger vers resultats/etudiant après CoefficientMissing + améliorer message bannière

### DIFF
--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -5921,7 +5921,14 @@ class ESBTPBulletinController extends Controller
                 'resultatsData'
             ));
         } catch (\RuntimeException $exception) {
-            return redirect()->route('esbtp.evaluations.index', ['open_coefficients' => 1])
+            $periodeParam = isset($periode) ? str_replace('semestre', '', $periode) : '1';
+            $redirectUrl = route('esbtp.resultats.etudiant', ['etudiant' => $etudiantId])
+                . '?classe_id=' . ($classeId ?? '')
+                . '&annee_universitaire_id=' . ($anneeUniversitaireId ?? '')
+                . '&periode=' . $periodeParam
+                . '&open_coeff_modal=1';
+
+            return redirect($redirectUrl)
                 ->with('error', $exception->getMessage().' Configurez les coefficients avant de continuer.');
         }
     }

--- a/resources/views/esbtp/resultats/partials/student-coefficients-modal.blade.php
+++ b/resources/views/esbtp/resultats/partials/student-coefficients-modal.blade.php
@@ -60,8 +60,8 @@
                             <strong>Matière hors combinaison</strong>
                             <span>{{ $coeffContext['matiere']['name'] ?? 'Matière inconnue' }} n'est pas rattachée à cette combinaison. Ajoutez son coefficient ci-dessous.</span>
                         @else
-                            <strong>Coefficient manquant — bulletin bloqué</strong>
-                            <span>La matière <em>{{ $coeffContext['matiere']['name'] ?? '—' }}</em> n'a pas de coefficient pour cette combinaison filière / niveau.</span>
+                            <strong>Coefficient manquant pour l'année en cours</strong>
+                            <span>La matière <em>{{ $coeffContext['matiere']['name'] ?? '—' }}</em> n'a pas de coefficient pour l'année universitaire actuelle. La valeur pré-remplie vient d'une autre année — cliquez <strong>Enregistrer</strong> pour l'appliquer.</span>
                         @endif
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Corrige la redirection après `CoefficientMissingException` dans `previewMoyennes()` : retourne maintenant vers la page résultats étudiant avec le modal ouvert au lieu de `evaluations.index`
- Améliore le message de la bannière BLOQUANT dans le modal coefficients pour expliquer que la valeur pré-remplie vient d'une autre année et qu'il suffit de cliquer Enregistrer

## Changes
- `app/Http/Controllers/ESBTPBulletinController.php` — catch `RuntimeException` dans `previewMoyennes()` redirige vers `resultats.etudiant?open_coeff_modal=1` avec les paramètres de contexte (classe_id, annee_universitaire_id, periode)
- `resources/views/esbtp/resultats/partials/student-coefficients-modal.blade.php` — message bannière "bloqué" remplacé par "manquant pour l'année en cours, valeur pré-remplie d'une autre année"

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (php -l) on all modified PHP files

closes #55 