### PR TITLE
fix(pdf): corriger logos preview, photo bulletin et avatar résultats

### DIFF
--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -4265,6 +4265,22 @@ class ESBTPBulletinController extends Controller
             $logoBase64 = $this->prepareLogoBase64($donnees['settings']['school_logo'] ?? null);
             $donnees['logoBase64'] = $logoBase64;
 
+            // Préparer la photo étudiant en base64 pour la preview
+            $donnees['photoEtudiantBase64'] = null;
+            if (!empty($donnees['etudiant']?->photo)) {
+                $photoCandidates = [
+                    storage_path('app/public/photos/etudiants/' . $donnees['etudiant']->photo),
+                    storage_path('app/public/' . $donnees['etudiant']->photo),
+                ];
+                foreach ($photoCandidates as $photoPath) {
+                    if (file_exists($photoPath)) {
+                        $mime = mime_content_type($photoPath) ?: 'image/jpeg';
+                        $donnees['photoEtudiantBase64'] = 'data:' . $mime . ';base64,' . base64_encode(file_get_contents($photoPath));
+                        break;
+                    }
+                }
+            }
+
             return view($this->getBulletinTemplateView(), $donnees);
 
         } catch (CoefficientMissingException $e) {

--- a/resources/views/components/student-results/student-info-card.blade.php
+++ b/resources/views/components/student-results/student-info-card.blade.php
@@ -10,7 +10,11 @@
     <div class="main-card-body">
         <div class="student-profile">
             <div class="student-avatar">
-                <i class="fas fa-user-circle"></i>
+                @if($etudiant->photo_url)
+                    <img src="{{ $etudiant->photo_url }}" alt="Photo de {{ $etudiant->nom }}" class="student-avatar-img">
+                @else
+                    <i class="fas fa-user-circle"></i>
+                @endif
             </div>
             <div class="student-details">
                 <h3 class="student-name">{{ $etudiant->nom }} {{ $etudiant->prenoms }}</h3>
@@ -63,6 +67,14 @@
     border-radius: 50%;
     color: white;
     font-size: 2.5rem;
+    overflow: hidden;
+}
+
+.student-avatar-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 50%;
 }
 
 .student-details {

--- a/resources/views/esbtp/bulletins/pdf-configurable.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable.blade.php
@@ -62,6 +62,7 @@
             width: 48%;
             text-align: center;
             padding: 0 8px;
+            vertical-align: middle;
         }
         .header-right {
             width: 26%;

--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -57,7 +57,7 @@
         width:110px; height:110px; border-radius:50%;
         background:rgba(255,255,255,.08); pointer-events:none;
     }
-    .doc-header-logo img { height:52px; filter:brightness(0) invert(1); }
+    .doc-header-logo img { max-height:60px; max-width:100px; }
     .doc-header-info { flex:1; }
     .doc-school-name {
         font-size:1.1rem; font-weight:800; text-transform:uppercase;

--- a/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
@@ -53,10 +53,9 @@
         }
 
         .doc-header-logo img {
-            max-height: 48px;
-            max-width: 90px;
+            max-height: 60px;
+            max-width: 100px;
             margin-bottom: 8px;
-            filter: brightness(0) invert(1);
         }
 
         .doc-school-name {

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -57,7 +57,7 @@
         width:110px; height:110px; border-radius:50%;
         background:rgba(255,255,255,.08); pointer-events:none;
     }
-    .doc-header-logo img { height:52px; filter:brightness(0) invert(1); }
+    .doc-header-logo img { max-height:60px; max-width:100px; }
     .doc-header-info { flex:1; }
     .doc-school-name {
         font-size:1.1rem; font-weight:800; text-transform:uppercase;


### PR DESCRIPTION
Fixes #70 (suite — PR #71 complétée)

## Problèmes résolus

### 1. Logos blancs dans les previews browser
- `certificat-preview.blade.php` : suppression de `filter:brightness(0) invert(1)` sur `.doc-header-logo img`
- `attestation-frequentation-preview.blade.php` : même fix
- `attestation-frequentation.blade.php` (PDF DomPDF) : même fix

Ces 3 fichiers avaient été **manqués** par la PR #71 qui ne corrigeait que `certificat.blade.php`.

### 2. Logo collé en haut dans le bulletin PDF
- `pdf-configurable.blade.php` : ajout de `vertical-align: middle` sur `.header-center` pour centrer le logo dans sa colonne

### 3. Photo étudiant absente dans la preview bulletin
- `ESBTPBulletinController::previewBulletinEtudiantNew()` : ajout de la préparation de `photoEtudiantBase64` (existait dans la méthode PDF mais pas dans la preview)

### 4. Photo étudiant absente sur la page résultats (`/esbtp/resultats/etudiant/{id}`)
- `student-info-card.blade.php` : remplacement de l'icône statique par la vraie photo avec fallback icône si pas de photo

## Test plan
- [ ] Vérifier `/esbtp/etudiants/{id}/certificat-preview` → logo couleur visible dans l'en-tête
- [ ] Vérifier `/esbtp/etudiants/{id}/attestation-frequentation-preview` → logo couleur visible
- [ ] Générer PDF attestation → logo couleur visible
- [ ] Preview bulletin → photo étudiant affichée (ou initiales si absente)
- [ ] Bulletin PDF → logo centré verticalement dans sa colonne gauche
- [ ] Page résultats étudiant → photo réelle affichée, fallback icône si pas de photo