### PR TITLE
feat(certificats): colonnes configurables, PDF aligné preview, navigation inter-documents

### DIFF
--- a/app/Http/Controllers/ESBTP/ESBTPSettingsController.php
+++ b/app/Http/Controllers/ESBTP/ESBTPSettingsController.php
@@ -105,6 +105,29 @@ class ESBTPSettingsController extends Controller
             $errors = [];
 
             // D'abord, traiter toutes les checkboxes (défaut à '0' si décochées)
+            // Ensure certificat column settings exist (create with default=1 if first save)
+            $certificatColumnDefaults = [
+                'certificat_show_classe'  => '1',
+                'certificat_show_niveau'  => '1',
+                'certificat_show_filiere' => '1',
+            ];
+            foreach ($certificatColumnDefaults as $key => $defaultValue) {
+                Setting::firstOrCreate(
+                    ['key' => $key],
+                    [
+                        'value'            => $defaultValue,
+                        'type'             => 'boolean',
+                        'group'            => 'documents',
+                        'category'         => 'documents',
+                        'description'      => 'Colonne certificat de scolarité',
+                        'is_required'      => false,
+                        'default_value'    => $defaultValue,
+                        'validation_rules' => ['nullable', 'in:0,1'],
+                        'sort_order'       => 200,
+                    ]
+                );
+            }
+
             $allCheckboxSettings = Setting::whereIn('key', [
                 'bulletin_show_logo', 'bulletin_show_header', 'bulletin_show_republic_info',
                 'bulletin_show_ministry_info', 'bulletin_show_school_info', 'bulletin_show_cycle_info',
@@ -113,7 +136,8 @@ class ESBTPSettingsController extends Controller
                 'bulletin_show_teachers', 'bulletin_show_absences', 'bulletin_show_statistics',
                 'bulletin_show_signature', 'bulletin_show_attendance_note', 'bulletin_show_council_decision',
                 'bulletin_show_highest_average', 'bulletin_show_lowest_average', 'bulletin_show_class_average',
-                'bulletin_auto_calculate_mention', 'bulletin_show_felicitation', 'bulletin_show_encouragement'
+                'bulletin_auto_calculate_mention', 'bulletin_show_felicitation', 'bulletin_show_encouragement',
+                'certificat_show_classe', 'certificat_show_niveau', 'certificat_show_filiere',
             ])->get();
 
             foreach ($allCheckboxSettings as $setting) {

--- a/app/Http/Controllers/ESBTPEtudiantController.php
+++ b/app/Http/Controllers/ESBTPEtudiantController.php
@@ -1560,8 +1560,13 @@ class ESBTPEtudiantController extends Controller
         $logoPath = \App\Helpers\SettingsHelper::get('school_logo');
         $logoBase64 = ($showLogo && $logoPath) ? $this->prepareLogoBase64($logoPath) : null;
 
-        $settings['show_logo'] = $showLogo;
-        $settings['logo_base64'] = $logoBase64;
+        $settings['show_logo']    = $showLogo;
+        $settings['logo_base64']  = $logoBase64;
+
+        // Colonnes configurables du tableau du certificat de scolarité
+        $settings['show_classe']  = \App\Helpers\SettingsHelper::get('certificat_show_classe', '1') == '1';
+        $settings['show_niveau']  = \App\Helpers\SettingsHelper::get('certificat_show_niveau', '1') == '1';
+        $settings['show_filiere'] = \App\Helpers\SettingsHelper::get('certificat_show_filiere', '1') == '1';
 
         return $settings;
     }

--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -161,6 +161,9 @@
         <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}" class="btn-acasi secondary">
             <i class="fas fa-arrow-left me-1"></i>Retour
         </a>
+        <a href="{{ route('esbtp.etudiants.certificat.preview', $etudiant->id) }}" class="btn-acasi info">
+            <i class="fas fa-certificate me-1"></i>Certificat
+        </a>
         <a href="{{ route('esbtp.etudiants.attestation-frequentation', $etudiant->id) }}" class="btn-acasi success">
             <i class="fas fa-file-pdf me-1"></i>Générer PDF
         </a>

