### PR TITLE
fix(bulletins): corriger chemin photo étudiant dans PDF

### DIFF
--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -959,9 +959,12 @@ class ESBTPBulletinController extends Controller
             // Préparer la photo étudiant en base64 pour le PDF (conversion JPEG pour DomPDF)
             $data['photoEtudiantBase64'] = null;
             if (!empty($data['etudiant']?->photo)) {
+                $photo = $data['etudiant']->photo;
                 $photoCandidates = [
-                    storage_path('app/public/' . $data['etudiant']->photo),
-                    public_path('storage/' . $data['etudiant']->photo),
+                    storage_path('app/public/' . $photo),
+                    storage_path('app/public/photos/etudiants/' . basename($photo)),
+                    public_path('storage/' . $photo),
+                    public_path('storage/photos/etudiants/' . basename($photo)),
                 ];
                 foreach ($photoCandidates as $photoPath) {
                     if (file_exists($photoPath)) {
@@ -4267,9 +4270,12 @@ class ESBTPBulletinController extends Controller
             // Préparer la photo étudiant en base64 pour la preview (conversion JPEG pour DomPDF)
             $donnees['photoEtudiantBase64'] = null;
             if (!empty($donnees['etudiant']?->photo)) {
+                $photo = $donnees['etudiant']->photo;
                 $photoCandidates = [
-                    storage_path('app/public/' . $donnees['etudiant']->photo),
-                    public_path('storage/' . $donnees['etudiant']->photo),
+                    storage_path('app/public/' . $photo),
+                    storage_path('app/public/photos/etudiants/' . basename($photo)),
+                    public_path('storage/' . $photo),
+                    public_path('storage/photos/etudiants/' . basename($photo)),
                 ];
                 foreach ($photoCandidates as $photoPath) {
                     if (file_exists($photoPath)) {
@@ -4842,9 +4848,12 @@ class ESBTPBulletinController extends Controller
             // Préparer la photo étudiant en base64 pour le PDF (conversion JPEG pour DomPDF)
             $donnees['photoEtudiantBase64'] = null;
             if (!empty($donnees['etudiant']?->photo)) {
+                $photo = $donnees['etudiant']->photo;
                 $photoCandidates = [
-                    storage_path('app/public/' . $donnees['etudiant']->photo),
-                    public_path('storage/' . $donnees['etudiant']->photo),
+                    storage_path('app/public/' . $photo),
+                    storage_path('app/public/photos/etudiants/' . basename($photo)),
+                    public_path('storage/' . $photo),
+                    public_path('storage/photos/etudiants/' . basename($photo)),
                 ];
                 foreach ($photoCandidates as $photoPath) {
                     if (file_exists($photoPath)) {

--- a/app/Services/BulletinService.php
+++ b/app/Services/BulletinService.php
@@ -955,9 +955,23 @@ class BulletinService
             return null;
         }
 
-        $photoPath = storage_path('app/public/'.$etudiant->photo);
+        $photo = $etudiant->photo;
+        $photoCandidates = [
+            storage_path('app/public/' . $photo),
+            storage_path('app/public/photos/etudiants/' . basename($photo)),
+            public_path('storage/' . $photo),
+            public_path('storage/photos/etudiants/' . basename($photo)),
+        ];
 
-        if (! file_exists($photoPath)) {
+        $photoPath = null;
+        foreach ($photoCandidates as $candidate) {
+            if (file_exists($candidate)) {
+                $photoPath = $candidate;
+                break;
+            }
+        }
+
+        if (! $photoPath) {
             return null;
         }
 


### PR DESCRIPTION
## Problème

La photo de l'étudiant n'apparaissait pas dans les bulletins PDF (initiales affichées à la place).

## Cause racine

`$etudiant->photo` stocke uniquement le nom de fichier (ex: `1767882890_gs7eVAN9Ln.png`) **sans le sous-dossier** `photos/etudiants/`.

Le code cherchait à :
```
storage/app/public/1767882890_gs7eVAN9Ln.png  ← N'EXISTE PAS
```

Alors que le fichier est à :
```
storage/app/public/photos/etudiants/1767882890_gs7eVAN9Ln.png  ← EXISTE
```

## Fix

Ajout d'un tableau de 4 candidats dans tous les points de chargement de photo :

```php
$photoCandidates = [
    storage_path('app/public/' . $photo),
    storage_path('app/public/photos/etudiants/' . basename($photo)),
    public_path('storage/' . $photo),
    public_path('storage/photos/etudiants/' . basename($photo)),
];
foreach ($photoCandidates as $photoPath) {
    if (file_exists($photoPath)) {
        $donnees['photoEtudiantBase64'] = $this->convertImageToJpegBase64($photoPath);
        break;
    }
}
```

## Fichiers modifiés

- `app/Http/Controllers/ESBTPBulletinController.php` — 3 blocs de chargement photo (genererPDF, previewBulletinEtudiantNew, genererPDFParParamsUnified)
- `app/Services/BulletinService.php` — méthode `preparePhotoEtudiantBase64()`

## Diagnostic

Confirmé via `php artisan tinker` sur le serveur :
- `file_exists(storage_path('app/public/photos/etudiants/' . basename($photo)))` → `true`
- `file_exists(storage_path('app/public/' . $photo))` → `false`