### PR TITLE
fix(inscriptions): corriger @media non échappé cassant le layout Blade

### DIFF
--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -114,7 +114,7 @@
         max-width: 60px;
     }
 
-    @media (max-width: 576px) {
+    @@media (max-width: 576px) {
         .step-label { display: none; }
         .step-divider { max-width: 20px; }
     }
@@ -820,7 +820,7 @@
     ============================================ */
     .choices.is-invalid .choices__inner { border-color: var(--kl-danger); }
 
-    @media (max-width: 768px) {
+    @@media (max-width: 768px) {
         .form-section { padding: 18px; }
         .parents-body  { padding: 16px; }
         .parent-card-body { padding: 14px; }


### PR DESCRIPTION
## Summary
- Corrige un bug critique où `@media` dans `@section('styles')` était interprété comme une directive Blade
- Le layout entier était cassé : `<head>` vide, `dashboard-acasi` rendu directement dans `<body>` sans wrapper
- Fix : échapper `@media` en `@@media` dans le `<style>` de la page

## Changes
- `resources/views/esbtp/inscriptions/create.blade.php` — 2 occurrences de `@media` → `@@media` (lignes 117 et 823)

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (php -l) on all modified PHP files