--- a/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
@@ -17,7 +17,7 @@
         * { box-sizing: border-box; }
 
         body {
-            font-family: "Helvetica", "Arial", sans-serif;
+            font-family: "DejaVu Sans", "Helvetica", "Arial", sans-serif;
             font-size: 12px;
             line-height: 1.55;
             color: {{ $pdfText }};
@@ -43,19 +43,34 @@
         .document-watermark img { max-width: 100%; }
         .document-content { position: relative; z-index: 1; }
 
-        /* En-tête établissement */
-        .doc-header {
-            background-color: {{ $pdfHeaderBg }};
-            color: {{ $pdfHeaderText }};
+        /* ── En-tête établissement — table layout DomPDF-safe (pas de flexbox) ── */
+        .doc-header-table {
+            width: 100%;
+            border-collapse: collapse;
             border-radius: 10px;
-            padding: 18px 22px;
-            text-align: center;
+            background-color: {{ $pdfHeaderBg }};
+            margin-bottom: 0;
         }
 
-        .doc-header-logo img {
-            max-height: 60px;
-            max-width: 100px;
-            margin-bottom: 8px;
+        .header-logo-cell {
+            width: 18%;
+            vertical-align: middle;
+            text-align: center;
+            padding: 16px 8px 16px 14px;
+        }
+
+        .header-logo-cell img {
+            width: 70px;
+            height: auto;
+            max-height: 70px;
+            display: block;
+            margin: 0 auto;
+        }
+
+        .header-info-cell {
+            width: 82%;
+            vertical-align: middle;
+            padding: 16px 16px 16px 8px;
         }
 
         .doc-school-name {
@@ -74,7 +89,7 @@
             color: {{ $pdfHeaderText }};
         }
 
-        /* Séparateur */
+        /* ── Séparateur ── */
         .doc-divider {
             height: 3px;
             background-color: {{ $pdfPrimary }};
@@ -82,7 +97,7 @@
             border: none;
         }
 
-        /* Titre document — underline uniquement */
+        /* ── Titre document ── */
         .doc-title-wrap {
             text-align: center;
             margin: 0 0 26px;
@@ -99,7 +114,7 @@
             padding-bottom: 5px;
         }
 
-        /* Corps */
+        /* ── Corps ── */
         .doc-body {
             margin: 0 0 20px;
             line-height: 1.7;
@@ -110,14 +125,14 @@
 
         .doc-body p { margin-bottom: 10px; }
 
-        /* Mots mis en valeur — couleur accent lisible sur fond blanc */
         .hl {
             font-weight: 700;
             color: {{ $pdfPrimary }};
             text-decoration: underline;
         }
 
-        /* Bloc infos étudiant — fond très clair + bordure gauche colorée */
+        /* ── Bloc infos étudiant — fond clair + bordure gauche colorée ── */
+        /* Utilise display:table (DomPDF-safe) plutôt que flexbox */
         .student-details {
             margin: 16px 0;
             padding: 12px 14px;
@@ -148,7 +163,7 @@
             word-break: break-word;
         }
 
-        /* Options statut/boursier */
+        /* ── Options statut/boursier ── */
         .status-options {
             margin: 14px 0;
             font-style: italic;
@@ -156,7 +171,7 @@
             color: {{ $pdfText }};
         }
 
-        /* Footer signature */
+        /* ── Footer signature — float layout DomPDF-safe ── */
         .doc-footer {
             margin-top: 36px;
             width: 100%;
@@ -204,7 +219,7 @@
             margin-top: 14px;
         }
 
-        /* Note de bas de page */
+        /* ── Note de bas de page ── */
         .doc-note {
             clear: both;
             margin-top: 28px;
@@ -245,39 +260,51 @@
 
     <div class="document-content">
 
-        {{-- En-tête établissement --}}
-        <div class="doc-header">
-            @if(isset($settings['show_logo']) && $settings['show_logo'] && isset($settings['logo_base64']))
-                <div class="doc-header-logo"><img src="{{ $settings['logo_base64'] }}" alt="Logo"></div>
-            @endif
-            <div class="doc-school-name">{{ $settings['name'] ?? '' }}</div>
-            @if($settings['address'] ?? null)
-                <div class="doc-school-meta">{{ $settings['address'] }}</div>
-            @endif
-            @if(($settings['phone'] ?? null) || ($settings['email'] ?? null))
-                <div class="doc-school-meta">
-                    @if($settings['phone'] ?? null)Tél : {{ $settings['phone'] }}@endif
-                    @if(($settings['phone'] ?? null) && ($settings['email'] ?? null)) – @endif
-                    @if($settings['email'] ?? null)Email : {{ $settings['email'] }}@endif
-                </div>
-            @endif
-        </div>
+        {{-- ── En-tête établissement : table 2 colonnes DomPDF-safe ── --}}
+        <table class="doc-header-table">
+            <tr>
+                {{-- Colonne logo (18%) --}}
+                @if(isset($settings['show_logo']) && $settings['show_logo'] && isset($settings['logo_base64']))
+                <td class="header-logo-cell">
+                    <img src="{{ $settings['logo_base64'] }}" alt="Logo">
+                </td>
+                @endif
+                {{-- Colonne infos école (82% ou 100% si pas de logo) --}}
+                <td class="header-info-cell"
+                    @if(!isset($settings['show_logo']) || !$settings['show_logo'] || !isset($settings['logo_base64']))
+                        style="width:100%; text-align:center;"
+                    @endif
+                >
+                    <div class="doc-school-name">{{ $settings['name'] ?? '' }}</div>
+                    @if($settings['address'] ?? null)
+                        <div class="doc-school-meta">{{ $settings['address'] }}</div>
+                    @endif
+                    @if(($settings['phone'] ?? null) || ($settings['email'] ?? null))
+                        <div class="doc-school-meta">
+                            @if($settings['phone'] ?? null)Tél : {{ $settings['phone'] }}@endif
+                            @if(($settings['phone'] ?? null) && ($settings['email'] ?? null)) – @endif
+                            @if($settings['email'] ?? null)Email : {{ $settings['email'] }}@endif
+                        </div>
+                    @endif
+                </td>
+            </tr>
+        </table>
 
-        {{-- Séparateur --}}
+        {{-- ── Séparateur ── --}}
         <div class="doc-divider"></div>
 
-        {{-- Titre --}}
+        {{-- ── Titre ── --}}
         <div class="doc-title-wrap">
             <span class="doc-title">Attestation de Fréquentation</span>
         </div>
 
-        {{-- Corps --}}
+        {{-- ── Corps ── --}}
         <div class="doc-body">
             <p>Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, atteste que :</p>
 
             <p>
                 {{ $etudiant->sexe === 'F' ? 'Mme / M. / Mlle' : 'M.' }}
-                <span class="hl">{{ strtoupper($etudiant->nom) }} {{ strtoupper($etudiant->prenom) }}</span>
+                <span class="hl">{{ strtoupper($etudiant->nom) }} {{ strtoupper($etudiant->prenoms) }}</span>
             </p>
 
             @if($etudiant->date_naissance)
@@ -328,7 +355,7 @@
             <p>En foi de quoi, la présente attestation lui est délivrée pour servir et valoir ce que de droit.</p>
         </div>
 
-        {{-- Footer signature --}}
+        {{-- ── Footer signature ── --}}
         <div class="doc-footer">
             <div class="doc-footer-date">
                 <p>Fait à {{ $settings['city'] ?? 'Yamoussoukro' }}, le {{ now()->format('d/m/Y') }}</p>
@@ -344,7 +371,7 @@
 
         <div class="sign-note">*Rayer la mention inutile</div>
 
-        {{-- Note de bas de page --}}
+        {{-- ── Note de bas de page ── --}}
         <div class="doc-note">
             Ce document est un certificat officiel. Toute falsification constitue un délit passible de poursuites judiciaires.
         </div>

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -142,6 +142,9 @@
         <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}" class="btn-acasi secondary">
             <i class="fas fa-arrow-left me-1"></i>Retour
         </a>
+        <a href="{{ route('esbtp.etudiants.attestation-frequentation.preview', $etudiant->id) }}" class="btn-acasi info">
+            <i class="fas fa-file-contract me-1"></i>Attestation
+        </a>
         <a href="{{ route('esbtp.etudiants.certificat', $etudiant->id) }}" class="btn-acasi success">
             <i class="fas fa-file-pdf me-1"></i>Générer PDF
         </a>
@@ -192,13 +195,19 @@
             <p>Matricule&nbsp;: <span class="doc-hl">{{ $etudiant->matricule }}</span></p>
             <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année académique&nbsp;:</p>
 
+            @php
+                $showClasse  = $settings['show_classe']  ?? true;
+                $showNiveau  = $settings['show_niveau']  ?? true;
+                $showFiliere = $settings['show_filiere'] ?? true;
+                $colCount = 2 + ($showClasse ? 1 : 0) + ($showNiveau ? 1 : 0) + ($showFiliere ? 1 : 0);
+            @endphp
             <table class="doc-table">
                 <thead>
                     <tr>
                         <th>Année scolaire</th>
-                        <th>Classe suivie</th>
-                        <th>Niveau d'étude</th>
-                        <th>Filière</th>
+                        @if($showClasse)<th>Classe suivie</th>@endif
+                        @if($showNiveau)<th>Niveau d'étude</th>@endif
+                        @if($showFiliere)<th>Filière</th>@endif
                         <th>Moyenne/20</th>
                     </tr>
                 </thead>
@@ -212,13 +221,13 @@
                                 ? (preg_match('/(\d{4}-\d{4})/', $rawYear, $m) ? $m[1] : $rawYear)
                                 : 'Non renseigné';
                         @endphp</td>
-                        <td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>
-                        <td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>
-                        <td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>
+                        @if($showClasse)<td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>@endif
+                        @if($showNiveau)<td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>@endif
+                        @if($showFiliere)<td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>@endif
                         <td>{{ $inscription->moyenne_generale ? number_format($inscription->moyenne_generale, 2) : '—' }}</td>
                     </tr>
                     @empty
-                    <tr><td colspan="5">Aucune inscription trouvée</td></tr>
+                    <tr><td colspan="{{ $colCount }}">Aucune inscription trouvée</td></tr>
                     @endforelse
                 </tbody>
             </table>

--- a/resources/views/esbtp/etudiants/certificat.blade.php
+++ b/resources/views/esbtp/etudiants/certificat.blade.php
@@ -10,6 +10,12 @@
         $pdfText        = $pdfSettings['text_color']        ?? '#1f2937';
         $pdfMuted       = '#6b7280';
         $pdfBorder      = '#e5e7eb';
+
+        // Colonnes configurables
+        $showClasse  = $settings['show_classe']  ?? true;
+        $showNiveau  = $settings['show_niveau']  ?? true;
+        $showFiliere = $settings['show_filiere'] ?? true;
+        $colCount    = 2 + ($showClasse ? 1 : 0) + ($showNiveau ? 1 : 0) + ($showFiliere ? 1 : 0);
     @endphp
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title>Certificat de Scolarité - {{ $etudiant->matricule }}</title>
@@ -17,7 +23,7 @@
         * { box-sizing: border-box; }
 
         body {
-            font-family: "Helvetica", "Arial", sans-serif;
+            font-family: "DejaVu Sans", "Helvetica", "Arial", sans-serif;
             font-size: 12px;
             line-height: 1.55;
             color: {{ $pdfText }};
@@ -43,19 +49,34 @@
         .document-watermark img { max-width: 100%; }
         .document-content { position: relative; z-index: 1; }
 
-        /* En-tête établissement */
-        .doc-header {
-            background-color: {{ $pdfHeaderBg }};
-            color: {{ $pdfHeaderText }};
+        /* ── En-tête établissement — table layout DomPDF-safe (pas de flexbox) ── */
+        .doc-header-table {
+            width: 100%;
+            border-collapse: collapse;
             border-radius: 10px;
-            padding: 18px 22px;
-            text-align: center;
+            background-color: {{ $pdfHeaderBg }};
+            margin-bottom: 0;
         }
 
-        .doc-header-logo img {
-            max-height: 60px;
-            max-width: 100px;
-            margin-bottom: 8px;
+        .header-logo-cell {
+            width: 18%;
+            vertical-align: middle;
+            text-align: center;
+            padding: 16px 8px 16px 14px;
+        }
+
+        .header-logo-cell img {
+            width: 70px;
+            height: auto;
+            max-height: 70px;
+            display: block;
+            margin: 0 auto;
+        }
+
+        .header-info-cell {
+            width: 82%;
+            vertical-align: middle;
+            padding: 16px 16px 16px 8px;
         }
 
         .doc-school-name {
@@ -74,7 +95,7 @@
             color: {{ $pdfHeaderText }};
         }
 
-        /* Séparateur */
+        /* ── Séparateur ── */
         .doc-divider {
             height: 3px;
             background-color: {{ $pdfPrimary }};
@@ -82,7 +103,7 @@
             border: none;
         }
 
-        /* Titre document — underline uniquement, pas de fond plein */
+        /* ── Titre document ── */
         .doc-title-wrap {
             text-align: center;
             margin: 0 0 26px;
@@ -99,7 +120,7 @@
             padding-bottom: 5px;
         }
 
-        /* Corps */
+        /* ── Corps ── */
         .doc-body {
             margin: 0 0 20px;
             line-height: 1.7;
@@ -110,14 +131,13 @@
 
         .doc-body p { margin-bottom: 10px; }
 
-        /* Mots mis en valeur */
         .hl {
             font-weight: 700;
             color: {{ $pdfPrimary }};
             text-decoration: underline;
         }
 
-        /* Tableau inscriptions */
+        /* ── Tableau inscriptions ── */
         .doc-table {
             width: 100%;
             border-collapse: collapse;
@@ -146,7 +166,7 @@
             background-color: #f8fafc;
         }
 
-        /* Footer signature */
+        /* ── Footer signature — float layout DomPDF-safe ── */
         .doc-footer {
             margin-top: 36px;
             width: 100%;
@@ -185,7 +205,7 @@
             margin-top: 18px;
         }
 
-        /* Note de bas de page */
+        /* ── Note de bas de page ── */
         .doc-note {
             clear: both;
             margin-top: 28px;
@@ -226,33 +246,45 @@
 
     <div class="document-content">
 
-        {{-- En-tête établissement --}}
-        <div class="doc-header">
-            @if(isset($settings['show_logo']) && $settings['show_logo'] && isset($settings['logo_base64']))
-                <div class="doc-header-logo"><img src="{{ $settings['logo_base64'] }}" alt="Logo"></div>
-            @endif
-            <div class="doc-school-name">{{ $settings['name'] ?? '' }}</div>
-            @if($settings['address'] ?? null)
-                <div class="doc-school-meta">{{ $settings['address'] }}</div>
-            @endif
-            @if(($settings['phone'] ?? null) || ($settings['email'] ?? null))
-                <div class="doc-school-meta">
-                    @if($settings['phone'] ?? null)Tél : {{ $settings['phone'] }}@endif
-                    @if(($settings['phone'] ?? null) && ($settings['email'] ?? null)) – @endif
-                    @if($settings['email'] ?? null)Email : {{ $settings['email'] }}@endif
-                </div>
-            @endif
-        </div>
+        {{-- ── En-tête établissement : table 2 colonnes DomPDF-safe ── --}}
+        <table class="doc-header-table">
+            <tr>
+                {{-- Colonne logo (18%) --}}
+                @if(isset($settings['show_logo']) && $settings['show_logo'] && isset($settings['logo_base64']))
+                <td class="header-logo-cell">
+                    <img src="{{ $settings['logo_base64'] }}" alt="Logo">
+                </td>
+                @endif
+                {{-- Colonne infos école (82% ou 100% si pas de logo) --}}
+                <td class="header-info-cell"
+                    @if(!isset($settings['show_logo']) || !$settings['show_logo'] || !isset($settings['logo_base64']))
+                        style="width:100%; text-align:center;"
+                    @endif
+                >
+                    <div class="doc-school-name">{{ $settings['name'] ?? '' }}</div>
+                    @if($settings['address'] ?? null)
+                        <div class="doc-school-meta">{{ $settings['address'] }}</div>
+                    @endif
+                    @if(($settings['phone'] ?? null) || ($settings['email'] ?? null))
+                        <div class="doc-school-meta">
+                            @if($settings['phone'] ?? null)Tél : {{ $settings['phone'] }}@endif
+                            @if(($settings['phone'] ?? null) && ($settings['email'] ?? null)) – @endif
+                            @if($settings['email'] ?? null)Email : {{ $settings['email'] }}@endif
+                        </div>
+                    @endif
+                </td>
+            </tr>
+        </table>
 
-        {{-- Séparateur --}}
+        {{-- ── Séparateur ── --}}
         <div class="doc-divider"></div>
 
-        {{-- Titre --}}
+        {{-- ── Titre ── --}}
         <div class="doc-title-wrap">
             <span class="doc-title">Certificat de Scolarité</span>
         </div>
 
-        {{-- Corps --}}
+        {{-- ── Corps ── --}}
         <div class="doc-body">
             <p>Je soussigné(e), {{ $settings['director_title'] ?? '' }} de {{ $settings['name'] ?? '' }}, certifie que :</p>
 
@@ -273,9 +305,9 @@
                 <thead>
                     <tr>
                         <th>Année scolaire</th>
-                        <th>Classe suivie</th>
-                        <th>Niveau d'étude</th>
-                        <th>Filière</th>
+                        @if($showClasse)<th>Classe suivie</th>@endif
+                        @if($showNiveau)<th>Niveau d'étude</th>@endif
+                        @if($showFiliere)<th>Filière</th>@endif
                         <th>Moyenne/20</th>
                     </tr>
                 </thead>
@@ -291,9 +323,9 @@
                                     : 'Non renseigné';
                             @endphp
                         </td>
-                        <td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>
-                        <td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>
-                        <td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>
+                        @if($showClasse)<td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>@endif
+                        @if($showNiveau)<td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>@endif
+                        @if($showFiliere)<td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>@endif
                         <td>
                             @if($inscription->moyenne_generale)
                                 {{ number_format($inscription->moyenne_generale, 2) }}
@@ -302,7 +334,7 @@
                     </tr>
                     @empty
                     <tr>
-                        <td colspan="5">Aucune inscription trouvée</td>
+                        <td colspan="{{ $colCount }}">Aucune inscription trouvée</td>
                     </tr>
                     @endforelse
                 </tbody>
@@ -313,7 +345,7 @@
             <p>Ce certificat est délivré à l'intéressé(e) pour servir et valoir ce que de droit.</p>
         </div>
 
-        {{-- Footer signature --}}
+        {{-- ── Footer signature ── --}}
         <div class="doc-footer">
             <div class="doc-footer-date">
                 <p>Fait à {{ $settings['city'] ?? 'Yamoussoukro' }}, le {{ now()->format('d/m/Y') }}</p>
@@ -327,7 +359,7 @@
             <div style="clear:both;"></div>
         </div>
 
-        {{-- Note de bas de page --}}
+        {{-- ── Note de bas de page ── --}}
         <div class="doc-note">
             Ce certificat est un document officiel. Toute falsification constitue un délit passible de poursuites judiciaires.
         </div>

--- a/resources/views/esbtp/settings/index.blade.php
+++ b/resources/views/esbtp/settings/index.blade.php
@@ -433,6 +433,11 @@
                 </button>
             </li>
             <li class="nav-item" role="presentation">
+                <button class="nav-link" id="documents-tab" data-bs-toggle="tab" data-bs-target="#documents" type="button" role="tab">
+                    <i class="fas fa-file-alt"></i> Documents
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
                 <button class="nav-link" id="notifications-tab" data-bs-toggle="tab" data-bs-target="#notifications" type="button" role="tab">
                     <i class="fas fa-bell"></i> Notifications et Rappels
                 </button>
@@ -1210,7 +1215,67 @@
                 </div>
                 <!-- End Tab 3: Configuration Bulletin -->
 
-                <!-- Tab 4: Notifications et Rappels -->
+                <!-- Tab 4: Documents (Certificats & Attestations) -->
+                <div class="tab-pane fade" id="documents" role="tabpanel">
+
+            <!-- Section: Colonnes du Certificat de Scolarité -->
+            <div class="settings-section">
+                <div class="section-header">
+                    <div class="section-icon" style="background: linear-gradient(135deg, #0453cb, #5e91de);">
+                        <i class="fas fa-certificate"></i>
+                    </div>
+                    <div>
+                        <h3 class="section-title">Certificat de Scolarité</h3>
+                        <p class="section-description">Colonnes affichées dans le tableau du certificat de scolarité</p>
+                    </div>
+                </div>
+
+                <div class="settings-grid-3">
+                    <div class="form-group">
+                        <label class="form-label-modern">
+                            <i class="fas fa-chalkboard-teacher text-primary me-1"></i>
+                            Classe suivie
+                        </label>
+                        <label class="form-switch-modern">
+                            <input type="checkbox" name="certificat_show_classe" value="1"
+                                   {{ \App\Helpers\SettingsHelper::get('certificat_show_classe', '1') == '1' ? 'checked' : '' }}>
+                            <span class="slider"></span>
+                        </label>
+                        <small class="text-muted d-block mt-1">Afficher la colonne "Classe suivie"</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label-modern">
+                            <i class="fas fa-layer-group text-primary me-1"></i>
+                            Niveau d'étude
+                        </label>
+                        <label class="form-switch-modern">
+                            <input type="checkbox" name="certificat_show_niveau" value="1"
+                                   {{ \App\Helpers\SettingsHelper::get('certificat_show_niveau', '1') == '1' ? 'checked' : '' }}>
+                            <span class="slider"></span>
+                        </label>
+                        <small class="text-muted d-block mt-1">Afficher la colonne "Niveau d'étude"</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label-modern">
+                            <i class="fas fa-code-branch text-primary me-1"></i>
+                            Filière
+                        </label>
+                        <label class="form-switch-modern">
+                            <input type="checkbox" name="certificat_show_filiere" value="1"
+                                   {{ \App\Helpers\SettingsHelper::get('certificat_show_filiere', '1') == '1' ? 'checked' : '' }}>
+                            <span class="slider"></span>
+                        </label>
+                        <small class="text-muted d-block mt-1">Afficher la colonne "Filière"</small>
+                    </div>
+                </div>
+            </div>
+
+                </div>
+                <!-- End Tab 4: Documents -->
+
+                <!-- Tab 5: Notifications et Rappels -->
                 <div class="tab-pane fade" id="notifications" role="tabpanel">
 
                     <!-- Section: Rappels Inscriptions -->


### PR DESCRIPTION
Closes #80

## Summary
- Ajout d'un onglet **Documents** dans `esbtp/settings` avec 3 toggles pour afficher/masquer les colonnes du certificat de scolarité (Classe suivie, Niveau d'étude, Filière)
- **PDF = Preview** : refonte du header PDF pour les deux documents (table DomPDF-safe 18%/82%) afin qu'il corresponde exactement à la prévisualisation
- **Navigation inter-documents** : boutons dans les toolbars de prévisualisation pour switcher directement entre Certificat et Attestation sans repasser par la fiche étudiant

## Changes
- `resources/views/esbtp/settings/index.blade.php` — nouvel onglet "Documents" avec 3 switches (classe/niveau/filière)
- `app/Http/Controllers/ESBTP/ESBTPSettingsController.php` — enregistrement des 3 nouvelles clés checkbox (`certificat_show_classe`, `certificat_show_niveau`, `certificat_show_filiere`)
- `app/Http/Controllers/ESBTPEtudiantController.php` — ajout `show_classe/show_niveau/show_filiere` dans `getCertificateDisplaySettings()` (partagé par les 4 méthodes preview/PDF)
- `resources/views/esbtp/etudiants/certificat-preview.blade.php` — colonnes conditionnelles + bouton "Attestation" dans toolbar
- `resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php` — bouton "Certificat" dans toolbar
- `resources/views/esbtp/etudiants/certificat.blade.php` — header DomPDF-safe (`<table>` 2 colonnes) + colonnes conditionnelles + DejaVu Sans
- `resources/views/esbtp/etudiants/attestation-frequentation.blade.php` — header DomPDF-safe (`<table>` 2 colonnes) + DejaVu Sans + fix champ `prenoms`

## Type of change
- [x] feat — new feature

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (`php -l`) on all modified PHP files