### PR TITLE
fix(inscriptions): échapper @keyframes dans styles Blade (layout cassé)

### DIFF
--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -557,7 +557,7 @@
         animation: slideDown 0.25s ease;
     }
 
-    @keyframes slideDown {
+    @@keyframes slideDown {
         from { opacity: 0; transform: translateY(-8px); }
         to   { opacity: 1; transform: translateY(0); }
     }


### PR DESCRIPTION
## Summary
- Corrige le vrai bug qui cassait le layout : `@keyframes` dans `@section('styles')` interprété comme directive Blade
- Le layout `app.blade.php` n'était pas rendu du tout (head vide, formulaire directement dans body)
- Fix : `@@keyframes` pour échapper en Blade (complète le fix `@@media` de PR #63)

## Changes
- `resources/views/esbtp/inscriptions/create.blade.php` — `@keyframes slideDown` → `@@keyframes slideDown` (ligne 560)

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] Aucun autre @ CSS non échappé dans le bloc <style>