### PR TITLE
fix(documents): aligner templates PDF DomPDF avec previews et settings couleurs

### DIFF
--- a/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
@@ -3,519 +3,317 @@
 <head>
     @include('pdf.partials.theme')
     @php
-        $pdfSettings = \App\Helpers\SettingsHelper::getPdfSettings();
-        $pdfHeaderBg = $pdfSettings['header_bg_color'] ?? '#0453cb';
-        $pdfHeaderText = $pdfSettings['header_text_color'] ?? '#ffffff';
-        $pdfText = $pdfSettings['text_color'] ?? '#1f2937';
+        $pdfSettings    = \App\Helpers\SettingsHelper::getPdfSettings();
+        $pdfHeaderBg    = $pdfSettings['header_bg_color']   ?? '#0453cb';
+        $pdfHeaderText  = $pdfSettings['header_text_color'] ?? '#ffffff';
+        $pdfPrimary     = $pdfSettings['primary_color']     ?? $pdfHeaderBg;
+        $pdfText        = $pdfSettings['text_color']        ?? '#1f2937';
+        $pdfMuted       = '#6b7280';
+        $pdfBorder      = '#e5e7eb';
     @endphp
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title>Attestation de Fréquentation - {{ $etudiant->matricule }}</title>
     <style>
+        * { box-sizing: border-box; }
+
         body {
-            font-family: Arial, sans-serif;
+            font-family: "Helvetica", "Arial", sans-serif;
             font-size: 12px;
-            line-height: 1.5;
-            color: #333;
+            line-height: 1.55;
+            color: {{ $pdfText }};
             margin: 0;
             padding: 0;
-            background-color: white;
+            background: white;
         }
-        
+
         .container {
             width: 100%;
-            max-width: 750px;
-            margin: 0 auto;
-            padding: 20px;
-            position: relative;
+            padding: 28px 30px;
         }
 
         .document-watermark {
             position: absolute;
-            top: 50%;
-            left: 50%;
+            top: 50%; left: 50%;
             transform: translate(-50%, -50%);
-            opacity: 0.08;
-            width: 60%;
+            opacity: 0.06;
+            width: 55%;
             z-index: 0;
             text-align: center;
         }
+        .document-watermark img { max-width: 100%; }
+        .document-content { position: relative; z-index: 1; }
 
