### PR TITLE
fix(pdf): ajouter photo étudiant dans génération PDF par paramètres

### DIFF
--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -4841,6 +4841,22 @@ class ESBTPBulletinController extends Controller
             $logoBase64 = $this->prepareLogoBase64($config['school_logo']);
             $donnees['logoBase64'] = $logoBase64;
 
+            // Préparer la photo étudiant en base64 pour le PDF
+            $donnees['photoEtudiantBase64'] = null;
+            if (!empty($donnees['etudiant']?->photo)) {
+                $photoCandidates = [
+                    storage_path('app/public/photos/etudiants/' . $donnees['etudiant']->photo),
+                    storage_path('app/public/' . $donnees['etudiant']->photo),
+                ];
+                foreach ($photoCandidates as $photoPath) {
+                    if (file_exists($photoPath)) {
+                        $mime = mime_content_type($photoPath) ?: 'image/jpeg';
+                        $donnees['photoEtudiantBase64'] = 'data:' . $mime . ';base64,' . base64_encode(file_get_contents($photoPath));
+                        break;
+                    }
+                }
+            }
+
             // Indiquer que c'est un export PDF pour cacher les éléments web
             $donnees['isPdfExport'] = true;
 


### PR DESCRIPTION
Fixes #70 (suite — PR #72 déjà mergée)

## Problème résolu

La méthode `genererPDFParParamsUnified()` utilisée par le bouton **"Télécharger PDF"** sur `/esbtp/resultats/etudiant/{id}` ne préparait pas `photoEtudiantBase64`, contrairement aux deux autres méthodes de génération de bulletin.

Résultat : la photo de l'étudiant n'apparaissait **jamais** dans le PDF téléchargé (initiales "DI" affichées à la place).

## Fichier modifié

- `app/Http/Controllers/ESBTPBulletinController.php` — ajout du bloc `photoEtudiantBase64` dans `genererPDFParParamsUnified()` (même logique que `genererPDF()` et `previewBulletinEtudiantNew()`)

## Tableau des 3 méthodes bulletin

| Méthode | Route | Photo |
|---|---|---|
| `genererPDF()` | `/esbtp/bulletins/{id}/generer-pdf` | ✅ Déjà OK |
| `previewBulletinEtudiantNew()` | `/resultats/etudiant/{id}/preview` | ✅ Fixé PR #72 |
| `genererPDFParParamsUnified()` | `/esbtp-special/bulletins-pdf` | ✅ **Fixé cette PR** |

## Test plan
- [ ] Aller sur `/esbtp/resultats/etudiant/6?classe_id=2&annee_universitaire_id=1`
- [ ] Cliquer "Télécharger PDF"
- [ ] Vérifier que la photo de l'étudiant apparaît dans le PDF (au lieu des initiales)