### PR TITLE
fix(resultats): corriger RouteNotFoundException sur moyennes-preview

### DIFF
--- a/resources/views/esbtp/resultats/moyennes-preview.blade.php
+++ b/resources/views/esbtp/resultats/moyennes-preview.blade.php
@@ -508,7 +508,7 @@
     // === GESTION DES COEFFICIENTS DE MATIÈRES ===
     
     // URL pour la récupération du coefficient
-    const getCoefficientUrl = '{{ route("resultats.get-matiere-coefficient") }}';
+    const getCoefficientUrl = '{{ route("esbtp.resultats.get-matiere-coefficient") }}';
     const classeId = '{{ $classe->id }}';
     
     // Fonction pour récupérer et afficher les informations du coefficient


### PR DESCRIPTION
## Summary

- Corrige l'erreur `Route [resultats.get-matiere-coefficient] not defined` sur `/esbtp-special/bulletins/moyennes-preview`
- La vue `moyennes-preview.blade.php` appelait `route("resultats.get-matiere-coefficient")` sans le préfixe `esbtp.`
- Le vrai nom de la route (définie dans le groupe `name('esbtp.')`) est `esbtp.resultats.get-matiere-coefficient`

## Test plan

- [ ] Ouvrir `/esbtp-special/bulletins/moyennes-preview?etudiant_id=90&classe_id=10&periode=semestre1&annee_universitaire_id=5`
- [ ] Vérifier qu'il n'y a plus d'erreur 500 RouteNotFoundException
- [ ] Vérifier que la récupération du coefficient fonctionne (appel AJAX)

🤖 Generated with [Claude Code](https://claude.com/claude-code)