### PR TITLE
feat(inscriptions): remplacer stepper horizontal par indicateur scroll-driven fixed

### DIFF
--- a/public/css/inscription-create.css
+++ b/public/css/inscription-create.css
@@ -28,85 +28,216 @@
     }
 
     /* ============================================
-       STEPPER DE PROGRESSION
+       STEPPER FIXED — INDICATEUR DE PROGRESSION
+       Vertical, positionné à droite du contenu,
+       animé au scroll (scroll-driven light travel)
     ============================================ */
-    .form-stepper {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0;
-        margin-bottom: 32px;
-        padding: 20px 16px;
-        background: var(--kl-surface);
-        border-radius: var(--kl-radius-lg);
-        border: 1px solid var(--kl-border);
-        box-shadow: var(--kl-shadow);
-        flex-wrap: wrap;
+
+    /* Keyframes lumière qui voyage sur le trait */
+@keyframes lightTravel {
+        0%   { background-position: 0% 0%;   opacity: 0; }
+        10%  { opacity: 1; }
+        90%  { opacity: 1; }
+        100% { background-position: 0% 100%; opacity: 0; }
     }
 
+@keyframes stepPulse {
+        0%   { box-shadow: 0 0 0 0   rgba(4,83,203,0.45); }
+        70%  { box-shadow: 0 0 0 8px rgba(4,83,203,0);    }
+        100% { box-shadow: 0 0 0 0   rgba(4,83,203,0);    }
+    }
+
+    /* Conteneur principal — fixed à droite */
+    .form-stepper {
+        position: fixed;
+        top: 50%;
+        right: 20px;
+        transform: translateY(-50%);
+        z-index: 900;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0;
+        padding: 16px 10px;
+        background: rgba(255,255,255,0.92);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border: 1px solid var(--kl-border);
+        border-radius: 20px;
+        box-shadow: 0 4px 24px rgba(4,83,203,0.10), 0 1px 4px rgba(0,0,0,0.06);
+        /* largeur fixe : cercle + label */
+        width: 88px;
+    }
+
+    /* Chaque étape = nœud + trait */
     .step-item {
         display: flex;
+        flex-direction: column;
         align-items: center;
-        flex: 1;
-        min-width: 0;
+        gap: 0;
+        width: 100%;
     }
 
+    /* Nœud (cercle + label) */
+    .step-node {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        position: relative;
+        z-index: 2;
+    }
+
+    /* Cercle */
     .step-circle {
-        width: 36px;
-        height: 36px;
+        width: 32px;
+        height: 32px;
         border-radius: 50%;
         background: var(--kl-bg);
         border: 2px solid var(--kl-border);
         color: var(--kl-text-muted);
         font-weight: 700;
-        font-size: 13px;
+        font-size: 12px;
         display: flex;
         align-items: center;
         justify-content: center;
         flex-shrink: 0;
-        transition: var(--kl-transition);
+        transition: background 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+        position: relative;
+        overflow: hidden;
     }
 
-    .step-item.active .step-circle {
-        background: var(--kl-primary);
-        border-color: var(--kl-primary);
-        color: white;
-        box-shadow: 0 0 0 4px rgba(4,83,203,0.15);
+    /* Icône check (cachée par défaut) */
+    .step-check {
+        position: absolute;
+        opacity: 0;
+        transform: scale(0.5);
+        transition: opacity 0.25s ease, transform 0.25s ease;
+        font-size: 11px;
     }
 
+    /* Numéro (visible par défaut) */
+    .step-num {
+        transition: opacity 0.25s ease, transform 0.25s ease;
+    }
+
+    /* État DONE : check visible, num caché */
     .step-item.done .step-circle {
         background: var(--kl-success);
         border-color: var(--kl-success);
         color: white;
     }
+    .step-item.done .step-num  { opacity: 0; transform: scale(0.5); }
+    .step-item.done .step-check{ opacity: 1; transform: scale(1);   }
 
+    /* État ACTIVE : bleu + pulse */
+    .step-item.active .step-circle {
+        background: var(--kl-primary);
+        border-color: var(--kl-primary);
+        color: white;
+        animation: stepPulse 2s infinite;
+    }
+
+    /* Label sous le cercle */
     .step-label {
-        font-size: 11px;
-        font-weight: 600;
+        font-size: 9px;
+        font-weight: 700;
         color: var(--kl-text-muted);
-        margin-left: 8px;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
         text-transform: uppercase;
-        letter-spacing: 0.4px;
+        letter-spacing: 0.5px;
+        text-align: center;
+        line-height: 1.2;
+        white-space: nowrap;
+        transition: color 0.3s ease;
     }
 
     .step-item.active .step-label { color: var(--kl-primary); }
     .step-item.done .step-label   { color: var(--kl-success); }
 
-    .step-divider {
-        flex: 1;
-        height: 2px;
+    /* Trait entre deux nœuds */
+    .step-track {
+        position: relative;
+        width: 2px;
+        /* hauteur pilotée dynamiquement via JS : --track-height */
+        height: var(--track-height, 40px);
         background: var(--kl-border);
-        margin: 0 8px;
-        min-width: 20px;
-        max-width: 60px;
+        margin: 0;          /* ZÉRO espace — collé directement aux cercles */
+        overflow: hidden;
+        border-radius: 2px;
+        flex-shrink: 0;
     }
 
-@media (max-width: 576px) {
-        .step-label { display: none; }
-        .step-divider { max-width: 20px; }
+    /* Remplissage de progression (0% → 100% de haut en bas) */
+    .step-track-fill {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: var(--fill, 0%);        /* piloté par JS */
+        background: var(--kl-primary);
+        border-radius: 2px;
+        transition: height 0.12s linear;
+    }
+
+    .step-item.done .step-track-fill { height: 100%; background: var(--kl-success); }
+
+    /* Lumière animée qui voyage sur le trait quand il est en cours */
+    .step-track-light {
+        position: absolute;
+        top: 0;
+        left: -50%;
+        width: 200%;
+        height: 40px;
+        background: linear-gradient(
+            to bottom,
+            transparent 0%,
+            rgba(255,255,255,0.0) 30%,
+            rgba(255,255,255,0.85) 50%,
+            rgba(255,255,255,0.0) 70%,
+            transparent 100%
+        );
+        background-size: 100% 80px;
+        background-repeat: no-repeat;
+        background-position: 0% -100%;
+        opacity: 0;
+        pointer-events: none;
+        /* animation déclenchée via classe .traveling */
+    }
+
+    .step-track.traveling .step-track-light {
+        animation: lightTravel 0.7s ease forwards;
+    }
+
+    /* ─── Responsive ─── */
+@media (max-width: 1100px) {
+        .form-stepper { right: 8px; width: 56px; }
+        .step-label   { display: none; }
+    }
+
+@media (max-width: 767px) {
+        /* Sur mobile : barre horizontale compacte en haut, sous la navbar */
+        .form-stepper {
+            position: fixed;
+            top: 80px;   /* = --navbar-height */
+            right: auto;
+            left: 0;
+            width: 100%;
+            transform: none;
+            flex-direction: row;
+            border-radius: 0;
+            padding: 8px 16px;
+            border-top: none;
+            border-left: none;
+            border-right: none;
+            border-bottom: 1px solid var(--kl-border);
+            box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+            z-index: 980;
+        }
+        .step-item      { flex-direction: row; align-items: center; flex: 1; }
+        .step-node      { flex-direction: row; gap: 6px; }
+        .step-track     { width: var(--track-height, 100%); height: 2px; }
+        .step-track-fill{ width: var(--fill, 0%); height: 100%; top: 0; left: 0; }
+        .step-label     { display: none; }
     }
 
     /* ============================================

--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -27,33 +27,71 @@
             </div>
         </div>
 
-        <!-- Stepper de progression -->
-        <div class="form-stepper" id="formStepper">
+        <!-- Stepper de progression — indicateur visuel fixed (scroll-driven) -->
+        <nav class="form-stepper" id="formStepper" aria-label="Progression du formulaire">
             <div class="step-item active" data-step="1">
-                <div class="step-circle">1</div>
-                <span class="step-label">Identité</span>
+                <div class="step-node">
+                    <div class="step-circle">
+                        <span class="step-num">1</span>
+                        <i class="fas fa-check step-check"></i>
+                    </div>
+                    <span class="step-label">Identité</span>
+                </div>
+                <div class="step-track" data-track="1">
+                    <div class="step-track-fill"></div>
+                    <div class="step-track-light"></div>
+                </div>
             </div>
-            <div class="step-divider"></div>
             <div class="step-item" data-step="2">
-                <div class="step-circle">2</div>
-                <span class="step-label">Académique</span>
+                <div class="step-node">
+                    <div class="step-circle">
+                        <span class="step-num">2</span>
+                        <i class="fas fa-check step-check"></i>
+                    </div>
+                    <span class="step-label">Académique</span>
+                </div>
+                <div class="step-track" data-track="2">
+                    <div class="step-track-fill"></div>
+                    <div class="step-track-light"></div>
+                </div>
             </div>
-            <div class="step-divider"></div>
             <div class="step-item" data-step="3">
-                <div class="step-circle">3</div>
-                <span class="step-label">Affectation</span>
+                <div class="step-node">
+                    <div class="step-circle">
+                        <span class="step-num">3</span>
+                        <i class="fas fa-check step-check"></i>
+                    </div>
+                    <span class="step-label">Affectation</span>
+                </div>
+                <div class="step-track" data-track="3">
+                    <div class="step-track-fill"></div>
+                    <div class="step-track-light"></div>
+                </div>
             </div>
-            <div class="step-divider"></div>
             <div class="step-item" data-step="4">
-                <div class="step-circle"><i class="fas fa-user-friends" style="font-size:12px"></i></div>
-                <span class="step-label">Parents</span>
+                <div class="step-node">
+                    <div class="step-circle">
+                        <span class="step-num"><i class="fas fa-users" style="font-size:10px"></i></span>
+                        <i class="fas fa-check step-check"></i>
+                    </div>
+                    <span class="step-label">Parents</span>
+                </div>
+                <div class="step-track" data-track="4">
+                    <div class="step-track-fill"></div>
+                    <div class="step-track-light"></div>
+                </div>
             </div>
-            <div class="step-divider"></div>
             <div class="step-item" data-step="5">
-                <div class="step-circle">5</div>
-                <span class="step-label">Frais</span>
+                <div class="step-node">
+                    <div class="step-circle">
+                        <span class="step-num">5</span>
+                        <i class="fas fa-check step-check"></i>
+                    </div>
+                    <span class="step-label">Frais</span>
+                </div>
+                <!-- pas de track après le dernier -->
             </div>
-        </div>
+        </nav>
 
         <form id="inscriptionForm" method="POST" action="{{ route('esbtp.inscriptions.store') }}" enctype="multipart/form-data">
             @csrf
@@ -1544,32 +1582,128 @@ document.addEventListener('DOMContentLoaded', function() {
     updateParentToggleSub();
 
     // =============================================
-    // STEPPER VISUEL (scroll-based)
+    // STEPPER VISUEL — SCROLL-DRIVEN (fixed, vertical)
+    // Algo :
+    //   • Pour chaque nœud i, on mesure top(section i) et top(section i+1)
+    //   • La progression du trait i = clamp((scrollMid - top_i) / (top_{i+1} - top_i), 0, 1)
+    //   • Le nœud i est "done" si scrollMid > top_{i+1}, "active" si scrollMid ∈ [top_i, top_{i+1}]
+    //   • L'accordéon parents modifie top(section-frais) → recalcul complet à chaque event
+    //   • Animation lumière : déclenchée quand --fill passe de 0% à >5% (début du remplissage)
     // =============================================
-    const stepSections = [
-        { step: 1, el: document.getElementById('section-identite') },
-        { step: 2, el: document.getElementById('section-academique') },
-        { step: 3, el: document.getElementById('section-affectation') },
-        { step: 4, el: document.getElementById('section-parents') },
-        { step: 5, el: document.getElementById('section-frais') },
-    ];
+    (function initScrollStepper() {
+        const sectionIds = [
+            'section-identite',
+            'section-academique',
+            'section-affectation',
+            'section-parents',
+            'section-frais',
+        ];
 
-    function updateStepper() {
-        const scrollMid = window.scrollY + window.innerHeight / 2;
-        let active = 1;
-        stepSections.forEach(({ step, el }) => {
-            if (el && el.getBoundingClientRect().top + window.scrollY <= scrollMid) active = step;
-        });
-        document.querySelectorAll('.step-item').forEach(item => {
-            const s = parseInt(item.dataset.step);
-            item.classList.remove('active', 'done');
-            if (s < active) item.classList.add('done');
-            else if (s === active) item.classList.add('active');
-        });
-    }
+        const stepItems  = Array.from(document.querySelectorAll('.step-item[data-step]'))
+                                .sort((a, b) => +a.dataset.step - +b.dataset.step);
+        const trackEls   = Array.from(document.querySelectorAll('.step-track'));  // 4 traits (entre 5 nœuds)
 
-    window.addEventListener('scroll', updateStepper, { passive: true });
-    updateStepper();
+        // Calcule la hauteur réelle de chaque trait (distance entre deux nœuds consécutifs)
+        // et l'injecte en CSS var --track-height pour que le trait s'adapte au contenu
+        function updateTrackHeights() {
+            const circles = stepItems.map(item => item.querySelector('.step-circle'));
+            circles.forEach((circ, i) => {
+                if (i >= circles.length - 1) return;  // pas de trait après le dernier
+                const rectA = circ.getBoundingClientRect();
+                const rectB = circles[i + 1].getBoundingClientRect();
+                // distance centre-à-centre entre deux cercles consécutifs
+                const centerA = rectA.top + rectA.height / 2;
+                const centerB = rectB.top + rectB.height / 2;
+                const h = Math.max(20, Math.round(centerB - centerA - rectA.height / 2 - rectB.height / 2));
+                if (trackEls[i]) trackEls[i].style.setProperty('--track-height', h + 'px');
+            });
+        }
+
+        // Retourne les tops absolus (window.scrollY + getBCR.top) de chaque section
+        function getSectionTops() {
+            return sectionIds.map(id => {
+                const el = document.getElementById(id);
+                if (!el) return 0;
+                return el.getBoundingClientRect().top + window.scrollY;
+            });
+        }
+
+        let rafId = null;
+        let prevFills = new Array(4).fill(0);  // pour détecter début de remplissage → lumière
+
+        function updateStepper() {
+            const tops     = getSectionTops();
+            const scrollMid = window.scrollY + window.innerHeight * 0.42;  // légèrement au-dessus du centre
+
+            // Détermine l'étape active (1-based)
+            let active = 1;
+            tops.forEach((top, i) => {
+                if (scrollMid >= top) active = i + 1;
+            });
+
+            // Met à jour les classes done/active sur les nœuds
+            stepItems.forEach((item, i) => {
+                const step = i + 1;
+                item.classList.remove('active', 'done');
+                if (step < active)       item.classList.add('done');
+                else if (step === active) item.classList.add('active');
+            });
+
+            // Calcule le fill de chaque trait (0–100%)
+            trackEls.forEach((track, i) => {
+                const topStart = tops[i];       // section i   (nœud i)
+                const topEnd   = tops[i + 1];   // section i+1 (nœud i+1)
+
+                let fill = 0;
+                if (topEnd > topStart) {
+                    fill = Math.min(1, Math.max(0, (scrollMid - topStart) / (topEnd - topStart)));
+                } else if (scrollMid >= topStart) {
+                    fill = 1;
+                }
+
+                const fillPct = Math.round(fill * 100);
+                track.querySelector('.step-track-fill').style.setProperty('--fill', fillPct + '%');
+
+                // Déclenche l'animation lumière quand le fill commence à monter (passage 0→>3%)
+                if (fillPct > 3 && prevFills[i] <= 3 && fillPct < 97) {
+                    track.classList.remove('traveling');
+                    // Force reflow pour relancer l'animation CSS
+                    void track.offsetWidth;
+                    track.classList.add('traveling');
+                    // Retire la classe après la durée de l'animation (0.7s)
+                    setTimeout(() => track.classList.remove('traveling'), 720);
+                }
+                prevFills[i] = fillPct;
+            });
+        }
+
+        function onScroll() {
+            if (rafId) return;
+            rafId = requestAnimationFrame(() => {
+                rafId = null;
+                updateStepper();
+            });
+        }
+
+        // Recalcul des hauteurs de traits quand l'accordéon parents s'ouvre/ferme
+        const parentsToggle = document.getElementById('parents-toggle-btn');
+        if (parentsToggle) {
+            parentsToggle.addEventListener('click', () => {
+                // Attendre la fin de la transition (300ms) puis recalculer
+                setTimeout(() => {
+                    updateTrackHeights();
+                    updateStepper();
+                }, 350);
+            });
+        }
+
+        window.addEventListener('scroll', onScroll, { passive: true });
+        window.addEventListener('resize', () => { updateTrackHeights(); updateStepper(); }, { passive: true });
+
+        // Init
+        updateTrackHeights();
+        updateStepper();
+    })();
 
     // =============================================
     // GESTION MATRICULES (inchangée)


### PR DESCRIPTION
## Summary
- Remplace l'ancien stepper horizontal (confus, semblait navigable) par un indicateur vertical fixed positionné à droite du contenu
- Animation lumière (« travelling light ») qui voyage sur le trait à chaque transition de section, pilotée par le scroll
- Aucune navigation au clic — indicateur purement visuel et non intrusif

## Changes
- `public/css/inscription-create.css` — Nouveau bloc stepper : `position: fixed`, keyframes `lightTravel` et `stepPulse`, traits collés aux cercles (margin: 0), responsive mobile (barre horizontale sous navbar)
- `resources/views/esbtp/inscriptions/create.blade.php` — HTML stepper refondu (`step-node` + `step-track` + `step-track-fill` + `step-track-light`) ; JS IIFE `initScrollStepper` avec calcul de fill par segment, recalcul après toggle accordéon parents, `requestAnimationFrame` pour fluidité

## Type of change
- [x] feat — new feature
- [ ] fix — bug fix
- [ ] refactor — no behavior change
- [ ] chore — maintenance

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (no PHP changes — HTML/CSS/JS only)