### PR TITLE
fix(inscriptions): @section() dans commentaire HTML cassait le layout

### DIFF
--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -677,7 +677,7 @@
         </form>
 
         <!-- =============================================
-             MODAL DOUBLONS — dans le @section('content')
+             MODAL DOUBLONS
         ============================================== -->
         <div class="modal fade" id="duplicateModal" tabindex="-1" aria-labelledby="duplicateModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-lg modal-dialog-centered">


### PR DESCRIPTION
## Summary
- Fix de la vraie cause racine du layout cassé sur `/esbtp/inscriptions/create`
- Un commentaire HTML contenait `@section('content')` que Blade interprétait comme directive réelle
- Cela ouvrait une 2e section `content`, terminait la 1ère, et rendait le formulaire AVANT le layout

## Root cause
```html
<!-- MODAL DOUBLONS — dans le @section('content') -->
```
Blade parse les directives `@` **avant** le rendu HTML. Même dans un commentaire `<!-- -->`, `@section('content')` est exécuté et casse la structure des sections.

## Changes
- `resources/views/esbtp/inscriptions/create.blade.php` ligne 680 — suppression de `@section('content')` du commentaire HTML

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on klassci.com after deploy + php artisan view:clear
- [ ] Layout restauré (sidebar, navbar, head CSS)

## Checklist
- [x] No secrets or sensitive data committed
- [x] Aucune directive Blade dans les commentaires HTML