### PR TITLE
feat(documents): redesign previews PDF + refonte settings couleurs

### DIFF
--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -956,6 +956,22 @@ class ESBTPBulletinController extends Controller
             // Préparer le logo en base64
             $data['logoBase64'] = $this->prepareLogoBase64($config['school_logo']);
 
+            // Préparer la photo étudiant en base64 pour le PDF
+            $data['photoEtudiantBase64'] = null;
+            if (!empty($data['etudiant']?->photo)) {
+                $photoCandidates = [
+                    storage_path('app/public/photos/etudiants/' . $data['etudiant']->photo),
+                    storage_path('app/public/' . $data['etudiant']->photo),
+                ];
+                foreach ($photoCandidates as $photoPath) {
+                    if (file_exists($photoPath)) {
+                        $mime = mime_content_type($photoPath) ?: 'image/jpeg';
+                        $data['photoEtudiantBase64'] = 'data:' . $mime . ';base64,' . base64_encode(file_get_contents($photoPath));
+                        break;
+                    }
+                }
+            }
+
             try {
                 Log::info('Chargement de la vue PDF avec le template configurable pour le bulletin #'.$bulletin->id);
                 $pdf = PDF::loadView($this->getBulletinTemplateView(), $data);

--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -6,577 +6,283 @@
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 @include('pdf.partials.theme')
 @php
-    $pdfSettings = \App\Helpers\SettingsHelper::getPdfSettings();
-    $pdfHeaderBg = $pdfSettings['header_bg_color'] ?? '#0453cb';
-    $pdfHeaderText = $pdfSettings['header_text_color'] ?? '#ffffff';
-    $pdfText = $pdfSettings['text_color'] ?? '#1f2937';
+    $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
+    $accentColor  = $pdfSettings['header_bg_color']   ?? '#0453cb';
+    $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
+    $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
 @endphp
 <style>
-    .preview-toolbar h4,
-    .preview-toolbar h4 i {
-        color: #1e293b !important;
+    :root {
+        --doc-accent: {{ $accentColor }};
+        --doc-atext:  {{ $accentText }};
+        --doc-body:   {{ $bodyText }};
+        --doc-muted:  #6b7280;
+        --doc-border: #e5e7eb;
+        --doc-radius: 12px;
+        --doc-shadow: 0 1px 3px rgba(0,0,0,.07), 0 6px 24px rgba(0,0,0,.07);
+    }
+    .doc-toolbar {
+        display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap;
+        gap:12px; padding:14px 22px; background:#fff;
+        border:1px solid var(--doc-border); border-radius:var(--doc-radius);
+        margin-bottom:28px; box-shadow:0 1px 4px rgba(0,0,0,.06);
+    }
+    .doc-toolbar-title { font-size:1rem; font-weight:700; color:var(--doc-body); display:flex; align-items:center; gap:8px; }
+    .doc-toolbar-title i { color:var(--doc-accent); }
+    .doc-toolbar-sub { font-size:.78rem; color:var(--doc-muted); margin-top:1px; }
+    .doc-toolbar-btns { display:flex; gap:8px; flex-wrap:wrap; }
+
+    .doc-page-wrap { max-width:820px; margin:0 auto; }
+    .doc-paper {
+        background:#fff; border:1px solid var(--doc-border);
+        border-radius:var(--doc-radius); box-shadow:var(--doc-shadow);
+        overflow:hidden; position:relative;
+    }
+    .doc-watermark {
+        position:absolute; top:50%; left:50%; transform:translate(-50%,-50%);
+        opacity:.05; width:55%; z-index:0; pointer-events:none; text-align:center;
+    }
+    .doc-watermark img { max-width:100%; }
+    .doc-inner { position:relative; z-index:1; padding:36px 42px 32px; }
+
+    /* Header établissement */
+    .doc-header {
+        background:var(--doc-accent); color:var(--doc-atext);
+        border-radius:10px; padding:20px 24px;
+        display:flex; align-items:center; gap:18px;
+        position:relative; overflow:hidden;
+    }
+    .doc-header::after {
+        content:''; position:absolute; bottom:-28px; right:-28px;
+        width:110px; height:110px; border-radius:50%;
+        background:rgba(255,255,255,.08); pointer-events:none;
+    }
+    .doc-header-logo img { height:52px; filter:brightness(0) invert(1); }
+    .doc-header-info { flex:1; }
+    .doc-school-name {
+        font-size:1.1rem; font-weight:800; text-transform:uppercase;
+        color:var(--doc-atext); letter-spacing:.02em; margin-bottom:4px;
+    }
+    .doc-school-meta { font-size:.78rem; opacity:.82; line-height:1.55; color:var(--doc-atext); }
+
+    .doc-divider {
+        height:3px;
+        background:linear-gradient(90deg, var(--doc-accent) 0%, color-mix(in srgb, var(--doc-accent) 20%, transparent) 100%);
+        border-radius:2px; margin:20px 0;
     }
 
-    .preview-toolbar small,
-    .preview-toolbar .text-muted {
-        color: #64748b !important;
+    .doc-title-wrap { text-align:center; margin:0 0 28px; }
+    .doc-title {
+        display:inline-block; font-size:1.3rem; font-weight:800;
+        text-transform:uppercase; letter-spacing:.12em; color:var(--doc-accent);
+        border-bottom:3px solid var(--doc-accent); padding-bottom:6px;
     }
 
-    .preview-toolbar {
-        background: var(--surface) !important;
-        border-color: var(--border) !important;
+    /* Alerte workflow */
+    .doc-alert {
+        background:#fffbeb; border-left:4px solid #f59e0b;
+        border-radius:8px; padding:12px 16px; margin-bottom:20px;
+        font-size:.84rem; color:#92400e;
     }
-    .preview-container {
-        max-width: 900px;
-        margin: 0 auto;
-        background: white;
-    }
-    
-    .preview-toolbar {
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: var(--radius-medium);
-        padding: var(--space-md);
-        margin-bottom: var(--space-lg);
-        display: flex;
-        justify-content: between;
-        align-items: center;
-        gap: var(--space-md);
-    }
-    
-    .preview-actions {
-        display: flex;
-        gap: var(--space-sm);
-        margin-left: auto;
-    }
-    
-    .preview-content {
-        border: 1px solid #ddd;
-        border-radius: var(--radius-medium);
-        box-shadow: var(--shadow-card);
-        padding: 0;
-        background: white;
-        min-height: 800px;
+    .doc-alert strong { color:#78350f; }
+
+    /* Corps */
+    .doc-body { font-size:.92rem; line-height:1.85; color:var(--doc-body); text-align:justify; }
+    .doc-body p { margin-bottom:14px; }
+    .doc-hl {
+        font-weight:700; color:var(--doc-accent);
+        border-bottom:1px solid color-mix(in srgb, var(--doc-accent) 40%, transparent);
     }
 
-    .preview-content .document-watermark {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        opacity: 0.08;
-        width: 60%;
-        z-index: 0;
-        text-align: center;
+    /* Bloc infos étudiant (fond accent) */
+    .doc-student-block {
+        background: color-mix(in srgb, var(--doc-accent) 8%, white);
+        border-left:4px solid var(--doc-accent);
+        border-radius:8px; padding:16px 20px; margin:16px 0;
+    }
+    .doc-student-row {
+        display:flex; align-items:baseline; gap:8px;
+        margin-bottom:8px; font-size:.88rem;
+    }
+    .doc-student-row:last-child { margin-bottom:0; }
+    .doc-student-lbl {
+        font-weight:700; color:var(--doc-accent); min-width:200px; flex-shrink:0;
+    }
+    .doc-student-val { color:var(--doc-body); }
+
+    /* Bloc statut */
+    .doc-status-block {
+        background:#f8fafc; border:1px solid var(--doc-border);
+        border-radius:8px; padding:12px 20px; margin:16px 0;
+        text-align:center; font-size:.86rem; font-style:italic;
+        color:var(--doc-muted);
+    }
+    .doc-status-block strong { color:var(--doc-body); }
+
+    /* Footer */
+    .doc-footer {
+        display:flex; justify-content:space-between; align-items:flex-end;
+        margin-top:40px; gap:20px;
+    }
+    .doc-date { font-style:italic; font-size:.85rem; color:var(--doc-muted); }
+    .doc-signature {
+        text-align:right; border-top:2px solid var(--doc-accent);
+        padding-top:12px; min-width:200px;
+    }
+    .doc-sig-title { font-weight:700; color:var(--doc-accent); font-size:.88rem; margin-bottom:8px; }
+    .doc-sig-name  { font-style:italic; color:var(--doc-muted); font-size:.84rem; margin-top:24px; }
+    .doc-sig-note  { text-align:center; font-size:.73rem; font-style:italic; color:var(--doc-muted); margin:16px 0; }
+
+    .doc-note {
+        margin-top:16px; text-align:center; font-size:.73rem;
+        font-style:italic; color:var(--doc-muted);
+        border-top:1px solid var(--doc-border); padding-top:12px;
     }
 
-    .preview-content .document-watermark img {
-        max-width: 100%;
-    }
-
-    .preview-content .document-content {
-        position: relative;
-        z-index: 1;
-    }
-
-    .certificat-document {
-        color: {{ $pdfText }};
-    }
-
-    .certificat-header,
-    .certificat-school-name,
-    .certificat-address {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-divider {
-        background-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-title {
-        background-color: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-highlight,
-    .signature-title,
-    .certificat-signature {
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .detail-label {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .detail-value {
-        color: {{ $pdfText }} !important;
-    }
-
-    .student-details {
-        background-color: {{ $pdfHeaderBg }} !important;
-        border-left-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .signature-name {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    /* Modern administrative look (preview) */
-    .certificat-header {
-        background: {{ $pdfHeaderBg }};
-        color: {{ $pdfHeaderText }};
-        border-radius: 12px;
-        padding: 18px 20px;
-        border-bottom: none;
-    }
-
-    .certificat-school-name,
-    .certificat-address {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-title {
-        background: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-        border-radius: 12px;
-        font-size: 22px;
-        letter-spacing: 0.5px;
-    }
-
-    .certificat-divider {
-        height: 2px;
-        background: {{ $pdfHeaderText }};
-    }
-
-    /* Final overrides to match PDF theme */
-    .certificat-document,
-    .certificat-header,
-    .certificat-school-name,
-    .certificat-address,
-    .certificat-title,
-    .certificat-highlight,
-    .signature-title,
-    .signature-name,
-    .detail-label {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-title {
-        background-color: {{ $pdfHeaderBg }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-divider {
-        background-color: {{ $pdfHeaderText }} !important;
-    }
-    
-    /* Styles pour l'attestation - similaires au certificat */
-    .certificat-document {
-        font-family: Arial, sans-serif;
-        font-size: 14px;
-        line-height: 1.6;
-        color: #333;
-        padding: 30px;
-        max-width: 750px;
-        margin: 0 auto;
-    }
-    
-    .certificat-header {
-        text-align: center;
-        margin-bottom: 30px;
-        border-bottom: 3px solid var(--primary);
-        padding-bottom: 20px;
-    }
-    
-    .certificat-logo {
-        max-width: 100px;
-        margin-bottom: 15px;
-    }
-    
-    .certificat-school-name {
-        font-size: 18px;
-        font-weight: bold;
-        margin-bottom: 8px;
-        text-transform: uppercase;
-        color: {{ $pdfHeaderText }};
-    }
-    
-    .certificat-address {
-        font-size: 12px;
-        color: {{ $pdfHeaderText }};
-        margin-bottom: 5px;
-    }
-    
-    .certificat-divider {
-        height: 6px;
-        background: {{ $pdfHeaderText }};
-        margin: 20px 0;
-    }
-    
-    .certificat-title {
-        font-size: 28px;
-        font-weight: bold;
-        text-align: center;
-        border: 3px double {{ $pdfHeaderText }};
-        border-radius: 10px;
-        padding: 15px;
-        margin: 30px auto;
-        max-width: 90%;
-        background: {{ $pdfHeaderBg }};
-        position: relative;
-        text-transform: uppercase;
-        color: {{ $pdfHeaderText }};
-    }
-    
-    .certificat-title::before {
-        border: 1px solid {{ $pdfHeaderText }};
-    }
-    
-    .certificat-content {
-        margin: 30px 0;
-        line-height: 1.8;
-        font-size: 16px;
-        text-align: justify;
-    }
-    
-    .certificat-content p {
-        margin-bottom: 15px;
-    }
-    
-    .certificat-highlight {
-        font-weight: bold;
-        color: {{ $pdfHeaderText }};
-        text-decoration: underline;
-    }
-
-    .student-info {
-        margin: 20px 0;
-        line-height: 1.8;
-    }
-
-    .student-details {
-        margin: 15px 0;
-        padding: 15px;
-        background-color: {{ $pdfHeaderBg }};
-        border-left: 4px solid {{ $pdfHeaderText }};
-        border-radius: var(--radius-small);
-    }
-
-    .detail-row {
-        margin-bottom: 10px;
-        display: flex;
-        align-items: flex-start;
-    }
-
-    .detail-label {
-        font-weight: bold;
-        min-width: 200px;
-        color: {{ $pdfHeaderText }};
-    }
-
-    .detail-value {
-        flex: 1;
-        color: {{ $pdfText }};
-    }
-
-    .status-options {
-        margin: 15px 0;
-        font-style: italic;
-        font-size: 14px;
-        background-color: #fff3cd;
-        border: 1px solid #ffeaa7;
-        border-radius: var(--radius-small);
-        padding: 10px;
-        text-align: center;
-    }
-    
-    .certificat-footer {
-        margin-top: 50px;
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-end;
-    }
-    
-    .certificat-date {
-        flex: 1;
-        text-align: left;
-        font-style: italic;
-        color: var(--text-secondary);
-    }
-    
-    .certificat-signature {
-        flex: 1;
-        text-align: right;
-        border-top: 2px solid var(--primary);
-        padding-top: 15px;
-        min-height: 80px;
-    }
-    
-    .signature-title {
-        font-weight: bold;
-        margin-bottom: 10px;
-        color: var(--primary);
-    }
-    
-    .signature-name {
-        color: var(--text-secondary);
-        font-style: italic;
-        margin-top: 20px;
-    }
-
-    .signature-note {
-        text-align: center;
-        font-size: 12px;
-        font-style: italic;
-        color: var(--text-secondary);
-        margin: 15px 0;
-    }
-    
-    .certificat-note {
-        margin-top: 40px;
-        text-align: center;
-        font-size: 11px;
-        font-style: italic;
-        color: var(--text-secondary);
-        border-top: 1px solid #ddd;
-        padding-top: 15px;
-    }
-    
     @media print {
-        .preview-toolbar {
-            display: none;
-        }
-        
-        .preview-content {
-            border: none;
-            box-shadow: none;
-        }
-        
-        .certificat-document {
-            padding: 0;
-        }
-    }
-
-    /* Overrides PDF theme for document area */
-    .certificat-document {
-        color: {{ $pdfText }} !important;
-        --primary: {{ $pdfHeaderText }};
-        --text-secondary: {{ $pdfText }};
-        --text: {{ $pdfText }};
-    }
-
-    .certificat-header,
-    .certificat-school-name,
-    .certificat-address {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-divider {
-        background-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-title {
-        background-color: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-highlight,
-    .signature-title,
-    .certificat-signature,
-    .signature-name,
-    .detail-label {
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .detail-value {
-        color: {{ $pdfText }} !important;
-    }
-
-    .student-details {
-        background-color: {{ $pdfHeaderBg }} !important;
-        border-left-color: {{ $pdfHeaderText }} !important;
+        .doc-toolbar, .no-print { display:none !important; }
+        .doc-paper { box-shadow:none; border:none; }
+        .doc-page-wrap { max-width:100%; }
+        .doc-inner { padding:20px; }
     }
 </style>
 @endsection
 
 @section('content')
 <div class="dashboard-acasi">
-    <div class="main-content">
-        <div class="preview-container">
-            <!-- Barre d'outils de prévisualisation -->
-            <div class="preview-toolbar">
-                <div class="toolbar-info">
-                    <h4 class="mb-0">
-                        <i class="fas fa-eye me-2"></i>
-                        Prévisualisation Attestation de Fréquentation
-                    </h4>
-                    <small class="text-muted">{{ $etudiant->nom }} {{ $etudiant->prenoms }} - {{ $etudiant->matricule }}</small>
-                </div>
-                
-                <div class="preview-actions">
-                    <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}" class="btn-acasi secondary">
-                        <i class="fas fa-arrow-left me-1"></i>Retour
-                    </a>
-                    
-                    <a href="{{ route('esbtp.etudiants.attestation-frequentation', $etudiant->id) }}" class="btn-acasi success">
-                        <i class="fas fa-file-pdf me-1"></i>Générer PDF
-                    </a>
-                    
-                    <button onclick="window.print()" class="btn-acasi info">
-                        <i class="fas fa-print me-1"></i>Imprimer
-                    </button>
-                </div>
-            </div>
+<div class="main-content">
 
-            <!-- Contenu de l'attestation -->
-            <div class="preview-content">
-                <div class="certificat-document" style="position: relative;">
-                    @if(!empty($settings['logo_base64']))
-                        <div class="document-watermark">
-                            <img src="{{ $settings['logo_base64'] }}" alt="Filigrane logo">
-                        </div>
-                    @endif
+<div class="doc-toolbar no-print">
+    <div>
+        <div class="doc-toolbar-title"><i class="fas fa-eye"></i>Prévisualisation Attestation de Fréquentation</div>
+        <div class="doc-toolbar-sub">{{ $etudiant->nom }} {{ $etudiant->prenoms }} — {{ $etudiant->matricule }}</div>
+    </div>
+    <div class="doc-toolbar-btns">
+        <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}" class="btn-acasi secondary">
+            <i class="fas fa-arrow-left me-1"></i>Retour
+        </a>
+        <a href="{{ route('esbtp.etudiants.attestation-frequentation', $etudiant->id) }}" class="btn-acasi success">
+            <i class="fas fa-file-pdf me-1"></i>Générer PDF
+        </a>
+        <button onclick="window.print()" class="btn-acasi info">
+            <i class="fas fa-print me-1"></i>Imprimer
+        </button>
+    </div>
+</div>
 
-                    <div class="document-content">
-                    <!-- En-tête -->
-                    <div class="certificat-header">
-                        @if(!empty($settings['show_logo']) && !empty($settings['logo_base64']))
-                            <img src="{{ $settings['logo_base64'] }}" alt="Logo École" class="certificat-logo">
-                        @endif
-                        
-                        <div class="certificat-school-name">{{ $settings['name'] ?? '' }}</div>
-                        
-                        @if(!empty($settings['address']))
-                            <div class="certificat-address">{{ $settings['address'] }}</div>
-                        @endif
-                        @if(!empty($settings['phone']) || !empty($settings['email']))
-                            <div class="certificat-address">
-                                @if(!empty($settings['phone']))Tél: {{ $settings['phone'] }}@endif
-                                @if(!empty($settings['phone']) && !empty($settings['email'])) - @endif
-                                @if(!empty($settings['email']))Email: {{ $settings['email'] }}@endif
-                            </div>
-                        @endif
-                    </div>
+<div class="doc-page-wrap">
+<div class="doc-paper">
+    @if(!empty($settings['logo_base64']))
+    <div class="doc-watermark"><img src="{{ $settings['logo_base64'] }}" alt=""></div>
+    @endif
 
-                    <!-- Séparateur décoratif -->
-                    <div class="certificat-divider"></div>
-
-                    <!-- Titre -->
-                    <div class="certificat-title">
-                        Attestation de Fréquentation
-                    </div>
-
-                    {{-- Alerte workflow --}}
-                    @if(!empty($alerteWorkflow))
-                    <div style="background:#fff3cd;border-left:4px solid #f59e0b;padding:10px 14px;margin:10px 0;border-radius:6px;font-size:13px;">
-                        <strong>⚠️ Attention :</strong> Aucune inscription active et finalisée trouvée pour cet étudiant.
-                        Veuillez <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}">valider et finaliser l'inscription</a> (étape "Étudiant créé") avant de générer l'attestation.
-                    </div>
-                    @endif
-
-                    <!-- Contenu principal -->
-                    <div class="certificat-content">
-                        <p>
-                        Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, atteste que :
-                    </p>
-
-                        <div class="student-info">
-                            <p>
-                                {{ $etudiant->sexe === 'F' ? 'Mme, M., Mlle' : 'M.' }} <span class="certificat-highlight">{{ strtoupper($etudiant->nom) }} {{ strtoupper($etudiant->prenoms) }}</span>
-                            </p>
-
-                            @if($etudiant->date_naissance)
-                            <p>
-                                Né(e) le <span class="certificat-highlight">{{ $etudiant->date_naissance->format('d/m/Y') }}</span>
-                                @if($etudiant->lieu_naissance) 
-                                    à <span class="certificat-highlight">{{ strtoupper($etudiant->lieu_naissance) }}</span>
-                                @endif
-                            </p>
-                            @endif
-                        </div>
-
-                        <p>
-                            Est régulièrement inscrit(e) au titre de l'année scolaire <span class="certificat-highlight">
-                            @php
-                                $anneeText = $inscription->anneeUniversitaire->name ?? $inscription->anneeUniversitaire->nom ?? $inscription->anneeUniversitaire->libelle ?? '';
-                                if (preg_match('/(\d{4}-\d{4})/', $anneeText, $matches)) {
-                                    echo $matches[1];
-                                } else {
-                                    echo $anneeText;
-                                }
-                            @endphp
-                            </span>
-                        </p>
-
-                        <div class="student-details">
-                            <div class="detail-row">
-                                <div class="detail-label">En classe de :</div>
-                                <div class="detail-value">{{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? 'Non renseigné') }}</div>
-                            </div>
-
-                            <div class="detail-row">
-                                <div class="detail-label">Filière :</div>
-                                <div class="detail-value">{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</div>
-                            </div>
-
-                            <div class="detail-row">
-                                <div class="detail-label">Sous le numéro Matricule :</div>
-                                <div class="detail-value">{{ $etudiant->numero_etudiant ?? $etudiant->matricule }}</div>
-                            </div>
-                        </div>
-
-                        <div class="status-options">
-                            <p><strong>Statut* :</strong> Affecté / Non affecté &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <strong>Boursier* :</strong> Oui / Non</p>
-                        </div>
-
-                        <p>
-                            En foi de quoi, la présente attestation lui est délivrée pour servir et valoir ce que de droit.
-                        </p>
-                    </div>
-
-                    <!-- Footer avec signature -->
-                    <div class="certificat-footer">
-                        <div class="certificat-date">
-                        <p>Fait à {{ $settings['city'] ?? '' }}, le {{ now()->format('d/m/Y') }}</p>
-                        </div>
-
-                        <div class="certificat-signature">
-                        <div class="signature-title">{{ $settings['director_title'] ?? '' }}</div>
-                        @if(!empty($settings['director_name']))
-                            <div class="signature-name">{{ $settings['director_name'] }}</div>
-                        @endif
-                        </div>
-                    </div>
-
-                    <div class="signature-note">
-                        *Rayer la mention inutile
-                    </div>
-
-                    <!-- Note de bas de page -->
-                    <div class="certificat-note">
-                        Ce document est un certificat officiel. Toute falsification constitue un délit passible de poursuites judiciaires.
-                    </div>
+    <div class="doc-inner">
+        <div class="doc-header">
+            @if(!empty($settings['show_logo']) && !empty($settings['logo_base64']))
+            <div class="doc-header-logo"><img src="{{ $settings['logo_base64'] }}" alt="Logo"></div>
+            @endif
+            <div class="doc-header-info">
+                <div class="doc-school-name">{{ $settings['name'] ?? '' }}</div>
+                <div class="doc-school-meta">
+                    @if(!empty($settings['address'])){{ $settings['address'] }}@endif
+                    @if(!empty($settings['phone'])) &nbsp;·&nbsp; Tél: {{ $settings['phone'] }}@endif
+                    @if(!empty($settings['email'])) &nbsp;·&nbsp; {{ $settings['email'] }}@endif
                 </div>
             </div>
         </div>
+
+        <div class="doc-divider"></div>
+
+        <div class="doc-title-wrap">
+            <span class="doc-title">Attestation de Fréquentation</span>
+        </div>
+
+        {{-- Alerte workflow si inscription non finalisée --}}
+        @if(!empty($alerteWorkflow))
+        <div class="doc-alert">
+            <strong>⚠️ Attention :</strong> Aucune inscription active et finalisée trouvée pour cet étudiant.
+            Veuillez <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}" style="color:var(--doc-accent);">valider et finaliser l'inscription</a>
+            (étape "Étudiant créé") avant de générer l'attestation.
+        </div>
+        @endif
+
+        <div class="doc-body">
+            <p>Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, atteste que&nbsp;:</p>
+
+            <p>
+                {{ $etudiant->sexe === 'F' ? 'Mme / M. / Mlle' : 'M.' }}
+                <span class="doc-hl">{{ strtoupper($etudiant->nom) }} {{ strtoupper($etudiant->prenoms) }}</span>
+            </p>
+
+            @if($etudiant->date_naissance)
+            <p>
+                Né(e) le <span class="doc-hl">{{ $etudiant->date_naissance->format('d/m/Y') }}</span>
+                @if($etudiant->lieu_naissance) à <span class="doc-hl">{{ strtoupper($etudiant->lieu_naissance) }}</span>@endif
+            </p>
+            @endif
+
+            <p>
+                Est régulièrement inscrit(e) au titre de l'année scolaire
+                <span class="doc-hl">
+                @php
+                    $anneeText = $inscription->anneeUniversitaire->name
+                        ?? $inscription->anneeUniversitaire->nom
+                        ?? $inscription->anneeUniversitaire->libelle ?? '';
+                    echo preg_match('/(\d{4}-\d{4})/', $anneeText, $m) ? $m[1] : $anneeText;
+                @endphp
+                </span>
+            </p>
+
+            <div class="doc-student-block">
+                <div class="doc-student-row">
+                    <span class="doc-student-lbl">En classe de&nbsp;:</span>
+                    <span class="doc-student-val">{{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? 'Non renseigné') }}</span>
+                </div>
+                <div class="doc-student-row">
+                    <span class="doc-student-lbl">Filière&nbsp;:</span>
+                    <span class="doc-student-val">{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</span>
+                </div>
+                <div class="doc-student-row">
+                    <span class="doc-student-lbl">Sous le numéro Matricule&nbsp;:</span>
+                    <span class="doc-student-val">{{ $etudiant->numero_etudiant ?? $etudiant->matricule }}</span>
+                </div>
+            </div>
+
+            <div class="doc-status-block">
+                <strong>Statut* :</strong> Affecté / Non affecté
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                <strong>Boursier* :</strong> Oui / Non
+            </div>
+
+            <p>En foi de quoi, la présente attestation lui est délivrée pour servir et valoir ce que de droit.</p>
+        </div>
+
+        <div class="doc-footer">
+            <div class="doc-date">Fait à {{ $settings['city'] ?? '' }}, le {{ now()->format('d/m/Y') }}</div>
+            <div class="doc-signature">
+                <div class="doc-sig-title">{{ $settings['director_title'] ?? '' }}</div>
+                @if(!empty($settings['director_name']))
+                <div class="doc-sig-name">{{ $settings['director_name'] }}</div>
+                @endif
+            </div>
+        </div>
+
+        <div class="doc-sig-note">*Rayer la mention inutile</div>
+
+        <div class="doc-note">
+            Ce document est un certificat officiel. Toute falsification constitue un délit passible de poursuites judiciaires.
+        </div>
     </div>
+</div>
+</div>
+
+</div>
 </div>
 @endsection
 
 @push('scripts')
 <script>
-// Gérer l'impression
-window.addEventListener('beforeprint', function() {
-    document.body.classList.add('printing');
-});
-
-window.addEventListener('afterprint', function() {
-    document.body.classList.remove('printing');
-});
+window.addEventListener('beforeprint', () => document.body.classList.add('printing'));
+window.addEventListener('afterprint',  () => document.body.classList.remove('printing'));
 </script>
 @endpush

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -6,569 +6,251 @@
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 @include('pdf.partials.theme')
 @php
-    $pdfSettings = \App\Helpers\SettingsHelper::getPdfSettings();
-    $pdfHeaderBg = $pdfSettings['header_bg_color'] ?? '#0453cb';
-    $pdfHeaderText = $pdfSettings['header_text_color'] ?? '#ffffff';
-    $pdfText = $pdfSettings['text_color'] ?? '#1f2937';
+    $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
+    $accentColor  = $pdfSettings['header_bg_color']   ?? '#0453cb';
+    $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
+    $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
 @endphp
 <style>
-    .preview-toolbar h4,
-    .preview-toolbar h4 i {
-        color: #1e293b !important;
+    :root {
+        --doc-accent: {{ $accentColor }};
+        --doc-atext:  {{ $accentText }};
+        --doc-body:   {{ $bodyText }};
+        --doc-muted:  #6b7280;
+        --doc-border: #e5e7eb;
+        --doc-radius: 12px;
+        --doc-shadow: 0 1px 3px rgba(0,0,0,.07), 0 6px 24px rgba(0,0,0,.07);
+    }
+    .doc-toolbar {
+        display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap;
+        gap:12px; padding:14px 22px; background:#fff;
+        border:1px solid var(--doc-border); border-radius:var(--doc-radius);
+        margin-bottom:28px; box-shadow:0 1px 4px rgba(0,0,0,.06);
+    }
+    .doc-toolbar-title { font-size:1rem; font-weight:700; color:var(--doc-body); display:flex; align-items:center; gap:8px; }
+    .doc-toolbar-title i { color:var(--doc-accent); }
+    .doc-toolbar-sub { font-size:.78rem; color:var(--doc-muted); margin-top:1px; }
+    .doc-toolbar-btns { display:flex; gap:8px; flex-wrap:wrap; }
+
+    .doc-page-wrap { max-width:820px; margin:0 auto; }
+    .doc-paper {
+        background:#fff; border:1px solid var(--doc-border);
+        border-radius:var(--doc-radius); box-shadow:var(--doc-shadow);
+        overflow:hidden; position:relative;
+    }
+    .doc-watermark {
+        position:absolute; top:50%; left:50%; transform:translate(-50%,-50%);
+        opacity:.05; width:55%; z-index:0; pointer-events:none; text-align:center;
+    }
+    .doc-watermark img { max-width:100%; }
+    .doc-inner { position:relative; z-index:1; padding:36px 42px 32px; }
+
+    /* Header établissement */
+    .doc-header {
+        background:var(--doc-accent); color:var(--doc-atext);
+        border-radius:10px; padding:20px 24px;
+        display:flex; align-items:center; gap:18px;
+        position:relative; overflow:hidden;
+    }
+    .doc-header::after {
+        content:''; position:absolute; bottom:-28px; right:-28px;
+        width:110px; height:110px; border-radius:50%;
+        background:rgba(255,255,255,.08); pointer-events:none;
+    }
+    .doc-header-logo img { height:52px; filter:brightness(0) invert(1); }
+    .doc-header-info { flex:1; }
+    .doc-school-name {
+        font-size:1.1rem; font-weight:800; text-transform:uppercase;
+        color:var(--doc-atext); letter-spacing:.02em; margin-bottom:4px;
+    }
+    .doc-school-meta { font-size:.78rem; opacity:.82; line-height:1.55; color:var(--doc-atext); }
+
+    /* Diviseur */
+    .doc-divider {
+        height:3px;
+        background:linear-gradient(90deg, var(--doc-accent) 0%, color-mix(in srgb, var(--doc-accent) 20%, transparent) 100%);
+        border-radius:2px; margin:20px 0;
     }
 
-    .preview-toolbar small,
-    .preview-toolbar .text-muted {
-        color: #64748b !important;
+    /* Titre document */
+    .doc-title-wrap { text-align:center; margin:0 0 28px; }
+    .doc-title {
+        display:inline-block; font-size:1.3rem; font-weight:800;
+        text-transform:uppercase; letter-spacing:.12em; color:var(--doc-accent);
+        border-bottom:3px solid var(--doc-accent); padding-bottom:6px;
     }
 
-    .preview-toolbar {
-        background: var(--surface) !important;
-        border-color: var(--border) !important;
-    }
-    .preview-container {
-        max-width: 900px;
-        margin: 0 auto;
-        background: white;
-    }
-    
-    .preview-toolbar {
-        background: var(--surface);
-        border: 1px solid var(--border);
-        border-radius: var(--radius-medium);
-        padding: var(--space-md);
-        margin-bottom: var(--space-lg);
-        display: flex;
-        justify-content: between;
-        align-items: center;
-        gap: var(--space-md);
-    }
-    
-    .preview-actions {
-        display: flex;
-        gap: var(--space-sm);
-        margin-left: auto;
-    }
-    
-    .preview-content {
-        border: 1px solid #ddd;
-        border-radius: var(--radius-medium);
-        box-shadow: var(--shadow-card);
-        padding: 0;
-        background: white;
-        min-height: 800px;
+    /* Corps */
+    .doc-body { font-size:.92rem; line-height:1.85; color:var(--doc-body); text-align:justify; }
+    .doc-body p { margin-bottom:14px; }
+    .doc-hl {
+        font-weight:700; color:var(--doc-accent);
+        border-bottom:1px solid color-mix(in srgb, var(--doc-accent) 40%, transparent);
     }
 
-    .preview-content .document-watermark {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        opacity: 0.08;
-        width: 60%;
-        z-index: 0;
-        text-align: center;
+    /* Table */
+    .doc-table { width:100%; border-collapse:collapse; font-size:.84rem; margin:18px 0 6px; }
+    .doc-table thead th {
+        background:var(--doc-accent); color:var(--doc-atext);
+        padding:9px 12px; font-weight:700; font-size:.73rem;
+        letter-spacing:.07em; text-transform:uppercase; border:none; text-align:center;
+    }
+    .doc-table thead th:first-child { border-radius:8px 0 0 0; }
+    .doc-table thead th:last-child  { border-radius:0 8px 0 0; }
+    .doc-table tbody tr { border-bottom:1px solid var(--doc-border); }
+    .doc-table tbody tr:last-child { border-bottom:none; }
+    .doc-table tbody td { padding:9px 12px; text-align:center; color:var(--doc-body); }
+
+    /* Footer */
+    .doc-footer {
+        display:flex; justify-content:space-between; align-items:flex-end;
+        margin-top:40px; gap:20px;
+    }
+    .doc-date { font-style:italic; font-size:.85rem; color:var(--doc-muted); }
+    .doc-signature {
+        text-align:right; border-top:2px solid var(--doc-accent);
+        padding-top:12px; min-width:200px;
+    }
+    .doc-sig-title { font-weight:700; color:var(--doc-accent); font-size:.88rem; margin-bottom:8px; }
+    .doc-sig-name  { font-style:italic; color:var(--doc-muted); font-size:.84rem; margin-top:24px; }
+
+    .doc-note {
+        margin-top:28px; text-align:center; font-size:.73rem;
+        font-style:italic; color:var(--doc-muted);
+        border-top:1px solid var(--doc-border); padding-top:12px;
     }
 
-    .preview-content .document-watermark img {
-        max-width: 100%;
-    }
-
-    .preview-content .document-content {
-        position: relative;
-        z-index: 1;
-    }
-
-    .certificat-document {
-        color: {{ $pdfText }};
-    }
-
-    .certificat-header,
-    .certificat-school-name,
-    .certificat-address {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-divider {
-        background-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-title {
-        background-color: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-highlight,
-    .signature-title,
-    .certificat-signature {
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-content table thead th {
-        background-color: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-content table td {
-        color: {{ $pdfText }} !important;
-        background: transparent !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-    
-    /* Styles pour le certificat - similaires au PDF mais adaptés pour l'affichage HTML */
-    .certificat-document {
-        font-family: Arial, sans-serif;
-        font-size: 14px;
-        line-height: 1.6;
-        color: {{ $pdfText }} !important;
-        padding: 30px;
-        max-width: 750px;
-        margin: 0 auto;
-        box-sizing: border-box;
-    }
-    
-    .certificat-header {
-        text-align: center;
-        margin-bottom: 30px;
-        border-bottom: 3px solid {{ $pdfHeaderText }};
-        padding-bottom: 20px;
-    }
-    
-    .certificat-logo {
-        max-width: 100px;
-        margin-bottom: 15px;
-    }
-    
-    .certificat-school-name {
-        font-size: 18px;
-        font-weight: bold;
-        margin-bottom: 8px;
-        text-transform: uppercase;
-        color: {{ $pdfHeaderText }} !important;
-    }
-    
-    .certificat-address {
-        font-size: 12px;
-        color: {{ $pdfHeaderText }} !important;
-        margin-bottom: 5px;
-    }
-    
-    .certificat-divider {
-        height: 6px;
-        background: {{ $pdfHeaderText }};
-        margin: 20px 0;
-    }
-    
-    .certificat-title {
-        font-size: 28px;
-        font-weight: bold;
-        text-align: center;
-        border: 3px double {{ $pdfHeaderText }};
-        border-radius: 10px;
-        padding: 15px;
-        margin: 30px auto;
-        max-width: 90%;
-        background: {{ $pdfHeaderBg }};
-        position: relative;
-        text-transform: uppercase;
-        color: {{ $pdfHeaderText }};
-    }
-    
-    .certificat-title::before {
-        border: 1px solid {{ $pdfHeaderText }};
-    }
-    
-    .certificat-content {
-        margin: 30px 0;
-        line-height: 1.8;
-        font-size: 16px;
-        text-align: justify;
-    }
-    
-    .certificat-content p {
-        margin-bottom: 15px;
-    }
-    
-    .certificat-highlight {
-        font-weight: bold;
-        color: {{ $pdfHeaderText }};
-        text-decoration: underline;
-    }
-    
-    .certificat-footer {
-        margin-top: 50px;
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-end;
-    }
-    
-    .certificat-date {
-        flex: 1;
-        text-align: left;
-        font-style: italic;
-        color: {{ $pdfText }};
-    }
-    
-    .certificat-signature {
-        flex: 1;
-        text-align: right;
-        border-top: 2px solid {{ $pdfHeaderText }};
-        padding-top: 15px;
-        min-height: 80px;
-    }
-    
-    .signature-title {
-        font-weight: bold;
-        margin-bottom: 10px;
-        color: {{ $pdfHeaderText }};
-    }
-    
-    .signature-name {
-        color: {{ $pdfHeaderText }};
-        font-style: italic;
-    }
-    
-    .certificat-note {
-        margin-top: 40px;
-        text-align: center;
-        font-size: 11px;
-        font-style: italic;
-        color: {{ $pdfText }};
-        border-top: 1px solid {{ $pdfHeaderText }};
-        padding-top: 15px;
-    }
-
-    .certificat-content table {
-        width: 100%;
-        table-layout: fixed;
-    }
-
-    .certificat-content table th,
-    .certificat-content table td {
-        word-wrap: break-word;
-        overflow-wrap: break-word;
-    }
-    
     @media print {
-        .preview-toolbar {
-            display: none;
-        }
-        
-        .preview-content {
-            border: none;
-            box-shadow: none;
-        }
-        
-        .certificat-document {
-            padding: 0;
-        }
-    }
-
-    /* Overrides PDF theme for document area */
-    .certificat-document {
-        color: {{ $pdfText }} !important;
-        --primary: {{ $pdfHeaderText }};
-        --text-secondary: {{ $pdfText }};
-        --text: {{ $pdfText }};
-    }
-
-    .certificat-header,
-    .certificat-school-name,
-    .certificat-address {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-divider {
-        background-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-title {
-        background-color: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-highlight,
-    .signature-title,
-    .certificat-signature,
-    .signature-name {
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-content table {
-        width: 100% !important;
-        table-layout: fixed;
-    }
-
-    .certificat-content table th,
-    .certificat-content table td {
-        word-wrap: break-word;
-        overflow-wrap: break-word;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-content table thead th {
-        background-color: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-content table tbody td {
-        color: {{ $pdfText }} !important;
-        background: transparent !important;
-    }
-
-    /* Modern administrative look (preview) */
-    .certificat-header {
-        background: {{ $pdfHeaderBg }};
-        color: {{ $pdfHeaderText }};
-        border-radius: 12px;
-        padding: 18px 20px;
-        border-bottom: none;
-    }
-
-    .certificat-school-name,
-    .certificat-address {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-title {
-        background: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-        border-radius: 12px;
-        font-size: 22px;
-        letter-spacing: 0.5px;
-    }
-
-    .certificat-divider {
-        height: 2px;
-        background: {{ $pdfHeaderText }};
-    }
-
-    .certificat-content table th {
-        background: {{ $pdfHeaderBg }} !important;
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    /* Final overrides to match PDF theme */
-    .certificat-header,
-    .certificat-school-name,
-    .certificat-address,
-    .certificat-title,
-    .certificat-highlight,
-    .signature-title,
-    .signature-name {
-        color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-title {
-        background-color: {{ $pdfHeaderBg }} !important;
-        border-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-divider {
-        background-color: {{ $pdfHeaderText }} !important;
-    }
-
-    .certificat-content {
-        color: {{ $pdfText }} !important;
+        .doc-toolbar, .no-print { display:none !important; }
+        .doc-paper { box-shadow:none; border:none; }
+        .doc-page-wrap { max-width:100%; }
+        .doc-inner { padding:20px; }
     }
 </style>
 @endsection
 
 @section('content')
 <div class="dashboard-acasi">
-    <div class="main-content">
-        <div class="preview-container">
-            <!-- Barre d'outils de prévisualisation -->
-            <div class="preview-toolbar">
-                <div class="toolbar-info">
-                    <h4 class="mb-0">
-                        <i class="fas fa-eye me-2"></i>
-                        Prévisualisation Certificat de Scolarité
-                    </h4>
-                    <small class="text-muted">{{ $etudiant->nom }} {{ $etudiant->prenoms }} - {{ $etudiant->matricule }}</small>
-                </div>
-                
-                <div class="preview-actions">
-                    <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}" class="btn-acasi secondary">
-                        <i class="fas fa-arrow-left me-1"></i>Retour
-                    </a>
-                    
-                    <a href="{{ route('esbtp.etudiants.certificat', $etudiant->id) }}" class="btn-acasi success">
-                        <i class="fas fa-file-pdf me-1"></i>Générer PDF
-                    </a>
-                    
-                    <button onclick="window.print()" class="btn-acasi info">
-                        <i class="fas fa-print me-1"></i>Imprimer
-                    </button>
-                </div>
-            </div>
+<div class="main-content">
 
-            <!-- Contenu du certificat -->
-            <div class="preview-content">
-                <div class="certificat-document" style="position: relative;">
-                    @if(!empty($settings['logo_base64']))
-                        <div class="document-watermark">
-                            <img src="{{ $settings['logo_base64'] }}" alt="Filigrane logo">
-                        </div>
-                    @endif
+<div class="doc-toolbar no-print">
+    <div>
+        <div class="doc-toolbar-title"><i class="fas fa-eye"></i>Prévisualisation Certificat de Scolarité</div>
+        <div class="doc-toolbar-sub">{{ $etudiant->nom }} {{ $etudiant->prenoms }} — {{ $etudiant->matricule }}</div>
+    </div>
+    <div class="doc-toolbar-btns">
+        <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}" class="btn-acasi secondary">
+            <i class="fas fa-arrow-left me-1"></i>Retour
+        </a>
+        <a href="{{ route('esbtp.etudiants.certificat', $etudiant->id) }}" class="btn-acasi success">
+            <i class="fas fa-file-pdf me-1"></i>Générer PDF
+        </a>
+        <button onclick="window.print()" class="btn-acasi info">
+            <i class="fas fa-print me-1"></i>Imprimer
+        </button>
+    </div>
+</div>
 
-                    <div class="document-content">
-                    <!-- En-tête -->
-                    <div class="certificat-header">
-                        @if(!empty($settings['show_logo']) && !empty($settings['logo_base64']))
-                            <img src="{{ $settings['logo_base64'] }}" alt="Logo École" class="certificat-logo">
-                        @endif
-                        
-                        <div class="certificat-school-name">{{ $settings['name'] ?? '' }}</div>
-                        
-                        @if(!empty($settings['address']))
-                            <div class="certificat-address">{{ $settings['address'] }}</div>
-                        @endif
-                        @if(!empty($settings['phone']) || !empty($settings['email']))
-                            <div class="certificat-address">
-                                @if(!empty($settings['phone']))Tél: {{ $settings['phone'] }}@endif
-                                @if(!empty($settings['phone']) && !empty($settings['email'])) - @endif
-                                @if(!empty($settings['email']))Email: {{ $settings['email'] }}@endif
-                            </div>
-                        @endif
-                    </div>
+<div class="doc-page-wrap">
+<div class="doc-paper">
+    @if(!empty($settings['logo_base64']))
+    <div class="doc-watermark"><img src="{{ $settings['logo_base64'] }}" alt=""></div>
+    @endif
 
-                    <!-- Séparateur décoratif -->
-                    <div class="certificat-divider"></div>
-
-                    <!-- Titre du certificat -->
-                    <div class="certificat-title">
-                        Certificat de Scolarité
-                    </div>
-
-                    <!-- Contenu principal -->
-                    <div class="certificat-content">
-                        <p>
-                            Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, certifie que :
-                        </p>
-
-                        <p>
-                            L'étudiant(e) <span class="certificat-highlight">{{ $etudiant->nom }} {{ $etudiant->prenoms }}</span>
-                        </p>
-
-                        @if($etudiant->date_naissance)
-                        <p>
-                            Né(e) le <span class="certificat-highlight">{{ $etudiant->date_naissance->format('d/m/Y') }}</span>
-                            @if($etudiant->lieu_naissance) 
-                                à <span class="certificat-highlight">{{ $etudiant->lieu_naissance }}</span>
-                            @endif
-                        </p>
-                        @endif
-
-                        <p>
-                            Matricule : <span class="certificat-highlight">{{ $etudiant->matricule }}</span>
-                        </p>
-
-                        <p>
-                            Est régulièrement inscrit(e) sur le registre des effectifs de l'année académique :
-                        </p>
-
-                        <!-- Tableau des inscriptions -->
-                        <div style="margin: 20px 0;">
-                            <table style="width: 100%; border-collapse: collapse; border: 2px solid var(--primary); font-size: 14px;">
-                                <thead>
-                                    <tr style="background-color: #f8fafc;">
-                                        <th style="border: 1px solid var(--primary); padding: 8px; text-align: center; font-weight: bold;">Année scolaire</th>
-                                        <th style="border: 1px solid var(--primary); padding: 8px; text-align: center; font-weight: bold;">Classe suivie</th>
-                                        <th style="border: 1px solid var(--primary); padding: 8px; text-align: center; font-weight: bold;">Niveau d'étude</th>
-                                        <th style="border: 1px solid var(--primary); padding: 8px; text-align: center; font-weight: bold;">Filière</th>
-                                        <th style="border: 1px solid var(--primary); padding: 8px; text-align: center; font-weight: bold;">Moyenne/20</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @forelse($inscriptions as $inscription)
-                                    <tr>
-                                        <td style="border: 1px solid var(--primary); padding: 8px; text-align: center;">
-                                        @php
-                                            $rawAcademicYear = $inscription->anneeUniversitaire?->libelle
-                                                ?? $inscription->anneeUniversitaire?->name
-                                                ?? null;
-                                            $displayAcademicYear = $rawAcademicYear
-                                                ? (preg_match('/(\d{4}-\d{4})/', $rawAcademicYear, $matches) ? $matches[1] : $rawAcademicYear)
-                                                : 'Non renseigné';
-                                        @endphp
-                                        {{ $displayAcademicYear }}
-                                        </td>
-                                        <td style="border: 1px solid var(--primary); padding: 8px; text-align: center;">
-                                            {{ $inscription->classe->name ?? 'Non renseigné' }}
-                                        </td>
-                                        <td style="border: 1px solid var(--primary); padding: 8px; text-align: center;">
-                                            {{ $inscription->niveauEtude->name ?? 'Non renseigné' }}
-                                        </td>
-                                        <td style="border: 1px solid var(--primary); padding: 8px; text-align: center;">
-                                            {{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}
-                                        </td>
-                                        <td style="border: 1px solid var(--primary); padding: 8px; text-align: center;">
-                                            @if($inscription->moyenne_generale)
-                                                {{ number_format($inscription->moyenne_generale, 2) }}
-                                            @else
-                                                <!-- Moyenne vide pour l'année en cours -->
-                                            @endif
-                                        </td>
-                                    </tr>
-                                    @empty
-                                    <tr>
-                                        <td colspan="5" style="border: 1px solid var(--primary); padding: 8px; text-align: center;">Aucune inscription trouvée</td>
-                                    </tr>
-                                    @endforelse
-                                </tbody>
-                            </table>
-                        </div>
-
-                        <p style="font-style: italic; margin: 15px 0;">
-                            Suivant l'horaire du programme complet.
-                        </p>
-
-                        <p>
-                            Ce certificat est délivré à l'intéressé(e) pour servir et valoir ce que de droit.
-                        </p>
-                    </div>
-
-                    <!-- Footer avec signature -->
-                    <div class="certificat-footer">
-                        <div class="certificat-date">
-                            <p>Fait à {{ $settings['city'] ?? '' }}, le {{ now()->format('d/m/Y') }}</p>
-                        </div>
-
-                        <div class="certificat-signature">
-                            <div class="signature-title">{{ $settings['director_title'] ?? '' }}</div>
-                            @if(!empty($settings['director_name']))
-                                <div class="signature-name">{{ $settings['director_name'] }}</div>
-                            @endif
-                        </div>
-                    </div>
-
-                    <!-- Note de bas de page -->
-                    <div class="certificat-note">
-                        Ce certificat est un document officiel. Toute falsification constitue un délit passible de poursuites judiciaires.
-                    </div>
+    <div class="doc-inner">
+        <div class="doc-header">
+            @if(!empty($settings['show_logo']) && !empty($settings['logo_base64']))
+            <div class="doc-header-logo"><img src="{{ $settings['logo_base64'] }}" alt="Logo"></div>
+            @endif
+            <div class="doc-header-info">
+                <div class="doc-school-name">{{ $settings['name'] ?? '' }}</div>
+                <div class="doc-school-meta">
+                    @if(!empty($settings['address'])){{ $settings['address'] }}@endif
+                    @if(!empty($settings['phone'])) &nbsp;·&nbsp; Tél: {{ $settings['phone'] }}@endif
+                    @if(!empty($settings['email'])) &nbsp;·&nbsp; {{ $settings['email'] }}@endif
                 </div>
             </div>
         </div>
+
+        <div class="doc-divider"></div>
+
+        <div class="doc-title-wrap">
+            <span class="doc-title">Certificat de Scolarité</span>
+        </div>
+
+        <div class="doc-body">
+            <p>Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, certifie que&nbsp;:</p>
+            <p>L'étudiant(e) <span class="doc-hl">{{ $etudiant->nom }} {{ $etudiant->prenoms }}</span></p>
+
+            @if($etudiant->date_naissance)
+            <p>
+                Né(e) le <span class="doc-hl">{{ $etudiant->date_naissance->format('d/m/Y') }}</span>
+                @if($etudiant->lieu_naissance) à <span class="doc-hl">{{ $etudiant->lieu_naissance }}</span>@endif
+            </p>
+            @endif
+
+            <p>Matricule&nbsp;: <span class="doc-hl">{{ $etudiant->matricule }}</span></p>
+            <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année académique&nbsp;:</p>
+
+            <table class="doc-table">
+                <thead>
+                    <tr>
+                        <th>Année scolaire</th>
+                        <th>Classe suivie</th>
+                        <th>Niveau d'étude</th>
+                        <th>Filière</th>
+                        <th>Moyenne/20</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($inscriptions as $inscription)
+                    <tr>
+                        <td>@php
+                            $rawYear = $inscription->anneeUniversitaire?->libelle
+                                ?? $inscription->anneeUniversitaire?->name ?? null;
+                            echo $rawYear
+                                ? (preg_match('/(\d{4}-\d{4})/', $rawYear, $m) ? $m[1] : $rawYear)
+                                : 'Non renseigné';
+                        @endphp</td>
+                        <td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>
+                        <td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>
+                        <td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>
+                        <td>{{ $inscription->moyenne_generale ? number_format($inscription->moyenne_generale, 2) : '—' }}</td>
+                    </tr>
+                    @empty
+                    <tr><td colspan="5">Aucune inscription trouvée</td></tr>
+                    @endforelse
+                </tbody>
+            </table>
+
+            <p style="font-style:italic;margin-top:16px;">Suivant l'horaire du programme complet.</p>
+            <p>Ce certificat est délivré à l'intéressé(e) pour servir et valoir ce que de droit.</p>
+        </div>
+
+        <div class="doc-footer">
+            <div class="doc-date">Fait à {{ $settings['city'] ?? '' }}, le {{ now()->format('d/m/Y') }}</div>
+            <div class="doc-signature">
+                <div class="doc-sig-title">{{ $settings['director_title'] ?? '' }}</div>
+                @if(!empty($settings['director_name']))
+                <div class="doc-sig-name">{{ $settings['director_name'] }}</div>
+                @endif
+            </div>
+        </div>
+
+        <div class="doc-note">
+            Ce certificat est un document officiel. Toute falsification constitue un délit passible de poursuites judiciaires.
+        </div>
     </div>
+</div>
+</div>
+
+</div>
 </div>
 @endsection
 
 @push('scripts')
 <script>
-// Gérer l'impression
-window.addEventListener('beforeprint', function() {
-    document.body.classList.add('printing');
-});
-
-window.addEventListener('afterprint', function() {
-    document.body.classList.remove('printing');
-});
+window.addEventListener('beforeprint', () => document.body.classList.add('printing'));
+window.addEventListener('afterprint',  () => document.body.classList.remove('printing'));
 </script>
 @endpush

--- a/resources/views/esbtp/inscriptions/situation-financiere-pdf.blade.php
+++ b/resources/views/esbtp/inscriptions/situation-financiere-pdf.blade.php
@@ -441,14 +441,23 @@
     <table class="student-info-table" style="width: 100%; margin-bottom: 15px; border-collapse: collapse;">
         <tr>
             <td rowspan="{{ $inscription->etudiant->parents && $inscription->etudiant->parents->count() > 0 ? '5' : '4' }}" style="width: 120px; text-align: center; vertical-align: top; padding: 10px; border: 1px solid #e5e7eb;">
-                @if($inscription->etudiant->photo && file_exists(storage_path('app/public/' . $inscription->etudiant->photo)))
+                @php
+                    $sfPhotoPath = null;
+                    if ($inscription->etudiant->photo) {
+                        $sfCandidates = [
+                            storage_path('app/public/photos/etudiants/' . $inscription->etudiant->photo),
+                            storage_path('app/public/' . $inscription->etudiant->photo),
+                        ];
+                        foreach ($sfCandidates as $sfCandidate) {
+                            if (file_exists($sfCandidate)) { $sfPhotoPath = $sfCandidate; break; }
+                        }
+                    }
+                @endphp
+                @if($sfPhotoPath)
                     @php
-                        $photoPath = storage_path('app/public/' . $inscription->etudiant->photo);
-                        $photoData = base64_encode(file_get_contents($photoPath));
-                        $photoMime = mime_content_type($photoPath);
-                        $photoSrc = 'data:' . $photoMime . ';base64,' . $photoData;
+                        $sfPhotoSrc = 'data:' . (mime_content_type($sfPhotoPath) ?: 'image/jpeg') . ';base64,' . base64_encode(file_get_contents($sfPhotoPath));
                     @endphp
-                    <img src="{{ $photoSrc }}" alt="Photo" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; border: 2px solid #007bff;">
+                    <img src="{{ $sfPhotoSrc }}" alt="Photo" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; border: 2px solid #007bff;">
                 @else
                     <div style="width: 100px; height: 100px; border-radius: 50%; background: #f3f4f6; border: 2px solid #007bff; text-align: center; line-height: 100px; font-size: 32px; color: #6b7280;">
                         👤

--- a/resources/views/esbtp/inscriptions/situation-financiere-preview.blade.php
+++ b/resources/views/esbtp/inscriptions/situation-financiere-preview.blade.php
@@ -5,478 +5,462 @@
 @section('styles')
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 @include('pdf.partials.theme')
+@php
+    $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
+    $accentColor  = $pdfSettings['header_bg_color']   ?? '#0453cb';
+    $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
+    $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
+@endphp
 <style>
-    .info-group {
-        margin-bottom: 1rem;
+    :root {
+        --sf-accent:   {{ $accentColor }};
+        --sf-atext:    {{ $accentText }};
+        --sf-body:     {{ $bodyText }};
+        --sf-muted:    #6b7280;
+        --sf-border:   #e5e7eb;
+        --sf-bg:       #f8fafc;
+        --sf-card:     #ffffff;
+        --sf-radius:   12px;
+        --sf-shadow:   0 1px 3px rgba(0,0,0,.07), 0 4px 16px rgba(0,0,0,.05);
     }
 
-    .info-label {
-        font-weight: 600;
-        color: #374151;
-        margin-right: 0.5rem;
+    /* Toolbar */
+    .sf-toolbar {
+        display: flex; align-items: center; justify-content: space-between;
+        flex-wrap: wrap; gap: 12px;
+        padding: 16px 24px;
+        background: var(--sf-card); border: 1px solid var(--sf-border);
+        border-radius: var(--sf-radius); margin-bottom: 24px;
+        box-shadow: var(--sf-shadow);
+    }
+    .sf-toolbar-title { font-size: 1.1rem; font-weight: 700; color: var(--sf-body); display: flex; align-items: center; gap: 8px; }
+    .sf-toolbar-title i { color: var(--sf-accent); }
+    .sf-toolbar-sub   { font-size: .8rem; color: var(--sf-muted); margin-top: 2px; }
+    .sf-toolbar-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
+    /* KPI Grid */
+    .sf-kpi-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+        gap: 14px; margin-bottom: 24px;
+    }
+    .sf-kpi {
+        background: var(--sf-card); border: 1px solid var(--sf-border);
+        border-radius: var(--sf-radius); padding: 18px 20px;
+        border-left: 4px solid var(--kpi-clr, var(--sf-accent));
+        box-shadow: var(--sf-shadow); position: relative; overflow: hidden;
+    }
+    .sf-kpi::after {
+        content:''; position: absolute; top:-24px; right:-24px;
+        width:80px; height:80px; border-radius:50%;
+        background: color-mix(in srgb, var(--kpi-clr, var(--sf-accent)) 8%, transparent);
+        pointer-events:none;
+    }
+    .sf-kpi-label { font-size:.7rem; font-weight:700; letter-spacing:.08em; text-transform:uppercase; color:var(--sf-muted); margin-bottom:5px; }
+    .sf-kpi-amount { font-size:1.6rem; font-weight:800; color:var(--kpi-clr, var(--sf-accent)); line-height:1.1; }
+    .sf-kpi-unit   { font-size:.85rem; font-weight:600; }
+    .sf-kpi-sub    { font-size:.73rem; color:var(--sf-muted); display:flex; align-items:center; gap:5px; margin-top:4px; }
+    .sf-kpi-sub i  { color:var(--kpi-clr, var(--sf-accent)); }
+
+    /* Main card */
+    .sf-card {
+        background: var(--sf-card); border: 1px solid var(--sf-border);
+        border-radius: var(--sf-radius); box-shadow: var(--sf-shadow);
+        margin-bottom: 20px; overflow: hidden;
     }
 
-    .info-value {
-        color: #6b7280;
+    /* Document header (établissement) */
+    .sf-doc-header {
+        background: var(--sf-accent); color: var(--sf-atext);
+        padding: 24px 28px 0; position: relative; overflow: hidden;
+    }
+    .sf-doc-header::before {
+        content:''; position:absolute; bottom:-40px; right:-40px;
+        width:160px; height:160px; border-radius:50%;
+        background:rgba(255,255,255,.07); pointer-events:none;
+    }
+    .sf-doc-header-top { display:flex; align-items:center; gap:18px; position:relative; z-index:1; }
+    .sf-doc-logo img   { height:52px; filter:brightness(0) invert(1); }
+    .sf-school-name    { font-size:1.2rem; font-weight:800; letter-spacing:.01em; }
+    .sf-school-meta    { font-size:.78rem; opacity:.8; margin-top:3px; line-height:1.5; }
+
+    .sf-doc-title-strip {
+        position:relative; z-index:1;
+        background:rgba(0,0,0,.18); backdrop-filter:blur(4px);
+        margin-top:18px; padding:13px 0 13px;
+        display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:10px;
+    }
+    .sf-doc-title-text {
+        font-size:.95rem; font-weight:800; letter-spacing:.12em; text-transform:uppercase;
+        color: var(--sf-atext);
+    }
+    .sf-meta-pills { display:flex; gap:8px; flex-wrap:wrap; }
+    .sf-pill {
+        background:rgba(255,255,255,.18); color:var(--sf-atext);
+        border:1px solid rgba(255,255,255,.25); border-radius:20px;
+        padding:3px 11px; font-size:.73rem; font-weight:600;
     }
 
-    .financial-table {
-        width: 100%;
+    /* Section head */
+    .sf-section-head {
+        padding: 14px 24px 12px; border-bottom: 1px solid var(--sf-border);
+        display: flex; align-items: baseline; gap: 10px;
     }
-
-    .section-title {
-        background: #f3f4f6;
-        padding: 0.75rem 1rem;
-        border-radius: 8px;
-        font-weight: 600;
-        color: #374151;
-        margin: 1.5rem 0 1rem 0;
-        display: flex;
-        align-items: center;
-        gap: 0.5rem;
+    .sf-section-title {
+        font-size:.78rem; font-weight:700; letter-spacing:.07em; text-transform:uppercase;
+        color: var(--sf-accent); display:flex; align-items:center; gap:6px;
     }
+    .sf-section-sub { font-size:.75rem; color:var(--sf-muted); }
+    .sf-body { padding: 20px 24px; }
 
-    .status-badge {
-        padding: 0.25rem 0.75rem;
-        border-radius: 12px;
-        font-size: 0.875rem;
-        font-weight: 500;
+    /* Student profile */
+    .sf-student-grid {
+        display: grid; grid-template-columns: 130px 1fr 1fr; gap: 28px; align-items: start;
     }
+    @media (max-width:768px) { .sf-student-grid { grid-template-columns:1fr; } }
+    .sf-photo-wrap { text-align:center; }
+    .sf-photo-img  {
+        width:110px; height:110px; border-radius:50%; object-fit:cover;
+        border:3px solid var(--sf-accent); display:block; margin:0 auto 10px;
+    }
+    .sf-photo-empty {
+        width:110px; height:110px; border-radius:50%;
+        background:var(--sf-bg); border:3px solid var(--sf-border);
+        display:flex; align-items:center; justify-content:center; margin:0 auto 10px;
+    }
+    .sf-photo-empty i { font-size:2.4rem; color:#d1d5db; }
+    .sf-student-name { font-size:.9rem; font-weight:700; color:var(--sf-body); text-align:center; }
+    .sf-student-mat  { font-size:.73rem; color:var(--sf-muted); text-align:center; margin-top:2px; }
+    .sf-info-group h6 {
+        font-size:.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.08em;
+        color:var(--sf-accent); margin-bottom:10px; display:flex; align-items:center; gap:6px;
+    }
+    .sf-info-row  { display:flex; font-size:.8rem; margin-bottom:6px; }
+    .sf-info-lbl  { font-weight:600; color:var(--sf-body); min-width:130px; flex-shrink:0; }
+    .sf-info-val  { color:var(--sf-muted); }
 
-    .status-badge.soldé { background: #d1fae5; color: #065f46; }
-    .status-badge.partiel { background: #fef3c7; color: #92400e; }
-    .status-badge.impayé { background: #fee2e2; color: #991b1b; }
-    .status-badge.reliquat { background: #fef3c7; color: #d97706; }
+    /* Table */
+    .sf-table { width:100%; border-collapse:collapse; font-size:.8rem; }
+    .sf-table thead th {
+        background: var(--sf-accent); color: var(--sf-atext);
+        padding:9px 14px; font-weight:700; font-size:.68rem;
+        letter-spacing:.07em; text-transform:uppercase; border:none;
+    }
+    .sf-table thead th:first-child { border-radius:8px 0 0 0; }
+    .sf-table thead th:last-child  { border-radius:0 8px 0 0; }
+    .sf-table tbody tr { border-bottom:1px solid var(--sf-border); }
+    .sf-table tbody tr:last-child { border-bottom:none; }
+    .sf-table tbody tr:hover { background:var(--sf-bg); }
+    .sf-table tbody tr.row-rq { background:#fffbeb; }
+    .sf-table tbody tr.row-rq:hover { background:#fef3c7; }
+    .sf-table td { padding:10px 14px; color:var(--sf-body); vertical-align:middle; }
+
+    /* Badges */
+    .sf-badge {
+        display:inline-flex; align-items:center; gap:4px;
+        padding:3px 9px; border-radius:20px; font-size:.7rem; font-weight:700; white-space:nowrap;
+    }
+    .b-danger   { background:#fee2e2; color:#991b1b; }
+    .b-info     { background:#dbeafe; color:#1d4ed8; }
+    .b-success  { background:#d1fae5; color:#065f46; }
+    .b-warning  { background:#fef3c7; color:#92400e; }
+    .b-partial  { background:#fce7f3; color:#9d174d; }
+    .b-reliquat { background:#fef3c7; color:#d97706; }
+
+    /* Footer */
+    .sf-footer { text-align:center; padding:14px; color:var(--sf-muted); font-size:.74rem; }
 
     @media print {
-        .dashboard-header, .btn-acasi, .no-print {
-            display: none !important;
-        }
-
-        .main-content {
-            padding: 0 !important;
-        }
-
-        .main-card {
-            box-shadow: none !important;
-            border: 1px solid #e5e7eb !important;
-            margin-bottom: 20px !important;
-        }
-
-        .kpi-grid {
-            display: none !important;
-        }
+        .sf-toolbar, .no-print { display:none !important; }
+        .sf-card { box-shadow:none; }
+        .main-content { padding:0 !important; }
     }
 </style>
 @endsection
 
 @section('content')
 <div class="dashboard-acasi">
-    <div class="main-content">
-        <!-- Header Section -->
-        <div class="dashboard-header">
-            <div class="header-left">
-                <h1><i class="fas fa-chart-line me-2"></i>Situation Financière</h1>
-                <p class="header-subtitle">{{ $inscription->etudiant->nom }} {{ $inscription->etudiant->prenoms }} - {{ $inscription->etudiant->matricule }}</p>
-            </div>
-            <div class="header-actions">
-                <a href="{{ route('esbtp.inscriptions.situation-financiere.pdf', $inscription->id) }}" class="btn-acasi danger">
-                    <i class="fas fa-file-pdf"></i>Télécharger PDF
-                </a>
-                <button onclick="window.print()" class="btn-acasi primary">
-                    <i class="fas fa-print"></i>Imprimer
-                </button>
-                @php
-                    // Récupérer l'URL de la page précédente (referrer)
-                    $returnUrl = request()->headers->get('referer')
-                        ? request()->headers->get('referer')
-                        : route('esbtp.inscriptions.show', $inscription->id);
+<div class="main-content">
 
-                    // Sécurité : Vérifier que le referrer est sur le même domaine
-                    $parsedUrl = parse_url($returnUrl);
-                    $appUrl = parse_url(config('app.url'));
-                    if (isset($parsedUrl['host']) && $parsedUrl['host'] !== ($appUrl['host'] ?? '')) {
-                        $returnUrl = route('esbtp.inscriptions.show', $inscription->id); // Fallback sécurisé
-                    }
-                @endphp
-                <a href="{{ $returnUrl }}" class="btn-acasi secondary">
-                    <i class="fas fa-arrow-left"></i>Retour
-                </a>
-            </div>
-        </div>
+{{-- Toolbar --}}
+<div class="sf-toolbar no-print">
+    <div>
+        <div class="sf-toolbar-title"><i class="fas fa-chart-line"></i>Situation Financière</div>
+        <div class="sf-toolbar-sub">{{ $inscription->etudiant->nom }} {{ $inscription->etudiant->prenoms }} — {{ $inscription->etudiant->matricule }}</div>
+    </div>
+    <div class="sf-toolbar-actions">
+        <a href="{{ route('esbtp.inscriptions.situation-financiere.pdf', $inscription->id) }}" class="btn-acasi danger">
+            <i class="fas fa-file-pdf"></i>Télécharger PDF
+        </a>
+        <button onclick="window.print()" class="btn-acasi primary">
+            <i class="fas fa-print"></i>Imprimer
+        </button>
+        @php
+            $returnUrl = request()->headers->get('referer') ?: route('esbtp.inscriptions.show', $inscription->id);
+            $pu = parse_url($returnUrl); $au = parse_url(config('app.url'));
+            if (isset($pu['host']) && $pu['host'] !== ($au['host'] ?? '')) {
+                $returnUrl = route('esbtp.inscriptions.show', $inscription->id);
+            }
+        @endphp
+        <a href="{{ $returnUrl }}" class="btn-acasi secondary">
+            <i class="fas fa-arrow-left"></i>Retour
+        </a>
+    </div>
+</div>
 
-        <!-- Statistiques KPI -->
-        <div class="kpi-grid">
-            <div class="kpi-card card-moderne" style="background: white; border: 1px solid #e5e7eb;">
-                <div class="kpi-title" style="color: #000; font-weight: 600;">Total Attendu</div>
-                <div class="kpi-value" style="color: var(--primary); font-size: 2rem; font-weight: bold;">{{ number_format($statistiques['total_attendu'], 0, ',', ' ') }} FCFA</div>
-                <div class="kpi-trend" style="color: #6b7280; font-size: 0.875rem;">
-                    <i class="fas fa-money-bill-wave"></i>
-                    Frais année + reliquats
-                </div>
-            </div>
+{{-- KPI Cards --}}
+<div class="sf-kpi-grid">
+    <div class="sf-kpi" style="--kpi-clr:var(--sf-accent);">
+        <div class="sf-kpi-label">Total Attendu</div>
+        <div class="sf-kpi-amount">{{ number_format($statistiques['total_attendu'], 0, ',', ' ') }} <span class="sf-kpi-unit">FCFA</span></div>
+        <div class="sf-kpi-sub"><i class="fas fa-money-bill-wave"></i> Frais année + reliquats</div>
+    </div>
+    <div class="sf-kpi" style="--kpi-clr:#059669; border-left-color:#059669;">
+        <div class="sf-kpi-label">Total Payé</div>
+        <div class="sf-kpi-amount">{{ number_format($statistiques['total_paye'], 0, ',', ' ') }} <span class="sf-kpi-unit">FCFA</span></div>
+        <div class="sf-kpi-sub"><i class="fas fa-check-circle"></i> Paiements validés</div>
+    </div>
+    @php $soldeColor = $statistiques['solde_restant'] > 0 ? '#dc2626' : '#059669'; @endphp
+    <div class="sf-kpi" style="--kpi-clr:{{ $soldeColor }}; border-left-color:{{ $soldeColor }};">
+        <div class="sf-kpi-label">Solde</div>
+        <div class="sf-kpi-amount">{{ number_format($statistiques['solde_restant'], 0, ',', ' ') }} <span class="sf-kpi-unit">FCFA</span></div>
+        <div class="sf-kpi-sub"><i class="fas fa-balance-scale"></i> {{ $statistiques['solde_restant'] > 0 ? 'Restant à payer' : 'Soldé' }}</div>
+    </div>
+    @if($statistiques['total_reliquats'] > 0)
+    <div class="sf-kpi" style="--kpi-clr:#d97706; border-left-color:#d97706;">
+        <div class="sf-kpi-label">Reliquats</div>
+        <div class="sf-kpi-amount">{{ number_format($statistiques['total_reliquats'], 0, ',', ' ') }} <span class="sf-kpi-unit">FCFA</span></div>
+        <div class="sf-kpi-sub"><i class="fas fa-history"></i> Années précédentes</div>
+    </div>
+    @endif
+</div>
 
-            <div class="kpi-card card-moderne" style="background: white; border: 1px solid #e5e7eb;">
-                <div class="kpi-title" style="color: #000; font-weight: 600;">Total Payé</div>
-                <div class="kpi-value" style="color: var(--success); font-size: 2rem; font-weight: bold;">{{ number_format($statistiques['total_paye'], 0, ',', ' ') }} FCFA</div>
-                <div class="kpi-trend" style="color: #6b7280; font-size: 0.875rem;">
-                    <i class="fas fa-check-circle"></i>
-                    Tous paiements validés
-                </div>
-            </div>
-
-            <div class="kpi-card card-moderne" style="background: white; border: 1px solid #e5e7eb;">
-                <div class="kpi-title" style="color: #000; font-weight: 600;">Solde</div>
-                <div class="kpi-value" style="color: {{ $statistiques['solde_restant'] > 0 ? 'var(--danger)' : 'var(--success)' }}; font-size: 2rem; font-weight: bold;">{{ number_format($statistiques['solde_restant'], 0, ',', ' ') }} FCFA</div>
-                <div class="kpi-trend" style="color: #6b7280; font-size: 0.875rem;">
-                    <i class="fas fa-balance-scale"></i>
-                    {{ $statistiques['solde_restant'] > 0 ? 'Restant à payer' : 'Soldé' }}
-                </div>
-            </div>
-
-            @if($statistiques['total_reliquats'] > 0)
-            <div class="kpi-card card-moderne" style="background: white; border: 1px solid #e5e7eb;">
-                <div class="kpi-title" style="color: #000; font-weight: 600;">Reliquats</div>
-                <div class="kpi-value" style="color: var(--warning); font-size: 2rem; font-weight: bold;">{{ number_format($statistiques['total_reliquats'], 0, ',', ' ') }} FCFA</div>
-                <div class="kpi-trend" style="color: #6b7280; font-size: 0.875rem;">
-                    <i class="fas fa-history"></i>
-                    Années précédentes
-                </div>
+{{-- Document card --}}
+<div class="sf-card">
+    {{-- Header établissement --}}
+    <div class="sf-doc-header">
+        <div class="sf-doc-header-top">
+            @if($etablissement['logo'] && file_exists(storage_path('app/public/' . $etablissement['logo'])))
+            <div class="sf-doc-logo">
+                <img src="data:image/{{ pathinfo($etablissement['logo'], PATHINFO_EXTENSION) }};base64,{{ base64_encode(file_get_contents(storage_path('app/public/' . $etablissement['logo']))) }}" alt="Logo">
             </div>
             @endif
-        </div>
-
-        <!-- En-tête de l'établissement -->
-        <div class="main-card">
-            <div class="main-card-header" style="background: #007bff; color: white; border-radius: 15px 15px 0 0;">
-                <div style="text-align: center; padding: 1rem;">
-                    @if($etablissement['logo'] && file_exists(storage_path('app/public/' . $etablissement['logo'])))
-                        <div style="margin-bottom: 15px;">
-                            <img src="data:image/{{ pathinfo($etablissement['logo'], PATHINFO_EXTENSION) }};base64,{{ base64_encode(file_get_contents(storage_path('app/public/' . $etablissement['logo']))) }}"
-                                 style="max-height: 60px; max-width: 150px; filter: brightness(0) invert(1);" alt="Logo">
-                        </div>
-                    @endif
-
-                    <h2 style="margin: 0 0 8px 0; font-size: 1.8rem; font-weight: 700;">{{ $etablissement['nom'] ?? 'KLASSCI' }}</h2>
-
-                    @if($etablissement['adresse'] || $etablissement['telephone'] || $etablissement['email'])
-                    <div style="font-size: 0.9rem; opacity: 0.9; margin-bottom: 15px;">
-                        @if($etablissement['adresse']){{ $etablissement['adresse'] }}@endif
-                        @if($etablissement['telephone'] && $etablissement['adresse']) | @endif
-                        @if($etablissement['telephone'])Tel: {{ $etablissement['telephone'] }}@endif
-                        @if($etablissement['email'] && ($etablissement['adresse'] || $etablissement['telephone'])) | @endif
-                        @if($etablissement['email'])Email: {{ $etablissement['email'] }}@endif
-                    </div>
-                    @endif
-
-                    <div style="background: rgba(255,255,255,0.2); padding: 15px; border-radius: 10px; backdrop-filter: blur(10px);">
-                        <h3 style="margin: 0 0 10px 0; font-size: 1.4rem; font-weight: 600;">BULLETIN DE SITUATION FINANCIÈRE</h3>
-                        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 15px; font-size: 0.95rem;">
-                            <div><strong>Année:</strong> <span style="background: rgba(255,255,255,0.3); padding: 3px 8px; border-radius: 12px;">{{ $inscription->anneeUniversitaire->name ?? 'N/A' }}</span></div>
-                            <div><strong>Date:</strong> <span style="background: rgba(255,255,255,0.3); padding: 3px 8px; border-radius: 12px;">{{ now()->format('d/m/Y') }}</span></div>
-                            <div><strong>Classe:</strong> <span style="background: rgba(255,255,255,0.3); padding: 3px 8px; border-radius: 12px;">{{ $inscription->classe->name ?? 'N/A' }}</span></div>
-                        </div>
-                    </div>
+            <div>
+                <div class="sf-school-name">{{ $etablissement['nom'] ?? 'KLASSCI' }}</div>
+                <div class="sf-school-meta">
+                    @if($etablissement['adresse']){{ $etablissement['adresse'] }}@endif
+                    @if($etablissement['telephone']) &nbsp;|&nbsp; Tél: {{ $etablissement['telephone'] }}@endif
+                    @if($etablissement['email']) &nbsp;|&nbsp; {{ $etablissement['email'] }}@endif
                 </div>
             </div>
         </div>
-
-        <!-- Informations de l'étudiant -->
-        <div class="main-card">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-user"></i>
-                    Informations de l'étudiant
-                </div>
-                <div class="main-card-subtitle">Données personnelles et académiques</div>
+        <div class="sf-doc-title-strip">
+            <span class="sf-doc-title-text">Bulletin de Situation Financière</span>
+            <div class="sf-meta-pills">
+                <span class="sf-pill"><i class="fas fa-calendar-alt me-1"></i>{{ $inscription->anneeUniversitaire->name ?? 'N/A' }}</span>
+                <span class="sf-pill"><i class="fas fa-calendar-day me-1"></i>{{ now()->format('d/m/Y') }}</span>
+                <span class="sf-pill"><i class="fas fa-users me-1"></i>{{ $inscription->classe->name ?? 'N/A' }}</span>
             </div>
-
-            <div class="main-card-body">
-                <div class="row">
-                    <div class="col-md-3 text-center">
-                        @if($inscription->etudiant->photo_url)
-                            <img src="{{ $inscription->etudiant->photo_url }}" alt="Photo de profil" class="rounded-circle img-thumbnail" style="width: 150px; height: 150px; object-fit: cover;">
-                        @else
-                            <div class="bg-light d-flex align-items-center justify-content-center rounded-circle mx-auto" style="width: 150px; height: 150px;">
-                                <i class="fas fa-user fa-5x text-secondary"></i>
-                            </div>
-                        @endif
-                        <h5 class="mt-3">{{ $inscription->etudiant->nom }} {{ $inscription->etudiant->prenoms }}</h5>
-                        <p class="text-muted">
-                            Matricule: <strong>{{ $inscription->etudiant->matricule }}</strong>
-                        </p>
-                    </div>
-
-                    <div class="col-md-4">
-                        <h6 style="color: #007bff; margin-bottom: 15px;"><i class="fas fa-info-circle me-2"></i>Informations personnelles</h6>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Genre:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->etudiant->genre == 'M' ? 'Masculin' : 'Féminin' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Date de naissance:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->etudiant->date_naissance ? \Carbon\Carbon::parse($inscription->etudiant->date_naissance)->format('d/m/Y') : 'Non renseigné' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Lieu de naissance:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->etudiant->lieu_naissance ?? 'Non renseigné' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Téléphone:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->etudiant->telephone ?? 'Non renseigné' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Email:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->etudiant->email ?? 'Non renseigné' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Adresse:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->etudiant->adresse ?? 'Non renseigné' }}</div>
-                        </div>
-                    </div>
-
-                    <div class="col-md-5">
-                        <h6 style="color: #007bff; margin-bottom: 15px;"><i class="fas fa-graduation-cap me-2"></i>Informations académiques</h6>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Filière:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->classe->filiere->name ?? 'Non renseigné' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Niveau:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->classe->niveau->name ?? 'Non renseigné' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Classe:</strong></div>
-                            <div class="col-sm-7">{{ $inscription->classe->name ?? 'Non renseigné' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Statut:</strong></div>
-                            <div class="col-sm-7">
-                                <span class="badge {{ $inscription->status == 'active' ? 'bg-success' : 'bg-secondary' }}">
-                                    {{ ucfirst($inscription->status) }}
-                                </span>
-                            </div>
-                        </div>
-
-                        @if($inscription->etudiant->parents && $inscription->etudiant->parents->count() > 0)
-                        <h6 style="color: #007bff; margin-bottom: 15px; margin-top: 20px;"><i class="fas fa-users me-2"></i>Contact parent/tuteur</h6>
-                        @php $parent = $inscription->etudiant->parents->first(); @endphp
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Nom:</strong></div>
-                            <div class="col-sm-7">{{ $parent->nom ?? 'Non renseigné' }} {{ $parent->prenoms ?? '' }}</div>
-                        </div>
-                        <div class="row mb-2">
-                            <div class="col-sm-5"><strong>Téléphone:</strong></div>
-                            <div class="col-sm-7">{{ $parent->telephone ?? 'Non renseigné' }}</div>
-                        </div>
-                        @endif
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Frais Souscrits - Année Courante -->
-        <div class="main-card">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-money-bill-wave"></i>
-                    Détail des Frais Souscrits - Année {{ $inscription->anneeUniversitaire->name }}
-                </div>
-                <div class="main-card-subtitle">Frais de l'année universitaire en cours</div>
-            </div>
-            <div class="main-card-body">
-                @if($fraisSouscrits->count() > 0)
-                    <div class="table-responsive">
-                        <table class="table table-hover financial-table">
-                            <thead class="table-light">
-                                <tr>
-                                    <th>Catégorie de Frais</th>
-                                    <th width="100" class="text-center">Type</th>
-                                    <th width="150" class="text-end">Montant Attendu</th>
-                                    <th width="150" class="text-end">Montant Payé</th>
-                                    <th width="150" class="text-end">Solde</th>
-                                    <th width="100" class="text-center">Statut</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach($fraisSouscrits as $frais)
-                                @php
-                                    $montantPaye = $inscription->paiements
-                                        ->where('frais_category_id', $frais->frais_category_id)
-                                        ->where('status', 'validé')
-                                        ->filter(function($paiement) {
-                                            return $paiement->type_paiement != 'reliquat' || is_null($paiement->type_paiement);
-                                        })
-                                        ->sum('montant');
-                                    $solde = $frais->amount - $montantPaye;
-                                @endphp
-                                <tr>
-                                    <td>
-                                        <div class="d-flex align-items-center">
-                                            <i class="fas fa-tag me-2 text-primary"></i>
-                                            <strong>{{ $frais->fraisCategory->name ?? 'Non renseigné' }}</strong>
-                                        </div>
-                                    </td>
-                                    <td class="text-center">
-                                        @if($frais->fraisCategory->is_mandatory)
-                                            <span class="badge bg-danger">
-                                                <i class="fas fa-exclamation-circle me-1"></i>Obligatoire
-                                            </span>
-                                        @else
-                                            <span class="badge bg-info">
-                                                <i class="fas fa-star me-1"></i>Optionnel
-                                            </span>
-                                        @endif
-                                    </td>
-                                    <td class="text-end">
-                                        <span class="fw-bold">{{ number_format($frais->amount, 0, ',', ' ') }} FCFA</span>
-                                    </td>
-                                    <td class="text-end">
-                                        <span class="text-success fw-bold">{{ number_format($montantPaye, 0, ',', ' ') }} FCFA</span>
-                                    </td>
-                                    <td class="text-end">
-                                        <span class="fw-bold {{ $solde > 0 ? 'text-danger' : 'text-success' }}">
-                                            {{ number_format($solde, 0, ',', ' ') }} FCFA
-                                        </span>
-                                    </td>
-                                    <td class="text-center">
-                                        @if($solde <= 0)
-                                            <span class="status-badge soldé">Soldé</span>
-                                        @elseif($montantPaye > 0)
-                                            <span class="status-badge partiel">Partiel</span>
-                                        @else
-                                            <span class="status-badge impayé">Impayé</span>
-                                        @endif
-                                    </td>
-                                </tr>
-                                @endforeach
-
-                                {{-- Intégrer les reliquats comme des lignes de frais --}}
-                                @if($reliquatsEntrants->count() > 0)
-                                    @foreach($reliquatsEntrants as $reliquat)
-                                        @if($reliquat->solde_restant > 0)
-                                            <tr class="table-warning">
-                                                <td>
-                                                    <div class="d-flex align-items-center">
-                                                        <i class="fas fa-history me-2 text-warning"></i>
-                                                        <div>
-                                                            <strong>{{ $reliquat->fraisSubscription->fraisCategory->name ?? 'Non renseigné' }}</strong>
-                                                            <br><small class="text-muted">Reliquat {{ $reliquat->inscriptionSource->anneeUniversitaire->name ?? 'N/A' }}</small>
-                                                        </div>
-                                                    </div>
-                                                </td>
-                                                <td class="text-center">
-                                                    @if($reliquat->fraisSubscription->fraisCategory->is_mandatory)
-                                                        <span class="badge bg-warning">
-                                                            <i class="fas fa-exclamation-circle me-1"></i>Obligatoire
-                                                        </span>
-                                                    @else
-                                                        <span class="badge bg-secondary">
-                                                            <i class="fas fa-star me-1"></i>Optionnel
-                                                        </span>
-                                                    @endif
-                                                </td>
-                                                <td class="text-end">
-                                                    <span class="fw-bold">{{ number_format($reliquat->montant_reliquat, 0, ',', ' ') }} FCFA</span>
-                                                </td>
-                                                <td class="text-end">
-                                                    <span class="text-success fw-bold">{{ number_format($reliquat->montant_regle, 0, ',', ' ') }} FCFA</span>
-                                                </td>
-                                                <td class="text-end">
-                                                    <span class="fw-bold text-warning">{{ number_format($reliquat->solde_restant, 0, ',', ' ') }} FCFA</span>
-                                                </td>
-                                                <td class="text-center">
-                                                    <span class="status-badge reliquat">Reliquat</span>
-                                                </td>
-                                            </tr>
-                                        @endif
-                                    @endforeach
-                                @endif
-                            </tbody>
-                        </table>
-                    </div>
-                @else
-                    <div class="text-center py-4">
-                        <i class="fas fa-exclamation-triangle text-warning fa-2x mb-3"></i>
-                        <h5>Aucun frais souscrit</h5>
-                        <p class="text-muted">Aucun frais souscrit pour cette inscription.</p>
-                    </div>
-                @endif
-            </div>
-        </div>
-
-
-        <!-- Historique des Paiements -->
-        <div class="main-card">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-receipt"></i>
-                    Historique des Paiements
-                </div>
-                <div class="main-card-subtitle">{{ $inscription->paiements->where('status', 'validé')->count() }} paiement(s) validé(s)</div>
-            </div>
-            <div class="main-card-body">
-                @if($inscription->paiements->where('status', 'validé')->count() > 0)
-                    <div class="table-responsive">
-                        <table class="table table-hover">
-                            <thead class="table-light">
-                                <tr>
-                                    <th>Date</th>
-                                    <th>Catégorie</th>
-                                    <th>Mode de Paiement</th>
-                                    <th width="120" class="text-end">Montant</th>
-                                    <th width="100" class="text-center">Statut</th>
-                                    <th>Référence</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach($inscription->paiements->where('status', 'validé')->sortByDesc('date_paiement') as $paiement)
-                                <tr>
-                                    <td>{{ $paiement->date_paiement ? \Carbon\Carbon::parse($paiement->date_paiement)->format('d/m/Y') : 'Non renseigné' }}</td>
-                                    <td>
-                                        <div class="d-flex align-items-center">
-                                            @if($paiement->type_paiement == 'reliquat')
-                                                <i class="fas fa-history me-2 text-warning"></i>
-                                                {{ $paiement->fraisCategory->name ?? 'Non renseigné' }}
-                                                <span class="badge bg-warning ms-2">Reliquat</span>
-                                            @else
-                                                <i class="fas fa-money-bill me-2 text-success"></i>
-                                                {{ $paiement->fraisCategory->name ?? 'Non renseigné' }}
-                                            @endif
-                                        </div>
-                                    </td>
-                                    <td>{{ $paiement->mode_paiement ?? 'Non renseigné' }}</td>
-                                    <td class="text-end">
-                                        <span class="fw-bold text-success">{{ number_format($paiement->montant, 0, ',', ' ') }} FCFA</span>
-                                    </td>
-                                    <td class="text-center">
-                                        <span class="badge bg-success">{{ strtoupper($paiement->status) }}</span>
-                                    </td>
-                                    <td>
-                                        <code class="text-muted">{{ $paiement->numero_recu ?? '-' }}</code>
-                                    </td>
-                                </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    </div>
-                @else
-                    <div class="text-center py-4">
-                        <i class="fas fa-receipt text-muted fa-2x mb-3"></i>
-                        <h5>Aucun paiement</h5>
-                        <p class="text-muted">Aucun paiement validé pour cette inscription.</p>
-                    </div>
-                @endif
-            </div>
-        </div>
-
-        <!-- Footer -->
-        <div class="text-center mt-4">
-            <small class="text-muted">
-                <i class="fas fa-info-circle me-1"></i>
-                Document généré automatiquement le {{ now()->format('d/m/Y à H:i') }}
-            </small>
         </div>
     </div>
+
+    {{-- Infos étudiant --}}
+    <div class="sf-section-head">
+        <div class="sf-section-title"><i class="fas fa-user-circle"></i>Informations de l'étudiant</div>
+        <span class="sf-section-sub">Données personnelles et académiques</span>
+    </div>
+    <div class="sf-body">
+        <div class="sf-student-grid">
+            {{-- Photo --}}
+            <div class="sf-photo-wrap">
+                @if($inscription->etudiant->photo_url)
+                    <img src="{{ $inscription->etudiant->photo_url }}" alt="Photo" class="sf-photo-img">
+                @else
+                    <div class="sf-photo-empty"><i class="fas fa-user"></i></div>
+                @endif
+                <div class="sf-student-name">{{ $inscription->etudiant->nom }}<br>{{ $inscription->etudiant->prenoms }}</div>
+                <div class="sf-student-mat">{{ $inscription->etudiant->matricule }}</div>
+            </div>
+
+            {{-- Infos perso --}}
+            <div class="sf-info-group">
+                <h6><i class="fas fa-info-circle"></i>Informations personnelles</h6>
+                <div class="sf-info-row"><span class="sf-info-lbl">Genre</span><span class="sf-info-val">{{ $inscription->etudiant->genre == 'M' ? 'Masculin' : 'Féminin' }}</span></div>
+                <div class="sf-info-row"><span class="sf-info-lbl">Date de naissance</span><span class="sf-info-val">{{ $inscription->etudiant->date_naissance ? \Carbon\Carbon::parse($inscription->etudiant->date_naissance)->format('d/m/Y') : 'Non renseigné' }}</span></div>
+                <div class="sf-info-row"><span class="sf-info-lbl">Lieu de naissance</span><span class="sf-info-val">{{ $inscription->etudiant->lieu_naissance ?? 'Non renseigné' }}</span></div>
+                <div class="sf-info-row"><span class="sf-info-lbl">Téléphone</span><span class="sf-info-val">{{ $inscription->etudiant->telephone ?? 'Non renseigné' }}</span></div>
+                <div class="sf-info-row"><span class="sf-info-lbl">Adresse</span><span class="sf-info-val">{{ $inscription->etudiant->adresse ?? 'Non renseigné' }}</span></div>
+            </div>
+
+            {{-- Infos académiques --}}
+            <div class="sf-info-group">
+                <h6><i class="fas fa-graduation-cap"></i>Informations académiques</h6>
+                <div class="sf-info-row"><span class="sf-info-lbl">Filière</span><span class="sf-info-val">{{ $inscription->classe->filiere->name ?? 'Non renseigné' }}</span></div>
+                <div class="sf-info-row"><span class="sf-info-lbl">Niveau</span><span class="sf-info-val">{{ $inscription->classe->niveau->name ?? 'Non renseigné' }}</span></div>
+                <div class="sf-info-row"><span class="sf-info-lbl">Classe</span><span class="sf-info-val">{{ $inscription->classe->name ?? 'Non renseigné' }}</span></div>
+                <div class="sf-info-row">
+                    <span class="sf-info-lbl">Statut</span>
+                    <span class="sf-info-val">
+                        <span class="sf-badge {{ $inscription->status == 'active' ? 'b-success' : 'b-warning' }}">{{ ucfirst($inscription->status) }}</span>
+                    </span>
+                </div>
+                @if($inscription->etudiant->parents && $inscription->etudiant->parents->count() > 0)
+                @php $parent = $inscription->etudiant->parents->first(); @endphp
+                <div style="border-top:1px solid var(--sf-border);margin-top:10px;padding-top:10px;">
+                    <div class="sf-info-row"><span class="sf-info-lbl" style="color:var(--sf-accent);font-weight:700;"><i class="fas fa-users me-1"></i>Parent / Tuteur</span></div>
+                    <div class="sf-info-row"><span class="sf-info-lbl">Nom</span><span class="sf-info-val">{{ ($parent->nom ?? '') . ' ' . ($parent->prenoms ?? '') }}</span></div>
+                    <div class="sf-info-row"><span class="sf-info-lbl">Téléphone</span><span class="sf-info-val">{{ $parent->telephone ?? 'Non renseigné' }}</span></div>
+                </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- Frais souscrits --}}
+<div class="sf-card">
+    <div class="sf-section-head">
+        <div class="sf-section-title"><i class="fas fa-money-bill-wave"></i>Détail des Frais — Année {{ $inscription->anneeUniversitaire->name }}</div>
+        <span class="sf-section-sub">Frais de l'année universitaire en cours</span>
+    </div>
+    <div class="sf-body" style="padding-top:0;">
+        @if($fraisSouscrits->count() > 0)
+        <div class="table-responsive">
+            <table class="sf-table">
+                <thead>
+                    <tr>
+                        <th>Catégorie de Frais</th>
+                        <th class="text-center" width="110">Type</th>
+                        <th class="text-end" width="150">Attendu</th>
+                        <th class="text-end" width="130">Payé</th>
+                        <th class="text-end" width="130">Solde</th>
+                        <th class="text-center" width="100">Statut</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($fraisSouscrits as $frais)
+                    @php
+                        $mp = $inscription->paiements
+                            ->where('frais_category_id', $frais->frais_category_id)
+                            ->where('status', 'validé')
+                            ->filter(fn($p) => $p->type_paiement != 'reliquat' || is_null($p->type_paiement))
+                            ->sum('montant');
+                        $sl = $frais->amount - $mp;
+                    @endphp
+                    <tr>
+                        <td><div style="display:flex;align-items:center;gap:8px;"><i class="fas fa-tag" style="color:var(--sf-accent);font-size:.72rem;"></i><strong>{{ $frais->fraisCategory->name ?? '—' }}</strong></div></td>
+                        <td class="text-center">
+                            @if($frais->fraisCategory->is_mandatory)
+                                <span class="sf-badge b-danger"><i class="fas fa-exclamation-circle"></i>Obligatoire</span>
+                            @else
+                                <span class="sf-badge b-info"><i class="fas fa-star"></i>Optionnel</span>
+                            @endif
+                        </td>
+                        <td class="text-end"><strong>{{ number_format($frais->amount, 0, ',', ' ') }} FCFA</strong></td>
+                        <td class="text-end" style="color:#059669;font-weight:600;">{{ number_format($mp, 0, ',', ' ') }} FCFA</td>
+                        <td class="text-end"><strong style="color:{{ $sl > 0 ? '#dc2626' : '#059669' }};">{{ number_format($sl, 0, ',', ' ') }} FCFA</strong></td>
+                        <td class="text-center">
+                            @if($sl <= 0) <span class="sf-badge b-success">Soldé</span>
+                            @elseif($mp > 0) <span class="sf-badge b-partial">Partiel</span>
+                            @else <span class="sf-badge b-danger">Impayé</span>
+                            @endif
+                        </td>
+                    </tr>
+                    @endforeach
+
+                    @if($reliquatsEntrants->count() > 0)
+                        @foreach($reliquatsEntrants as $rq)
+                        @if($rq->solde_restant > 0)
+                        <tr class="row-rq">
+                            <td>
+                                <div style="display:flex;align-items:center;gap:8px;">
+                                    <i class="fas fa-history" style="color:#d97706;font-size:.72rem;"></i>
+                                    <div>
+                                        <strong>{{ $rq->fraisSubscription->fraisCategory->name ?? '—' }}</strong>
+                                        <br><small style="color:var(--sf-muted);">Reliquat {{ $rq->inscriptionSource->anneeUniversitaire->name ?? 'N/A' }}</small>
+                                    </div>
+                                </div>
+                            </td>
+                            <td class="text-center"><span class="sf-badge b-warning"><i class="fas fa-exclamation-circle"></i>{{ $rq->fraisSubscription->fraisCategory->is_mandatory ? 'Obligatoire' : 'Optionnel' }}</span></td>
+                            <td class="text-end"><strong>{{ number_format($rq->montant_reliquat, 0, ',', ' ') }} FCFA</strong></td>
+                            <td class="text-end" style="color:#059669;font-weight:600;">{{ number_format($rq->montant_regle, 0, ',', ' ') }} FCFA</td>
+                            <td class="text-end" style="color:#d97706;font-weight:600;">{{ number_format($rq->solde_restant, 0, ',', ' ') }} FCFA</td>
+                            <td class="text-center"><span class="sf-badge b-reliquat">Reliquat</span></td>
+                        </tr>
+                        @endif
+                        @endforeach
+                    @endif
+                </tbody>
+            </table>
+        </div>
+        @else
+        <div class="text-center py-5" style="color:var(--sf-muted);">
+            <i class="fas fa-exclamation-triangle fa-2x mb-3" style="color:#f59e0b;"></i>
+            <div style="font-weight:600;margin-bottom:4px;">Aucun frais souscrit</div>
+            <div style="font-size:.8rem;">Aucun frais souscrit pour cette inscription.</div>
+        </div>
+        @endif
+    </div>
+</div>
+
+{{-- Historique paiements --}}
+<div class="sf-card">
+    <div class="sf-section-head">
+        <div class="sf-section-title"><i class="fas fa-receipt"></i>Historique des Paiements</div>
+        <span class="sf-section-sub">{{ $inscription->paiements->where('status', 'validé')->count() }} paiement(s) validé(s)</span>
+    </div>
+    <div class="sf-body" style="padding-top:0;">
+        @if($inscription->paiements->where('status', 'validé')->count() > 0)
+        <div class="table-responsive">
+            <table class="sf-table">
+                <thead>
+                    <tr>
+                        <th>Date</th><th>Catégorie</th><th>Mode</th>
+                        <th class="text-end" width="140">Montant</th>
+                        <th class="text-center" width="100">Statut</th>
+                        <th>Référence</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($inscription->paiements->where('status', 'validé')->sortByDesc('date_paiement') as $p)
+                    <tr>
+                        <td>{{ $p->date_paiement ? \Carbon\Carbon::parse($p->date_paiement)->format('d/m/Y') : '—' }}</td>
+                        <td>
+                            <div style="display:flex;align-items:center;gap:7px;">
+                                @if($p->type_paiement == 'reliquat')
+                                    <i class="fas fa-history" style="color:#d97706;font-size:.72rem;"></i>
+                                    {{ $p->fraisCategory->name ?? '—' }}
+                                    <span class="sf-badge b-reliquat">Reliquat</span>
+                                @else
+                                    <i class="fas fa-money-bill" style="color:#059669;font-size:.72rem;"></i>
+                                    {{ $p->fraisCategory->name ?? '—' }}
+                                @endif
+                            </div>
+                        </td>
+                        <td style="color:var(--sf-muted);">{{ $p->mode_paiement ?? '—' }}</td>
+                        <td class="text-end" style="color:#059669;font-weight:700;">{{ number_format($p->montant, 0, ',', ' ') }} FCFA</td>
+                        <td class="text-center"><span class="sf-badge b-success">{{ strtoupper($p->status) }}</span></td>
+                        <td><code style="font-size:.73rem;color:var(--sf-muted);">{{ $p->numero_recu ?? '—' }}</code></td>
+                    </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+        @else
+        <div class="text-center py-5" style="color:var(--sf-muted);">
+            <i class="fas fa-receipt fa-2x mb-3"></i>
+            <div style="font-weight:600;margin-bottom:4px;">Aucun paiement</div>
+            <div style="font-size:.8rem;">Aucun paiement validé pour cette inscription.</div>
+        </div>
+        @endif
+    </div>
+</div>
+
+<div class="sf-footer">
+    <i class="fas fa-info-circle me-1"></i>
+    Document généré automatiquement le {{ now()->format('d/m/Y à H:i') }}
+</div>
+
+</div>
 </div>
 @endsection

--- a/resources/views/esbtp/settings/index.blade.php
+++ b/resources/views/esbtp/settings/index.blade.php
@@ -40,6 +40,139 @@
     .section-icon.display { background: linear-gradient(135deg, #9b59b6, #8e44ad); }
     .section-icon.mentions { background: linear-gradient(135deg, #1abc9c, #16a085); }
     .section-icon.stats { background: linear-gradient(135deg, #34495e, #2c3e50); }
+
+    /* ── Zone upload logo premium ──────────────────────────── */
+    .pdf-logo-zone {
+        display: flex; gap: 24px; align-items: flex-start;
+        background: #f8fafc; border: 1px solid #e5e7eb;
+        border-radius: 14px; padding: 20px;
+    }
+    .pdf-logo-current {
+        position: relative; flex-shrink: 0;
+        width: 120px; height: 120px;
+        border-radius: 12px; overflow: hidden;
+        background: #fff; border: 2px dashed #d1d5db;
+        display: flex; align-items: center; justify-content: center;
+    }
+    .pdf-logo-current img { max-width: 100%; max-height: 100%; object-fit: contain; }
+    .pdf-logo-placeholder { color: #9ca3af; text-align: center; font-size: .78rem; }
+    .pdf-logo-placeholder i { display: block; font-size: 2rem; margin-bottom: 4px; }
+    .pdf-logo-badge {
+        position: absolute; bottom: 4px; left: 50%; transform: translateX(-50%);
+        background: #10b981; color: #fff; font-size: .65rem; font-weight: 700;
+        padding: 2px 7px; border-radius: 20px; white-space: nowrap;
+    }
+    .pdf-logo-upload-side { flex: 1; display: flex; flex-direction: column; gap: 14px; }
+    .pdf-logo-drop {
+        display: flex; flex-direction: column; align-items: center; justify-content: center;
+        border: 2px dashed #cbd5e1; border-radius: 12px; padding: 20px 16px;
+        cursor: pointer; transition: all .25s; background: #fff; text-align: center;
+    }
+    .pdf-logo-drop:hover { border-color: var(--primary); background: #f0f7ff; }
+    .pdf-logo-drop-icon { font-size: 2rem; color: #94a3b8; margin-bottom: 8px; transition: color .2s; }
+    .pdf-logo-drop:hover .pdf-logo-drop-icon { color: var(--primary); }
+    .pdf-logo-drop-title { font-weight: 700; color: #374151; font-size: .9rem; }
+    .pdf-logo-drop-sub { color: #6b7280; font-size: .82rem; }
+    .pdf-logo-drop-hint { color: #9ca3af; font-size: .73rem; margin-top: 4px; }
+    .pdf-logo-toggles { display: flex; gap: 20px; flex-wrap: wrap; align-items: center; }
+
+    /* ── Layout couleurs : 2 colonnes ─────────────────────── */
+    .pdf-color-layout {
+        display: grid; grid-template-columns: 1fr 300px; gap: 28px; align-items: start;
+    }
+    @media (max-width: 900px) { .pdf-color-layout { grid-template-columns: 1fr; } }
+
+    /* ── Lignes de picker ──────────────────────────────────── */
+    .pdf-color-pickers { display: flex; flex-direction: column; gap: 12px; }
+    .pdf-picker-row {
+        display: flex; align-items: flex-start; gap: 14px;
+        padding: 14px 16px; border-radius: 10px; background: #f8fafc;
+        border: 1px solid #e5e7eb; cursor: pointer;
+        transition: border-color .2s, box-shadow .2s;
+    }
+    .pdf-picker-row:hover { border-color: var(--primary); box-shadow: 0 0 0 3px rgba(4,83,203,.07); }
+    .pdf-picker-swatch-wrap {
+        position: relative; flex-shrink: 0; width: 48px; height: 48px; cursor: pointer;
+    }
+    .pdf-color-input {
+        position: absolute; inset: 0; opacity: 0; width: 100%; height: 100%;
+        cursor: pointer; border: none; padding: 0;
+    }
+    .pdf-picker-swatch {
+        display: block; width: 48px; height: 48px;
+        border-radius: 10px; border: 2px solid rgba(0,0,0,.12);
+        pointer-events: none; transition: background .15s;
+        box-shadow: 0 2px 6px rgba(0,0,0,.12);
+    }
+    .pdf-picker-meta { flex: 1; }
+    .pdf-picker-label { font-weight: 700; color: #1e293b; font-size: .88rem; margin-bottom: 3px; }
+    .pdf-picker-desc { color: #6b7280; font-size: .78rem; line-height: 1.4; }
+    .pdf-contrast-badge {
+        display: inline-flex; align-items: center; gap: 4px;
+        font-size: .7rem; font-weight: 700; padding: 2px 8px;
+        border-radius: 20px; margin-top: 6px;
+    }
+    .pdf-contrast-badge.ok { background: #d1fae5; color: #065f46; }
+    .pdf-contrast-badge.warn { background: #fef3c7; color: #92400e; }
+    .pdf-contrast-badge.bad { background: #fee2e2; color: #991b1b; }
+
+    /* ── Prévisualisation mini-document ───────────────────── */
+    .pdf-color-preview {
+        border: 1px solid #e5e7eb; border-radius: 12px; overflow: hidden;
+        box-shadow: 0 2px 12px rgba(0,0,0,.07); background: #fff; font-family: serif;
+        position: sticky; top: 100px;
+    }
+    .prev-header {
+        display: flex; align-items: center; gap: 10px;
+        padding: 10px 14px; transition: background .2s;
+    }
+    .prev-logo-placeholder {
+        width: 30px; height: 30px; display: flex; align-items: center; justify-content: center;
+        background: rgba(255,255,255,.25); border-radius: 6px; font-size: .9rem; color: rgba(255,255,255,.7);
+        flex-shrink: 0;
+    }
+    .prev-school-name { font-size: .72rem; font-weight: 800; text-transform: uppercase; letter-spacing: .04em; }
+    .prev-school-meta { font-size: .6rem; opacity: .82; }
+    .prev-divider { height: 3px; transition: background .2s; }
+    .prev-doc-title {
+        text-align: center; font-size: .7rem; font-weight: 800; letter-spacing: .1em;
+        padding: 10px 14px 6px; text-transform: uppercase; transition: color .2s, border-color .2s;
+        border-bottom-width: 2px; border-bottom-style: solid; display: inline-block;
+        margin: 0 auto; display: block;
+    }
+    .prev-body { padding: 10px 14px; }
+    .prev-line {
+        height: 6px; background: #e2e8f0; border-radius: 3px; margin-bottom: 6px;
+    }
+    .prev-line-lg { width: 90%; }
+    .prev-line-md { width: 70%; }
+    .prev-line-sm { width: 50%; }
+    .prev-hl-block {
+        padding: 8px 10px; border-radius: 6px; margin: 8px 0;
+        transition: border-color .2s, background .2s;
+    }
+    .prev-table { border-collapse: collapse; width: 100%; font-size: .65rem; }
+    .prev-table-head {
+        display: flex; transition: background .2s, color .2s;
+        padding: 5px 14px;
+    }
+    .prev-table-head span, .prev-table-row span { flex: 1; }
+    .prev-table-row {
+        display: flex; padding: 4px 14px;
+        border-bottom: 1px solid #e5e7eb; transition: color .2s;
+    }
+    .prev-legend {
+        text-align: center; font-size: .58rem; color: #9ca3af; font-style: italic;
+        padding: 6px; border-top: 1px solid #f1f5f9;
+    }
+
+    /* ── Avertissement contraste global ──────────────────── */
+    .pdf-contrast-warning {
+        display: flex; align-items: center; gap: 8px;
+        background: #fef3c7; border-left: 4px solid #f59e0b;
+        border-radius: 8px; padding: 10px 14px; margin-top: 16px;
+        font-size: .83rem; color: #92400e;
+    }
     
     .section-title {
         font-size: 1.25rem;
@@ -448,19 +581,71 @@
                 <!-- Tab 2: Configuration PDF -->
                 <div class="tab-pane fade" id="pdf" role="tabpanel">
 
-            <!-- Section 2: Configuration PDF de Base -->
+            <!-- Section 2: Logo & Identité Visuelle -->
             <div class="settings-section">
                 <div class="section-header">
                     <div class="section-icon pdf">
-                        <i class="fas fa-file-pdf"></i>
+                        <i class="fas fa-image"></i>
                     </div>
                     <div>
-                        <h3 class="section-title">Configuration PDF de Base</h3>
-                        <p class="section-description">Paramètres généraux des bulletins PDF</p>
+                        <h3 class="section-title">Logo & Identité Visuelle</h3>
+                        <p class="section-description">Logo affiché en en-tête de tous vos documents (bulletins, certificats, attestations…)</p>
                     </div>
                 </div>
 
-                <div class="settings-grid-2">
+                <!-- Zone upload logo premium -->
+                <div class="pdf-logo-zone">
+                    <div class="pdf-logo-current" id="logoCurrentWrap">
+                        @if(\App\Helpers\SettingsHelper::get('school_logo', ''))
+                            <img id="logoPreviewImg"
+                                 src="{{ asset('storage/' . \App\Helpers\SettingsHelper::get('school_logo', '')) }}"
+                                 alt="Logo actuel">
+                            <span class="pdf-logo-badge"><i class="fas fa-check-circle"></i> Logo actuel</span>
+                        @else
+                            <div class="pdf-logo-placeholder" id="logoPlaceholder">
+                                <i class="fas fa-image"></i>
+                                <span>Aucun logo</span>
+                            </div>
+                            <img id="logoPreviewImg" src="" alt="" style="display:none;">
+                        @endif
+                    </div>
+                    <div class="pdf-logo-upload-side">
+                        <label class="pdf-logo-drop" id="logoDrop" for="logoFileInput">
+                            <i class="fas fa-cloud-upload-alt pdf-logo-drop-icon"></i>
+                            <div class="pdf-logo-drop-title">Déposer votre logo ici</div>
+                            <div class="pdf-logo-drop-sub">ou cliquez pour choisir un fichier</div>
+                            <div class="pdf-logo-drop-hint">PNG, JPG, SVG — max 2 Mo · Recommandé : fond transparent</div>
+                        </label>
+                        <input type="file" id="logoFileInput" name="setting_school_logo"
+                               accept="image/*" style="display:none" onchange="handleLogoUpload(this)">
+                        <div class="pdf-logo-toggles">
+                            <div class="form-group mb-0">
+                                <label class="form-label-modern mb-1" style="font-size:.82rem;">
+                                    <i class="fas fa-eye text-primary"></i>
+                                    Afficher le logo sur les documents
+                                </label>
+                                <label class="form-switch-modern">
+                                    <input type="checkbox" name="bulletin_show_logo" value="1"
+                                           {{ \App\Helpers\SettingsHelper::get('bulletin_show_logo', '1') == '1' ? 'checked' : '' }}>
+                                    <span class="slider"></span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="settings-grid-2" style="margin-top:20px;">
+                    <div class="form-group">
+                        <label class="form-label-modern">
+                            <i class="fas fa-university text-primary"></i>
+                            Nom affiché sur les bulletins
+                        </label>
+                        <input type="text" class="form-control form-control-modern"
+                               name="bulletin_school_name_custom"
+                               value="{{ \App\Helpers\SettingsHelper::get('bulletin_school_name_custom', '') }}"
+                               placeholder="Laissez vide pour utiliser le nom de l'établissement">
+                        <small class="text-muted"><i class="fas fa-info-circle"></i> Si vide, utilise le nom défini dans l'onglet Général.</small>
+                    </div>
                     <div class="form-group">
                         <label class="form-label-modern">
                             <i class="fas fa-font text-primary"></i>
@@ -471,62 +656,13 @@
                                value="{{ \App\Helpers\SettingsHelper::get('bulletin_font_size', '11') }}"
                                min="8" max="16" step="1">
                     </div>
-
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-image text-primary"></i>
-                            Afficher le logo
-                        </label>
-                        <label class="form-switch-modern">
-                            <input type="checkbox" name="bulletin_show_logo" value="1" 
-                                   {{ \App\Helpers\SettingsHelper::get('bulletin_show_logo', '1') == '1' ? 'checked' : '' }}>
-                            <span class="slider"></span>
-                        </label>
-                    </div>
-
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-image text-primary"></i>
-                            Logo de l'établissement
-                        </label>
-                        <div class="file-upload-area">
-                            @if(\App\Helpers\SettingsHelper::get('school_logo', ''))
-                                <div class="current-logo mb-2">
-                                    <img src="{{ asset('storage/' . \App\Helpers\SettingsHelper::get('school_logo', '')) }}" 
-                                         alt="Logo actuel" style="max-height: 80px;" class="img-thumbnail">
-                                    <p class="text-muted small">Logo actuel</p>
-                                </div>
-                            @endif
-                            <input type="file" class="form-control form-control-modern"
-                                   name="setting_school_logo"
-                                   accept="image/*"
-                                   onchange="previewLogo(this)">
-                            <small class="text-muted">Formats acceptés: PNG, JPG, GIF (max 2MB)</small>
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-university text-primary"></i>
-                            Nom pour les bulletins
-                        </label>
-                        <input type="text" class="form-control form-control-modern"
-                               name="bulletin_school_name_custom"
-                               value="{{ \App\Helpers\SettingsHelper::get('bulletin_school_name_custom', '') }}"
-                               placeholder="Laissez vide pour utiliser le nom de l'établissement">
-                        <small class="text-muted">
-                            <i class="fas fa-info-circle"></i>
-                            Ce nom apparaîtra sur les bulletins. Si vide, utilisera le nom de l'établissement défini ci-dessus.
-                        </small>
-                    </div>
-
                     <div class="form-group">
                         <label class="form-label-modern">
                             <i class="fas fa-calendar text-primary"></i>
                             Afficher date d'édition
                         </label>
                         <label class="form-switch-modern">
-                            <input type="checkbox" name="bulletin_show_edition_date" value="1" 
+                            <input type="checkbox" name="bulletin_show_edition_date" value="1"
                                    {{ \App\Helpers\SettingsHelper::get('bulletin_show_edition_date', '1') == '1' ? 'checked' : '' }}>
                             <span class="slider"></span>
                         </label>
@@ -534,81 +670,141 @@
                 </div>
             </div>
 
-            <!-- Section: Couleurs PDF -->
+            <!-- Section: Couleurs des Documents -->
             <div class="settings-section">
                 <div class="section-header">
                     <div class="section-icon pdf">
                         <i class="fas fa-palette"></i>
                     </div>
                     <div>
-                        <h3 class="section-title">Couleurs des PDFs</h3>
-                        <p class="section-description">Palette appliquée à tous les documents PDF</p>
+                        <h3 class="section-title">Couleurs des Documents PDF</h3>
+                        <p class="section-description">Chaque couleur cible un élément précis — le prévisionnement ci-contre se met à jour en temps réel</p>
                     </div>
                 </div>
 
-                <div class="settings-grid-3">
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-fill-drip text-primary"></i>
-                            Couleur principale
-                        </label>
-                        <input type="color" class="form-control form-control-modern"
-                               name="setting_pdf_primary_color"
-                               value="{{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}">
-                    </div>
+                <!-- Layout 2 colonnes : pickers gauche | preview droite -->
+                <div class="pdf-color-layout">
 
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-fill-drip text-secondary"></i>
-                            Couleur secondaire
-                        </label>
-                        <input type="color" class="form-control form-control-modern"
-                               name="setting_pdf_secondary_color"
-                               value="{{ \App\Helpers\SettingsHelper::get('pdf_secondary_color', '#64748b') }}">
-                    </div>
+                    <!-- Colonne pickers -->
+                    <div class="pdf-color-pickers">
 
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-highlighter text-warning"></i>
-                            Couleur d'accent
-                        </label>
-                        <input type="color" class="form-control form-control-modern"
-                               name="setting_pdf_accent_color"
-                               value="{{ \App\Helpers\SettingsHelper::get('pdf_accent_color', '#f59e0b') }}">
-                    </div>
+                        <!-- Picker 1 : Fond en-tête -->
+                        <div class="pdf-picker-row" data-target="prev-header-bg">
+                            <div class="pdf-picker-swatch-wrap">
+                                <input type="color" id="colorHeaderBg" class="pdf-color-input"
+                                       name="setting_pdf_header_bg_color"
+                                       value="{{ \App\Helpers\SettingsHelper::get('pdf_header_bg_color', '#0453cb') }}"
+                                       oninput="updatePreview()">
+                                <span class="pdf-picker-swatch" id="swatchHeaderBg"
+                                      style="background:{{ \App\Helpers\SettingsHelper::get('pdf_header_bg_color', '#0453cb') }}"></span>
+                            </div>
+                            <div class="pdf-picker-meta">
+                                <div class="pdf-picker-label">Fond de l'en-tête établissement</div>
+                                <div class="pdf-picker-desc">Bannière colorée en haut de chaque document (bulletins, certificats, attestations)</div>
+                                <div class="pdf-contrast-badge" id="contrastHeaderBg"></div>
+                            </div>
+                        </div>
+
+                        <!-- Picker 2 : Texte en-tête -->
+                        <div class="pdf-picker-row" data-target="prev-header-text">
+                            <div class="pdf-picker-swatch-wrap">
+                                <input type="color" id="colorHeaderText" class="pdf-color-input"
+                                       name="setting_pdf_header_text_color"
+                                       value="{{ \App\Helpers\SettingsHelper::get('pdf_header_text_color', '#ffffff') }}"
+                                       oninput="updatePreview()">
+                                <span class="pdf-picker-swatch" id="swatchHeaderText"
+                                      style="background:{{ \App\Helpers\SettingsHelper::get('pdf_header_text_color', '#ffffff') }}"></span>
+                            </div>
+                            <div class="pdf-picker-meta">
+                                <div class="pdf-picker-label">Texte dans l'en-tête établissement</div>
+                                <div class="pdf-picker-desc">Nom de l'école, adresse, téléphone affichés sur la bannière colorée</div>
+                                <div class="pdf-contrast-badge" id="contrastHeaderText"></div>
+                            </div>
+                        </div>
+
+                        <!-- Picker 3 : Couleur accent / titres -->
+                        <div class="pdf-picker-row" data-target="prev-accent">
+                            <div class="pdf-picker-swatch-wrap">
+                                <input type="color" id="colorAccent" class="pdf-color-input"
+                                       name="setting_pdf_primary_color"
+                                       value="{{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}"
+                                       oninput="updatePreview()">
+                                <span class="pdf-picker-swatch" id="swatchAccent"
+                                      style="background:{{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}"></span>
+                            </div>
+                            <div class="pdf-picker-meta">
+                                <div class="pdf-picker-label">Couleur d'accent — titres & soulignements</div>
+                                <div class="pdf-picker-desc">Titre du document (ex: « CERTIFICAT DE SCOLARITÉ »), en-têtes de tableaux, séparateurs colorés</div>
+                                <div class="pdf-contrast-badge" id="contrastAccent"></div>
+                            </div>
+                        </div>
+
+                        <!-- Picker 4 : Texte principal -->
+                        <div class="pdf-picker-row" data-target="prev-body">
+                            <div class="pdf-picker-swatch-wrap">
+                                <input type="color" id="colorBody" class="pdf-color-input"
+                                       name="setting_pdf_text_color"
+                                       value="{{ \App\Helpers\SettingsHelper::get('pdf_text_color', '#1f2937') }}"
+                                       oninput="updatePreview()">
+                                <span class="pdf-picker-swatch" id="swatchBody"
+                                      style="background:{{ \App\Helpers\SettingsHelper::get('pdf_text_color', '#1f2937') }}"></span>
+                            </div>
+                            <div class="pdf-picker-meta">
+                                <div class="pdf-picker-label">Texte principal du corps du document</div>
+                                <div class="pdf-picker-desc">Paragraphes, informations étudiant, notes de bas de page</div>
+                                <div class="pdf-contrast-badge" id="contrastBody"></div>
+                            </div>
+                        </div>
+
+                    </div><!-- /pdf-color-pickers -->
+
+                    <!-- Colonne preview -->
+                    <div class="pdf-color-preview" id="docPreview">
+                        <!-- En-tête établissement -->
+                        <div class="prev-header" id="prev-header-bg" style="background:{{ \App\Helpers\SettingsHelper::get('pdf_header_bg_color', '#0453cb') }}">
+                            <div class="prev-logo-placeholder"><i class="fas fa-university"></i></div>
+                            <div id="prev-header-text" style="color:{{ \App\Helpers\SettingsHelper::get('pdf_header_text_color', '#ffffff') }}">
+                                <div class="prev-school-name">NOM DE L'ÉTABLISSEMENT</div>
+                                <div class="prev-school-meta">Adresse · Tél · Email</div>
+                            </div>
+                        </div>
+                        <!-- Séparateur accent -->
+                        <div class="prev-divider" id="prev-accent" style="background:{{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}"></div>
+                        <!-- Titre document -->
+                        <div class="prev-doc-title" style="color:{{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}; border-bottom:2px solid {{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}">
+                            CERTIFICAT DE SCOLARITÉ
+                        </div>
+                        <!-- Corps -->
+                        <div class="prev-body" id="prev-body" style="color:{{ \App\Helpers\SettingsHelper::get('pdf_text_color', '#1f2937') }}">
+                            <div class="prev-line prev-line-lg"></div>
+                            <div class="prev-line"></div>
+                            <div class="prev-hl-block" style="border-left:3px solid {{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}; background:{{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}12">
+                                <div class="prev-line prev-line-sm" style="background:{{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}55"></div>
+                                <div class="prev-line prev-line-md" style="background:{{ \App\Helpers\SettingsHelper::get('pdf_text_color', '#1f2937') }}33"></div>
+                            </div>
+                            <div class="prev-line prev-line-md"></div>
+                        </div>
+                        <!-- Tableau -->
+                        <div class="prev-table">
+                            <div class="prev-table-head" style="background:{{ \App\Helpers\SettingsHelper::get('pdf_primary_color', '#0453cb') }}; color:{{ \App\Helpers\SettingsHelper::get('pdf_header_text_color', '#ffffff') }}">
+                                <span>Année</span><span>Classe</span><span>Filière</span>
+                            </div>
+                            <div class="prev-table-row" style="color:{{ \App\Helpers\SettingsHelper::get('pdf_text_color', '#1f2937') }}">
+                                <span>2024-2025</span><span>BTS2</span><span>GC</span>
+                            </div>
+                        </div>
+                        <!-- Légende -->
+                        <div class="prev-legend">Aperçu non contractuel · Données fictives</div>
+                    </div><!-- /pdf-color-preview -->
+
+                </div><!-- /pdf-color-layout -->
+
+                <!-- Avertissement contraste global -->
+                <div class="pdf-contrast-warning" id="globalContrastWarning" style="display:none">
+                    <i class="fas fa-exclamation-triangle"></i>
+                    <span id="globalContrastMsg"></span>
                 </div>
 
-                <div class="settings-grid-3">
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-font text-muted"></i>
-                            Couleur du texte
-                        </label>
-                        <input type="color" class="form-control form-control-modern"
-                               name="setting_pdf_text_color"
-                               value="{{ \App\Helpers\SettingsHelper::get('pdf_text_color', '#1f2937') }}">
-                    </div>
-
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-square text-primary"></i>
-                            Fond des en-têtes
-                        </label>
-                        <input type="color" class="form-control form-control-modern"
-                               name="setting_pdf_header_bg_color"
-                               value="{{ \App\Helpers\SettingsHelper::get('pdf_header_bg_color', '#0453cb') }}">
-                    </div>
-
-                    <div class="form-group">
-                        <label class="form-label-modern">
-                            <i class="fas fa-font text-light"></i>
-                            Texte des en-têtes
-                        </label>
-                        <input type="color" class="form-control form-control-modern"
-                               name="setting_pdf_header_text_color"
-                               value="{{ \App\Helpers\SettingsHelper::get('pdf_header_text_color', '#ffffff') }}">
-                    </div>
-                </div>
             </div>
 
                 </div>
@@ -1282,39 +1478,162 @@ function toggleSectionCheckboxes(sectionId, state) {
     }, 300);
 }
 
-// Fonction pour prévisualiser le logo avant upload
-function previewLogo(input) {
-    if (input.files && input.files[0]) {
-        const file = input.files[0];
-        
-        // Vérifier la taille (2MB max)
-        if (file.size > 2 * 1024 * 1024) {
-            alert('Le fichier est trop volumineux (max 2MB)');
-            input.value = '';
-            return;
+// ── Upload logo avec preview ──────────────────────────────────
+function handleLogoUpload(input) {
+    if (!input.files || !input.files[0]) return;
+    const file = input.files[0];
+    if (file.size > 2 * 1024 * 1024) {
+        alert('Le fichier est trop volumineux (max 2 Mo)');
+        input.value = '';
+        return;
+    }
+    const reader = new FileReader();
+    reader.onload = function(e) {
+        const img = document.getElementById('logoPreviewImg');
+        const placeholder = document.getElementById('logoPlaceholder');
+        const badge = document.querySelector('.pdf-logo-badge');
+        if (img) {
+            img.src = e.target.result;
+            img.style.display = '';
         }
-        
-        // Créer une prévisualisation
-        const reader = new FileReader();
-        reader.onload = function(e) {
-            // Trouver ou créer la div de prévisualisation
-            let previewDiv = input.parentNode.querySelector('.logo-preview');
-            if (!previewDiv) {
-                previewDiv = document.createElement('div');
-                previewDiv.className = 'logo-preview mt-2';
-                input.parentNode.insertBefore(previewDiv, input.nextSibling);
+        if (placeholder) placeholder.style.display = 'none';
+        if (!badge) {
+            const b = document.createElement('span');
+            b.className = 'pdf-logo-badge';
+            b.innerHTML = '<i class="fas fa-check-circle"></i> Nouveau logo';
+            document.querySelector('.pdf-logo-current').appendChild(b);
+        } else {
+            badge.innerHTML = '<i class="fas fa-check-circle"></i> Nouveau logo';
+        }
+    };
+    reader.readAsDataURL(file);
+}
+
+// Drag & drop sur la zone logo
+document.addEventListener('DOMContentLoaded', function() {
+    const drop = document.getElementById('logoDrop');
+    if (drop) {
+        drop.addEventListener('dragover', e => { e.preventDefault(); drop.style.borderColor = 'var(--primary)'; });
+        drop.addEventListener('dragleave', () => { drop.style.borderColor = ''; });
+        drop.addEventListener('drop', e => {
+            e.preventDefault();
+            drop.style.borderColor = '';
+            const dt = e.dataTransfer;
+            if (dt && dt.files.length) {
+                const fi = document.getElementById('logoFileInput');
+                // DataTransfer trick to set files on input
+                try {
+                    const dtt = new DataTransfer();
+                    dtt.items.add(dt.files[0]);
+                    fi.files = dtt.files;
+                } catch(err) {}
+                handleLogoUpload({ files: dt.files, value: '' });
             }
-            
-            previewDiv.innerHTML = `
-                <div class="text-center">
-                    <img src="${e.target.result}" alt="Aperçu" style="max-height: 80px;" class="img-thumbnail">
-                    <p class="text-success small"><i class="fas fa-eye"></i> Aperçu - Cliquez sur Sauvegarder pour confirmer</p>
-                </div>
-            `;
-        };
-        reader.readAsDataURL(file);
+        });
+    }
+});
+
+// ── Calcul ratio de contraste WCAG ───────────────────────────
+function hexToRgb(hex) {
+    const r = parseInt(hex.slice(1,3),16)/255;
+    const g = parseInt(hex.slice(3,5),16)/255;
+    const b = parseInt(hex.slice(5,7),16)/255;
+    return [r,g,b];
+}
+function relativeLuminance(r,g,b) {
+    const c = [r,g,b].map(v => v <= 0.03928 ? v/12.92 : Math.pow((v+0.055)/1.055,2.4));
+    return 0.2126*c[0] + 0.7152*c[1] + 0.0722*c[2];
+}
+function contrastRatio(hex1, hex2) {
+    const [r1,g1,b1] = hexToRgb(hex1);
+    const [r2,g2,b2] = hexToRgb(hex2);
+    const L1 = relativeLuminance(r1,g1,b1);
+    const L2 = relativeLuminance(r2,g2,b2);
+    const lighter = Math.max(L1,L2);
+    const darker  = Math.min(L1,L2);
+    return (lighter + 0.05) / (darker + 0.05);
+}
+function setContrastBadge(badgeId, ratio, label) {
+    const el = document.getElementById(badgeId);
+    if (!el) return;
+    if (ratio >= 4.5) {
+        el.className = 'pdf-contrast-badge ok';
+        el.innerHTML = `<i class="fas fa-check-circle"></i> Contraste ${ratio.toFixed(1)}:1 — lisible`;
+    } else if (ratio >= 3) {
+        el.className = 'pdf-contrast-badge warn';
+        el.innerHTML = `<i class="fas fa-exclamation-triangle"></i> Contraste ${ratio.toFixed(1)}:1 — passable`;
+    } else {
+        el.className = 'pdf-contrast-badge bad';
+        el.innerHTML = `<i class="fas fa-times-circle"></i> Contraste ${ratio.toFixed(1)}:1 — difficile à lire`;
     }
 }
+
+// ── Mise à jour live preview ──────────────────────────────────
+function updatePreview() {
+    const bg    = document.getElementById('colorHeaderBg')?.value   || '#0453cb';
+    const txt   = document.getElementById('colorHeaderText')?.value || '#ffffff';
+    const acc   = document.getElementById('colorAccent')?.value     || '#0453cb';
+    const body  = document.getElementById('colorBody')?.value       || '#1f2937';
+
+    // Mettre à jour les swatches
+    ['HeaderBg','HeaderText','Accent','Body'].forEach(k => {
+        const s = document.getElementById('swatch'+k);
+        const v = {HeaderBg:bg,HeaderText:txt,Accent:acc,Body:body}[k];
+        if (s) s.style.background = v;
+    });
+
+    // Mettre à jour la preview
+    const header = document.getElementById('prev-header-bg');
+    const headerTxt = document.getElementById('prev-header-text');
+    const divider = document.getElementById('prev-accent');
+    const docTitle = document.querySelector('.prev-doc-title');
+    const prevBody = document.getElementById('prev-body');
+    const tableHead = document.querySelector('.prev-table-head');
+    const tableRow  = document.querySelector('.prev-table-row');
+    const hlBlock   = document.querySelector('.prev-hl-block');
+    const hlLine1   = hlBlock ? hlBlock.querySelectorAll('.prev-line')[0] : null;
+    const hlLine2   = hlBlock ? hlBlock.querySelectorAll('.prev-line')[1] : null;
+
+    if (header)    header.style.background = bg;
+    if (headerTxt) headerTxt.style.color = txt;
+    if (divider)   divider.style.background = acc;
+    if (docTitle)  { docTitle.style.color = acc; docTitle.style.borderBottomColor = acc; }
+    if (prevBody)  prevBody.style.color = body;
+    if (tableHead) { tableHead.style.background = acc; tableHead.style.color = txt; }
+    if (tableRow)  tableRow.style.color = body;
+    if (hlBlock) {
+        hlBlock.style.borderLeftColor = acc;
+        hlBlock.style.background = acc + '12';
+    }
+    if (hlLine1)  hlLine1.style.background = acc + '55';
+    if (hlLine2)  hlLine2.style.background = body + '33';
+
+    // Badges de contraste
+    setContrastBadge('contrastHeaderBg',   contrastRatio(bg,  txt), 'En-tête');
+    setContrastBadge('contrastHeaderText', contrastRatio(txt, bg),  'Texte en-tête');
+    setContrastBadge('contrastAccent',     contrastRatio(acc, '#ffffff'), 'Titre');
+    setContrastBadge('contrastBody',       contrastRatio(body,'#ffffff'), 'Corps');
+
+    // Avertissement global blanc-sur-blanc ou bleu-sur-bleu
+    const warnings = [];
+    if (contrastRatio(bg,txt) < 3)   warnings.push('Fond en-tête / Texte en-tête peu lisible');
+    if (contrastRatio(acc,'#ffffff') < 3) warnings.push('Couleur accent trop claire pour titres blancs');
+    const warn = document.getElementById('globalContrastWarning');
+    const msg  = document.getElementById('globalContrastMsg');
+    if (warn && msg) {
+        if (warnings.length) {
+            warn.style.display = 'flex';
+            msg.textContent = '⚠ ' + warnings.join(' · ');
+        } else {
+            warn.style.display = 'none';
+        }
+    }
+}
+
+// Initialiser la preview et les badges au chargement
+document.addEventListener('DOMContentLoaded', function() {
+    updatePreview();
+});
 
 // Fonction pour tester les rappels
 function testReminders() {


### PR DESCRIPTION
## Summary
- Fix photo étudiant manquante dans les PDFs (bulletin et situation financière)
- Redesign complet des documents preview (certificat, attestation de fréquentation, situation financière) avec système CSS variables tiré des settings
- Refonte de l'onglet « Configuration PDF » dans les settings : color pickers annotés avec mini-preview live, drop zone logo, badges de contraste WCAG

## Changes
- `app/Http/Controllers/ESBTPBulletinController.php` — encodage base64 photo étudiant avec vérification double chemin storage
- `resources/views/esbtp/inscriptions/situation-financiere-pdf.blade.php` — fix double chemin photo pour DomPDF
- `resources/views/esbtp/inscriptions/situation-financiere-preview.blade.php` — redesign complet CSS variables `--sf-*`, KPI cards espacées, plus de bleu hardcodé
- `resources/views/esbtp/etudiants/certificat-preview.blade.php` — redesign système `--doc-*`, header accent depuis settings, highlights, filigrane logo
- `resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php` — même système `--doc-*`, bloc infos accent, bloc statut neutre
- `resources/views/esbtp/settings/index.blade.php` — drop zone logo avec preview drag & drop, 4 color pickers avec labels explicites (fond en-tête / texte en-tête / accent-titres / corps), mini-preview live, badges contraste WCAG, avertissement blanc-sur-blanc

## Type of change
- [x] feat — new feature
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (php -l) on all modified PHP files