### PR TITLE
fix(bulletins): centrer logo et corriger sa taille dans header PDF abidjan

### DIFF
--- a/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
@@ -60,7 +60,7 @@
         .header-table td {
             border: none;
             padding: 0;
-            vertical-align: top;
+            vertical-align: middle;
         }
 
         /* Colonne gauche : logo — largeur % explicite requise par DomPDF */
@@ -71,14 +71,12 @@
             text-align: center;
             border-right: 1.5px solid #e5e7eb;
         }
+        /* width/height fixes (pas max-width/auto) : seule approche fiable DomPDF + browser */
         .logo {
-            max-width: 80px;
-            max-height: 80px;
-            width: auto;
-            height: auto;
-        }
-        .header-logo-cell img {
-            max-width: none;
+            width: 80px;
+            height: 80px;
+            display: block;
+            margin: 0 auto;
         }
 
         /* Colonne droite : infos école + titre bulletin — largeur % explicite requise par DomPDF */

--- a/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
@@ -71,10 +71,11 @@
             text-align: center;
             border-right: 1.5px solid #e5e7eb;
         }
-        /* width/height fixes (pas max-width/auto) : seule approche fiable DomPDF + browser */
+        /* width fixe + height auto = ratio préservé ; max-height = protection logo portrait */
         .logo {
             width: 80px;
-            height: 80px;
+            height: auto;
+            max-height: 80px;
             display: block;
             margin: 0 auto;
         }


### PR DESCRIPTION
## Summary
- Corrige le logo non centré verticalement dans la cellule header (collé en haut)
- Corrige le logo trop large en preview browser (133px au lieu de 80px, chevauchement avec les infos école)

## Changes
- `pdf-configurable-abidjan.blade.php` — 2 corrections CSS :
  1. `.header-table td { vertical-align: top }` → `vertical-align: middle` : le sélecteur parent overridait le `middle` de `.header-logo-cell`
  2. `.logo { max-width: 80px; width: auto }` → `width: 80px; height: 80px; display: block` : `width: auto` se résolvait à 133px en browser (image naturelle 600px) ; les dimensions fixes sont l'approche fiable pour DomPDF + browser

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified on all modified PHP files

Closes #77