### PR TITLE
fix(bulletins): afficher photo étudiant et centrer logo header PDF

### DIFF
--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -959,9 +959,15 @@ class ESBTPBulletinController extends Controller
             // Préparer la photo étudiant en base64 pour le PDF (conversion JPEG pour DomPDF)
             $data['photoEtudiantBase64'] = null;
             if (!empty($data['etudiant']?->photo)) {
-                $photoPath = storage_path('app/public/' . $data['etudiant']->photo);
-                if (file_exists($photoPath)) {
-                    $data['photoEtudiantBase64'] = $this->convertImageToJpegBase64($photoPath);
+                $photoCandidates = [
+                    storage_path('app/public/' . $data['etudiant']->photo),
+                    public_path('storage/' . $data['etudiant']->photo),
+                ];
+                foreach ($photoCandidates as $photoPath) {
+                    if (file_exists($photoPath)) {
+                        $data['photoEtudiantBase64'] = $this->convertImageToJpegBase64($photoPath);
+                        break;
+                    }
                 }
             }
 
@@ -4261,9 +4267,15 @@ class ESBTPBulletinController extends Controller
             // Préparer la photo étudiant en base64 pour la preview (conversion JPEG pour DomPDF)
             $donnees['photoEtudiantBase64'] = null;
             if (!empty($donnees['etudiant']?->photo)) {
-                $photoPath = storage_path('app/public/' . $donnees['etudiant']->photo);
-                if (file_exists($photoPath)) {
-                    $donnees['photoEtudiantBase64'] = $this->convertImageToJpegBase64($photoPath);
+                $photoCandidates = [
+                    storage_path('app/public/' . $donnees['etudiant']->photo),
+                    public_path('storage/' . $donnees['etudiant']->photo),
+                ];
+                foreach ($photoCandidates as $photoPath) {
+                    if (file_exists($photoPath)) {
+                        $donnees['photoEtudiantBase64'] = $this->convertImageToJpegBase64($photoPath);
+                        break;
+                    }
                 }
             }
 
@@ -4830,9 +4842,15 @@ class ESBTPBulletinController extends Controller
             // Préparer la photo étudiant en base64 pour le PDF (conversion JPEG pour DomPDF)
             $donnees['photoEtudiantBase64'] = null;
             if (!empty($donnees['etudiant']?->photo)) {
-                $photoPath = storage_path('app/public/' . $donnees['etudiant']->photo);
-                if (file_exists($photoPath)) {
-                    $donnees['photoEtudiantBase64'] = $this->convertImageToJpegBase64($photoPath);
+                $photoCandidates = [
+                    storage_path('app/public/' . $donnees['etudiant']->photo),
+                    public_path('storage/' . $donnees['etudiant']->photo),
+                ];
+                foreach ($photoCandidates as $photoPath) {
+                    if (file_exists($photoPath)) {
+                        $donnees['photoEtudiantBase64'] = $this->convertImageToJpegBase64($photoPath);
+                        break;
+                    }
                 }
             }
 

--- a/resources/views/esbtp/bulletins/pdf-configurable.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable.blade.php
@@ -47,7 +47,7 @@
         .header-table td {
             border: none;
             padding: 4px 5px;
-            vertical-align: top;
+            vertical-align: middle;
             word-wrap: break-word;
         }
         .header-left {


### PR DESCRIPTION
## Problème diagnostiqué

Via Playwright, on a déterminé que :
- `photoEtudiantBase64` était `null` dans le template → fallback "DI" affiché
- `file_exists(storage_path('app/public/...'))` retourne `false` sur le serveur de prod
- La photo est accessible via `/storage/photos/...` (symlink public), donc `public_path('storage/...')` fonctionne

Le logo utilisait déjà ce fallback via `prepareLogoBase64()`, d'où il s'affichait correctement.

## Corrections

### Photo étudiant (3 méthodes)
Ajout d'un fallback `public_path('storage/')` identique à `prepareLogoBase64` dans :
- `genererPDF()`
- `previewBulletinEtudiantNew()`
- `genererPDFParParamsUnified()`

### Centrage logo header
Correction `vertical-align: top → middle` sur `.header-table td` dans `pdf-configurable.blade.php` pour centrer verticalement le logo par rapport au contenu du header.

## Test
- Vérifier que la photo apparaît dans le PDF téléchargé
- Vérifier que le logo est centré verticalement dans le header