-        .document-watermark img {
-            max-width: 100%;
-        }
-
-        .document-content {
-            position: relative;
-            z-index: 1;
-        }
-        
-        /* En-tête moderne */
-        .certificat-header {
+        /* En-tête établissement */
+        .doc-header {
+            background-color: {{ $pdfHeaderBg }};
+            color: {{ $pdfHeaderText }};
+            border-radius: 10px;
+            padding: 18px 22px;
             text-align: center;
-            margin-bottom: 25px;
-            border-bottom: 3px solid #1e40af;
-            padding-bottom: 15px;
         }
-        
-        .certificat-logo {
-            max-width: 80px;
-            margin-bottom: 10px;
+
+        .doc-header-logo img {
+            max-height: 48px;
+            max-width: 90px;
+            margin-bottom: 8px;
+            filter: brightness(0) invert(1);
         }
-        
-        .certificat-school-name {
-            font-size: 16px;
-            font-weight: bold;
-            margin-bottom: 6px;
+
+        .doc-school-name {
+            font-size: 15px;
+            font-weight: 800;
             text-transform: uppercase;
-            color: #1e40af;
+            letter-spacing: 0.03em;
+            color: {{ $pdfHeaderText }};
+            margin-bottom: 4px;
         }
-        
-        .certificat-address {
-            font-size: 10px;
-            color: #64748b;
-            margin-bottom: 3px;
+
+        .doc-school-meta {
+            font-size: 9px;
+            opacity: 0.88;
+            line-height: 1.5;
+            color: {{ $pdfHeaderText }};
         }
-        
-        /* Séparateur décoratif - Compatible DomPDF */
-        .certificat-divider {
-            height: 4px;
-            background-color: #1e40af;
-            margin: 15px 0;
+
+        /* Séparateur */
+        .doc-divider {
+            height: 3px;
+            background-color: {{ $pdfPrimary }};
+            margin: 18px 0;
             border: none;
         }
-        
-        /* Titre du certificat - Compatible DomPDF */
-        .certificat-title {
-            font-size: 20px;
-            font-weight: bold;
+
+        /* Titre document — underline uniquement */
+        .doc-title-wrap {
             text-align: center;
-            border: 3px double #1e40af;
-            padding: 12px;
-            margin: 25px auto;
-            max-width: 85%;
-            background-color: #f8fafc;
-            text-transform: uppercase;
-            color: #1e40af;
+            margin: 0 0 26px;
         }
-        
-        /* Contenu principal */
-        .certificat-content {
-            margin: 25px 0;
+
+        .doc-title {
+            display: inline-block;
+            font-size: 18px;
+            font-weight: 800;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: {{ $pdfPrimary }};
+            border-bottom: 3px solid {{ $pdfPrimary }};
+            padding-bottom: 5px;
+        }
+
+        /* Corps */
+        .doc-body {
+            margin: 0 0 20px;
             line-height: 1.7;
             font-size: 12px;
             text-align: justify;
+            color: {{ $pdfText }};
         }
-        
-        .certificat-content p {
-            margin-bottom: 12px;
-        }
-        
-        .certificat-highlight {
-            font-weight: bold;
-            color: #1e40af;
+
+        .doc-body p { margin-bottom: 10px; }
+
+        /* Mots mis en valeur — couleur accent lisible sur fond blanc */
+        .hl {
+            font-weight: 700;
+            color: {{ $pdfPrimary }};
             text-decoration: underline;
         }
 
-        /* Informations étudiant en bloc */
-        .student-info {
-            margin: 20px 0;
-            line-height: 1.8;
-        }
-
+        /* Bloc infos étudiant — fond très clair + bordure gauche colorée */
         .student-details {
-            margin: 15px 0;
-            padding: 10px;
+            margin: 16px 0;
+            padding: 12px 14px;
             background-color: #f8fafc;
-            border-left: 4px solid #1e40af;
+            border-left: 4px solid {{ $pdfPrimary }};
+            width: 100%;
         }
 
         .detail-row {
-            margin-bottom: 8px;
             display: table;
             width: 100%;
+            margin-bottom: 7px;
         }
 
         .detail-label {
             display: table-cell;
-            width: 30%;
-            font-weight: bold;
-            vertical-align: top;
-        }
-
-        .detail-value {
-            display: table-cell;
-            width: 70%;
-            vertical-align: top;
-        }
-
-        .status-options {
-            margin: 15px 0;
-            font-style: italic;
-            font-size: 11px;
-        }
-        
-        /* Footer avec signature - Compatible DomPDF */
-        .certificat-footer {
-            margin-top: 40px;
-            width: 100%;
-            overflow: hidden;
-        }
-        
-        .certificat-date {
-            float: left;
-            width: 48%;
-            text-align: left;
-            font-style: italic;
-            color: #64748b;
-            font-size: 11px;
-            margin-top: 30px;
-        }
-        
-        .certificat-signature {
-            float: right;
-            width: 48%;
-            text-align: right;
-            border-top: 2px solid #1e40af;
-            padding-top: 10px;
-            min-height: 60px;
-        }
-        
-        .signature-title {
-            font-weight: bold;
-            margin-bottom: 8px;
-            color: #1e40af;
-            font-size: 12px;
-        }
-        
-        .signature-name {
-            color: #64748b;
-            font-style: italic;
-            font-size: 10px;
-            margin-top: 20px;
-        }
-
-        .signature-note {
-            font-size: 9px;
-            font-style: italic;
-            color: #64748b;
-            margin-top: 10px;
-            text-align: center;
-        }
-        
-        /* Note de bas de page modernisée */
-        .certificat-note {
-            margin-top: 30px;
-            text-align: center;
-            font-size: 9px;
-            font-style: italic;
-            color: #64748b;
-            border-top: 1px solid #e2e8f0;
-            padding-top: 10px;
-            clear: both;
-        }
-
-        /* Fix overflow in PDF layout */
-        .container {
-            max-width: 100%;
-            box-sizing: border-box;
-        }
-
-        .certificat-document {
-            max-width: 100%;
-            box-sizing: border-box;
-        }
-
-        .student-details {
-            width: 100%;
-            box-sizing: border-box;
-        }
-
-        .detail-label {
             width: 35%;
+            font-weight: 700;
+            color: {{ $pdfPrimary }};
+            vertical-align: top;
         }
 
         .detail-value {
+            display: table-cell;
             width: 65%;
+            color: {{ $pdfText }};
+            vertical-align: top;
             word-break: break-word;
         }
 
-        /* Modern administrative look (overrides) */
-        body {
-            font-family: "Helvetica", "Arial", sans-serif;
-            line-height: 1.55;
-        }
-
-        .container {
-            max-width: 780px;
-            padding: 28px 30px;
-        }
-
-        .certificat-header {
-            background: {{ $pdfHeaderBg }};
-            color: {{ $pdfHeaderText }};
-            border-radius: 12px;
-            padding: 18px 20px;
-            border-bottom: none;
-        }
-
-        .certificat-school-name,
-        .certificat-address {
-            color: {{ $pdfHeaderText }};
-        }
-
-        .certificat-logo {
-            max-width: 70px;
-            margin-bottom: 8px;
-        }
-
-        .certificat-divider {
-            height: 2px;
-            background: {{ $pdfHeaderText }};
-            margin: 18px 0;
-        }
-
-        .certificat-title {
-            background: {{ $pdfHeaderBg }};
-            color: {{ $pdfHeaderText }};
-            border-color: {{ $pdfHeaderText }};
-            border-radius: 12px;
-            letter-spacing: 0.5px;
-            box-shadow: none;
-            padding: 12px 16px;
-            font-size: 22px;
-        }
-
-        .certificat-content {
-            font-size: 12px;
+        /* Options statut/boursier */
+        .status-options {
+            margin: 14px 0;
+            font-style: italic;
+            font-size: 11px;
             color: {{ $pdfText }};
         }
 
-        .certificat-highlight {
-            color: {{ $pdfHeaderText }};
-        }
-
-        .student-details {
-            background-color: {{ $pdfHeaderBg }};
-            border-left: 4px solid {{ $pdfHeaderText }};
-        }
-
-        .detail-label {
-            color: {{ $pdfHeaderText }};
-        }
-
-        .detail-value {
-            color: {{ $pdfText }};
-        }
-
-        .certificat-footer {
+        /* Footer signature */
+        .doc-footer {
             margin-top: 36px;
+            width: 100%;
+            overflow: hidden;
         }
 
-        .certificat-signature {
-            border-top: 2px solid {{ $pdfHeaderText }};
-            color: {{ $pdfHeaderText }};
+        .doc-footer-date {
+            float: left;
+            width: 48%;
+            font-style: italic;
+            color: {{ $pdfMuted }};
+            font-size: 11px;
+            margin-top: 32px;
         }
 
-        .signature-title,
-        .signature-name {
-            color: {{ $pdfHeaderText }};
+        .doc-footer-sign {
+            float: right;
+            width: 48%;
+            text-align: right;
+            border-top: 2px solid {{ $pdfPrimary }};
+            padding-top: 10px;
+            min-height: 60px;
         }
 
-        .certificat-note {
-            color: {{ $pdfText }};
-            border-top: 1px solid {{ $pdfHeaderText }};
+        .sign-title {
+            font-weight: 700;
+            color: {{ $pdfPrimary }};
+            font-size: 12px;
+            margin-bottom: 6px;
         }
 
-        /* Final overrides for PDF rendering */
-        .container,
-        .certificat-document {
-            max-width: 100% !important;
-            box-sizing: border-box !important;
+        .sign-name {
+            color: {{ $pdfMuted }};
+            font-style: italic;
+            font-size: 10px;
+            margin-top: 18px;
         }
 
-        .certificat-header,
-        .certificat-school-name,
-        .certificat-address,
-        .certificat-title,
-        .certificat-highlight,
-        .signature-title,
-        .signature-name,
-        .detail-label {
-            color: {{ $pdfHeaderText }} !important;
+        .sign-note {
+            clear: both;
+            text-align: center;
+            font-size: 9px;
+            font-style: italic;
+            color: {{ $pdfMuted }};
+            margin-top: 14px;
         }
 
-        .certificat-title {
-            background-color: {{ $pdfHeaderBg }} !important;
-            border-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-divider {
-            background-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .detail-value {
-            color: {{ $pdfText }} !important;
-        }
-
-        .student-details {
-            background-color: {{ $pdfHeaderBg }} !important;
-            border-left-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-document {
-            --primary: {{ $pdfHeaderText }};
-            --text-secondary: {{ $pdfText }};
-            --text: {{ $pdfText }};
-        }
-
-        .certificat-document {
-            color: {{ $pdfText }};
-        }
-
-        .certificat-header,
-        .certificat-school-name,
-        .certificat-address {
-            color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-divider {
-            background-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-title {
-            background-color: {{ $pdfHeaderBg }} !important;
-            color: {{ $pdfHeaderText }} !important;
-            border-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-highlight,
-        .signature-title,
-        .certificat-signature {
-            color: {{ $pdfHeaderText }} !important;
-            border-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .detail-label {
-            color: {{ $pdfHeaderText }} !important;
-        }
-
-        .detail-value {
-            color: {{ $pdfText }} !important;
-        }
-
-        .student-details {
-            background-color: {{ $pdfHeaderBg }} !important;
-            border-left-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .signature-name {
-            color: {{ $pdfHeaderText }} !important;
+        /* Note de bas de page */
+        .doc-note {
+            clear: both;
+            margin-top: 28px;
+            text-align: center;
+            font-size: 9px;
+            font-style: italic;
+            color: {{ $pdfMuted }};
+            border-top: 1px solid {{ $pdfBorder }};
+            padding-top: 8px;
         }
     </style>
 </head>
 <body>
-    <div class="container">
-        @php
-            $logoPath = \App\Helpers\SettingsHelper::get('school_logo');
-            $logoBase64 = null;
-            if ($logoPath) {
-                $paths = [
-                    storage_path('app/public/' . $logoPath),
-                    public_path($logoPath),
-                    public_path('images/LOGO-KLASSCI-PNG.png'),
-                ];
+<div class="container">
 
-                foreach ($paths as $path) {
-                    if (file_exists($path)) {
-                        $imageData = file_get_contents($path);
-                        $extension = pathinfo($path, PATHINFO_EXTENSION);
-                        $logoBase64 = 'data:image/' . $extension . ';base64,' . base64_encode($imageData);
-                        break;
-                    }
+    @php
+        $logoPath   = \App\Helpers\SettingsHelper::get('school_logo');
+        $logoBase64 = null;
+        if ($logoPath) {
+            foreach ([
+                storage_path('app/public/' . $logoPath),
+                public_path($logoPath),
+            ] as $path) {
+                if (file_exists($path)) {
+                    $ext        = pathinfo($path, PATHINFO_EXTENSION);
+                    $logoBase64 = 'data:image/' . $ext . ';base64,' . base64_encode(file_get_contents($path));
+                    break;
                 }
             }
-        @endphp
+        }
+    @endphp
 
-        @if($logoBase64)
-            <div class="document-watermark">
-                <img src="{{ $logoBase64 }}" alt="Filigrane logo">
-            </div>
-        @endif
+    @if($logoBase64)
+        <div class="document-watermark">
+            <img src="{{ $logoBase64 }}" alt="">
+        </div>
+    @endif
 
-        <div class="document-content">
-        <!-- En-tête -->
-        <div class="certificat-header">
+    <div class="document-content">
+
+        {{-- En-tête établissement --}}
+        <div class="doc-header">
             @if(isset($settings['show_logo']) && $settings['show_logo'] && isset($settings['logo_base64']))
-                <img src="{{ $settings['logo_base64'] }}" alt="Logo École" class="certificat-logo">
+                <div class="doc-header-logo"><img src="{{ $settings['logo_base64'] }}" alt="Logo"></div>
             @endif
-            
-            <div class="certificat-school-name">{{ $settings['name'] ?? '' }}</div>
-            
+            <div class="doc-school-name">{{ $settings['name'] ?? '' }}</div>
             @if($settings['address'] ?? null)
-                <div class="certificat-address">{{ $settings['address'] }}</div>
+                <div class="doc-school-meta">{{ $settings['address'] }}</div>
             @endif
             @if(($settings['phone'] ?? null) || ($settings['email'] ?? null))
-                <div class="certificat-address">
-                    @if($settings['phone'] ?? null)Tél: {{ $settings['phone'] }}@endif
-                    @if(($settings['phone'] ?? null) && ($settings['email'] ?? null)) - @endif
-                    @if($settings['email'] ?? null)Email: {{ $settings['email'] }}@endif
+                <div class="doc-school-meta">
+                    @if($settings['phone'] ?? null)Tél : {{ $settings['phone'] }}@endif
+                    @if(($settings['phone'] ?? null) && ($settings['email'] ?? null)) – @endif
+                    @if($settings['email'] ?? null)Email : {{ $settings['email'] }}@endif
                 </div>
             @endif
         </div>
 
-        <!-- Séparateur décoratif -->
-        <div class="certificat-divider"></div>
+        {{-- Séparateur --}}
+        <div class="doc-divider"></div>
 
-        <!-- Titre du certificat -->
-        <div class="certificat-title">
-            Attestation de Fréquentation
+        {{-- Titre --}}
+        <div class="doc-title-wrap">
+            <span class="doc-title">Attestation de Fréquentation</span>
         </div>
 
-        <!-- Contenu principal -->
-        <div class="certificat-content">
+        {{-- Corps --}}
+        <div class="doc-body">
+            <p>Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, atteste que :</p>
+
             <p>
-                Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, atteste que :
+                {{ $etudiant->sexe === 'F' ? 'Mme / M. / Mlle' : 'M.' }}
+                <span class="hl">{{ strtoupper($etudiant->nom) }} {{ strtoupper($etudiant->prenom) }}</span>
             </p>
 
-            <div class="student-info">
-                <p>
-                    {{ $etudiant->sexe === 'F' ? 'Mme, M., Mlle' : 'M.' }} <span class="certificat-highlight">{{ strtoupper($etudiant->nom) }} {{ strtoupper($etudiant->prenom) }}</span>
-                </p>
-
-                @if($etudiant->date_naissance)
-                <p>
-                    Né(e) le <span class="certificat-highlight">{{ $etudiant->date_naissance->format('d/m/Y') }}</span>
-                    @if($etudiant->lieu_naissance) 
-                        à <span class="certificat-highlight">{{ strtoupper($etudiant->lieu_naissance) }}</span>
-                    @endif
-                </p>
+            @if($etudiant->date_naissance)
+            <p>
+                Né(e) le <span class="hl">{{ $etudiant->date_naissance->format('d/m/Y') }}</span>
+                @if($etudiant->lieu_naissance)
+                    à <span class="hl">{{ strtoupper($etudiant->lieu_naissance) }}</span>
                 @endif
-            </div>
+            </p>
+            @endif
 
             <p>
-                Est régulièrement inscrit(e) au titre de l'année scolaire <span class="certificat-highlight">
+                Est régulièrement inscrit(e) au titre de l'année scolaire
+                <span class="hl">
                 @php
-                    $anneeText = $inscription->anneeUniversitaire->name ?? $inscription->anneeUniversitaire->nom ?? $inscription->anneeUniversitaire->libelle ?? '';
-                    if (preg_match('/(\d{4}-\d{4})/', $anneeText, $matches)) {
-                        echo $matches[1];
-                    } else {
-                        echo $anneeText;
-                    }
+                    $anneeText = $inscription->anneeUniversitaire->name
+                        ?? $inscription->anneeUniversitaire->nom
+                        ?? $inscription->anneeUniversitaire->libelle
+                        ?? '';
+                    echo preg_match('/(\d{4}-\d{4})/', $anneeText, $matches)
+                        ? $matches[1] : $anneeText;
                 @endphp
                 </span>
             </p>
 
+            {{-- Bloc infos étudiant — fond clair + bordure gauche colorée --}}
             <div class="student-details">
                 <div class="detail-row">
                     <div class="detail-label">En classe de :</div>
                     <div class="detail-value">{{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? 'Non renseigné') }}</div>
                 </div>
-
                 <div class="detail-row">
                     <div class="detail-label">Filière :</div>
                     <div class="detail-value">{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</div>
                 </div>
-
                 <div class="detail-row">
                     <div class="detail-label">Sous le numéro Matricule :</div>
                     <div class="detail-value">{{ $etudiant->numero_etudiant ?? $etudiant->matricule }}</div>
@@ -523,40 +321,36 @@
             </div>
 
             <div class="status-options">
-                <p><strong>Statut* :</strong> Affecté / Non affecté &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <strong>Boursier* :</strong> Oui / Non</p>
+                <strong>Statut* :</strong> Affecté / Non affecté
+                &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                <strong>Boursier* :</strong> Oui / Non
             </div>
 
-            <p>
-                En foi de quoi, la présente attestation lui est délivrée pour servir et valoir ce que de droit.
-            </p>
+            <p>En foi de quoi, la présente attestation lui est délivrée pour servir et valoir ce que de droit.</p>
         </div>
 
-        <!-- Footer avec signature -->
-        <div class="certificat-footer">
-            <div class="certificat-date">
+        {{-- Footer signature --}}
+        <div class="doc-footer">
+            <div class="doc-footer-date">
                 <p>Fait à {{ $settings['city'] ?? 'Yamoussoukro' }}, le {{ now()->format('d/m/Y') }}</p>
             </div>
-
-            <div class="certificat-signature">
-                <div class="signature-title">{{ $settings['director_title'] ?? '' }}</div>
+            <div class="doc-footer-sign">
+                <div class="sign-title">{{ $settings['director_title'] ?? '' }}</div>
                 @if($settings['director_name'] ?? null)
-                    <div class="signature-name">{{ $settings['director_name'] }}</div>
+                    <div class="sign-name">{{ $settings['director_name'] }}</div>
                 @endif
             </div>
-            
-            <!-- Clearfix pour le footer -->
-            <div style="clear: both;"></div>
+            <div style="clear:both;"></div>
         </div>
 
-        <div class="signature-note">
-            *Rayer la mention inutile
-        </div>
+        <div class="sign-note">*Rayer la mention inutile</div>
 
-        <!-- Note de bas de page -->
-        <div class="certificat-note">
+        {{-- Note de bas de page --}}
+        <div class="doc-note">
             Ce document est un certificat officiel. Toute falsification constitue un délit passible de poursuites judiciaires.
         </div>
-        </div>
+
     </div>
+</div>
 </body>
 </html>

--- a/resources/views/esbtp/etudiants/certificat.blade.php
+++ b/resources/views/esbtp/etudiants/certificat.blade.php
@@ -3,517 +3,337 @@
 <head>
     @include('pdf.partials.theme')
     @php
-        $pdfSettings = \App\Helpers\SettingsHelper::getPdfSettings();
-        $pdfHeaderBg = $pdfSettings['header_bg_color'] ?? '#0453cb';
-        $pdfHeaderText = $pdfSettings['header_text_color'] ?? '#ffffff';
-        $pdfText = $pdfSettings['text_color'] ?? '#1f2937';
+        $pdfSettings    = \App\Helpers\SettingsHelper::getPdfSettings();
+        $pdfHeaderBg    = $pdfSettings['header_bg_color']   ?? '#0453cb';
+        $pdfHeaderText  = $pdfSettings['header_text_color'] ?? '#ffffff';
+        $pdfPrimary     = $pdfSettings['primary_color']     ?? $pdfHeaderBg;
+        $pdfText        = $pdfSettings['text_color']        ?? '#1f2937';
+        $pdfMuted       = '#6b7280';
+        $pdfBorder      = '#e5e7eb';
     @endphp
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title>Certificat de Scolarité - {{ $etudiant->matricule }}</title>
     <style>
+        * { box-sizing: border-box; }
+
         body {
-            font-family: Arial, sans-serif;
+            font-family: "Helvetica", "Arial", sans-serif;
             font-size: 12px;
-            line-height: 1.5;
-            color: #333;
+            line-height: 1.55;
+            color: {{ $pdfText }};
             margin: 0;
             padding: 0;
-            background-color: white;
+            background: white;
         }
-        
+
         .container {
             width: 100%;
-            max-width: 750px;
-            margin: 0 auto;
-            padding: 20px;
-            position: relative;
+            padding: 28px 30px;
         }
 
         .document-watermark {
             position: absolute;
-            top: 50%;
-            left: 50%;
+            top: 50%; left: 50%;
             transform: translate(-50%, -50%);
-            opacity: 0.08;
-            width: 60%;
+            opacity: 0.06;
+            width: 55%;
             z-index: 0;
             text-align: center;
         }
+        .document-watermark img { max-width: 100%; }
+        .document-content { position: relative; z-index: 1; }
 
-        .document-watermark img {
-            max-width: 100%;
-        }
-
-        .document-content {
-            position: relative;
-            z-index: 1;
-        }
-        
-        /* En-tête moderne */
-        .certificat-header {
+        /* En-tête établissement */
+        .doc-header {
+            background-color: {{ $pdfHeaderBg }};
+            color: {{ $pdfHeaderText }};
+            border-radius: 10px;
+            padding: 18px 22px;
             text-align: center;
-            margin-bottom: 25px;
-            border-bottom: 3px solid #1e40af;
-            padding-bottom: 15px;
         }
-        
-        .certificat-logo {
-            max-width: 80px;
-            margin-bottom: 10px;
+
+        .doc-header-logo img {
+            max-height: 48px;
+            max-width: 90px;
+            margin-bottom: 8px;
+            filter: brightness(0) invert(1);
         }
-        
-        .certificat-school-name {
-            font-size: 16px;
-            font-weight: bold;
-            margin-bottom: 6px;
+
+        .doc-school-name {
+            font-size: 15px;
+            font-weight: 800;
             text-transform: uppercase;
-            color: #1e40af;
+            letter-spacing: 0.03em;
+            color: {{ $pdfHeaderText }};
+            margin-bottom: 4px;
         }
-        
-        .certificat-address {
-            font-size: 10px;
-            color: #64748b;
-            margin-bottom: 3px;
+
+        .doc-school-meta {
+            font-size: 9px;
+            opacity: 0.88;
+            line-height: 1.5;
+            color: {{ $pdfHeaderText }};
         }
-        
-        /* Séparateur décoratif - Compatible DomPDF */
-        .certificat-divider {
-            height: 4px;
-            background-color: #1e40af;
-            margin: 15px 0;
+
+        /* Séparateur */
+        .doc-divider {
+            height: 3px;
+            background-color: {{ $pdfPrimary }};
+            margin: 18px 0;
             border: none;
         }
-        
-        /* Titre du certificat - Compatible DomPDF */
-        .certificat-title {
-            font-size: 20px;
-            font-weight: bold;
+
+        /* Titre document — underline uniquement, pas de fond plein */
+        .doc-title-wrap {
             text-align: center;
-            border: 3px double #1e40af;
-            padding: 12px;
-            margin: 25px auto;
-            max-width: 85%;
-            background-color: #f8fafc;
-            text-transform: uppercase;
-            color: #1e40af;
+            margin: 0 0 26px;
         }
-        
-        /* Contenu principal */
-        .certificat-content {
-            margin: 25px 0;
+
+        .doc-title {
+            display: inline-block;
+            font-size: 18px;
+            font-weight: 800;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: {{ $pdfPrimary }};
+            border-bottom: 3px solid {{ $pdfPrimary }};
+            padding-bottom: 5px;
+        }
+
+        /* Corps */
+        .doc-body {
+            margin: 0 0 20px;
             line-height: 1.7;
             font-size: 12px;
             text-align: justify;
+            color: {{ $pdfText }};
         }
-        
-        .certificat-content p {
-            margin-bottom: 12px;
-        }
-        
-        .certificat-highlight {
-            font-weight: bold;
-            color: #1e40af;
+
+        .doc-body p { margin-bottom: 10px; }
+
+        /* Mots mis en valeur */
+        .hl {
+            font-weight: 700;
+            color: {{ $pdfPrimary }};
             text-decoration: underline;
         }
-        
-        /* Footer avec signature - Compatible DomPDF */
-        .certificat-footer {
-            margin-top: 40px;
+
+        /* Tableau inscriptions */
+        .doc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 14px 0 18px;
+            font-size: 11px;
+        }
+
+        .doc-table th {
+            background-color: {{ $pdfHeaderBg }};
+            color: {{ $pdfHeaderText }};
+            border: 1px solid {{ $pdfHeaderBg }};
+            padding: 8px 7px;
+            text-align: center;
+            font-size: 10px;
+            font-weight: 700;
+        }
+
+        .doc-table td {
+            border: 1px solid {{ $pdfBorder }};
+            padding: 7px;
+            text-align: center;
+            color: {{ $pdfText }};
+        }
+
+        .doc-table tbody tr:nth-child(even) td {
+            background-color: #f8fafc;
+        }
+
+        /* Footer signature */
+        .doc-footer {
+            margin-top: 36px;
             width: 100%;
             overflow: hidden;
         }
-        
-        .certificat-date {
+
+        .doc-footer-date {
             float: left;
             width: 48%;
-            text-align: left;
             font-style: italic;
-            color: #64748b;
+            color: {{ $pdfMuted }};
             font-size: 11px;
-            margin-top: 30px;
+            margin-top: 32px;
         }
-        
-        .certificat-signature {
+
+        .doc-footer-sign {
             float: right;
             width: 48%;
             text-align: right;
-            border-top: 2px solid #1e40af;
+            border-top: 2px solid {{ $pdfPrimary }};
             padding-top: 10px;
             min-height: 60px;
         }
-        
-        .signature-title {
-            font-weight: bold;
-            margin-bottom: 8px;
-            color: #1e40af;
+
+        .sign-title {
+            font-weight: 700;
+            color: {{ $pdfPrimary }};
             font-size: 12px;
+            margin-bottom: 6px;
         }
-        
-        .signature-name {
-            color: #64748b;
+
+        .sign-name {
+            color: {{ $pdfMuted }};
             font-style: italic;
             font-size: 10px;
+            margin-top: 18px;
         }
-        
-        /* Note de bas de page modernisée */
-        .certificat-note {
-            margin-top: 30px;
+
+        /* Note de bas de page */
+        .doc-note {
+            clear: both;
+            margin-top: 28px;
             text-align: center;
             font-size: 9px;
             font-style: italic;
-            color: #64748b;
-            border-top: 1px solid #e2e8f0;
-            padding-top: 10px;
-            clear: both;
-        }
-
-        .certificat-document {
-            --primary: {{ $pdfHeaderText }};
-            --text-secondary: {{ $pdfText }};
-            --text: {{ $pdfText }};
-        }
-
-        .certificat-content table {
-            width: 100%;
-            table-layout: fixed;
-        }
-
-        .certificat-content table th,
-        .certificat-content table td {
-            word-wrap: break-word;
-            overflow-wrap: break-word;
-        }
-
-        /* Modern administrative look (overrides) */
-        body {
-            font-family: "Helvetica", "Arial", sans-serif;
-            line-height: 1.55;
-        }
-
-        .container {
-            max-width: 780px;
-            padding: 28px 30px;
-        }
-
-        .certificat-header {
-            background: {{ $pdfHeaderBg }};
-            color: {{ $pdfHeaderText }};
-            border-radius: 12px;
-            padding: 18px 20px;
-            border-bottom: none;
-        }
-
-        .certificat-school-name,
-        .certificat-address {
-            color: {{ $pdfHeaderText }};
-        }
-
-        .certificat-logo {
-            max-width: 70px;
-            margin-bottom: 8px;
-        }
-
-        .certificat-divider {
-            height: 2px;
-            background: {{ $pdfHeaderText }};
-            margin: 18px 0;
-        }
-
-        .certificat-title {
-            background: {{ $pdfHeaderBg }};
-            color: {{ $pdfHeaderText }};
-            border-color: {{ $pdfHeaderText }};
-            border-radius: 12px;
-            letter-spacing: 0.5px;
-            box-shadow: none;
-            padding: 12px 16px;
-            font-size: 22px;
-        }
-
-        .certificat-content {
-            font-size: 12px;
-            color: {{ $pdfText }};
-        }
-
-        .certificat-highlight {
-            color: {{ $pdfHeaderText }};
-        }
-
-        .certificat-content table {
-            width: 100%;
-            table-layout: fixed;
-            border-collapse: collapse;
-            margin-top: 12px;
-        }
-
-        .certificat-content table th {
-            background: {{ $pdfHeaderBg }};
-            color: {{ $pdfHeaderText }};
-            border: 1px solid {{ $pdfHeaderText }};
-            padding: 8px 6px;
-            font-size: 11px;
-        }
-
-        .certificat-content table td {
-            border: 1px solid {{ $pdfHeaderText }};
-            padding: 8px 6px;
-            text-align: center;
-            font-size: 11px;
-        }
-
-        .certificat-footer {
-            margin-top: 36px;
-        }
-
-        .certificat-signature {
-            border-top: 2px solid {{ $pdfHeaderText }};
-            color: {{ $pdfHeaderText }};
-        }
-
-        .signature-title,
-        .signature-name {
-            color: {{ $pdfHeaderText }};
-        }
-
-        .certificat-note {
-            color: {{ $pdfText }};
-            border-top: 1px solid {{ $pdfHeaderText }};
-        }
-
-        .certificat-document {
-            color: {{ $pdfText }};
-        }
-
-        .certificat-header,
-        .certificat-school-name,
-        .certificat-address {
-            color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-divider {
-            background-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-title {
-            background-color: {{ $pdfHeaderBg }} !important;
-            color: {{ $pdfHeaderText }} !important;
-            border-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-highlight,
-        .signature-title,
-        .certificat-signature {
-            color: {{ $pdfHeaderText }} !important;
-            border-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-content table thead th {
-            background-color: {{ $pdfHeaderBg }} !important;
-            color: {{ $pdfHeaderText }} !important;
-            border-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-content table td {
-            color: {{ $pdfText }} !important;
-            background: transparent !important;
-            border-color: {{ $pdfHeaderText }} !important;
-        }
-
-        /* Final overrides for PDF rendering */
-        .container,
-        .certificat-document {
-            max-width: 100% !important;
-            box-sizing: border-box !important;
-        }
-
-        .certificat-header,
-        .certificat-school-name,
-        .certificat-address,
-        .certificat-title,
-        .certificat-highlight,
-        .signature-title,
-        .signature-name {
-            color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-title {
-            background-color: {{ $pdfHeaderBg }} !important;
-            border-color: {{ $pdfHeaderText }} !important;
-        }
-
-        .certificat-divider {
-            background-color: {{ $pdfHeaderText }} !important;
+            color: {{ $pdfMuted }};
+            border-top: 1px solid {{ $pdfBorder }};
+            padding-top: 8px;
         }
     </style>
 </head>
 <body>
-    <div class="container">
-        @php
-            $logoPath = \App\Helpers\SettingsHelper::get('school_logo');
-            $logoBase64 = null;
-            if ($logoPath) {
-                $paths = [
-                    storage_path('app/public/' . $logoPath),
-                    public_path($logoPath),
-                    public_path('images/LOGO-KLASSCI-PNG.png'),
-                ];
+<div class="container">
 
-                foreach ($paths as $path) {
-                    if (file_exists($path)) {
-                        $imageData = file_get_contents($path);
-                        $extension = pathinfo($path, PATHINFO_EXTENSION);
-                        $logoBase64 = 'data:image/' . $extension . ';base64,' . base64_encode($imageData);
-                        break;
-                    }
+    @php
+        $logoPath   = \App\Helpers\SettingsHelper::get('school_logo');
+        $logoBase64 = null;
+        if ($logoPath) {
+            foreach ([
+                storage_path('app/public/' . $logoPath),
+                public_path($logoPath),
+            ] as $path) {
+                if (file_exists($path)) {
+                    $ext        = pathinfo($path, PATHINFO_EXTENSION);
+                    $logoBase64 = 'data:image/' . $ext . ';base64,' . base64_encode(file_get_contents($path));
+                    break;
                 }
             }
-        @endphp
+        }
+    @endphp
 
-        @if($logoBase64)
-            <div class="document-watermark">
-                <img src="{{ $logoBase64 }}" alt="Filigrane logo">
-            </div>
-        @endif
+    @if($logoBase64)
+        <div class="document-watermark">
+            <img src="{{ $logoBase64 }}" alt="">
+        </div>
+    @endif
 
-        <div class="document-content">
-        <!-- En-tête -->
-        <div class="certificat-header">
+    <div class="document-content">
+
+        {{-- En-tête établissement --}}
+        <div class="doc-header">
             @if(isset($settings['show_logo']) && $settings['show_logo'] && isset($settings['logo_base64']))
-                <img src="{{ $settings['logo_base64'] }}" alt="Logo École" class="certificat-logo">
+                <div class="doc-header-logo"><img src="{{ $settings['logo_base64'] }}" alt="Logo"></div>
             @endif
-            
-            <div class="certificat-school-name">{{ $settings['name'] ?? '' }}</div>
-            
+            <div class="doc-school-name">{{ $settings['name'] ?? '' }}</div>
             @if($settings['address'] ?? null)
-                <div class="certificat-address">{{ $settings['address'] }}</div>
+                <div class="doc-school-meta">{{ $settings['address'] }}</div>
             @endif
             @if(($settings['phone'] ?? null) || ($settings['email'] ?? null))
-                <div class="certificat-address">
-                    @if($settings['phone'] ?? null)Tél: {{ $settings['phone'] }}@endif
-                    @if(($settings['phone'] ?? null) && ($settings['email'] ?? null)) - @endif
-                    @if($settings['email'] ?? null)Email: {{ $settings['email'] }}@endif
+                <div class="doc-school-meta">
+                    @if($settings['phone'] ?? null)Tél : {{ $settings['phone'] }}@endif
+                    @if(($settings['phone'] ?? null) && ($settings['email'] ?? null)) – @endif
+                    @if($settings['email'] ?? null)Email : {{ $settings['email'] }}@endif
                 </div>
             @endif
         </div>
 
-        <!-- Séparateur décoratif -->
-        <div class="certificat-divider"></div>
+        {{-- Séparateur --}}
+        <div class="doc-divider"></div>
 
-        <!-- Titre du certificat -->
-        <div class="certificat-title">
-            Certificat de Scolarité
+        {{-- Titre --}}
+        <div class="doc-title-wrap">
+            <span class="doc-title">Certificat de Scolarité</span>
         </div>
 
-        <!-- Contenu principal -->
-        <div class="certificat-content">
-            <p>
-                Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, certifie que :
-            </p>
+        {{-- Corps --}}
+        <div class="doc-body">
+            <p>Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, certifie que :</p>
 
-            <p>
-                L'étudiant(e) <span class="certificat-highlight">{{ $etudiant->nom }} {{ $etudiant->prenoms }}</span>
-            </p>
+            <p>L'étudiant(e) <span class="hl">{{ $etudiant->nom }} {{ $etudiant->prenoms }}</span></p>
 
             @if($etudiant->date_naissance)
             <p>
-                Né(e) le <span class="certificat-highlight">{{ $etudiant->date_naissance->format('d/m/Y') }}</span>
-                @if($etudiant->lieu_naissance) 
-                    à <span class="certificat-highlight">{{ $etudiant->lieu_naissance }}</span>
-                @endif
+                Né(e) le <span class="hl">{{ $etudiant->date_naissance->format('d/m/Y') }}</span>
+                @if($etudiant->lieu_naissance)à <span class="hl">{{ $etudiant->lieu_naissance }}</span>@endif
             </p>
             @endif
 
-            <p>
-                Matricule : <span class="certificat-highlight">{{ $etudiant->matricule }}</span>
-            </p>
+            <p>Matricule : <span class="hl">{{ $etudiant->matricule }}</span></p>
 
-            <p>
-                Est régulièrement inscrit(e) sur le registre des effectifs de l'année académique :
-            </p>
+            <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année académique :</p>
 
-            <!-- Tableau des inscriptions -->
-            <div style="margin: 15px 0;">
-                <table style="width: 100%; border-collapse: collapse; border: 2px solid #1e40af; font-size: 11px;">
-                    <thead>
-                        <tr style="background-color: #f8fafc;">
-                            <th style="border: 1px solid #1e40af; padding: 8px; text-align: center; font-weight: bold;">Année scolaire</th>
-                            <th style="border: 1px solid #1e40af; padding: 8px; text-align: center; font-weight: bold;">Classe suivie</th>
-                            <th style="border: 1px solid #1e40af; padding: 8px; text-align: center; font-weight: bold;">Niveau d'étude</th>
-                            <th style="border: 1px solid #1e40af; padding: 8px; text-align: center; font-weight: bold;">Filière</th>
-                            <th style="border: 1px solid #1e40af; padding: 8px; text-align: center; font-weight: bold;">Moyenne/20</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @forelse($inscriptions as $inscription)
-                        <tr>
-                            <td style="border: 1px solid #1e40af; padding: 8px; text-align: center;">
-                                @php
-                                    $rawAcademicYear = $inscription->anneeUniversitaire?->libelle
-                                        ?? $inscription->anneeUniversitaire?->name
-                                        ?? null;
-                                    $displayAcademicYear = $rawAcademicYear
-                                        ? (preg_match('/(\d{4}-\d{4})/', $rawAcademicYear, $matches) ? $matches[1] : $rawAcademicYear)
-                                        : 'Non renseigné';
-                                @endphp
-                                {{ $displayAcademicYear }}
-                            </td>
-                            <td style="border: 1px solid #1e40af; padding: 8px; text-align: center;">
-                                {{ $inscription->classe->name ?? 'Non renseigné' }}
-                            </td>
-                            <td style="border: 1px solid #1e40af; padding: 8px; text-align: center;">
-                                {{ $inscription->niveauEtude->name ?? 'Non renseigné' }}
-                            </td>
-                            <td style="border: 1px solid #1e40af; padding: 8px; text-align: center;">
-                                {{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}
-                            </td>
-                            <td style="border: 1px solid #1e40af; padding: 8px; text-align: center;">
-                                @if($inscription->moyenne_generale)
-                                    {{ number_format($inscription->moyenne_generale, 2) }}
-                                @else
-                                    <!-- Moyenne vide pour l'année en cours -->
-                                @endif
-                            </td>
-                        </tr>
-                        @empty
-                        <tr>
-                            <td colspan="5" style="border: 1px solid #1e40af; padding: 8px; text-align: center;">Aucune inscription trouvée</td>
-                        </tr>
-                        @endforelse
-                    </tbody>
-                </table>
-            </div>
+            <table class="doc-table">
+                <thead>
+                    <tr>
+                        <th>Année scolaire</th>
+                        <th>Classe suivie</th>
+                        <th>Niveau d'étude</th>
+                        <th>Filière</th>
+                        <th>Moyenne/20</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($inscriptions as $inscription)
+                    <tr>
+                        <td>
+                            @php
+                                $rawAY = $inscription->anneeUniversitaire?->libelle
+                                    ?? $inscription->anneeUniversitaire?->name ?? null;
+                                echo $rawAY
+                                    ? (preg_match('/(\d{4}-\d{4})/', $rawAY, $m) ? $m[1] : $rawAY)
+                                    : 'Non renseigné';
+                            @endphp
+                        </td>
+                        <td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>
+                        <td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>
+                        <td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>
+                        <td>
+                            @if($inscription->moyenne_generale)
+                                {{ number_format($inscription->moyenne_generale, 2) }}
+                            @endif
+                        </td>
+                    </tr>
+                    @empty
+                    <tr>
+                        <td colspan="5">Aucune inscription trouvée</td>
+                    </tr>
+                    @endforelse
+                </tbody>
+            </table>
 
-            <p style="font-style: italic; margin: 12px 0;">
-                Suivant l'horaire du programme complet.
-            </p>
+            <p style="font-style:italic;">Suivant l'horaire du programme complet.</p>
 
-            <p>
-                Ce certificat est délivré à l'intéressé(e) pour servir et valoir ce que de droit.
-            </p>
+            <p>Ce certificat est délivré à l'intéressé(e) pour servir et valoir ce que de droit.</p>
         </div>
 
-        <!-- Footer avec signature -->
-        <div class="certificat-footer">
-            <div class="certificat-date">
-                <p>Fait à {{ $settings['city'] ?? 'Yamoussoukro' }}, le 13/09/2025</p>
+        {{-- Footer signature --}}
+        <div class="doc-footer">
+            <div class="doc-footer-date">
+                <p>Fait à {{ $settings['city'] ?? 'Yamoussoukro' }}, le {{ now()->format('d/m/Y') }}</p>
             </div>
-
-            <div class="certificat-signature">
-                <div class="signature-title">{{ $settings['director_title'] ?? 'Le Directeur' }}</div>
+            <div class="doc-footer-sign">
+                <div class="sign-title">{{ $settings['director_title'] ?? 'Le Directeur' }}</div>
                 @if($settings['director_name'] ?? null)
-                    <div class="signature-name">{{ $settings['director_name'] }}</div>
+                    <div class="sign-name">{{ $settings['director_name'] }}</div>
                 @endif
             </div>
-            
-            <!-- Clearfix pour le footer -->
-            <div style="clear: both;"></div>
+            <div style="clear:both;"></div>
         </div>
 
-        <!-- Note de bas de page -->
-        <div class="certificat-note">
+        {{-- Note de bas de page --}}
+        <div class="doc-note">
             Ce certificat est un document officiel. Toute falsification constitue un délit passible de poursuites judiciaires.
         </div>
-        </div>
+
     </div>
+</div>
 </body>
 </html>

--- a/resources/views/esbtp/inscriptions/situation-financiere-pdf.blade.php
+++ b/resources/views/esbtp/inscriptions/situation-financiere-pdf.blade.php
@@ -2,517 +2,433 @@
 <html lang="fr">
 <head>
     @include('pdf.partials.theme')
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Situation Financiere - {{ $inscription->etudiant->nom }} {{ $inscription->etudiant->prenoms }}</title>
+    @php
+        $pdfSettings    = \App\Helpers\SettingsHelper::getPdfSettings();
+        $sfHeaderBg     = $pdfSettings['header_bg_color']   ?? '#0453cb';
+        $sfHeaderText   = $pdfSettings['header_text_color'] ?? '#ffffff';
+        $sfPrimary      = $pdfSettings['primary_color']     ?? $sfHeaderBg;
+        $sfText         = $pdfSettings['text_color']        ?? '#1f2937';
+        $sfMuted        = '#6b7280';
+        $sfBorder       = '#e5e7eb';
+    @endphp
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <title>Situation Financière - {{ $inscription->etudiant->nom }} {{ $inscription->etudiant->prenoms }}</title>
     <style>
+        * { box-sizing: border-box; }
+
         body {
-            font-family: 'Arial', sans-serif;
+            font-family: "Helvetica", "Arial", sans-serif;
             font-size: 10px;
             margin: 0;
             padding: 10px;
-            color: #333;
-            line-height: 1.3;
+            color: {{ $sfText }};
+            line-height: 1.4;
             background: white;
         }
 
         .container {
             max-width: 100%;
-            background: white;
-            padding: 15px;
+            padding: 12px 15px;
         }
 
-        /* Header principal */
-        .header-section {
-            background: #007bff;
-            color: white;
-            padding: 15px;
-            border-radius: 8px;
+        /* ── En-tête établissement ───────────────────────────── */
+        .doc-header {
+            background-color: {{ $sfHeaderBg }};
+            color: {{ $sfHeaderText }};
+            border-radius: 10px;
+            padding: 16px 20px;
             text-align: center;
-            margin-bottom: 15px;
-            -webkit-print-color-adjust: exact;
-            color-adjust: exact;
+            margin-bottom: 14px;
         }
 
-        .header-logo {
+        .doc-header-logo img {
             max-height: 40px;
-            max-width: 100px;
-            margin-bottom: 8px;
+            max-width: 90px;
+            margin-bottom: 7px;
             filter: brightness(0) invert(1);
         }
 
-        .school-name {
+        .doc-school-name {
             font-size: 14px;
-            font-weight: 700;
+            font-weight: 800;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+            color: {{ $sfHeaderText }};
             margin-bottom: 4px;
         }
 
-        .school-info {
+        .doc-school-meta {
             font-size: 8px;
+            opacity: 0.88;
+            color: {{ $sfHeaderText }};
             margin-bottom: 10px;
-            opacity: 0.9;
         }
 
-        .document-title-section {
-            background: rgba(255,255,255,0.2);
-            padding: 8px;
+        /* Bandeau titre dans l'en-tête */
+        .doc-title-band {
+            background-color: rgba(255,255,255,0.18);
             border-radius: 6px;
+            padding: 7px 12px;
             margin-top: 8px;
         }
 
-        .document-title {
+        .doc-title-band-label {
             font-size: 12px;
-            font-weight: 600;
-            margin-bottom: 8px;
+            font-weight: 700;
+            color: {{ $sfHeaderText }};
+            letter-spacing: 0.06em;
+            margin-bottom: 6px;
         }
 
-        .student-info-grid {
+        /* Grille étudiant/année dans l'en-tête */
+        .hdr-info-grid {
             display: table;
             width: 100%;
             font-size: 9px;
         }
-
-        .student-info-row {
-            display: table-row;
-        }
-
-        .student-info-cell {
+        .hdr-info-row { display: table-row; }
+        .hdr-info-cell {
             display: table-cell;
             width: 50%;
             text-align: center;
-            padding: 3px;
-        }
-
-        .info-badge {
-            background: rgba(255,255,255,0.3);
             padding: 2px 4px;
+            color: {{ $sfHeaderText }};
+        }
+        .hdr-badge {
+            background-color: rgba(255,255,255,0.25);
             border-radius: 8px;
             display: inline-block;
+            padding: 2px 8px;
             margin-top: 2px;
+            font-weight: 700;
+            color: {{ $sfHeaderText }};
         }
 
-        /* KPI Section */
+        /* ── KPI cards ───────────────────────────────────────── */
         .kpi-section {
             display: table;
             width: 100%;
-            margin-bottom: 15px;
+            margin-bottom: 14px;
+            border-collapse: separate;
+            border-spacing: 5px;
         }
-
-        .kpi-row {
-            display: table-row;
-        }
-
+        .kpi-row { display: table-row; }
         .kpi-card {
             display: table-cell;
             width: 25%;
-            padding: 6px;
+            padding: 8px 6px;
             text-align: center;
-            background: #f8f9fa;
-            border: 1px solid #e9ecef;
-            vertical-align: top;
-            font-size: 8px;
+            background-color: white;
+            border: 1px solid {{ $sfBorder }};
+            border-top: 3px solid {{ $sfPrimary }};
+            vertical-align: middle;
         }
-
-        .kpi-card:first-child {
-            border-radius: 6px 0 0 6px;
-        }
-
-        .kpi-card:last-child {
-            border-radius: 0 6px 6px 0;
-        }
-
         .kpi-title {
             font-size: 7px;
-            font-weight: 600;
-            color: #6b7280;
+            font-weight: 700;
+            color: {{ $sfMuted }};
             text-transform: uppercase;
-            letter-spacing: 0.3px;
-            margin-bottom: 3px;
+            letter-spacing: 0.4px;
+            margin-bottom: 4px;
         }
-
         .kpi-value {
-            font-size: 11px;
-            font-weight: bold;
-            color: #007bff;
+            font-size: 13px;
+            font-weight: 800;
+            color: {{ $sfPrimary }};
             margin-bottom: 2px;
         }
-
+        .kpi-value.negative { color: #dc3545; }
+        .kpi-value.zero     { color: #16a34a; }
         .kpi-desc {
-            font-size: 6px;
-            color: #9ca3af;
+            font-size: 7px;
+            color: {{ $sfMuted }};
         }
 
-        .student-info {
-            background: #f8f9fa;
-            padding: 10px;
-            border-radius: 6px;
-            margin-bottom: 15px;
-            font-size: 9px;
-        }
-
-        .student-info-grid {
-            display: table;
-            width: 100%;
-        }
-
-        .student-info-row {
-            display: table-row;
-        }
-
-        .student-info-cell {
-            display: table-cell;
-            padding: 2px 10px 2px 0;
-            vertical-align: top;
-            width: 50%;
-        }
-
-        .info-label {
-            font-weight: 600;
-            color: #495057;
-            margin-right: 8px;
-        }
-
-        .info-value {
-            color: #212529;
-        }
-
+        /* ── Section title ───────────────────────────────────── */
         .section-title {
             font-size: 10px;
-            font-weight: bold;
-            color: #007bff;
-            margin: 15px 0 8px 0;
+            font-weight: 700;
+            color: {{ $sfPrimary }};
+            margin: 14px 0 7px;
             padding-bottom: 3px;
-            border-bottom: 1px solid #e9ecef;
+            border-bottom: 1px solid {{ $sfBorder }};
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
         }
 
-        .summary-box {
-            background: linear-gradient(135deg, #007bff 0%, #0056b3 100%);
-            color: white;
-            padding: 15px;
-            border-radius: 5px;
-            margin-bottom: 20px;
-        }
-
-        .summary-row {
-            display: table;
-            width: 100%;
-            margin-bottom: 5px;
-        }
-
-        .summary-label {
-            display: table-cell;
-            width: 70%;
-        }
-
-        .summary-value {
-            display: table-cell;
-            text-align: right;
-            font-weight: 600;
-        }
-
-        .summary-total {
-            border-top: 1px solid rgba(255,255,255,0.3);
-            margin-top: 10px;
-            padding-top: 10px;
-            font-size: 14px;
-            font-weight: bold;
-        }
-
-        .progress-bar {
-            width: 100%;
-            height: 15px;
-            background: rgba(255,255,255,0.3);
-            border-radius: 8px;
-            overflow: hidden;
-            margin-top: 8px;
-        }
-
-        .progress-fill {
-            height: 100%;
-            background: rgba(255,255,255,0.9);
-            border-radius: 8px;
-            text-align: center;
-            line-height: 15px;
-            font-size: 10px;
-            color: #007bff;
-            font-weight: bold;
-        }
-
-        .table {
+        /* ── Tableau étudiant (photo + infos) ────────────────── */
+        .student-info-table {
             width: 100%;
             border-collapse: collapse;
-            margin-bottom: 15px;
-            font-size: 11px;
-        }
-
-        .table th,
-        .table td {
-            padding: 6px 8px;
-            text-align: left;
-            border: 1px solid #dee2e6;
-        }
-
-        .table th {
-            background-color: #007bff;
-            color: white;
-            font-weight: 600;
-            font-size: 10px;
-        }
-
-        .table tbody tr:nth-child(even) {
-            background-color: #f8f9fa;
-        }
-
-        .amount {
-            text-align: right;
-            font-weight: 600;
-        }
-
-        .amount.positive {
-            color: #28a745;
-        }
-
-        .amount.negative {
-            color: #dc3545;
-        }
-
-        .status-badge {
-            padding: 2px 6px;
-            border-radius: 10px;
+            margin-bottom: 14px;
             font-size: 9px;
+        }
+        .student-info-table td {
+            padding: 5px 8px;
+            border: 1px solid {{ $sfBorder }};
+            vertical-align: top;
+        }
+        .cell-label {
             font-weight: 600;
-            text-transform: uppercase;
+            color: {{ $sfText }};
+            background-color: #f8fafc;
+            width: 20%;
+        }
+        .cell-value { color: {{ $sfText }}; }
+        .cell-label-parent {
+            font-weight: 600;
+            background-color: #fef9ec;
+            color: {{ $sfText }};
+            width: 20%;
         }
 
-        .status-badge.paye {
-            background: #d4edda;
-            color: #155724;
-        }
-
-        .status-badge.partiel {
-            background: #fff3cd;
-            color: #856404;
-        }
-
-        .status-badge.impaye {
-            background: #f8d7da;
-            color: #721c24;
-        }
-
-        .no-data {
+        /* Placeholder photo */
+        .photo-placeholder {
+            width: 80px;
+            height: 80px;
+            border-radius: 4px;
+            background-color: #f3f4f6;
+            border: 2px solid {{ $sfPrimary }};
             text-align: center;
-            color: #6c757d;
-            font-style: italic;
-            padding: 15px;
-            background: #f8f9fa;
-            border-radius: 5px;
-            margin: 10px 0;
+            vertical-align: middle;
+            font-size: 9px;
+            color: {{ $sfMuted }};
+            line-height: 80px;
         }
 
-        .footer {
-            margin-top: 30px;
+        .photo-real {
+            width: 80px;
+            height: 80px;
+            border-radius: 4px;
+            object-fit: cover;
+            border: 2px solid {{ $sfPrimary }};
+        }
+
+        .matricule-label {
+            margin-top: 5px;
+            font-weight: 700;
+            font-size: 8px;
             text-align: center;
-            color: #666;
+            color: {{ $sfText }};
+        }
+
+        /* ── Badges statut ───────────────────────────────────── */
+        .badge-status {
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 8px;
+            font-weight: 600;
+            color: white;
+        }
+        .badge-active   { background-color: #16a34a; }
+        .badge-inactive { background-color: {{ $sfMuted }}; }
+
+        /* ── Tableaux données ────────────────────────────────── */
+        .doc-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 14px;
             font-size: 10px;
-            border-top: 1px solid #dee2e6;
-            padding-top: 15px;
+        }
+        .doc-table th {
+            background-color: {{ $sfHeaderBg }};
+            color: {{ $sfHeaderText }};
+            border: 1px solid {{ $sfHeaderBg }};
+            padding: 6px 8px;
+            font-weight: 700;
+            font-size: 9px;
+        }
+        .doc-table td {
+            padding: 5px 8px;
+            border: 1px solid {{ $sfBorder }};
+            text-align: left;
+        }
+        .doc-table tbody tr:nth-child(even) td {
+            background-color: #f8fafc;
         }
 
-        .page-break {
-            page-break-before: always;
-        }
+        .amount { text-align: right; font-weight: 600; }
+        .amount-positive { color: #16a34a; }
+        .amount-negative { color: #dc3545; }
+        .amount-neutral  { color: {{ $sfText }}; }
 
-        /* Informations de génération */
-        .generation-info {
-            text-align: center;
-            font-size: 7px;
-            color: #6b7280;
-            margin-top: 15px;
-            padding-top: 10px;
-            border-top: 1px solid #e5e7eb;
-        }
+        /* Badges frais */
+        .badge-mandatory { background-color: #dc3545; color: white; padding: 1px 4px; border-radius: 6px; font-size: 7px; }
+        .badge-optional  { background-color: #0dcaf0; color: white; padding: 1px 4px; border-radius: 6px; font-size: 7px; }
+        .badge-reliquat  { background-color: #f59e0b; color: white; padding: 1px 4px; border-radius: 6px; font-size: 7px; }
+
+        /* Badges paiement */
+        .badge-paye    { background-color: #dcfce7; color: #15803d; padding: 2px 6px; border-radius: 8px; font-size: 8px; font-weight: 600; }
+        .badge-partiel { background-color: #fef9c3; color: #854d0e; padding: 2px 6px; border-radius: 8px; font-size: 8px; font-weight: 600; }
+        .badge-impaye  { background-color: #fee2e2; color: #991b1b; padding: 2px 6px; border-radius: 8px; font-size: 8px; font-weight: 600; }
 
         .no-data {
             text-align: center;
-            color: #6c757d;
+            color: {{ $sfMuted }};
             font-style: italic;
-            padding: 15px;
-            background: #f8f9fa;
-            border-radius: 5px;
-            margin: 10px 0;
+            padding: 12px;
+            background-color: #f8fafc;
+            margin: 8px 0;
         }
 
-        /* Eviter les coupures de page dans les elements importants */
-        .summary-box, .student-info {
-            page-break-inside: avoid;
+        /* ── Pied de page ────────────────────────────────────── */
+        .doc-footer {
+            margin-top: 22px;
+            text-align: center;
+            color: {{ $sfMuted }};
+            font-size: 8px;
+            border-top: 1px solid {{ $sfBorder }};
+            padding-top: 10px;
         }
 
-        .section-title {
-            page-break-after: avoid;
-        }
+        .footer-alert-danger { color: #dc3545; font-weight: 700; }
+        .footer-alert-ok     { color: #16a34a; font-weight: 700; }
 
-        /* Print optimizations */
-        @media print {
-            body {
-                background: white;
-                padding: 5px;
-            }
-
-            .container {
-                padding: 10px;
-            }
-
-            .header-section {
-                margin-bottom: 10px;
-            }
-
-            .kpi-section {
-                margin-bottom: 10px;
-            }
-        }
+        /* page-break */
+        .page-break { page-break-before: always; }
     </style>
 </head>
 <body>
-    <div class="container">
-        <!-- Header Section -->
-        <div class="header-section">
-            @if($etablissement['logo'] && file_exists(storage_path('app/public/' . $etablissement['logo'])))
-                <img src="data:image/{{ pathinfo($etablissement['logo'], PATHINFO_EXTENSION) }};base64,{{ base64_encode(file_get_contents(storage_path('app/public/' . $etablissement['logo']))) }}" class="header-logo" alt="Logo">
-            @endif
+<div class="container">
 
-            <div class="school-name">{{ $etablissement['nom'] ?? 'KLASSCI' }}</div>
-
-            @if($etablissement['adresse'] || $etablissement['telephone'] || $etablissement['email'])
-            <div class="school-info">
-                @if($etablissement['adresse']){{ $etablissement['adresse'] }}@endif
-                @if($etablissement['telephone'] && $etablissement['adresse']) | @endif
-                @if($etablissement['telephone'])Tel: {{ $etablissement['telephone'] }}@endif
-                @if($etablissement['email'] && ($etablissement['adresse'] || $etablissement['telephone'])) | @endif
-                @if($etablissement['email'])Email: {{ $etablissement['email'] }}@endif
+    {{-- ── En-tête établissement ── --}}
+    <div class="doc-header">
+        @if($etablissement['logo'] && file_exists(storage_path('app/public/' . $etablissement['logo'])))
+            <div class="doc-header-logo">
+                <img src="data:image/{{ pathinfo($etablissement['logo'], PATHINFO_EXTENSION) }};base64,{{ base64_encode(file_get_contents(storage_path('app/public/' . $etablissement['logo']))) }}" alt="Logo">
             </div>
-            @endif
+        @endif
 
-            <div class="document-title-section">
-                <div class="document-title">SITUATION FINANCIERE</div>
-                <div class="student-info-grid">
-                    <div class="student-info-row">
-                        <div class="student-info-cell">
-                            <strong>Etudiant:</strong><br>
-                            <span class="info-badge">{{ $inscription->etudiant->nom }} {{ $inscription->etudiant->prenoms }}</span>
-                        </div>
-                        <div class="student-info-cell">
-                            <strong>Annee:</strong><br>
-                            <span class="info-badge">{{ $inscription->anneeUniversitaire->name }}</span>
-                        </div>
+        <div class="doc-school-name">{{ $etablissement['nom'] ?? 'KLASSCI' }}</div>
+
+        @if($etablissement['adresse'] || $etablissement['telephone'] || $etablissement['email'])
+        <div class="doc-school-meta">
+            @if($etablissement['adresse']){{ $etablissement['adresse'] }}@endif
+            @if($etablissement['telephone'] && $etablissement['adresse']) &nbsp;|&nbsp; @endif
+            @if($etablissement['telephone'])Tél : {{ $etablissement['telephone'] }}@endif
+            @if($etablissement['email'] && ($etablissement['adresse'] || $etablissement['telephone'])) &nbsp;|&nbsp; @endif
+            @if($etablissement['email'])Email : {{ $etablissement['email'] }}@endif
+        </div>
+        @endif
+
+        <div class="doc-title-band">
+            <div class="doc-title-band-label">SITUATION FINANCIÈRE</div>
+            <div class="hdr-info-grid">
+                <div class="hdr-info-row">
+                    <div class="hdr-info-cell">
+                        <div>Étudiant</div>
+                        <span class="hdr-badge">{{ $inscription->etudiant->nom }} {{ $inscription->etudiant->prenoms }}</span>
+                    </div>
+                    <div class="hdr-info-cell">
+                        <div>Année universitaire</div>
+                        <span class="hdr-badge">{{ $inscription->anneeUniversitaire->name }}</span>
                     </div>
                 </div>
             </div>
         </div>
+    </div>
 
-        <!-- KPI Section -->
-        <div class="kpi-section">
-            <div class="kpi-row">
-                <div class="kpi-card">
-                    <div class="kpi-title">Total Attendu</div>
-                    <div class="kpi-value">{{ number_format($statistiques['total_attendu'], 0, ',', ' ') }}</div>
-                    <div class="kpi-desc">FCFA</div>
+    {{-- ── KPI cards ── --}}
+    <div class="kpi-section">
+        <div class="kpi-row">
+            <div class="kpi-card">
+                <div class="kpi-title">Total Attendu</div>
+                <div class="kpi-value">{{ number_format($statistiques['total_attendu'], 0, ',', ' ') }}</div>
+                <div class="kpi-desc">FCFA</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-title">Total Payé</div>
+                <div class="kpi-value amount-positive">{{ number_format($statistiques['total_paye'], 0, ',', ' ') }}</div>
+                <div class="kpi-desc">FCFA</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-title">Solde Restant</div>
+                <div class="kpi-value {{ $statistiques['solde_restant'] > 0 ? 'negative' : 'zero' }}">
+                    {{ number_format($statistiques['solde_restant'], 0, ',', ' ') }}
                 </div>
-                <div class="kpi-card">
-                    <div class="kpi-title">Total Paye</div>
-                    <div class="kpi-value">{{ number_format($statistiques['total_paye'], 0, ',', ' ') }}</div>
-                    <div class="kpi-desc">FCFA</div>
-                </div>
-                <div class="kpi-card">
-                    <div class="kpi-title">Solde Restant</div>
-                    <div class="kpi-value" style="color: {{ $statistiques['solde_restant'] > 0 ? '#dc3545' : '#28a745' }};">{{ number_format($statistiques['solde_restant'], 0, ',', ' ') }}</div>
-                    <div class="kpi-desc">FCFA</div>
-                </div>
-                <div class="kpi-card">
-                    <div class="kpi-title">Progression</div>
-                    <div class="kpi-value">{{ $statistiques['pourcentage_paye'] }}%</div>
-                    <div class="kpi-desc">Complete</div>
-                </div>
+                <div class="kpi-desc">FCFA</div>
+            </div>
+            <div class="kpi-card">
+                <div class="kpi-title">Progression</div>
+                <div class="kpi-value">{{ $statistiques['pourcentage_paye'] }}%</div>
+                <div class="kpi-desc">Complété</div>
             </div>
         </div>
+    </div>
 
-
-    <!-- Informations detaillees de l'etudiant -->
-    <div class="section-title">INFORMATIONS DE L'ETUDIANT</div>
-    <table class="student-info-table" style="width: 100%; margin-bottom: 15px; border-collapse: collapse;">
+    {{-- ── Informations de l'étudiant ── --}}
+    <div class="section-title">Informations de l'étudiant</div>
+    <table class="student-info-table">
         <tr>
-            <td rowspan="{{ $inscription->etudiant->parents && $inscription->etudiant->parents->count() > 0 ? '5' : '4' }}" style="width: 120px; text-align: center; vertical-align: top; padding: 10px; border: 1px solid #e5e7eb;">
+            <td rowspan="{{ $inscription->etudiant->parents && $inscription->etudiant->parents->count() > 0 ? '5' : '4' }}"
+                style="width:100px; text-align:center; vertical-align:middle; padding:10px; border:1px solid {{ $sfBorder }};">
                 @php
                     $sfPhotoPath = null;
                     if ($inscription->etudiant->photo) {
-                        $sfCandidates = [
+                        foreach ([
                             storage_path('app/public/photos/etudiants/' . $inscription->etudiant->photo),
                             storage_path('app/public/' . $inscription->etudiant->photo),
-                        ];
-                        foreach ($sfCandidates as $sfCandidate) {
+                        ] as $sfCandidate) {
                             if (file_exists($sfCandidate)) { $sfPhotoPath = $sfCandidate; break; }
                         }
                     }
                 @endphp
                 @if($sfPhotoPath)
-                    @php
-                        $sfPhotoSrc = 'data:' . (mime_content_type($sfPhotoPath) ?: 'image/jpeg') . ';base64,' . base64_encode(file_get_contents($sfPhotoPath));
-                    @endphp
-                    <img src="{{ $sfPhotoSrc }}" alt="Photo" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; border: 2px solid #007bff;">
+                    @php $sfPhotoSrc = 'data:' . (mime_content_type($sfPhotoPath) ?: 'image/jpeg') . ';base64,' . base64_encode(file_get_contents($sfPhotoPath)); @endphp
+                    <img src="{{ $sfPhotoSrc }}" alt="Photo" class="photo-real">
                 @else
-                    <div style="width: 100px; height: 100px; border-radius: 50%; background: #f3f4f6; border: 2px solid #007bff; text-align: center; line-height: 100px; font-size: 32px; color: #6b7280;">
-                        👤
-                    </div>
+                    <div class="photo-placeholder">Photo</div>
                 @endif
-                <div style="margin-top: 8px; font-weight: bold; font-size: 9px;">{{ $inscription->etudiant->matricule }}</div>
+                <div class="matricule-label">{{ $inscription->etudiant->matricule }}</div>
             </td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #f8f9fa;">Genre:</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb;">{{ $inscription->etudiant->genre == 'M' ? 'Masculin' : 'Feminin' }}</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #f8f9fa;">Lieu naissance:</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb;">{{ $inscription->etudiant->lieu_naissance ?? 'Non renseigne' }}</td>
+            <td class="cell-label">Genre</td>
+            <td class="cell-value">{{ $inscription->etudiant->genre == 'M' ? 'Masculin' : 'Féminin' }}</td>
+            <td class="cell-label">Lieu de naissance</td>
+            <td class="cell-value">{{ $inscription->etudiant->lieu_naissance ?? 'Non renseigné' }}</td>
         </tr>
         <tr>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #f8f9fa;">Date naissance:</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb;">{{ $inscription->etudiant->date_naissance ? \Carbon\Carbon::parse($inscription->etudiant->date_naissance)->format('d/m/Y') : 'Non renseigne' }}</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #f8f9fa;">Telephone:</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb;">{{ $inscription->etudiant->telephone ?? 'Non renseigne' }}</td>
+            <td class="cell-label">Date de naissance</td>
+            <td class="cell-value">{{ $inscription->etudiant->date_naissance ? \Carbon\Carbon::parse($inscription->etudiant->date_naissance)->format('d/m/Y') : 'Non renseigné' }}</td>
+            <td class="cell-label">Téléphone</td>
+            <td class="cell-value">{{ $inscription->etudiant->telephone ?? 'Non renseigné' }}</td>
         </tr>
         <tr>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #f8f9fa;">Email:</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-size: 8px;">{{ $inscription->etudiant->email ?? 'Non renseigne' }}</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #f8f9fa;">Statut:</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb;">
-                <span style="background: {{ $inscription->status == 'active' ? '#28a745' : '#6c757d' }}; color: white; padding: 2px 6px; border-radius: 4px; font-size: 8px;">
+            <td class="cell-label">Email</td>
+            <td class="cell-value" style="font-size:8px;">{{ $inscription->etudiant->email ?? 'Non renseigné' }}</td>
+            <td class="cell-label">Statut</td>
+            <td class="cell-value">
+                <span class="badge-status {{ $inscription->status == 'active' ? 'badge-active' : 'badge-inactive' }}">
                     {{ ucfirst($inscription->status) }}
                 </span>
             </td>
         </tr>
         <tr>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #f8f9fa;">Adresse:</td>
-            <td colspan="3" style="padding: 5px 10px; border: 1px solid #e5e7eb; font-size: 9px;">{{ $inscription->etudiant->adresse ?? 'Non renseigne' }}</td>
+            <td class="cell-label">Adresse</td>
+            <td colspan="3" class="cell-value">{{ $inscription->etudiant->adresse ?? 'Non renseigné' }}</td>
         </tr>
         @if($inscription->etudiant->parents && $inscription->etudiant->parents->count() > 0)
         @php $parent = $inscription->etudiant->parents->first(); @endphp
         <tr>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #fef3c7;">Contact parent:</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb;">{{ $parent->nom ?? 'Non renseigne' }} {{ $parent->prenoms ?? '' }}</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb; font-weight: bold; background: #fef3c7;">Tel. parent:</td>
-            <td style="padding: 5px 10px; border: 1px solid #e5e7eb;">{{ $parent->telephone ?? 'Non renseigne' }}</td>
+            <td class="cell-label-parent">Contact parent</td>
+            <td class="cell-value">{{ $parent->nom ?? 'Non renseigné' }} {{ $parent->prenoms ?? '' }}</td>
+            <td class="cell-label-parent">Tél. parent</td>
+            <td class="cell-value">{{ $parent->telephone ?? 'Non renseigné' }}</td>
         </tr>
         @endif
     </table>
 
-    <!-- Detail des frais souscrits -->
-    <div class="section-title">DETAIL DES FRAIS SOUSCRITS</div>
+    {{-- ── Détail des frais souscrits ── --}}
+    <div class="section-title">Détail des frais souscrits</div>
     @if($fraisSouscrits->count() > 0)
-    <table class="table">
+    <table class="doc-table">
         <thead>
             <tr>
-                <th>Categorie de Frais</th>
-                <th>Type</th>
-                <th>Montant Attendu</th>
-                <th>Montant Paye</th>
-                <th>Solde</th>
-                <th>Statut</th>
+                <th>Catégorie de frais</th>
+                <th style="text-align:center;">Type</th>
+                <th style="text-align:right;">Montant attendu</th>
+                <th style="text-align:right;">Montant payé</th>
+                <th style="text-align:right;">Solde</th>
+                <th style="text-align:center;">Statut</th>
             </tr>
         </thead>
         <tbody>
@@ -521,59 +437,50 @@
                 $montantPaye = $inscription->paiements
                     ->where('frais_category_id', $frais->frais_category_id)
                     ->where('status', 'validé')
-                    ->where(function($paiement) {
-                        return $paiement->type_paiement != 'reliquat' || is_null($paiement->type_paiement);
-                    })
+                    ->where(function($p) { return $p->type_paiement != 'reliquat' || is_null($p->type_paiement); })
                     ->sum('montant');
                 $solde = $frais->amount - $montantPaye;
             @endphp
             <tr>
-                <td>{{ $frais->fraisCategory->name ?? 'Non renseigne' }}</td>
-                <td style="text-align: center; font-size: 8px;">
+                <td>{{ $frais->fraisCategory->name ?? 'Non renseigné' }}</td>
+                <td style="text-align:center;">
                     @if($frais->fraisCategory->is_mandatory)
-                        <span style="background: #dc3545; color: white; padding: 2px 4px; border-radius: 6px; font-size: 7px;">Obligatoire</span>
+                        <span class="badge-mandatory">Obligatoire</span>
                     @else
-                        <span style="background: #0dcaf0; color: white; padding: 2px 4px; border-radius: 6px; font-size: 7px;">Optionnel</span>
+                        <span class="badge-optional">Optionnel</span>
                     @endif
                 </td>
-                <td class="amount">{{ number_format($frais->amount, 0, ',', ' ') }} FCFA</td>
-                <td class="amount positive">{{ number_format($montantPaye, 0, ',', ' ') }} FCFA</td>
-                <td class="amount {{ $solde > 0 ? 'negative' : 'positive' }}">
-                    {{ number_format($solde, 0, ',', ' ') }} FCFA
-                </td>
-                <td>
+                <td class="amount amount-neutral">{{ number_format($frais->amount, 0, ',', ' ') }} FCFA</td>
+                <td class="amount amount-positive">{{ number_format($montantPaye, 0, ',', ' ') }} FCFA</td>
+                <td class="amount {{ $solde > 0 ? 'amount-negative' : 'amount-positive' }}">{{ number_format($solde, 0, ',', ' ') }} FCFA</td>
+                <td style="text-align:center;">
                     @if($solde <= 0)
-                        <span class="status-badge paye">Solde</span>
+                        <span class="badge-paye">Soldé</span>
                     @elseif($montantPaye > 0)
-                        <span class="status-badge partiel">Partiel</span>
+                        <span class="badge-partiel">Partiel</span>
                     @else
-                        <span class="status-badge impaye">Impaye</span>
+                        <span class="badge-impaye">Impayé</span>
                     @endif
                 </td>
             </tr>
             @endforeach
 
-            {{-- Intégrer les reliquats comme des lignes de frais --}}
             @if($reliquatsEntrants->count() > 0)
                 @foreach($reliquatsEntrants as $reliquat)
                     @if($reliquat->solde_restant > 0)
-                        <tr style="background-color: #fef3c7;">
-                            <td>
-                                {{ $reliquat->fraisSubscription->fraisCategory->name ?? 'Non renseigne' }}<br>
-                                <small style="color: #6b7280;">Reliquat {{ $reliquat->inscriptionSource->anneeUniversitaire->name ?? 'N/A' }}</small>
-                            </td>
-                            <td style="text-align: center; font-size: 8px;">
-                                @if($reliquat->fraisSubscription->fraisCategory->is_mandatory)
-                                    <span style="background: #f59e0b; color: white; padding: 2px 4px; border-radius: 6px; font-size: 7px;">Obligatoire</span>
-                                @else
-                                    <span style="background: #6b7280; color: white; padding: 2px 4px; border-radius: 6px; font-size: 7px;">Optionnel</span>
-                                @endif
-                            </td>
-                            <td class="amount">{{ number_format($reliquat->montant_reliquat, 0, ',', ' ') }} FCFA</td>
-                            <td class="amount positive">{{ number_format($reliquat->montant_regle, 0, ',', ' ') }} FCFA</td>
-                            <td class="amount" style="color: #d97706;">{{ number_format($reliquat->solde_restant, 0, ',', ' ') }} FCFA</td>
-                            <td><span class="status-badge" style="background: #fef3c7; color: #d97706;">Reliquat</span></td>
-                        </tr>
+                    <tr style="background-color:#fef9ec;">
+                        <td>
+                            {{ $reliquat->fraisSubscription->fraisCategory->name ?? 'Non renseigné' }}<br>
+                            <small style="color:{{ $sfMuted }};">Reliquat {{ $reliquat->inscriptionSource->anneeUniversitaire->name ?? 'N/A' }}</small>
+                        </td>
+                        <td style="text-align:center;">
+                            <span class="badge-reliquat">Reliquat</span>
+                        </td>
+                        <td class="amount amount-neutral">{{ number_format($reliquat->montant_reliquat, 0, ',', ' ') }} FCFA</td>
+                        <td class="amount amount-positive">{{ number_format($reliquat->montant_regle, 0, ',', ' ') }} FCFA</td>
+                        <td class="amount" style="color:#d97706;">{{ number_format($reliquat->solde_restant, 0, ',', ' ') }} FCFA</td>
+                        <td style="text-align:center;"><span class="badge-partiel">Reliquat</span></td>
+                    </tr>
                     @endif
                 @endforeach
             @endif
@@ -583,65 +490,65 @@
     <div class="no-data">Aucun frais souscrit pour cette inscription.</div>
     @endif
 
-
-    <!-- Historique des paiements -->
-    <div class="section-title">HISTORIQUE DES PAIEMENTS</div>
+    {{-- ── Historique des paiements ── --}}
+    <div class="section-title">Historique des paiements</div>
     @if($inscription->paiements->count() > 0)
-    <table class="table">
+    <table class="doc-table">
         <thead>
             <tr>
                 <th>Date</th>
-                <th>Categorie</th>
+                <th>Catégorie</th>
                 <th>Mode</th>
-                <th>Montant</th>
-                <th>Statut</th>
-                <th>Reference</th>
+                <th style="text-align:right;">Montant</th>
+                <th style="text-align:center;">Statut</th>
+                <th>Référence</th>
             </tr>
         </thead>
         <tbody>
             @foreach($inscription->paiements as $paiement)
             <tr>
-                <td>{{ $paiement->date_paiement ? $paiement->date_paiement->format('d/m/Y') : 'Non renseigne' }}</td>
+                <td>{{ $paiement->date_paiement ? $paiement->date_paiement->format('d/m/Y') : 'Non renseigné' }}</td>
                 <td>
-                    {{ $paiement->fraisCategory->name ?? 'Non renseigne' }}
+                    {{ $paiement->fraisCategory->name ?? 'Non renseigné' }}
                     @if($paiement->type_paiement === 'reliquat')
-                        <br><span style="background: #f59e0b; color: white; padding: 1px 3px; border-radius: 4px; font-size: 7px;">Reliquat</span>
+                        <br><span class="badge-reliquat">Reliquat</span>
                     @endif
                 </td>
-                <td>{{ ucfirst($paiement->mode_paiement ?? 'Non renseigne') }}</td>
-                <td class="amount positive">{{ number_format($paiement->montant, 0, ',', ' ') }} FCFA</td>
-                <td>
+                <td>{{ ucfirst($paiement->mode_paiement ?? 'Non renseigné') }}</td>
+                <td class="amount amount-positive">{{ number_format($paiement->montant, 0, ',', ' ') }} FCFA</td>
+                <td style="text-align:center;">
                     @if($paiement->status === 'validé')
-                        <span class="status-badge paye">Validé</span>
+                        <span class="badge-paye">Validé</span>
                     @elseif($paiement->status === 'en_attente')
-                        <span class="status-badge partiel">En attente</span>
+                        <span class="badge-partiel">En attente</span>
                     @else
-                        <span class="status-badge impaye">{{ ucfirst($paiement->status) }}</span>
+                        <span class="badge-impaye">{{ ucfirst($paiement->status) }}</span>
                     @endif
                 </td>
-                <td>{{ $paiement->numero_recu ?? 'Non renseigne' }}</td>
+                <td>{{ $paiement->numero_recu ?? 'Non renseigné' }}</td>
             </tr>
             @endforeach
         </tbody>
     </table>
     @else
-    <div class="no-data">Aucun paiement enregistre pour cette inscription.</div>
+    <div class="no-data">Aucun paiement enregistré pour cette inscription.</div>
     @endif
 
-        <!-- Informations de génération -->
-        <div class="generation-info">
-            <strong>Document genere automatiquement le {{ now()->format('d/m/Y a H:i') }}</strong><br>
-            {{ $etablissement['nom'] ?? 'KLASSCI' }} - Systeme de Gestion des Inscriptions<br>
-            @if($statistiques['solde_restant'] > 0)
-                <span style="color: #dc3545; font-weight: bold;">
-                    ATTENTION: Solde restant a payer: {{ number_format($statistiques['solde_restant'], 0, ',', ' ') }} FCFA
-                </span>
-            @else
-                <span style="color: #28a745; font-weight: bold;">
-                    SITUATION FINANCIERE A JOUR - Tous les frais sont soldes
-                </span>
-            @endif
-        </div>
+    {{-- ── Pied de page ── --}}
+    <div class="doc-footer">
+        <strong>Document généré automatiquement le {{ now()->format('d/m/Y à H:i') }}</strong><br>
+        {{ $etablissement['nom'] ?? 'KLASSCI' }} — Système de Gestion des Inscriptions<br>
+        @if($statistiques['solde_restant'] > 0)
+            <span class="footer-alert-danger">
+                ATTENTION : Solde restant à payer : {{ number_format($statistiques['solde_restant'], 0, ',', ' ') }} FCFA
+            </span>
+        @else
+            <span class="footer-alert-ok">
+                Situation financière à jour — Tous les frais sont soldés
+            </span>
+        @endif
     </div>
+
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Branchement de `getPdfSettings()` dans `situation-financiere-pdf` (était complètement absent)
- Alignement des 3 templates PDF DomPDF avec leurs previews redesignées (PR #57)

## Changes
- `certificat.blade.php` — titre en underline seul (plus de fond bleu plein), `.hl` en `$pdfPrimary` lisible, table borders via settings, CSS dédoublonné
- `attestation-frequentation.blade.php` — même corrections titre + `.hl`, bloc `.student-details` en fond clair `#f8fafc` + bordure gauche colorée (plus de fond bleu plein), labels lisibles
- `situation-financiere-pdf.blade.php` — `getPdfSettings()` ajouté, tous les `#007bff`/`#1e40af` hardcodés remplacés par variables settings, KPI cards avec `border-top` colorée, emoji `👤` supprimé → placeholder texte

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (php -l) on all modified PHP files