### PR TITLE
fix(pdf): supprimer filtre blanc logos et refonte bulletins avec couleurs dynamiques

### DIFF
--- a/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
@@ -2,50 +2,55 @@
 <html lang="fr">
 <head>
     @include('pdf.partials.theme')
+    @php
+        $pdfSettings   = \App\Helpers\SettingsHelper::getPdfSettings();
+        $pdfHeaderBg   = $pdfSettings['header_bg_color']   ?? '#0453cb';
+        $pdfHeaderText = $pdfSettings['header_text_color'] ?? '#ffffff';
+        $pdfPrimary    = $pdfSettings['primary_color']     ?? $pdfHeaderBg;
+        $pdfText       = $pdfSettings['text_color']        ?? '#1f2937';
+    @endphp
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bulletin de Notes - {{ $etudiant->nom }} {{ $etudiant->prenoms ?? $etudiant->prenom }}</title>
     <style>
+        /* ── Base ─────────────────────────────────────────────── */
+        * { box-sizing: border-box; }
         body {
             font-family: DejaVu Sans, Arial, sans-serif;
             font-size: {{ $settings['bulletin_font_size'] ?? '11' }}px;
             margin: 0;
             padding: 0;
-            background-color: #ffffff;
-            line-height: 1.2;
+            background: #fff;
             color: #111827;
-        }
-        * {
-            box-sizing: border-box;
+            line-height: 1.35;
         }
         .container {
-            width: 100%;
-            max-width: 820px;
+            width: 210mm;
+            max-width: 794px;
             margin: 0 auto;
-            background-color: #ffffff;
-            padding: 14px 16px;
-            border: 1px solid #e5e7eb;
-            border-radius: 14px;
+            background: #fff;
+            padding: 10px 14px 14px;
         }
+
+        /* ── En-tête institution ──────────────────────────────── */
         .top-entete {
-            width: 100%;
             text-align: center;
-            font-size: 10px;
-            color: #1f2937;
-            padding-bottom: 6px;
-            margin-bottom: 10px;
-            border-bottom: 1px solid #e5e7eb;
+            font-size: 9.5px;
+            color: #374151;
+            padding-bottom: 5px;
+            margin-bottom: 8px;
+            border-bottom: 1px solid #d1d5db;
         }
-        .top-entete .line-strong {
-            font-weight: bold;
-        }
+        .top-entete .line-strong { font-weight: 700; }
+
+        /* ── Header principal ─────────────────────────────────── */
         .header {
             width: 100%;
-            margin-bottom: 14px;
-            padding: 10px;
-            border: 1px solid #e5e7eb;
-            border-radius: 12px;
-            background: #f8fafc;
+            margin-bottom: 10px;
+            border: 1.5px solid {{ $pdfPrimary }};
+            border-radius: 10px;
+            overflow: hidden;
+            background: #f9fafb;
         }
         .header-table {
             width: 100%;
@@ -54,59 +59,74 @@
         }
         .header-table td {
             border: none;
-            padding: 4px 6px;
+            padding: 0;
+            vertical-align: top;
+        }
+
+        /* Colonne gauche : logo */
+        .header-logo-cell {
+            width: 110px;
+            padding: 10px 8px 10px 12px;
             vertical-align: middle;
-            word-wrap: break-word;
-        }
-        .header-logo {
-            width: 33%;
-            text-align: left;
-        }
-        .header-info {
-            width: 67%;
-            text-align: right;
+            text-align: center;
+            border-right: 1.5px solid #e5e7eb;
         }
         .logo {
-            width: 90px;
-            height: 90px;
+            width: 80px;
+            height: 80px;
             object-fit: contain;
-            border-radius: 10px;
+        }
+
+        /* Colonne droite : infos école + titre bulletin */
+        .header-info-cell {
+            padding: 10px 12px 10px 14px;
+            vertical-align: top;
         }
         .school-name {
-            font-weight: bold;
-            font-size: 14px;
-            color: #0f5132;
+            font-weight: 700;
+            font-size: 13px;
+            color: {{ $pdfPrimary }};
             text-transform: uppercase;
+            letter-spacing: 0.04em;
+            margin-bottom: 2px;
         }
         .school-contact {
-            font-size: 9px;
+            font-size: 8.5px;
             color: #4b5563;
+            margin-bottom: 6px;
+        }
+        .header-divider {
+            height: 1px;
+            background: #e5e7eb;
+            margin: 6px 0;
         }
         .bulletin-title {
-            font-weight: bold;
-            font-size: 12px;
+            font-weight: 700;
+            font-size: 13px;
             text-transform: uppercase;
-            margin-top: 6px;
-            color: #1f2937;
+            letter-spacing: 0.05em;
+            color: {{ $pdfPrimary }};
+            margin-bottom: 2px;
         }
         .bulletin-period {
-            font-size: 10px;
-            color: #1f2937;
-            margin-top: 2px;
+            font-size: 9.5px;
+            color: #374151;
+            margin-bottom: 1px;
         }
         .academic-year {
-            font-size: 10px;
-            font-weight: bold;
-            color: #1f2937;
-            margin-top: 6px;
+            font-size: 9.5px;
+            font-weight: 700;
+            color: #111827;
         }
+
+        /* ── Fiche étudiant ───────────────────────────────────── */
         .student-info {
             width: 100%;
-            margin-bottom: 12px;
-            background-color: #ffffff;
-            border: 1px solid #e5e7eb;
-            border-radius: 12px;
-            padding: 8px;
+            margin-bottom: 10px;
+            border: 1px solid #d1d5db;
+            border-radius: 8px;
+            background: #fff;
+            overflow: hidden;
         }
         .student-info-table {
             width: 100%;
@@ -115,240 +135,252 @@
         }
         .student-info-table td {
             border: none;
-            padding: 6px;
+            padding: 7px 8px;
             vertical-align: top;
             word-wrap: break-word;
         }
+
+        /* Colonne photo */
         .student-info-table td:first-child {
-            width: 150px;
+            width: 118px;
+            min-width: 118px;
             text-align: center;
-            vertical-align: top;
+            vertical-align: middle;
             padding: 8px;
-            min-width: 150px;
+            background: #f8fafb;
+            border-right: 1px solid #e5e7eb;
             display: table-cell;
         }
         .student-info-table td:first-child img {
-            width: 96px;
-            height: 96px;
-            border-radius: 50%;
+            width: 90px;
+            height: 90px;
+            border-radius: 8px;
             object-fit: cover;
-            border: 2px solid #0f5132;
+            border: 2px solid {{ $pdfPrimary }};
             display: block;
             margin: 0 auto;
         }
