### PR TITLE
fix(bulletins): corriger layout header PDF style abidjan (DomPDF table widths)

### DIFF
--- a/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
@@ -63,22 +63,27 @@
             vertical-align: top;
         }
 
-        /* Colonne gauche : logo */
+        /* Colonne gauche : logo — largeur % explicite requise par DomPDF */
         .header-logo-cell {
-            width: 110px;
+            width: 16%;
             padding: 10px 8px 10px 12px;
             vertical-align: middle;
             text-align: center;
             border-right: 1.5px solid #e5e7eb;
         }
         .logo {
-            width: 80px;
-            height: 80px;
-            object-fit: contain;
+            max-width: 80px;
+            max-height: 80px;
+            width: auto;
+            height: auto;
+        }
+        .header-logo-cell img {
+            max-width: none;
         }
 
-        /* Colonne droite : infos école + titre bulletin */
+        /* Colonne droite : infos école + titre bulletin — largeur % explicite requise par DomPDF */
         .header-info-cell {
+            width: 84%;
             padding: 10px 12px 10px 14px;
             vertical-align: top;
         }


### PR DESCRIPTION
## Summary
- Corrige la colonne logo qui prenait ~50% de la largeur dans le PDF abidjan alors qu'elle devrait être étroite (~16%)
- La preview HTML était correcte mais le PDF généré par DomPDF était mal proportionné

## Changes
- `pdf-configurable-abidjan.blade.php` — Remplace `width: 110px` (pixels) par `width: 16%` sur `.header-logo-cell` et ajoute `width: 84%` explicite sur `.header-info-cell` ; DomPDF v2 avec `table-layout: fixed` requiert des pourcentages explicites sur **toutes** les cellules sinon la distribution est imprévisible (~50/50). Remplace aussi `object-fit: contain` (non supporté DomPDF v2) par `max-width`/`max-height`.

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified on all modified PHP files

Closes #77