-        .student-info-table td:first-child .avatar-fallback {
-            width: 96px;
-            height: 96px;
-            border-radius: 50%;
-            border: 2px solid #0f5132;
+        .avatar-fallback {
+            width: 90px;
+            height: 90px;
+            border-radius: 8px;
+            border: 2px solid {{ $pdfPrimary }};
             display: table;
             margin: 0 auto;
-            background: #eef2f7;
+            background: #e5e7eb;
         }
-        .student-info-table td:first-child .avatar-fallback span {
+        .avatar-fallback span {
             display: table-cell;
             vertical-align: middle;
             text-align: center;
-            font-size: 28px;
-            color: #475569;
-            font-weight: bold;
-            line-height: 1;
+            font-size: 26px;
+            color: {{ $pdfPrimary }};
+            font-weight: 700;
         }
-        .student-info-table td:first-child .matricule-text {
-            margin-top: 8px;
-            font-weight: bold;
-            font-size: 9px;
+        .matricule-text {
+            margin-top: 5px;
+            font-weight: 700;
+            font-size: 8.5px;
             text-align: center;
-            width: 100%;
-            white-space: nowrap;
+            color: #374151;
         }
+
+        /* Colonnes infos */
         .info-group {
             width: 40%;
             vertical-align: top;
         }
-        .info-row {
-            margin-bottom: 4px;
-        }
+        .info-row { margin-bottom: 4px; font-size: 10px; }
         .info-label {
-            font-weight: bold;
+            font-weight: 700;
             display: inline-block;
-            width: 120px;
-            color: #111827;
+            width: 115px;
+            color: #374151;
+            font-size: 9.5px;
         }
+        .info-value { color: #111827; font-size: 10px; }
+
+        /* ── Tableau matières ─────────────────────────────────── */
         table {
             width: 100%;
             border-collapse: collapse;
-            margin-bottom: 12px;
-            font-size: 10px;
+            margin-bottom: 8px;
+            font-size: 9.5px;
         }
         th, td {
             border: 1px solid #d1d5db;
-            padding: 5px;
+            padding: 4px 5px;
             text-align: left;
         }
         th {
-            background-color: #f3f4f6;
-            font-weight: bold;
+            background: #f3f4f6;
+            font-weight: 700;
             text-align: center;
+            font-size: 9px;
+            color: #111827;
         }
-        .center {
-            text-align: center;
-        }
+        .center { text-align: center; }
+
         .section-header {
-            background-color: #0f5132;
-            color: #ffffff;
-            font-weight: bold;
+            background: {{ $pdfPrimary }};
+            color: {{ $pdfHeaderText }};
+            font-weight: 700;
             text-align: center;
-            padding: 8px 10px;
+            padding: 5px 8px;
+            font-size: 9.5px;
         }
-        .subject-row:nth-child(even) {
-            background-color: #f8fafc;
-        }
+        .subject-row:nth-child(even) { background: #f8fafb; }
         .summary-row {
-            background-color: #f3f4f6;
-            font-weight: bold;
+            background: #e5e7eb;
+            font-weight: 700;
         }
-        .results-container {
-            width: 100%;
-            margin-bottom: 14px;
-        }
-        .results-container-table {
-            width: 100%;
-            border-collapse: collapse;
-        }
+
+        /* Absences */
+        .absences-table { width: 100%; margin-bottom: 8px; }
+
+        /* ── Résultats & Statistiques ─────────────────────────── */
+        .results-container { width: 100%; margin-bottom: 10px; }
+        .results-container-table { width: 100%; border-collapse: collapse; }
         .results-container-table td {
             border: none;
             padding: 0;
             vertical-align: top;
         }
-        .results-left {
-            width: 50%;
-            padding-right: 6px;
-        }
-        .results-right {
-            width: 50%;
-            padding-left: 6px;
-        }
-        .results-card,
-        .stats-card {
-            border: 1px solid #e5e7eb;
-            border-radius: 12px;
-            background: #ffffff;
-            padding: 8px;
+        .results-left { width: 50%; padding-right: 5px; }
+        .results-right { width: 50%; padding-left: 5px; }
+
+        .results-card, .stats-card {
+            border: 1px solid #d1d5db;
+            border-radius: 8px;
+            background: #fff;
+            overflow: hidden;
         }
         .results-table, .stats-table {
             width: 100%;
-            font-size: 10px;
-            border-collapse: separate;
-            border-spacing: 0;
-            border: 1px solid #e5e7eb;
-            border-radius: 10px;
-            overflow: hidden;
-            background: #ffffff;
+            font-size: 9.5px;
+            border-collapse: collapse;
+            background: #fff;
         }
-        .results-table th,
-        .results-table td,
-        .stats-table th,
-        .stats-table td {
-            padding: 6px 8px;
-            border-bottom: 1px solid #e5e7eb;
-        }
-        .results-table tr:last-child td,
-        .stats-table tr:last-child td {
-            border-bottom: none;
-        }
-        .results-table th,
-        .stats-table th {
-            background: #f3f4f6;
+        .results-table th, .stats-table th {
+            background: {{ $pdfPrimary }};
+            color: {{ $pdfHeaderText }};
+            padding: 5px 8px;
+            font-size: 9px;
+            border: none;
             text-align: left;
         }
-        .mention-box {
-            width: 100%;
-            margin-bottom: 5px;
-            border: 1px solid #e5e7eb;
-            border-radius: 8px;
-            font-size: 9px;
-            background: #ffffff;
+        .results-table td, .stats-table td {
+            padding: 4px 8px;
+            border-bottom: 1px solid #f3f4f6;
+            border-left: none;
+            border-right: none;
+            border-top: none;
         }
-        .mention-table {
-            width: 100%;
-            border-collapse: collapse;
-        }
-        .mention-table td {
-            padding: 6px 10px;
-            border-bottom: 1px solid #e5e7eb;
-            vertical-align: middle;
-        }
-        .mention-table tr:last-child td {
+        .results-table tr:last-child td, .stats-table tr:last-child td {
             border-bottom: none;
         }
-        .mention-label {
-            font-weight: 600;
-            color: #111827;
+        .result-value-box {
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            padding: 2px 6px;
+            min-width: 52px;
+            display: inline-block;
+            text-align: center;
+            font-weight: 700;
+            background: #f8fafb;
+            font-size: 10px;
         }
+
+        /* ── Mentions ─────────────────────────────────────────── */
+        .mention-box {
+            width: 100%;
+            margin-bottom: 4px;
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            font-size: 9px;
+            background: #fff;
+            overflow: hidden;
+        }
+        .mention-table { width: 100%; border-collapse: collapse; }
+        .mention-table td {
+            padding: 4px 8px;
+            border-bottom: none;
+            border-left: none;
+            border-right: none;
+            border-top: none;
+        }
+        .mention-label { font-weight: 600; color: #111827; }
         .mention-value {
             width: 28px;
             text-align: right;
         }
-        .mention-table input[type="checkbox"] {
-            margin: 0;
-            vertical-align: middle;
-        }
-        .mention-value input {
-            width: 14px;
-            height: 14px;
-        }
+
+        /* ── Décision conseil ─────────────────────────────────── */
         .decision-container {
-            margin: 16px 0;
+            margin: 10px 0;
             border: 1px solid #d1d5db;
-            border-radius: 10px;
-            padding: 10px;
-            min-height: 60px;
+            border-radius: 8px;
+            padding: 8px 10px;
+            min-height: 52px;
             background: #f9fafb;
         }
         .decision-title {
-            font-weight: bold;
-            margin-bottom: 8px;
+            font-weight: 700;
+            margin-bottom: 5px;
             text-transform: uppercase;
+            font-size: 9.5px;
+            color: {{ $pdfPrimary }};
+            border-bottom: 1px solid #e5e7eb;
+            padding-bottom: 3px;
         }
+
+        /* ── Signature ────────────────────────────────────────── */
         .signature-container {
-            margin-top: 16px;
+            margin-top: 12px;
             text-align: right;
         }
         .signature-box {
             display: inline-block;
             text-align: center;
-            min-width: 220px;
+            min-width: 200px;
         }
         .signature-line {
-            width: 220px;
-            height: 50px;
-            border-bottom: 1px solid #111827;
-            margin-top: 6px;
+            width: 200px;
+            height: 44px;
+            border-bottom: 1.5px solid {{ $pdfPrimary }};
+            margin-top: 4px;
         }
+
+        /* ── Mode PDF export ──────────────────────────────────── */
         @if($isPdfExport ?? false)
         @page {
-            margin: 18mm 12mm !important;
+            size: A4 portrait;
+            margin: 12mm 10mm;
         }
         body.pdf-export {
             margin: 0;
             padding: 0;
-            background-color: white;
-            font-family: DejaVu Sans, Arial, sans-serif;
-            font-size: {{ $settings['bulletin_font_size'] ?? '11' }}px;
+            background: #fff;
         }
         body.pdf-export .container {
             width: 100%;
             max-width: none;
-            margin: 0 auto;
             padding: 0;
             border: none;
         }
         @endif
+
+        @media print {
+            body { margin: 0; padding: 0; background: #fff; }
+            .container { box-shadow: none; width: 100%; max-width: none; }
+            .print-button, .pdf-toggle { display: none !important; }
+        }
     </style>
 </head>
 <body @if($isPdfExport ?? false)class="pdf-export"@endif>
     <div class="container">
+
+        {{-- Entête ministère / république --}}
         @if(($settings['bulletin_show_header'] ?? '1') == '1')
             @if(($settings['bulletin_show_ministry_info'] ?? '1') == '1' || ($settings['bulletin_show_republic_info'] ?? '1') == '1')
                 <div class="top-entete">
@@ -360,6 +392,7 @@
                     @endif
                 </div>
             @endif
+
             @php
                 $bulletin = $bulletin ?? null;
                 $anneeAffichee = $bulletin && $bulletin->anneeUniversitaire ? $bulletin->anneeUniversitaire : $anneeUniversitaire;
@@ -374,129 +407,131 @@
                     $anneeLabel = $anneeAffichee ? ('Annee '.$anneeAffichee->id) : '';
                 }
             @endphp
+
+            {{-- Header : logo à gauche | infos école + titre à droite --}}
             <div class="header">
                 <table class="header-table">
                     <tr>
-                        <td class="header-logo">
+                        <td class="header-logo-cell">
                             @if(($settings['bulletin_show_logo'] ?? '1') == '1' && isset($logoBase64) && $logoBase64)
                                 <img src="{{ $logoBase64 }}" alt="Logo" class="logo">
                             @endif
                         </td>
-                        <td class="header-info">
+                        <td class="header-info-cell">
                             @if(($settings['bulletin_show_school_info'] ?? '1') == '1')
                                 <div class="school-name">
                                     {{ $settings['bulletin_school_name_custom'] ?: $settings['school_name'] }}
                                 </div>
                                 <div class="school-contact">
-                                    {{ $settings['school_address'] }} • Tel: {{ $settings['school_phone'] }} • {{ $settings['school_email'] }}
+                                    {{ $settings['school_address'] }}
+                                    @if($settings['school_phone'] ?? null) &bull; Tél : {{ $settings['school_phone'] }}@endif
+                                    @if($settings['school_email'] ?? null) &bull; {{ $settings['school_email'] }}@endif
                                 </div>
                             @endif
-                            <div class="bulletin-title">BULLETIN DE NOTES</div>
+                            <div class="header-divider"></div>
+                            <div class="bulletin-title">Bulletin de Notes</div>
                             <div class="bulletin-period">
-                                @if($periode == 'semestre1')
-                                    PREMIER SEMESTRE
-                                @elseif($periode == 'semestre2')
-                                    DEUXIEME SEMESTRE
-                                @else
-                                    ANNUEL
+                                @if($periode == 'semestre1') Premier Semestre
+                                @elseif($periode == 'semestre2') Deuxième Semestre
+                                @else Annuel
                                 @endif
                             </div>
                             @if(($settings['bulletin_show_edition_date'] ?? '1') == '1')
-                                <div class="bulletin-period">Edition du: {{ $date_edition }}</div>
+                                <div class="bulletin-period">Édition du : {{ $date_edition }}</div>
                             @endif
-                            <div class="academic-year">Annee Scolaire: {{ $anneeLabel }}</div>
+                            <div class="academic-year">Année Scolaire : {{ $anneeLabel }}</div>
                         </td>
                     </tr>
                 </table>
             </div>
         @endif
 
-        @if(true)
-            @php
-                $prenom = $etudiant->prenoms ?? $etudiant->prenom ?? '';
-                $initials = strtoupper(substr($etudiant->nom ?? 'E', 0, 1) . substr($prenom ?: 'T', 0, 1));
-            @endphp
-            <div class="student-info">
-                <table class="student-info-table">
-                    <tr>
-                        <td>
-                            @if(isset($photoEtudiantBase64) && $photoEtudiantBase64)
-                                <img src="{{ $photoEtudiantBase64 }}" alt="Photo">
-                            @else
-                                <div class="avatar-fallback"><span>{{ $initials }}</span></div>
-                            @endif
-                            @if(($settings['bulletin_show_matricule'] ?? '1') == '1')
-                                <div class="matricule-text">{{ $etudiant->matricule }}</div>
-                            @endif
-                        </td>
-                        <td class="info-group">
+        {{-- Fiche étudiant --}}
+        @php
+            $prenom = $etudiant->prenoms ?? $etudiant->prenom ?? '';
+            $initials = strtoupper(substr($etudiant->nom ?? 'E', 0, 1) . substr($prenom ?: 'T', 0, 1));
+        @endphp
+        <div class="student-info">
+            <table class="student-info-table">
+                <tr>
+                    <td>
+                        @if(isset($photoEtudiantBase64) && $photoEtudiantBase64)
+                            <img src="{{ $photoEtudiantBase64 }}" alt="Photo">
+                        @else
+                            <div class="avatar-fallback"><span>{{ $initials }}</span></div>
+                        @endif
+                        @if(($settings['bulletin_show_matricule'] ?? '1') == '1')
+                            <div class="matricule-text">{{ $etudiant->matricule }}</div>
+                        @endif
+                    </td>
+                    <td class="info-group">
+                        <div class="info-row">
+                            <span class="info-label">Nom et Prénoms :</span>
+                            <span class="info-value">{{ $etudiant->nom }} {{ $etudiant->prenoms ?? $etudiant->prenom }}</span>
+                        </div>
+                        @if(($settings['bulletin_show_birth_date'] ?? '1') == '1')
                             <div class="info-row">
-                                <span class="info-label">Nom et Prenoms :</span>
-                                <span class="info-value">{{ $etudiant->nom }} {{ $etudiant->prenoms ?? $etudiant->prenom }}</span>
+                                <span class="info-label">Date de Naissance :</span>
+                                <span class="info-value">{{ $etudiant->date_naissance ? \Carbon\Carbon::parse($etudiant->date_naissance)->format('d/m/Y') : 'Non renseignée' }}</span>
                             </div>
-                            @if(($settings['bulletin_show_birth_date'] ?? '1') == '1')
-                                <div class="info-row">
-                                    <span class="info-label">Date de Naissance :</span>
-                                    <span class="info-value">{{ $etudiant->date_naissance ? \Carbon\Carbon::parse($etudiant->date_naissance)->format('d/m/Y') : 'Non renseignee' }}</span>
-                                </div>
-                            @endif
+                        @endif
+                        <div class="info-row">
+                            <span class="info-label">Lieu de Naissance :</span>
+                            <span class="info-value">{{ $etudiant->lieu_naissance ?? 'Non renseigné' }}</span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Genre :</span>
+                            <span class="info-value">{{ $etudiant->genre == 'M' ? 'Masculin' : 'Féminin' }}</span>
+                        </div>
+                        @if(($settings['bulletin_show_redoublant'] ?? '1') == '1')
                             <div class="info-row">
-                                <span class="info-label">Lieu de Naissance :</span>
-                                <span class="info-value">{{ $etudiant->lieu_naissance ?? 'Non renseigne' }}</span>
+                                <span class="info-label">Redoublant :</span>
+                                <span class="info-value">{{ $etudiant->inscriptions->first()->is_redoublant ?? false ? 'Oui' : 'Non' }}</span>
                             </div>
-                            <div class="info-row">
-                                <span class="info-label">Genre :</span>
-                                <span class="info-value">{{ $etudiant->genre == 'M' ? 'Masculin' : 'Feminin' }}</span>
-                            </div>
-                            @if(($settings['bulletin_show_redoublant'] ?? '1') == '1')
-                                <div class="info-row">
-                                    <span class="info-label">Redoublant :</span>
-                                    <span class="info-value">{{ $etudiant->inscriptions->first()->is_redoublant ?? false ? 'Oui' : 'Non' }}</span>
-                                </div>
-                            @endif
-                            <div class="info-row">
-                                <span class="info-label">Telephone :</span>
-                                <span class="info-value">{{ $etudiant->telephone ?? 'Non renseigne' }}</span>
-                            </div>
-                        </td>
-                        <td class="info-group">
-                            <div class="info-row">
-                                <span class="info-label">Classe :</span>
-                                <span class="info-value">{{ $classe->libelle ?? $classe->name }}</span>
-                            </div>
-                            <div class="info-row">
-                                <span class="info-label">Annee d'etude :</span>
-                                <span class="info-value">{{ $classe->niveau->libelle ?? $classe->niveau->name ?? ($classe->annee ?? 'N/A') }}</span>
-                            </div>
-                            <div class="info-row">
-                                <span class="info-label">Filiere :</span>
-                                <span class="info-value">{{ $classe->filiere->name ?? 'N/A' }}</span>
-                            </div>
-                            <div class="info-row">
-                                <span class="info-label">Effectif :</span>
-                                <span class="info-value">{{ $effectif }}</span>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        @endif
+                        @endif
+                        <div class="info-row">
+                            <span class="info-label">Téléphone :</span>
+                            <span class="info-value">{{ $etudiant->telephone ?? 'Non renseigné' }}</span>
+                        </div>
+                    </td>
+                    <td class="info-group">
+                        <div class="info-row">
+                            <span class="info-label">Classe :</span>
+                            <span class="info-value">{{ $classe->libelle ?? $classe->name }}</span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Année d'étude :</span>
+                            <span class="info-value">{{ $classe->niveau->libelle ?? $classe->niveau->name ?? ($classe->annee ?? 'N/A') }}</span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Filière :</span>
+                            <span class="info-value">{{ $classe->filiere->name ?? 'N/A' }}</span>
+                        </div>
+                        <div class="info-row">
+                            <span class="info-label">Effectif :</span>
+                            <span class="info-value">{{ $effectif }}</span>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </div>
 
+        {{-- Tableau des matières --}}
         @if(($settings['bulletin_show_subjects_table'] ?? '1') == '1')
             <table>
                 <thead>
                     <tr>
-                        <th>Matiere</th>
+                        <th>Matière</th>
                         @if(($settings['bulletin_show_subject_average'] ?? '1') == '1')<th>Moyenne M</th>@endif
                         @if(($settings['bulletin_show_coefficient'] ?? '1') == '1')<th>Coef C</th>@endif
-                        @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<th>Moy Ponderee M*C</th>@endif
+                        @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<th>Moy Pondérée M×C</th>@endif
                         @if(($settings['bulletin_show_rank_per_subject'] ?? '1') == '1')<th>Rang</th>@endif
                         @if(($settings['bulletin_show_teachers'] ?? '1') == '1')<th>Professeurs</th>@endif
-                        @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<th>Appreciations</th>@endif
+                        @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<th>Appréciations</th>@endif
                     </tr>
                     @if(($settings['bulletin_show_general_subjects'] ?? '1') == '1')
                         <tr class="section-header">
-                            <td colspan="7">Enseignement General</td>
+                            <td colspan="7">Enseignement Général</td>
                         </tr>
                     @endif
                 </thead>
@@ -516,12 +551,12 @@
                             @endforeach
                         @else
                             <tr>
-                                <td colspan="7" class="center">Aucune matiere d'enseignement general</td>
+                                <td colspan="7" class="center">Aucune matière d'enseignement général</td>
                             </tr>
                         @endif
                         @if(($settings['bulletin_show_section_averages'] ?? '1') == '1')
                             <tr class="summary-row">
-                                <td>Moyenne enseignement general</td>
+                                <td>Moyenne enseignement général</td>
                                 <td colspan="2" class="center">{{ number_format($moyenneGenerale, 2) }}</td>
                                 <td colspan="4"></td>
                             </tr>
@@ -546,7 +581,7 @@
                             @endforeach
                         @else
                             <tr>
-                                <td colspan="7" class="center">Aucune matiere d'enseignement technique</td>
+                                <td colspan="7" class="center">Aucune matière d'enseignement technique</td>
                             </tr>
                         @endif
                         @if(($settings['bulletin_show_section_averages'] ?? '1') == '1')
@@ -561,6 +596,7 @@
             </table>
         @endif
 
+        {{-- Absences --}}
         @if(($settings['bulletin_show_absences'] ?? '1') == '1')
             <table class="absences-table">
                 <thead>
@@ -571,13 +607,13 @@
                 <tbody>
                     @if(($settings['bulletin_show_justified_absences'] ?? '1') == '1')
                         <tr>
-                            <td>Absences justifiees</td>
+                            <td>Absences justifiées</td>
                             <td class="center" style="width: 50%;">{{ isset($absencesJustifiees) ? $absencesJustifiees : (isset($absences_justifiees) ? $absences_justifiees : (isset($bulletin->absences_justifiees) ? $bulletin->absences_justifiees : '00')) }} Heure(s)</td>
                         </tr>
                     @endif
                     @if(($settings['bulletin_show_unjustified_absences'] ?? '1') == '1')
                         <tr>
-                            <td>Absences non justifiees</td>
+                            <td>Absences non justifiées</td>
                             <td class="center">{{ isset($absencesNonJustifiees) ? $absencesNonJustifiees : (isset($absences_non_justifiees) ? $absences_non_justifiees : (isset($bulletin->absences_non_justifiees) ? $bulletin->absences_non_justifiees : '00')) }} Heure(s)</td>
                         </tr>
                     @endif
@@ -585,174 +621,100 @@
             </table>
         @endif
 
+        {{-- Résultats & Statistiques --}}
         @if(($settings['bulletin_show_results_section'] ?? '1') == '1')
             <div class="results-container">
                 <table class="results-container-table">
                     <tr>
                         <td class="results-left">
                             <div class="results-card">
-                            <table class="results-table">
-                                <thead>
-                                    <tr>
-                                        <th colspan="2">RESULTATS</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    @if(($settings['bulletin_show_raw_average'] ?? '1') == '1')
-                                        <tr>
-                                            <td>Moyenne Brute</td>
-                                            <td class="center" style="width: 140px;">
-                                                <div style="border: 1px solid #111827; padding: 4px; width: 60px; display: inline-block;">{{ number_format($moyenneGlobale, 2) }}</div>
-                                            </td>
-                                        </tr>
-                                    @endif
-                                    @if(($settings['bulletin_show_attendance_note'] ?? '1') == '1')
-                                        <tr>
-                                            <td>Note d'assiduite</td>
-                                            <td class="center">
-                                                <div style="border: 1px solid #111827; padding: 4px; width: 60px; display: inline-block;">
-                                                    {{ $note_assiduite > 0 ? '+' . number_format($note_assiduite, 2) : number_format($note_assiduite, 2) }}
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    @endif
-                                    @if(($settings['bulletin_show_semester_average'] ?? '1') == '1')
-                                        <tr>
-                                            <td>Moyenne {{ $periode == 'semestre1' ? '1er' : '2e' }} Semestre</td>
-                                            <td class="center">
-                                                <div style="border: 1px solid #111827; padding: 4px; width: 60px; display: inline-block;">{{ number_format($moyenneAvecAssiduite, 2) }}</div>
-                                            </td>
-                                        </tr>
-                                        @if($periode == 'semestre2')
-                                            <tr>
-                                                <td>Moyenne Semestre 1</td>
-                                                <td class="center">
-                                                    <div style="border: 1px solid #111827; padding: 4px; width: 60px; display: inline-block;">{{ $moyenneSemestre1 !== null ? number_format($moyenneSemestre1, 2) : '-' }}</div>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td>Moyenne Annuelle</td>
-                                                <td class="center">
-                                                    <div style="border: 1px solid #111827; padding: 4px; width: 60px; display: inline-block;">{{ $moyenneAnnuelle !== null ? number_format($moyenneAnnuelle, 2) : '-' }}</div>
-                                                </td>
-                                            </tr>
-                                        @endif
-                                    @endif
-                                    @if(($settings['bulletin_show_student_rank'] ?? '1') == '1')
-                                        <tr>
-                                            <td>Rang</td>
-                                            <td class="center">
-                                                <div style="border: 1px solid #111827; padding: 4px; width: 60px; display: inline-block;">{{ $rang }}</div>
-                                            </td>
-                                        </tr>
-                                    @endif
-                                </tbody>
-                            </table>
-                            </div>
-
-                            @if(($settings['bulletin_show_mentions'] ?? '1') == '1')
-                                <div style="margin-top: 12px;">
-                                    @if(($settings['bulletin_show_felicitation'] ?? '1') == '1')
-                                        <div class="mention-box">
-                                            @php
-                                                $felicitationThreshold = floatval($settings['bulletin_felicitation_threshold'] ?? 16);
-                                                $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $felicitationThreshold) : false;
-                                            @endphp
-                                            <table class="mention-table">
-                                                <tr>
-                                                    <td class="mention-label">Felicitation</td>
-                                                    <td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td>
-                                                </tr>
-                                            </table>
-                                        </div>
-                                    @endif
-                                    @if(($settings['bulletin_show_encouragement'] ?? '1') == '1')
-                                        <div class="mention-box">
-                                            @php
-                                                $encouragementThreshold = floatval($settings['bulletin_encouragement_threshold'] ?? 14);
-                                                $felicitationThreshold = floatval($settings['bulletin_felicitation_threshold'] ?? 16);
-                                                $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $encouragementThreshold && $moyenneGlobale < $felicitationThreshold) : false;
-                                            @endphp
-                                            <table class="mention-table">
-                                                <tr>
-                                                    <td class="mention-label">Encouragement</td>
-                                                    <td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td>
-                                                </tr>
-                                            </table>
-                                        </div>
-                                    @endif
-                                    @if(($settings['bulletin_show_honor_roll'] ?? '1') == '1')
-                                        <div class="mention-box">
-                                            @php
-                                                $honorRollThreshold = floatval($settings['bulletin_honor_roll_threshold'] ?? 12);
-                                                $encouragementThreshold = floatval($settings['bulletin_encouragement_threshold'] ?? 14);
-                                                $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $honorRollThreshold && $moyenneGlobale < $encouragementThreshold) : false;
-                                            @endphp
-                                            <table class="mention-table">
-                                                <tr>
-                                                    <td class="mention-label">Tableau d'honneur</td>
-                                                    <td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td>
-                                                </tr>
-                                            </table>
-                                        </div>
-                                    @endif
-                                    @if(($settings['bulletin_show_work_warning'] ?? '1') == '1')
-                                        <div class="mention-box">
-                                            @php
-                                                $workWarningThreshold = floatval($settings['bulletin_work_warning_threshold'] ?? 8);
-                                                $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $workWarningThreshold && $moyenneGlobale < 10) : false;
-                                            @endphp
-                                            <table class="mention-table">
-                                                <tr>
-                                                    <td class="mention-label">Avertissement (Travail)</td>
-                                                    <td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td>
-                                                </tr>
-                                            </table>
-                                        </div>
-                                    @endif
-                                    @if(($settings['bulletin_show_conduct_blame'] ?? '1') == '1')
-                                        <div class="mention-box">
-                                            <table class="mention-table">
-                                                <tr>
-                                                    <td class="mention-label">Blame (Conduite)</td>
-                                                    <td class="mention-value"><input type="checkbox"></td>
-                                                </tr>
-                                            </table>
-                                        </div>
-                                    @endif
-                                </div>
-                            @endif
-                        </td>
-                        @if(($settings['bulletin_show_statistics'] ?? '1') == '1')
-                            <td class="results-right">
-                                <div class="stats-card">
-                                <table class="stats-table">
+                                <table class="results-table">
                                     <thead>
-                                        <tr>
-                                            <th colspan="2">STATISTIQUES - {{ $periode == 'semestre2' ? 'SEMESTRE 2' : 'SEMESTRE 1' }}</th>
-                                        </tr>
+                                        <tr><th colspan="2">RÉSULTATS</th></tr>
                                     </thead>
                                     <tbody>
-                                        @if(($settings['bulletin_show_highest_average'] ?? '1') == '1')
+                                        @if(($settings['bulletin_show_raw_average'] ?? '1') == '1')
                                             <tr>
-                                                <td>Plus forte moyenne</td>
-                                                <td class="center" style="width: 60px;">{{ number_format($meilleure_moyenne, 2) }}</td>
+                                                <td>Moyenne Brute</td>
+                                                <td class="center"><span class="result-value-box">{{ number_format($moyenneGlobale, 2) }}</span></td>
                                             </tr>
                                         @endif
-                                        @if(($settings['bulletin_show_lowest_average'] ?? '1') == '1')
+                                        @if(($settings['bulletin_show_attendance_note'] ?? '1') == '1')
                                             <tr>
-                                                <td>Plus faible moyenne</td>
-                                                <td class="center">{{ number_format($plus_faible_moyenne, 2) }}</td>
+                                                <td>Note d'assiduité</td>
+                                                <td class="center"><span class="result-value-box">{{ $note_assiduite > 0 ? '+'.number_format($note_assiduite, 2) : number_format($note_assiduite, 2) }}</span></td>
                                             </tr>
                                         @endif
-                                        @if(($settings['bulletin_show_class_average'] ?? '1') == '1')
+                                        @if(($settings['bulletin_show_semester_average'] ?? '1') == '1')
                                             <tr>
-                                                <td>Moyenne de la classe</td>
-                                                <td class="center">{{ number_format($moyenne_classe, 2) }}</td>
+                                                <td>Moyenne {{ $periode == 'semestre1' ? '1er' : '2e' }} Semestre</td>
+                                                <td class="center"><span class="result-value-box">{{ number_format($moyenneAvecAssiduite, 2) }}</span></td>
+                                            </tr>
+                                            @if($periode == 'semestre2')
+                                                <tr>
+                                                    <td>Moyenne Semestre 1</td>
+                                                    <td class="center"><span class="result-value-box">{{ $moyenneSemestre1 !== null ? number_format($moyenneSemestre1, 2) : '-' }}</span></td>
+                                                </tr>
+                                                <tr>
+                                                    <td>Moyenne Annuelle</td>
+                                                    <td class="center"><span class="result-value-box">{{ $moyenneAnnuelle !== null ? number_format($moyenneAnnuelle, 2) : '-' }}</span></td>
+                                                </tr>
+                                            @endif
+                                        @endif
+                                        @if(($settings['bulletin_show_student_rank'] ?? '1') == '1')
+                                            <tr>
+                                                <td>Rang</td>
+                                                <td class="center"><span class="result-value-box">{{ $rang }}</span></td>
                                             </tr>
                                         @endif
                                     </tbody>
                                 </table>
+                            </div>
+
+                            @if(($settings['bulletin_show_mentions'] ?? '1') == '1')
+                                <div style="margin-top: 8px;">
+                                    @if(($settings['bulletin_show_felicitation'] ?? '1') == '1')
+                                        @php $felicitationThreshold = floatval($settings['bulletin_felicitation_threshold'] ?? 16); $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $felicitationThreshold) : false; @endphp
+                                        <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Félicitation</td><td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td></tr></table></div>
+                                    @endif
+                                    @if(($settings['bulletin_show_encouragement'] ?? '1') == '1')
+                                        @php $encouragementThreshold = floatval($settings['bulletin_encouragement_threshold'] ?? 14); $felicitationThreshold = floatval($settings['bulletin_felicitation_threshold'] ?? 16); $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $encouragementThreshold && $moyenneGlobale < $felicitationThreshold) : false; @endphp
+                                        <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Encouragement</td><td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td></tr></table></div>
+                                    @endif
+                                    @if(($settings['bulletin_show_honor_roll'] ?? '1') == '1')
+                                        @php $honorRollThreshold = floatval($settings['bulletin_honor_roll_threshold'] ?? 12); $encouragementThreshold = floatval($settings['bulletin_encouragement_threshold'] ?? 14); $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $honorRollThreshold && $moyenneGlobale < $encouragementThreshold) : false; @endphp
+                                        <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Tableau d'honneur</td><td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td></tr></table></div>
+                                    @endif
+                                    @if(($settings['bulletin_show_work_warning'] ?? '1') == '1')
+                                        @php $workWarningThreshold = floatval($settings['bulletin_work_warning_threshold'] ?? 8); $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $workWarningThreshold && $moyenneGlobale < 10) : false; @endphp
+                                        <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Avertissement (Travail)</td><td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td></tr></table></div>
+                                    @endif
+                                    @if(($settings['bulletin_show_conduct_blame'] ?? '1') == '1')
+                                        <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Blâme (Conduite)</td><td class="mention-value"><input type="checkbox"></td></tr></table></div>
+                                    @endif
+                                </div>
+                            @endif
+                        </td>
+
+                        @if(($settings['bulletin_show_statistics'] ?? '1') == '1')
+                            <td class="results-right">
+                                <div class="stats-card">
+                                    <table class="stats-table">
+                                        <thead>
+                                            <tr><th colspan="2">STATISTIQUES — {{ $periode == 'semestre2' ? 'SEMESTRE 2' : 'SEMESTRE 1' }}</th></tr>
+                                        </thead>
+                                        <tbody>
+                                            @if(($settings['bulletin_show_highest_average'] ?? '1') == '1')
+                                                <tr><td>Plus forte moyenne</td><td class="center">{{ number_format($meilleure_moyenne, 2) }}</td></tr>
+                                            @endif
+                                            @if(($settings['bulletin_show_lowest_average'] ?? '1') == '1')
+                                                <tr><td>Plus faible moyenne</td><td class="center">{{ number_format($plus_faible_moyenne, 2) }}</td></tr>
+                                            @endif
+                                            @if(($settings['bulletin_show_class_average'] ?? '1') == '1')
+                                                <tr><td>Moyenne de la classe</td><td class="center">{{ number_format($moyenne_classe, 2) }}</td></tr>
+                                            @endif
+                                        </tbody>
+                                    </table>
                                 </div>
                             </td>
                         @endif
@@ -761,30 +723,31 @@
             </div>
         @endif
 
+        {{-- Décision du conseil --}}
         @if(($settings['bulletin_show_council_decision'] ?? '1') == '1')
             <div class="decision-container">
-                <div class="decision-title">Decision du conseil de classe</div>
-                <div style="min-height: 40px;">
-                    {{ $appreciation }}
-                </div>
+                <div class="decision-title">Décision du conseil de classe</div>
+                <div style="min-height: 36px; font-size: 10px;">{{ $appreciation }}</div>
             </div>
         @endif
 
+        {{-- Signature --}}
         @if(($settings['bulletin_show_signature'] ?? '1') == '1' || ($settings['bulletin_show_director_signature'] ?? '1') == '1')
             @php
                 $directorTitle = $settings['director_title'] ?? \App\Helpers\SettingsHelper::get('director_title', 'Directeur');
-                $directorName = $settings['director_name'] ?? \App\Helpers\SettingsHelper::get('director_name', '');
+                $directorName  = $settings['director_name']  ?? \App\Helpers\SettingsHelper::get('director_name', '');
             @endphp
             <div class="signature-container">
                 <div class="signature-box">
-                    <div>{{ $directorTitle }}</div>
+                    <div style="font-size: 10px;">{{ $directorTitle }}</div>
                     <div class="signature-line"></div>
                     @if($directorName)
-                        <div style="margin-top: 6px; font-weight: bold;">{{ $directorName }}</div>
+                        <div style="margin-top: 4px; font-weight: 700; font-size: 9.5px;">{{ $directorName }}</div>
                     @endif
                 </div>
             </div>
         @endif
+
     </div>
 </body>
 </html>

--- a/resources/views/esbtp/bulletins/pdf-configurable.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable.blade.php
@@ -2,38 +2,42 @@
 <html lang="fr">
 <head>
     @include('pdf.partials.theme')
+    @php
+        $pdfSettings   = \App\Helpers\SettingsHelper::getPdfSettings();
+        $pdfHeaderBg   = $pdfSettings['header_bg_color']   ?? '#0453cb';
+        $pdfHeaderText = $pdfSettings['header_text_color'] ?? '#ffffff';
+        $pdfPrimary    = $pdfSettings['primary_color']     ?? $pdfHeaderBg;
+        $pdfText       = $pdfSettings['text_color']        ?? '#1f2937';
+    @endphp
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bulletin de Notes - {{ $etudiant->nom }} {{ $etudiant->prenoms ?? $etudiant->prenom }}</title>
     <style>
-        /* CSS compatible DomPDF et navigateur */
+        /* ── Base ─────────────────────────────────────────────── */
+        * { box-sizing: border-box; }
         body {
             font-family: DejaVu Sans, Arial, sans-serif;
             font-size: {{ $settings['bulletin_font_size'] ?? '11' }}px;
             margin: 0;
             padding: 0;
-            background-color: white;
-            line-height: 1.2;
+            background: #fff;
+            color: #111827;
+            line-height: 1.35;
         }
         .container {
-            width: 100%;
-            max-width: 800px;
+            width: 210mm;
+            max-width: 794px;
             margin: 0 auto;
-            background-color: white;
-            padding: 10px;
+            background: #fff;
+            padding: 10px 14px 14px;
         }
-        
-        /* Reset pour éviter les conflits DomPDF */
-        * {
-            box-sizing: border-box;
-        }
-        
-        /* Version table pour header (compatible DomPDF) */
+
+        /* ── Header principal ─────────────────────────────────── */
         .header {
             width: 100%;
-            margin-bottom: 20px;
-            border-bottom: 2px solid #000;
-            padding-bottom: 10px;
+            margin-bottom: 10px;
+            border-bottom: 2.5px solid {{ $pdfPrimary }};
+            padding-bottom: 8px;
         }
         .header-table {
             width: 100%;
@@ -42,44 +46,76 @@
         }
         .header-table td {
             border: none;
-            padding: 5px;
+            padding: 4px 5px;
             vertical-align: top;
             word-wrap: break-word;
         }
-        .header-left, .header-right {
-            width: 25%;
-            font-size: 10px;
-            line-height: 1.2;
+        .header-left {
+            width: 26%;
+            font-size: 9px;
+            line-height: 1.5;
+            color: #374151;
+            border-right: 1px solid #e5e7eb;
+            padding-right: 8px;
         }
         .header-center {
-            width: 50%;
+            width: 48%;
             text-align: center;
+            padding: 0 8px;
+        }
+        .header-right {
+            width: 26%;
+            font-size: 9.5px;
+            line-height: 1.5;
+            text-align: right;
+            padding-left: 8px;
+            border-left: 1px solid #e5e7eb;
         }
         .logo {
-            width: 80px;
-            height: 80px;
-            margin-bottom: 10px;
+            width: 72px;
+            height: 72px;
+            object-fit: contain;
+            margin-bottom: 4px;
         }
         .school-name {
-            font-weight: bold;
-            font-size: 14px;
-            margin-bottom: 5px;
+            font-weight: 700;
+            font-size: 13px;
+            color: {{ $pdfPrimary }};
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            margin-bottom: 2px;
         }
         .school-address {
-            font-size: 9px;
+            font-size: 8px;
+            color: #6b7280;
         }
-        .title {
-            font-weight: bold;
-            font-size: 12px;
+        .header-right .title {
+            font-weight: 700;
+            font-size: 11.5px;
             text-decoration: underline;
-            margin-bottom: 5px;
+            color: {{ $pdfPrimary }};
+            text-transform: uppercase;
+            margin-bottom: 3px;
         }
-        /* Version table pour student-info (compatible DomPDF) */
+        .header-right .period {
+            font-size: 9px;
+            font-weight: 600;
+            color: #1f2937;
+            margin-bottom: 2px;
+        }
+        .header-right .year {
+            font-size: 9px;
+            color: #374151;
+        }
+
+        /* ── Fiche étudiant ───────────────────────────────────── */
         .student-info {
             width: 100%;
-            margin-bottom: 20px;
-            background-color: #f9f9f9;
-            border: 1px solid #ddd;
+            margin-bottom: 10px;
+            border: 1px solid #d1d5db;
+            border-radius: 8px;
+            background: #f9fafb;
+            overflow: hidden;
         }
         .student-info-table {
             width: 100%;
@@ -88,339 +124,243 @@
         }
         .student-info-table td {
             border: none;
-            padding: 8px;
+            padding: 7px 8px;
             vertical-align: top;
             word-wrap: break-word;
         }
 
-        /* Styles pour la colonne photo et matricule */
+        /* Colonne photo */
         .student-info-table td:first-child {
-            width: 150px;
+            width: 118px;
+            min-width: 118px;
             text-align: center;
-            vertical-align: top;
-            padding: 10px;
-            min-width: 150px;
+            vertical-align: middle;
+            padding: 8px;
+            background: #eff6ff;
+            border-right: 1px solid #dbeafe;
             display: table-cell;
         }
-
         .student-info-table td:first-child img {
-            width: 100px;
-            height: 100px;
-            border-radius: 50%;
+            width: 90px;
+            height: 90px;
+            border-radius: 6px;
             object-fit: cover;
-            border: 2px solid #007bff;
+            border: 2px solid {{ $pdfPrimary }};
             display: block;
             margin: 0 auto;
         }
-
-        .student-info-table td:first-child > div:not(.matricule-text) {
-            width: 100px;
-            height: 100px;
-            border-radius: 50%;
-            border: 2px solid #007bff;
-            display: block;
+        .avatar-fallback {
+            width: 90px;
+            height: 90px;
+            border-radius: 6px;
+            border: 2px solid {{ $pdfPrimary }};
+            display: table;
             margin: 0 auto;
-            background: #f3f4f6;
+            background: #e5e7eb;
+        }
+        .avatar-fallback span {
+            display: table-cell;
+            vertical-align: middle;
             text-align: center;
-            line-height: 100px;
-            font-size: 32px;
-            color: #6b7280;
+            font-size: 26px;
+            color: {{ $pdfPrimary }};
+            font-weight: 700;
+        }
+        .matricule-text {
+            margin-top: 5px;
+            font-weight: 700;
+            font-size: 8.5px;
+            text-align: center;
+            color: #374151;
         }
 
-        .student-info-table td:first-child .matricule-text {
-            margin-top: 8px;
-            margin-left: auto;
-            margin-right: auto;
-            font-weight: bold;
-            font-size: 9px;
-            text-align: center;
-            width: 100%;
-            white-space: nowrap;
-            overflow: visible;
-            word-break: keep-all;
-            word-wrap: normal;
-            writing-mode: horizontal-tb;
-            display: block;
-            position: relative;
-            left: 0;
-            right: 0;
-        }
+        /* Colonnes infos */
         .info-group {
             width: 40%;
             vertical-align: top;
         }
-        .info-row {
-            margin-bottom: 5px;
-        }
+        .info-row { margin-bottom: 4px; font-size: 10px; }
         .info-label {
-            font-weight: bold;
+            font-weight: 700;
             display: inline-block;
-            width: 120px;
+            width: 115px;
+            color: #374151;
+            font-size: 9.5px;
         }
-        .info-value {
-            display: inline;
-        }
+        .info-value { color: #111827; font-size: 10px; }
+
+        /* ── Tableau matières ─────────────────────────────────── */
         table {
             width: 100%;
             border-collapse: collapse;
-            margin-bottom: 15px;
-            font-size: 10px;
+            margin-bottom: 8px;
+            font-size: 9.5px;
         }
         th, td {
-            border: 1px solid #000;
-            padding: 5px;
+            border: 1px solid #d1d5db;
+            padding: 4px 5px;
             text-align: left;
         }
         th {
-            background-color: #f0f0f0;
-            font-weight: bold;
+            background: #f3f4f6;
+            font-weight: 700;
             text-align: center;
+            font-size: 9px;
+            color: #111827;
         }
-        .center {
-            text-align: center;
-        }
+        .center { text-align: center; }
+
         .section-header {
-            background-color: #e0e0e0;
-            font-weight: bold;
+            background: {{ $pdfPrimary }};
+            color: {{ $pdfHeaderText }};
+            font-weight: 700;
             text-align: center;
+            padding: 5px 8px;
+            font-size: 9.5px;
         }
-        .subject-row:nth-child(even) {
-            background-color: #f9f9f9;
-        }
+        .subject-row:nth-child(even) { background: #f8fafb; }
         .summary-row {
-            background-color: #f0f0f0;
-            font-weight: bold;
+            background: #e5e7eb;
+            font-weight: 700;
         }
-        .absences-table {
-            width: 100%;
-            margin-bottom: 15px;
-        }
-        /* Version table pour results-container (compatible DomPDF) */
-        .results-container {
-            width: 100%;
-            margin-bottom: 20px;
-        }
-        .results-container-table {
-            width: 100%;
-            border-collapse: collapse;
-        }
+
+        /* Absences */
+        .absences-table { width: 100%; margin-bottom: 8px; }
+
+        /* ── Résultats & Statistiques ─────────────────────────── */
+        .results-container { width: 100%; margin-bottom: 10px; }
+        .results-container-table { width: 100%; border-collapse: collapse; }
         .results-container-table td {
             border: none;
             padding: 0;
             vertical-align: top;
         }
-        .results-left {
-            width: 50%;
-            padding-right: 5px;
-        }
-        .results-right {
-            width: 50%;
-            padding-left: 5px;
+        .results-left { width: 50%; padding-right: 5px; }
+        .results-right { width: 50%; padding-left: 5px; }
+
+        .results-card, .stats-card {
+            border: 1px solid #d1d5db;
+            border-radius: 8px;
+            background: #fff;
+            overflow: hidden;
         }
         .results-table, .stats-table {
             width: 100%;
-            font-size: 10px;
-        }
-        /* Version table pour mention-box (compatible DomPDF) */
-        .mention-box {
-            width: 100%;
-            margin-bottom: 5px;
-            border: 1px solid #ccc;
-            font-size: 9px;
-        }
-        .mention-table {
-            width: 100%;
+            font-size: 9.5px;
             border-collapse: collapse;
         }
-        .mention-table td {
+        .results-table th, .stats-table th {
+            background: {{ $pdfPrimary }};
+            color: {{ $pdfHeaderText }};
+            padding: 5px 8px;
+            font-size: 9px;
             border: none;
-            padding: 2px 5px;
-        }
-        .mention-label {
             text-align: left;
         }
-        .mention-value {
-            width: 20px;
-            text-align: center;
+        .results-table td, .stats-table td {
+            padding: 4px 8px;
+            border-bottom: 1px solid #f3f4f6;
+            border-left: none;
+            border-right: none;
+            border-top: none;
         }
+        .results-table tr:last-child td, .stats-table tr:last-child td {
+            border-bottom: none;
+        }
+        .result-value-box {
+            border: 1px solid #d1d5db;
+            border-radius: 4px;
+            padding: 2px 6px;
+            min-width: 52px;
+            display: inline-block;
+            text-align: center;
+            font-weight: 700;
+            background: #f8fafb;
+            font-size: 10px;
+        }
+
+        /* ── Mentions ─────────────────────────────────────────── */
+        .mention-box {
+            width: 100%;
+            margin-bottom: 4px;
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            font-size: 9px;
+            background: #fff;
+            overflow: hidden;
+        }
+        .mention-table { width: 100%; border-collapse: collapse; }
+        .mention-table td {
+            padding: 4px 8px;
+            border: none;
+        }
+        .mention-label { font-weight: 600; color: #111827; }
+        .mention-value { width: 28px; text-align: right; }
+
+        /* ── Décision conseil ─────────────────────────────────── */
         .decision-container {
-            margin: 20px 0;
-            border: 1px solid #000;
-            padding: 10px;
-            min-height: 60px;
+            margin: 10px 0;
+            border: 1px solid #d1d5db;
+            border-radius: 8px;
+            padding: 8px 10px;
+            min-height: 52px;
+            background: #f9fafb;
         }
         .decision-title {
-            font-weight: bold;
-            margin-bottom: 10px;
+            font-weight: 700;
+            margin-bottom: 5px;
             text-decoration: underline;
+            font-size: 9.5px;
+            text-transform: uppercase;
+            color: {{ $pdfPrimary }};
         }
+
+        /* ── Signature ────────────────────────────────────────── */
         .signature-container {
-            margin-top: 30px;
+            margin-top: 12px;
             text-align: right;
         }
         .signature-box {
             display: inline-block;
             text-align: center;
-            margin-left: 50px;
+            min-width: 200px;
         }
         .signature-line {
             width: 200px;
-            height: 60px;
-            border-bottom: 1px solid #000;
-            margin-top: 10px;
-        }
-        .print-button {
-            background-color: #007bff;
-            color: white;
-            padding: 10px 20px;
-            border: none;
-            border-radius: 4px;
-            cursor: pointer;
-        }
-        /* Mode PDF simulation pour preview */
-        .pdf-mode body {
-            margin: 0;
-            padding: 0;
-            background-color: white;
-            font-family: DejaVu Sans, Arial, sans-serif;
-        }
-        .pdf-mode .container {
-            width: 210mm;
-            min-height: 297mm;
-            margin: 0 auto;
-            padding: 20mm;
-            box-sizing: border-box;
-            background-color: white;
-            box-shadow: 0 0 10px rgba(0,0,0,0.3);
+            height: 44px;
+            border-bottom: 1.5px solid {{ $pdfPrimary }};
+            margin-top: 4px;
         }
 
+        /* ── Mode PDF export ──────────────────────────────────── */
         @if($isPdfExport ?? false)
-        /* Styles spécifiques pour l'export PDF - Approche simplifiée et éprouvée */
         @page {
-            margin: 20mm 15mm !important;
+            size: A4 portrait;
+            margin: 12mm 10mm;
         }
-        
-        html {
-            margin: 0;
-            padding: 0;
-        }
-        
         body.pdf-export {
             margin: 0;
             padding: 0;
-            background-color: white;
-            font-family: DejaVu Sans, Arial, sans-serif;
-            font-size: {{ $settings['bulletin_font_size'] ?? '11' }}px;
+            background: #fff;
         }
-        
         body.pdf-export .container {
             width: 100%;
             max-width: none;
-            margin: 0 auto;
             padding: 0;
-            background-color: white;
-        }
-        
-        /* Reset spécifique pour PDF */
-        body.pdf-export .student-info-table {
-            table-layout: fixed;
-            width: 100%;
-            border-collapse: collapse;
-        }
-
-        body.pdf-export .student-info-table td {
-            border: none;
-            padding: 8px;
-            vertical-align: top;
-            word-wrap: break-word;
-        }
-
-        /* Styles spécifiques pour la photo et matricule en PDF */
-        body.pdf-export .student-info-table td:first-child {
-            width: 150px !important;
-            min-width: 150px !important;
-            text-align: center !important;
-            vertical-align: top !important;
-            padding: 10px !important;
-        }
-
-        body.pdf-export .info-group {
-            width: 40% !important;
-            vertical-align: top !important;
-        }
-
-        body.pdf-export .student-info-table td:first-child img {
-            width: 100px !important;
-            height: 100px !important;
-            border-radius: 50% !important;
-            object-fit: cover !important;
-            border: 2px solid #007bff !important;
-            display: block !important;
-            margin: 0 auto !important;
-            margin-left: auto !important;
-            margin-right: auto !important;
-        }
-
-        /* Centrage spécifique pour DomPDF avec transform en fallback */
-        body.pdf-export .student-info-table td:first-child img,
-        body.pdf-export .student-info-table td:first-child > div:not(.matricule-text) {
-            position: relative !important;
-            left: 50% !important;
-            transform: translateX(-50%) !important;
-        }
-
-        body.pdf-export .student-info-table td:first-child .matricule-text {
-            margin-top: 8px !important;
-            margin-left: auto !important;
-            margin-right: auto !important;
-            font-weight: bold !important;
-            font-size: 9px !important;
-            text-align: center !important;
-            width: 100% !important;
-            white-space: nowrap !important;
-            overflow: visible !important;
-            word-break: keep-all !important;
-            word-wrap: normal !important;
-            writing-mode: horizontal-tb !important;
-            display: block !important;
-            position: relative !important;
-            left: 0 !important;
-            right: 0 !important;
-        }
-        body.pdf-export th, 
-        body.pdf-export td, 
-        body.pdf-export p, 
-        body.pdf-export div, 
-        body.pdf-export h1, 
-        body.pdf-export h2, 
-        body.pdf-export h3 {
-            margin: 0;
-            padding: 2px;
         }
         @endif
-        
+
         @media print {
-            body {
-                margin: 0;
-                padding: 0;
-                background-color: white;
-            }
-            .container {
-                box-shadow: none;
-                width: 100%;
-                max-width: none;
-            }
-            .print-button, .pdf-toggle {
-                display: none !important;
-            }
+            body { margin: 0; padding: 0; background: #fff; }
+            .container { box-shadow: none; width: 100%; max-width: none; }
+            .print-button, .pdf-toggle { display: none !important; }
         }
-        
-        /* Bouton de simulation PDF */
+
+        /* Bouton mode PDF preview */
         .pdf-toggle {
             position: fixed;
-            top: 10px;
-            right: 10px;
-            background-color: #28a745;
+            top: 10px; right: 10px;
+            background: #28a745;
             color: white;
             padding: 8px 16px;
             border: none;
@@ -429,18 +369,16 @@
             z-index: 1000;
             font-size: 12px;
         }
-        .pdf-toggle:hover {
-            background-color: #218838;
-        }
     </style>
 </head>
 <body @if($isPdfExport ?? false)class="pdf-export"@endif>
-    <!-- Bouton pour basculer en mode PDF preview (seulement pour preview web) -->
     @unless($isPdfExport ?? false)
     <button class="pdf-toggle" onclick="togglePDFMode()" id="pdfToggle">Mode PDF</button>
     @endunless
-    
+
     <div class="container">
+
+        {{-- Header 3 colonnes --}}
         @if(($settings['bulletin_show_header'] ?? '1') == '1')
         <div class="header">
             <table class="header-table">
@@ -451,73 +389,66 @@
                         <div>{{ $settings['bulletin_union_text'] ?? 'Union-Discipline-Travail' }}</div>
                         @endif
                         @if(($settings['bulletin_show_ministry_info'] ?? '1') == '1')
-                        <div>{{ $settings['bulletin_ministry_text'] ?? 'Ministère de l\'Enseignement Supérieur' }}</div>
+                        <div style="margin-top: 4px;">{{ $settings['bulletin_ministry_text'] ?? 'Ministère de l\'Enseignement Supérieur' }}</div>
                         <div>et de la Recherche Scientifique</div>
                         @endif
                     </td>
                     <td class="header-center">
                         @if(($settings['bulletin_show_logo'] ?? '1') == '1' && isset($logoBase64) && $logoBase64)
-                        <img src="{{ $logoBase64 }}" alt="Logo ESBTP" class="logo">
+                        <img src="{{ $logoBase64 }}" alt="Logo" class="logo">
                         @endif
                         @if(($settings['bulletin_show_school_info'] ?? '1') == '1')
                         <div class="school-name">
                             {{ $settings['bulletin_school_name_custom'] ?: $settings['school_name'] }}
                         </div>
-                        <div class="school-address">{{ $settings['school_address'] }} • Tel: {{ $settings['school_phone'] }} • {{ $settings['school_email'] }}</div>
+                        <div class="school-address">
+                            {{ $settings['school_address'] }}
+                            @if($settings['school_phone'] ?? null) &bull; Tél : {{ $settings['school_phone'] }}@endif
+                            @if($settings['school_email'] ?? null) &bull; {{ $settings['school_email'] }}@endif
+                        </div>
                         @endif
                     </td>
                     <td class="header-right">
-                        <div class="title">BULLETIN DE NOTES</div>
-                        <div>
-                            @if($periode == 'semestre1')
-                                PREMIER SEMESTRE
-                            @elseif($periode == 'semestre2')
-                                DEUXIÈME SEMESTRE
-                            @else
-                                ANNUEL
+                        <div class="title">Bulletin de Notes</div>
+                        <div class="period">
+                            @if($periode == 'semestre1') Premier Semestre
+                            @elseif($periode == 'semestre2') Deuxième Semestre
+                            @else Annuel
                             @endif
                         </div>
                         @if(($settings['bulletin_show_edition_date'] ?? '1') == '1')
-                        <div>Édition du: {{ $date_edition }}</div>
+                        <div class="year">Édition : {{ $date_edition }}</div>
                         @endif
                         @if(($settings['bulletin_show_cycle_info'] ?? '1') == '1')
-                        <div>Cycle: {{ $settings['bulletin_cycle_text'] ?? 'Brevet de Technicien Supérieur' }}</div>
-                        <div>{{ $settings['bulletin_cycle_abbreviation'] ?? 'BTS' }}</div>
+                        <div class="year">{{ $settings['bulletin_cycle_text'] ?? 'Brevet de Technicien Supérieur' }}</div>
+                        <div class="year">{{ $settings['bulletin_cycle_abbreviation'] ?? 'BTS' }}</div>
                         @endif
-                        <div>Année Scolaire: {{ $anneeUniversitaire->annee_debut }}-{{ $anneeUniversitaire->annee_fin }}</div>
+                        <div class="year" style="font-weight: 700;">Année Scolaire : {{ $anneeUniversitaire->annee_debut }}-{{ $anneeUniversitaire->annee_fin }}</div>
                     </td>
                 </tr>
             </table>
         </div>
         @endif
 
-        {{-- Debug temporaire --}}
-        <!-- DEBUG: photoEtudiantBase64 = {{ $photoEtudiantBase64 ? 'PRÉSENT' : 'ABSENT' }} -->
-        <!-- DEBUG: etudiant nom = {{ $etudiant->nom ?? 'NON DÉFINI' }} -->
-
-        @if(true) {{-- Force l'affichage des informations étudiant --}}
-        <!-- SECTION INFORMATIONS ÉTUDIANT -->
-        <div style="background: #e3f2fd; padding: 10px; margin: 15px 0; border: 2px solid #2196f3; text-align: center; font-weight: bold; color: #1976d2;">
-            INFORMATIONS DE L'ÉTUDIANT
-        </div>
+        {{-- Fiche étudiant --}}
+        @php
+            $prenom   = $etudiant->prenoms ?? $etudiant->prenom ?? '';
+            $initials = strtoupper(substr($etudiant->nom ?? 'E', 0, 1) . substr($prenom ?: 'T', 0, 1));
+        @endphp
         <div class="student-info">
             <table class="student-info-table">
                 <tr>
-                    <!-- Photo de l'étudiant -->
-                    <td style="width: 150px; min-width: 150px; text-align: center; vertical-align: top; padding: 10px; position: relative;">
+                    <td>
                         @if(isset($photoEtudiantBase64) && $photoEtudiantBase64)
-                            <img src="{{ $photoEtudiantBase64 }}" alt="Photo" style="width: 100px; height: 100px; border-radius: 50%; object-fit: cover; border: 2px solid #007bff; display: block; margin: 0 auto;">
+                            <img src="{{ $photoEtudiantBase64 }}" alt="Photo">
                         @else
-                            <div style="width: 100px; height: 100px; border-radius: 50%; background: #f3f4f6; border: 2px solid #007bff; text-align: center; line-height: 100px; font-size: 32px; color: #6b7280; margin: 0 auto;">
-                                👤
-                            </div>
+                            <div class="avatar-fallback"><span>{{ $initials }}</span></div>
                         @endif
                         @if(($settings['bulletin_show_matricule'] ?? '1') == '1')
-                        <div class="matricule-text" style="white-space: nowrap; overflow: visible; word-break: keep-all; word-wrap: normal; display: block; text-align: center; margin: 8px auto 0 auto; width: 100%; position: relative; left: 0; right: 0;">{{ $etudiant->matricule }}</div>
+                        <div class="matricule-text">{{ $etudiant->matricule }}</div>
                         @endif
                     </td>
-                    <!-- Informations personnelles -->
-                    <td class="info-group" style="width: 40%; vertical-align: top;">
+                    <td class="info-group">
                         <div class="info-row">
                             <span class="info-label">Nom et Prénoms :</span>
                             <span class="info-value">{{ $etudiant->nom }} {{ $etudiant->prenoms ?? $etudiant->prenom }}</span>
@@ -525,7 +456,7 @@
                         @if(($settings['bulletin_show_birth_date'] ?? '1') == '1')
                         <div class="info-row">
                             <span class="info-label">Date de Naissance :</span>
-                            <span class="info-value">{{ $etudiant->date_naissance ? \Carbon\Carbon::parse($etudiant->date_naissance)->format('d/m/Y') : 'Non renseigné' }}</span>
+                            <span class="info-value">{{ $etudiant->date_naissance ? \Carbon\Carbon::parse($etudiant->date_naissance)->format('d/m/Y') : 'Non renseignée' }}</span>
                         </div>
                         @endif
                         <div class="info-row">
@@ -547,8 +478,7 @@
                             <span class="info-value">{{ $etudiant->telephone ?? 'Non renseigné' }}</span>
                         </div>
                     </td>
-                    <!-- Informations académiques -->
-                    <td class="info-group" style="width: 40%; vertical-align: top;">
+                    <td class="info-group">
                         <div class="info-row">
                             <span class="info-label">Classe :</span>
                             <span class="info-value">{{ $classe->libelle ?? $classe->name }}</span>
@@ -569,8 +499,8 @@
                 </tr>
             </table>
         </div>
-        @endif
 
+        {{-- Tableau des matières --}}
         @if(($settings['bulletin_show_subjects_table'] ?? '1') == '1')
         <table>
             <thead>
@@ -578,7 +508,7 @@
                     <th>Matière</th>
                     @if(($settings['bulletin_show_subject_average'] ?? '1') == '1')<th>Moyenne M</th>@endif
                     @if(($settings['bulletin_show_coefficient'] ?? '1') == '1')<th>Coef C</th>@endif
-                    @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<th>Moy Pondérée M*C</th>@endif
+                    @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<th>Moy Pondérée M×C</th>@endif
                     @if(($settings['bulletin_show_rank_per_subject'] ?? '1') == '1')<th>Rang</th>@endif
                     @if(($settings['bulletin_show_teachers'] ?? '1') == '1')<th>Professeurs</th>@endif
                     @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<th>Appréciations</th>@endif
@@ -604,9 +534,7 @@
                             </tr>
                         @endforeach
                     @else
-                        <tr>
-                            <td colspan="7" class="center">Aucune matière d'enseignement général</td>
-                        </tr>
+                        <tr><td colspan="7" class="center">Aucune matière d'enseignement général</td></tr>
                     @endif
                     @if(($settings['bulletin_show_section_averages'] ?? '1') == '1')
                     <tr class="summary-row">
@@ -634,9 +562,7 @@
                         </tr>
                     @endforeach
                 @else
-                    <tr>
-                        <td colspan="7" class="center">Aucune matière d'enseignement technique</td>
-                    </tr>
+                    <tr><td colspan="7" class="center">Aucune matière d'enseignement technique</td></tr>
                 @endif
                 @if(($settings['bulletin_show_section_averages'] ?? '1') == '1')
                 <tr class="summary-row">
@@ -650,6 +576,7 @@
         </table>
         @endif
 
+        {{-- Absences --}}
         @if(($settings['bulletin_show_absences'] ?? '1') == '1')
         <table class="absences-table">
             <thead>
@@ -674,171 +601,97 @@
         </table>
         @endif
 
+        {{-- Résultats & Statistiques --}}
         @if(($settings['bulletin_show_results_section'] ?? '1') == '1')
         <div class="results-container">
             <table class="results-container-table">
                 <tr>
                     <td class="results-left">
-                <table class="results-table">
-                    <thead>
-                        <tr class="section-header">
-                            <td colspan="2">RÉSULTATS</td>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @if(($settings['bulletin_show_raw_average'] ?? '1') == '1')
-                        <tr>
-                            <td>Moyenne Brute</td>
-                            <td class="center" style="width: 140px;">
-                                <div style="border: 1px solid #000; padding: 4px; width: 60px; display: inline-block;">{{ number_format($moyenneGlobale, 2) }}</div>
-                            </td>
-                        </tr>
-                        @endif
-                        @if(($settings['bulletin_show_attendance_note'] ?? '1') == '1')
-                        <tr>
-                            <td>Note d'assiduité</td>
-                            <td class="center">
-                                <div style="border: 1px solid #000; padding: 4px; width: 60px; display: inline-block;">
-                                    {{ $note_assiduite > 0 ? '+' . number_format($note_assiduite, 2) : number_format($note_assiduite, 2) }}
-                                </div>
-                            </td>
-                        </tr>
-                        @endif
-                        @if(($settings['bulletin_show_semester_average'] ?? '1') == '1')
-                        <tr>
-                            <td>Moyenne {{ $periode == 'semestre1' ? '1er' : '2e' }} Semestre</td>
-                            <td class="center">
-                                <div style="border: 1px solid #000; padding: 4px; width: 60px; display: inline-block;">{{ number_format($moyenneAvecAssiduite, 2) }}</div>
-                            </td>
-                        </tr>
-                        @if($periode == 'semestre2')
-                        <tr>
-                            <td>Moyenne Semestre 1</td>
-                            <td class="center">
-                                <div style="border: 1px solid #000; padding: 4px; width: 60px; display: inline-block;">{{ $moyenneSemestre1 !== null ? number_format($moyenneSemestre1, 2) : '-' }}</div>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>Moyenne Annuelle</td>
-                            <td class="center">
-                                <div style="border: 1px solid #000; padding: 4px; width: 60px; display: inline-block;">{{ $moyenneAnnuelle !== null ? number_format($moyenneAnnuelle, 2) : '-' }}</div>
-                            </td>
-                        </tr>
-                        @endif
-                        @endif
-                        @if(($settings['bulletin_show_student_rank'] ?? '1') == '1')
-                        <tr>
-                            <td>Rang</td>
-                            <td class="center">
-                                <div style="border: 1px solid #000; padding: 4px; width: 60px; display: inline-block;">{{ $rang }}</div>
-                            </td>
-                        </tr>
-                        @endif
-                    </tbody>
-                </table>
+                        <div class="results-card">
+                            <table class="results-table">
+                                <thead><tr><th colspan="2">RÉSULTATS</th></tr></thead>
+                                <tbody>
+                                    @if(($settings['bulletin_show_raw_average'] ?? '1') == '1')
+                                    <tr>
+                                        <td>Moyenne Brute</td>
+                                        <td class="center"><span class="result-value-box">{{ number_format($moyenneGlobale, 2) }}</span></td>
+                                    </tr>
+                                    @endif
+                                    @if(($settings['bulletin_show_attendance_note'] ?? '1') == '1')
+                                    <tr>
+                                        <td>Note d'assiduité</td>
+                                        <td class="center"><span class="result-value-box">{{ $note_assiduite > 0 ? '+'.number_format($note_assiduite, 2) : number_format($note_assiduite, 2) }}</span></td>
+                                    </tr>
+                                    @endif
+                                    @if(($settings['bulletin_show_semester_average'] ?? '1') == '1')
+                                    <tr>
+                                        <td>Moyenne {{ $periode == 'semestre1' ? '1er' : '2e' }} Semestre</td>
+                                        <td class="center"><span class="result-value-box">{{ number_format($moyenneAvecAssiduite, 2) }}</span></td>
+                                    </tr>
+                                    @if($periode == 'semestre2')
+                                    <tr>
+                                        <td>Moyenne Semestre 1</td>
+                                        <td class="center"><span class="result-value-box">{{ $moyenneSemestre1 !== null ? number_format($moyenneSemestre1, 2) : '-' }}</span></td>
+                                    </tr>
+                                    <tr>
+                                        <td>Moyenne Annuelle</td>
+                                        <td class="center"><span class="result-value-box">{{ $moyenneAnnuelle !== null ? number_format($moyenneAnnuelle, 2) : '-' }}</span></td>
+                                    </tr>
+                                    @endif
+                                    @endif
+                                    @if(($settings['bulletin_show_student_rank'] ?? '1') == '1')
+                                    <tr>
+                                        <td>Rang</td>
+                                        <td class="center"><span class="result-value-box">{{ $rang }}</span></td>
+                                    </tr>
+                                    @endif
+                                </tbody>
+                            </table>
+                        </div>
 
-                @if(($settings['bulletin_show_mentions'] ?? '1') == '1')
-                <div style="margin-top: 15px;">
-                    @if(($settings['bulletin_show_felicitation'] ?? '1') == '1')
-                    <div class="mention-box">
-                        <table class="mention-table"><tr>
-                            <td class="mention-label">Félicitation</td>
-                            <td class="mention-value">
-                            @php
-                                $felicitationThreshold = floatval($settings['bulletin_felicitation_threshold'] ?? 16);
-                                $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $felicitationThreshold) : false;
-                            @endphp
-                            <input type="checkbox" {{ $isChecked ? 'checked' : '' }}>
-                        </td>
-                        </tr></table>
-                    </div>
-                    @endif
-                    @if(($settings['bulletin_show_encouragement'] ?? '1') == '1')
-                    <div class="mention-box">
-                        <table class="mention-table"><tr>
-                            <td class="mention-label">Encouragement</td>
-                            <td class="mention-value">
-                            @php
-                                $encouragementThreshold = floatval($settings['bulletin_encouragement_threshold'] ?? 14);
-                                $felicitationThreshold = floatval($settings['bulletin_felicitation_threshold'] ?? 16);
-                                $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $encouragementThreshold && $moyenneGlobale < $felicitationThreshold) : false;
-                            @endphp
-                            <input type="checkbox" {{ $isChecked ? 'checked' : '' }}>
-                        </td>
-                        </tr></table>
-                    </div>
-                    @endif
-                    @if(($settings['bulletin_show_honor_roll'] ?? '1') == '1')
-                    <div class="mention-box">
-                        <table class="mention-table"><tr>
-                            <td class="mention-label">Tableau d'honneur</td>
-                            <td class="mention-value">
-                            @php
-                                $honorRollThreshold = floatval($settings['bulletin_honor_roll_threshold'] ?? 12);
-                                $encouragementThreshold = floatval($settings['bulletin_encouragement_threshold'] ?? 14);
-                                $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $honorRollThreshold && $moyenneGlobale < $encouragementThreshold) : false;
-                            @endphp
-                            <input type="checkbox" {{ $isChecked ? 'checked' : '' }}>
-                        </td>
-                        </tr></table>
-                    </div>
-                    @endif
-                    @if(($settings['bulletin_show_work_warning'] ?? '1') == '1')
-                    <div class="mention-box">
-                        <table class="mention-table"><tr>
-                            <td class="mention-label">Avertissement (Travail)</td>
-                            <td class="mention-value">
-                            @php
-                                $workWarningThreshold = floatval($settings['bulletin_work_warning_threshold'] ?? 8);
-                                $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $workWarningThreshold && $moyenneGlobale < 10) : false;
-                            @endphp
-                            <input type="checkbox" {{ $isChecked ? 'checked' : '' }}>
-                        </td>
-                        </tr></table>
-                    </div>
-                    @endif
-                    @if(($settings['bulletin_show_conduct_blame'] ?? '1') == '1')
-                    <div class="mention-box">
-                        <table class="mention-table"><tr>
-                            <td class="mention-label">Blâme (Conduite)</td>
-                            <td class="mention-value">
-                            <input type="checkbox">
-                        </td>
-                        </tr></table>
-                    </div>
-                    @endif
-                </div>
-                @endif
+                        @if(($settings['bulletin_show_mentions'] ?? '1') == '1')
+                        <div style="margin-top: 8px;">
+                            @if(($settings['bulletin_show_felicitation'] ?? '1') == '1')
+                                @php $felicitationThreshold = floatval($settings['bulletin_felicitation_threshold'] ?? 16); $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $felicitationThreshold) : false; @endphp
+                                <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Félicitation</td><td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td></tr></table></div>
+                            @endif
+                            @if(($settings['bulletin_show_encouragement'] ?? '1') == '1')
+                                @php $encouragementThreshold = floatval($settings['bulletin_encouragement_threshold'] ?? 14); $felicitationThreshold = floatval($settings['bulletin_felicitation_threshold'] ?? 16); $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $encouragementThreshold && $moyenneGlobale < $felicitationThreshold) : false; @endphp
+                                <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Encouragement</td><td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td></tr></table></div>
+                            @endif
+                            @if(($settings['bulletin_show_honor_roll'] ?? '1') == '1')
+                                @php $honorRollThreshold = floatval($settings['bulletin_honor_roll_threshold'] ?? 12); $encouragementThreshold = floatval($settings['bulletin_encouragement_threshold'] ?? 14); $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $honorRollThreshold && $moyenneGlobale < $encouragementThreshold) : false; @endphp
+                                <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Tableau d'honneur</td><td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td></tr></table></div>
+                            @endif
+                            @if(($settings['bulletin_show_work_warning'] ?? '1') == '1')
+                                @php $workWarningThreshold = floatval($settings['bulletin_work_warning_threshold'] ?? 8); $isChecked = ($settings['bulletin_auto_calculate_mention'] ?? '1') == '1' ? ($moyenneGlobale >= $workWarningThreshold && $moyenneGlobale < 10) : false; @endphp
+                                <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Avertissement (Travail)</td><td class="mention-value"><input type="checkbox" {{ $isChecked ? 'checked' : '' }}></td></tr></table></div>
+                            @endif
+                            @if(($settings['bulletin_show_conduct_blame'] ?? '1') == '1')
+                                <div class="mention-box"><table class="mention-table"><tr><td class="mention-label">Blâme (Conduite)</td><td class="mention-value"><input type="checkbox"></td></tr></table></div>
+                            @endif
+                        </div>
+                        @endif
                     </td>
+
                     @if(($settings['bulletin_show_statistics'] ?? '1') == '1')
                     <td class="results-right">
-                <table class="stats-table">
-                            <thead>
-                                <tr class="section-header">
-                                    <td colspan="2">STATISTIQUES - {{ $periode == 'semestre2' ? 'SEMESTRE 2' : 'SEMESTRE 1' }}</td>
-                                </tr>
-                            </thead>
-                    <tbody>
-                        @if(($settings['bulletin_show_highest_average'] ?? '1') == '1')
-                        <tr>
-                            <td>Plus forte moyenne</td>
-                            <td class="center" style="width: 60px;">{{ number_format($meilleure_moyenne, 2) }}</td>
-                        </tr>
-                        @endif
-                        @if(($settings['bulletin_show_lowest_average'] ?? '1') == '1')
-                        <tr>
-                            <td>Plus faible moyenne</td>
-                            <td class="center">{{ number_format($plus_faible_moyenne, 2) }}</td>
-                        </tr>
-                        @endif
-                        @if(($settings['bulletin_show_class_average'] ?? '1') == '1')
-                        <tr>
-                            <td>Moyenne de la classe</td>
-                            <td class="center">{{ number_format($moyenne_classe, 2) }}</td>
-                        </tr>
-                        @endif
-                    </tbody>
-                </table>
+                        <div class="stats-card">
+                            <table class="stats-table">
+                                <thead><tr><th colspan="2">STATISTIQUES — {{ $periode == 'semestre2' ? 'SEMESTRE 2' : 'SEMESTRE 1' }}</th></tr></thead>
+                                <tbody>
+                                    @if(($settings['bulletin_show_highest_average'] ?? '1') == '1')
+                                    <tr><td>Plus forte moyenne</td><td class="center">{{ number_format($meilleure_moyenne, 2) }}</td></tr>
+                                    @endif
+                                    @if(($settings['bulletin_show_lowest_average'] ?? '1') == '1')
+                                    <tr><td>Plus faible moyenne</td><td class="center">{{ number_format($plus_faible_moyenne, 2) }}</td></tr>
+                                    @endif
+                                    @if(($settings['bulletin_show_class_average'] ?? '1') == '1')
+                                    <tr><td>Moyenne de la classe</td><td class="center">{{ number_format($moyenne_classe, 2) }}</td></tr>
+                                    @endif
+                                </tbody>
+                            </table>
+                        </div>
                     </td>
                     @endif
                 </tr>
@@ -846,34 +699,33 @@
         </div>
         @endif
 
+        {{-- Décision du conseil --}}
         @if(($settings['bulletin_show_council_decision'] ?? '1') == '1')
         <div class="decision-container">
             <div class="decision-title">Décision du conseil de classe</div>
-            <div style="min-height: 40px;">
-                {{ $appreciation }}
-            </div>
+            <div style="min-height: 36px; font-size: 10px;">{{ $appreciation }}</div>
         </div>
         @endif
 
+        {{-- Signature --}}
         @if(($settings['bulletin_show_signature'] ?? '1') == '1' || ($settings['bulletin_show_director_signature'] ?? '1') == '1')
         @php
             $directorTitle = $settings['director_title'] ?? \App\Helpers\SettingsHelper::get('director_title', 'Directeur');
-            $directorName = $settings['director_name'] ?? \App\Helpers\SettingsHelper::get('director_name', '');
+            $directorName  = $settings['director_name']  ?? \App\Helpers\SettingsHelper::get('director_name', '');
         @endphp
         <div class="signature-container">
             @if(($settings['bulletin_show_director_signature'] ?? '1') == '1')
             <div class="signature-box">
-                <div>{{ $directorTitle }}</div>
+                <div style="font-size: 10px;">{{ $directorTitle }}</div>
                 <div class="signature-line"></div>
                 @if($directorName)
-                    <div style="margin-top: 6px; font-weight: bold;">{{ $directorName }}</div>
+                    <div style="margin-top: 4px; font-weight: 700; font-size: 9.5px;">{{ $directorName }}</div>
                 @endif
             </div>
             @endif
         </div>
         @endif
 
-        {{-- Bouton d'impression supprimé car le fichier est déjà un PDF généré --}}
     </div>
 
     @unless($isPdfExport ?? false)
@@ -881,7 +733,6 @@
         function togglePDFMode() {
             const body = document.body;
             const button = document.getElementById('pdfToggle');
-            
             if (body.classList.contains('pdf-mode')) {
                 body.classList.remove('pdf-mode');
                 button.textContent = 'Mode PDF';
@@ -892,11 +743,7 @@
                 button.style.backgroundColor = '#dc3545';
             }
         }
-
-        // Auto-basculer en mode PDF si le paramètre est présent dans l'URL
-        if (window.location.search.includes('preview=pdf')) {
-            togglePDFMode();
-        }
+        if (window.location.search.includes('preview=pdf')) { togglePDFMode(); }
     </script>
     @endunless
 </body>

--- a/resources/views/esbtp/etudiants/certificat.blade.php
+++ b/resources/views/esbtp/etudiants/certificat.blade.php
@@ -53,10 +53,9 @@
         }
 
         .doc-header-logo img {
-            max-height: 48px;
-            max-width: 90px;
+            max-height: 60px;
+            max-width: 100px;
             margin-bottom: 8px;
-            filter: brightness(0) invert(1);
         }
 
         .doc-school-name {

--- a/resources/views/pdf/emploi-temps.blade.php
+++ b/resources/views/pdf/emploi-temps.blade.php
@@ -63,9 +63,9 @@
         }
         .header-logo img,
         .header-right img {
-            max-height: 18px;
-            max-width: 60px;
-            filter: brightness(0) invert(1);
+            max-height: 28px;
+            max-width: 70px;
+            object-fit: contain;
         }
 
 


### PR DESCRIPTION
Closes #70

## Résumé

- **Logo blanc invisible** : Suppression de `filter: brightness(0) invert(1)` dans `certificat.blade.php` et `emploi-temps.blade.php` qui forçait les logos transparents à apparaître en blanc (invisibles sur fond blanc)
- **Bulletin ESBTP-Abidjan** (`pdf-configurable-abidjan.blade.php`) : Refonte complète — dimensions A4 correctes (210mm), header 2 colonnes (logo gauche / infos école + titre droite), photo étudiant en carré, couleurs dynamiques via `SettingsHelper::getPdfSettings()`
- **Bulletin ESBTP-Yakro** (`pdf-configurable.blade.php`) : Refonte complète — dimensions A4 correctes, header 3 colonnes (République | logo+école | titre), suppression code debug (banner bleu, emoji), couleurs dynamiques via `SettingsHelper::getPdfSettings()`

## Plan de test

- [ ] Générer un certificat de scolarité → vérifier que le logo est visible (pas blanc)
- [ ] Générer un emploi du temps PDF → vérifier que le logo est visible
- [ ] Générer un bulletin style `abidjan` → vérifier layout 2 colonnes header, dimensions A4, couleurs issues des settings
- [ ] Générer un bulletin style `yakro` → vérifier layout 3 colonnes header, dimensions A4, couleurs issues des settings
- [ ] Modifier les couleurs dans `/esbtp/settings` → vérifier que les bulletins reflètent les nouvelles couleurs
- [ ] Tester avec logo à fond transparent → doit être visible sur fond blanc