### PR TITLE
feat(contract): compte à rebours expiration abonnement 30 jours avant échéance

### DIFF
--- a/app/Http/Controllers/ContractExpiryController.php
+++ b/app/Http/Controllers/ContractExpiryController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ContractExpiryController extends Controller
+{
+    /**
+     * Retourner le statut d'expiration en JSON (polling AJAX)
+     */
+    public function status(Request $request)
+    {
+        $expiryData = session('contract_expiry');
+        $shouldShow = session('contract_expiry_should_show', false);
+        $lastShown = session('contract_expiry_last_shown', 0);
+
+        return response()->json([
+            'has_warning'    => (bool) $expiryData,
+            'should_show'    => $shouldShow && (bool) $expiryData,
+            'expiry'         => $expiryData,
+            'last_shown_ago' => $lastShown ? (time() - $lastShown) : null,
+            'next_show_in'   => $lastShown
+                ? max(0, \App\Http\Middleware\ContractExpiryMiddleware::DISMISS_COOLDOWN_SECONDS - (time() - $lastShown))
+                : 0,
+        ]);
+    }
+
+    /**
+     * Marquer le modal comme "vu" — remet le cooldown 12h
+     */
+    public function dismiss(Request $request)
+    {
+        session([
+            'contract_expiry_last_shown' => time(),
+            'contract_expiry_should_show' => false,
+        ]);
+
+        return response()->json([
+            'success'       => true,
+            'next_show_in'  => \App\Http\Middleware\ContractExpiryMiddleware::DISMISS_COOLDOWN_SECONDS,
+        ]);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -81,6 +81,7 @@ class Kernel extends HttpKernel
         'attendance.rate_limit' => \App\Http\Middleware\AttendanceRateLimiter::class,
         'force.password.change' => \App\Http\Middleware\ForcePasswordChange::class,
         'paywall' => \App\Http\Middleware\PaywallMiddleware::class,
+        'contract.expiry' => \App\Http\Middleware\ContractExpiryMiddleware::class,
     ];
 
     /**

--- a/app/Http/Middleware/ContractExpiryMiddleware.php
+++ b/app/Http/Middleware/ContractExpiryMiddleware.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Cache;
+use Carbon\Carbon;
+
+class ContractExpiryMiddleware
+{
+    /**
+     * Nombre de jours avant expiration à partir duquel afficher l'alerte
+     */
+    const WARNING_THRESHOLD_DAYS = 30;
+
+    /**
+     * Délai minimum entre deux affichages du modal (en secondes = 12h)
+     */
+    const DISMISS_COOLDOWN_SECONDS = 43200; // 12 * 60 * 60
+
+    /**
+     * Routes exclues de la vérification
+     */
+    protected array $excludedRoutes = [
+        'login',
+        'logout',
+        'register',
+        'password.*',
+        'contract-expiry.*',
+        'esbtp.paywall-config.*',
+    ];
+
+    public function handle(Request $request, Closure $next)
+    {
+        // Ne pas vérifier si pas authentifié
+        if (! auth()->check()) {
+            return $next($request);
+        }
+
+        // Ne pas vérifier sur les routes exclues
+        if ($this->shouldExclude($request)) {
+            return $next($request);
+        }
+
+        // Ne pas vérifier sur les requêtes AJAX / JSON
+        if ($request->expectsJson() || $request->ajax()) {
+            return $next($request);
+        }
+
+        // Récupérer les données d'expiration (avec cache 5 min, partagé avec PaywallMiddleware)
+        $expiryData = $this->getExpiryData();
+
+        if ($expiryData && $expiryData['show_warning']) {
+            // Stocker les données dans la session pour la vue
+            session(['contract_expiry' => $expiryData]);
+
+            // Vérifier si on doit afficher le modal (cooldown 12h)
+            $lastShown = session('contract_expiry_last_shown', 0);
+            $shouldShow = (time() - $lastShown) >= self::DISMISS_COOLDOWN_SECONDS;
+
+            session(['contract_expiry_should_show' => $shouldShow]);
+        } else {
+            // Nettoyer si plus dans la zone d'alerte
+            session()->forget(['contract_expiry', 'contract_expiry_should_show']);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Récupérer les données d'expiration depuis l'API Master (cache partagé)
+     */
+    protected function getExpiryData(): ?array
+    {
+        $masterApiUrl = config('services.master.api_url');
+        $masterApiToken = config('services.master.api_token');
+        $tenantCode = config('app.tenant_code');
+
+        if (! $masterApiUrl || ! $masterApiToken || ! $tenantCode) {
+            return null;
+        }
+
+        // Réutiliser le cache du PaywallMiddleware (même clé, 5 min)
+        $cacheKey = 'paywall_limits_' . $tenantCode;
+
+        $apiData = Cache::get($cacheKey);
+
+        // Si pas en cache, faire l'appel
+        if (! $apiData) {
+            $apiData = Cache::remember($cacheKey, 300, function () use ($masterApiUrl, $masterApiToken, $tenantCode) {
+                try {
+                    $response = Http::withToken($masterApiToken)
+                        ->timeout(10)
+                        ->get($masterApiUrl . '/tenants/' . $tenantCode . '/limits');
+
+                    return $response->successful() ? $response->json() : null;
+                } catch (\Exception $e) {
+                    return null;
+                }
+            });
+        }
+
+        if (! $apiData || ! isset($apiData['subscription'])) {
+            return null;
+        }
+
+        $subscription = $apiData['subscription'];
+        $daysRemaining = isset($subscription['days_remaining'])
+            ? (int) $subscription['days_remaining']
+            : null;
+
+        if ($daysRemaining === null) {
+            return null;
+        }
+
+        $isExpired = $subscription['is_expired'] ?? false;
+        $endDate = $subscription['end_date'] ?? null;
+        $showWarning = $isExpired || $daysRemaining <= self::WARNING_THRESHOLD_DAYS;
+
+        if (! $showWarning) {
+            return null;
+        }
+
+        // Déterminer le niveau d'urgence
+        $urgency = 'green'; // 16-30 jours
+        if ($isExpired || $daysRemaining <= 0) {
+            $urgency = 'expired';
+        } elseif ($daysRemaining <= 7) {
+            $urgency = 'red';
+        } elseif ($daysRemaining <= 14) {
+            $urgency = 'orange';
+        }
+
+        return [
+            'show_warning'   => true,
+            'days_remaining' => $daysRemaining,
+            'end_date'       => $endDate,
+            'end_date_formatted' => $endDate ? Carbon::parse($endDate)->translatedFormat('d F Y') : null,
+            'is_expired'     => $isExpired,
+            'urgency'        => $urgency,
+            'plan'           => $apiData['plan'] ?? 'Inconnu',
+            'tenant_name'    => $apiData['tenant_name'] ?? config('app.name'),
+        ];
+    }
+
+    /**
+     * Vérifier si la route est exclue
+     */
+    protected function shouldExclude(Request $request): bool
+    {
+        $routeName = $request->route()?->getName();
+
+        if (! $routeName) {
+            return false;
+        }
+
+        foreach ($this->excludedRoutes as $pattern) {
+            if (fnmatch($pattern, $routeName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/public/css/contract-expiry.css
+++ b/public/css/contract-expiry.css
@@ -1,0 +1,267 @@
+/* ============================================================
+   Contract Expiry Modal — KLASSCI
+   Design System ACASI 2025 — Isolation totale du CSS global
+   ============================================================ */
+
+/* ── Overlay ── */
+.ce-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 99999;
+    background: rgba(10, 15, 30, 0.82);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    animation: ce-overlay-in 0.35s ease both;
+}
+
+@keyframes ce-overlay-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+/* ── Card ── */
+.ce-card {
+    background: #ffffff;
+    border-radius: 20px;
+    box-shadow:
+        0 32px 80px rgba(0, 0, 0, 0.35),
+        0 0 0 1px rgba(255,255,255,0.06);
+    width: 100%;
+    max-width: 480px;
+    overflow: hidden;
+    animation: ce-card-in 0.40s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes ce-card-in {
+    from {
+        opacity: 0;
+        transform: translateY(40px) scale(0.96);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+/* ── Header (bande de couleur) ── */
+.ce-header {
+    padding: 28px 32px 24px;
+    text-align: center;
+    position: relative;
+}
+
+.ce-header--green  { background: linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%); }
+.ce-header--orange { background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%); }
+.ce-header--red    { background: linear-gradient(135deg, #fee2e2 0%, #fca5a5 100%); }
+.ce-header--expired{ background: linear-gradient(135deg, #f1f5f9 0%, #e2e8f0 100%); }
+
+/* ── Icône urgence ── */
+.ce-icon {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 28px;
+    margin-bottom: 12px;
+}
+
+.ce-icon--green  { background: #059669; color: #fff; }
+.ce-icon--orange { background: #d97706; color: #fff; }
+.ce-icon--red    { background: #dc2626; color: #fff; }
+.ce-icon--expired{ background: #64748b; color: #fff; }
+
+/* ── Titre header ── */
+.ce-header-title {
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0;
+    color: #1e293b;
+}
+
+.ce-header-sub {
+    font-size: 0.8rem;
+    color: #64748b;
+    margin: 4px 0 0;
+}
+
+/* ── Corps ── */
+.ce-body {
+    padding: 28px 32px;
+    text-align: center;
+}
+
+/* ── Compte à rebours ── */
+.ce-countdown {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 20px;
+}
+
+.ce-countdown svg {
+    transform: rotate(-90deg);
+}
+
+.ce-countdown-inner {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.ce-days-number {
+    font-size: 2.8rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: -2px;
+}
+
+.ce-days-label {
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: #64748b;
+    margin-top: 2px;
+}
+
+/* Couleurs du compte à rebours selon urgence */
+.ce-countdown--green .ce-days-number  { color: #059669; }
+.ce-countdown--green circle.ce-track  { stroke: #d1fae5; }
+.ce-countdown--green circle.ce-progress { stroke: #059669; }
+
+.ce-countdown--orange .ce-days-number { color: #d97706; }
+.ce-countdown--orange circle.ce-track { stroke: #fef3c7; }
+.ce-countdown--orange circle.ce-progress { stroke: #d97706; }
+
+.ce-countdown--red .ce-days-number    { color: #dc2626; }
+.ce-countdown--red circle.ce-track   { stroke: #fee2e2; }
+.ce-countdown--red circle.ce-progress { stroke: #dc2626; }
+.ce-countdown--red circle.ce-progress { animation: ce-pulse-ring 1.5s ease-in-out infinite; }
+
+.ce-countdown--expired .ce-days-number { color: #64748b; font-size: 1.8rem; letter-spacing: 0; }
+.ce-countdown--expired circle.ce-track { stroke: #e2e8f0; }
+.ce-countdown--expired circle.ce-progress { stroke: #94a3b8; }
+
+@keyframes ce-pulse-ring {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+}
+
+/* ── Message ── */
+.ce-message {
+    font-size: 0.95rem;
+    color: #334155;
+    line-height: 1.6;
+    margin-bottom: 8px;
+}
+
+.ce-date {
+    font-size: 0.85rem;
+    color: #64748b;
+    margin-bottom: 20px;
+}
+
+.ce-date strong {
+    color: #1e293b;
+}
+
+/* ── Boutons ── */
+.ce-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.ce-btn-primary {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 14px 24px;
+    border-radius: 12px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    border: none;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-decoration: none;
+    width: 100%;
+}
+
+.ce-btn-primary--whatsapp {
+    background: #25D366;
+    color: #fff;
+}
+.ce-btn-primary--whatsapp:hover {
+    background: #20bd5a;
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 6px 20px rgba(37, 211, 102, 0.35);
+}
+
+.ce-btn-secondary {
+    background: transparent;
+    border: 1.5px solid #e2e8f0;
+    color: #64748b;
+    padding: 12px 24px;
+    border-radius: 12px;
+    font-size: 0.9rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    width: 100%;
+}
+.ce-btn-secondary:hover {
+    background: #f8fafc;
+    border-color: #cbd5e1;
+    color: #475569;
+}
+
+/* ── Footer ── */
+.ce-footer {
+    padding: 16px 32px 20px;
+    border-top: 1px solid #f1f5f9;
+    text-align: center;
+}
+
+.ce-footer-text {
+    font-size: 0.75rem;
+    color: #94a3b8;
+    margin: 0;
+}
+
+/* ── Bande rouge pulsante (< 7 jours) ── */
+.ce-urgency-strip {
+    display: none;
+    background: #dc2626;
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-align: center;
+    padding: 6px;
+    letter-spacing: 0.5px;
+    animation: ce-strip-blink 1.5s step-end infinite;
+}
+.ce-urgency-strip--visible { display: block; }
+
+@keyframes ce-strip-blink {
+    0%, 100% { background: #dc2626; }
+    50%  { background: #b91c1c; }
+}
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+    .ce-header { padding: 20px 20px 16px; }
+    .ce-body   { padding: 20px 20px; }
+    .ce-footer { padding: 12px 20px 16px; }
+    .ce-days-number { font-size: 2.2rem; }
+}

--- a/resources/views/components/contract-expiry-modal.blade.php
+++ b/resources/views/components/contract-expiry-modal.blade.php
@@ -1,0 +1,266 @@
+{{--
+    Composant : Compte à rebours expiration contrat
+    Affiché uniquement si session('contract_expiry_should_show') === true
+    Se ferme via AJAX POST /contract-expiry/dismiss
+--}}
+@php
+    $expiry = session('contract_expiry');
+    $shouldShow = session('contract_expiry_should_show', false);
+
+    if (!$expiry || !$shouldShow) return;
+
+    $urgency    = $expiry['urgency'];        // green | orange | red | expired
+    $days       = $expiry['days_remaining'];
+    $endDate    = $expiry['end_date_formatted'] ?? $expiry['end_date'];
+    $isExpired  = $expiry['is_expired'];
+    $plan       = $expiry['plan'];
+    $tenantName = $expiry['tenant_name'];
+
+    // SVG circle : rayon 54, circumférence ≈ 339.3
+    $radius = 54;
+    $circ   = round(2 * M_PI * $radius, 1); // 339.3
+    $ratio  = $isExpired ? 0 : min(1, max(0, $days / 30));
+    $dash   = round($circ * $ratio, 1);
+    $gap    = $circ - $dash;
+
+    // Icône selon urgence
+    $icons = [
+        'green'   => 'fa-clock',
+        'orange'  => 'fa-exclamation-triangle',
+        'red'     => 'fa-fire',
+        'expired' => 'fa-ban',
+    ];
+    $icon = $icons[$urgency] ?? 'fa-clock';
+
+    // Titre header
+    $titles = [
+        'green'   => 'Renouvellement à planifier',
+        'orange'  => 'Contrat bientôt expiré',
+        'red'     => 'Expiration imminente !',
+        'expired' => 'Contrat expiré',
+    ];
+    $title = $titles[$urgency] ?? 'Alerte contrat';
+
+    // Message principal
+    if ($isExpired) {
+        $message = 'Votre abonnement <strong>' . e($plan) . '</strong> a expiré. Contactez-nous pour le renouveler et éviter toute interruption de service.';
+    } elseif ($days <= 1) {
+        $message = 'Votre abonnement <strong>' . e($plan) . '</strong> expire <strong>demain</strong>. Renouvelez maintenant pour ne pas perdre l\'accès.';
+    } else {
+        $message = 'Votre abonnement <strong>' . e($plan) . '</strong> expire dans <strong>' . $days . ' jours</strong>. Prenez contact avec nous pour le renouveler sans interruption.';
+    }
+
+    // Lien WhatsApp avec message pré-rempli
+    $whatsappMsg = urlencode(
+        "Bonjour, je souhaite renouveler l'abonnement de {$tenantName} (Plan {$plan}). " .
+        ($isExpired ? "Mon contrat a expiré le {$endDate}." : "Mon contrat expire le {$endDate} ({$days} jours restants).")
+    );
+    $whatsappUrl = "https://wa.me/2250708080808?text={$whatsappMsg}";
+@endphp
+
+{{-- CSS chargé une seule fois --}}
+<link rel="stylesheet" href="{{ asset('css/contract-expiry.css') }}">
+
+{{-- Bande rouge clignotante si < 7 jours --}}
+@if(!$isExpired && $days <= 7)
+    <div class="ce-urgency-strip ce-urgency-strip--visible" id="ce-strip">
+        ⚠ URGENT — Votre contrat expire dans {{ $days }} jour{{ $days > 1 ? 's' : '' }} — Renouvelez maintenant
+    </div>
+@endif
+
+{{-- Overlay principal --}}
+<div class="ce-overlay" id="contractExpiryModal" role="dialog" aria-modal="true" aria-labelledby="ce-title">
+    <div class="ce-card">
+
+        {{-- Header coloré --}}
+        <div class="ce-header ce-header--{{ $urgency }}">
+            <div class="ce-icon ce-icon--{{ $urgency }}">
+                <i class="fas {{ $icon }}"></i>
+            </div>
+            <p class="ce-header-title" id="ce-title">{{ $title }}</p>
+            <p class="ce-header-sub">{{ $tenantName }}</p>
+        </div>
+
+        {{-- Corps --}}
+        <div class="ce-body">
+
+            {{-- Compte à rebours SVG --}}
+            <div class="ce-countdown ce-countdown--{{ $urgency }}" aria-label="{{ $days }} jours restants">
+                <svg width="140" height="140" viewBox="0 0 140 140">
+                    {{-- Piste de fond --}}
+                    <circle
+                        class="ce-track"
+                        cx="70" cy="70" r="{{ $radius }}"
+                        fill="none"
+                        stroke-width="10"
+                        stroke-linecap="round"
+                    />
+                    {{-- Arc de progression --}}
+                    <circle
+                        class="ce-progress"
+                        cx="70" cy="70" r="{{ $radius }}"
+                        fill="none"
+                        stroke-width="10"
+                        stroke-linecap="round"
+                        stroke-dasharray="{{ $dash }} {{ $gap }}"
+                    />
+                </svg>
+                <div class="ce-countdown-inner">
+                    @if($isExpired)
+                        <span class="ce-days-number">Expiré</span>
+                    @else
+                        <span class="ce-days-number">{{ $days }}</span>
+                        <span class="ce-days-label">{{ $days > 1 ? 'jours' : 'jour' }}</span>
+                    @endif
+                </div>
+            </div>
+
+            {{-- Message --}}
+            <p class="ce-message">{!! $message !!}</p>
+
+            @if($endDate)
+                <p class="ce-date">
+                    Date d'expiration : <strong>{{ $endDate }}</strong>
+                </p>
+            @endif
+
+            {{-- Actions --}}
+            <div class="ce-actions">
+                <a href="{{ $whatsappUrl }}"
+                   target="_blank"
+                   rel="noopener"
+                   class="ce-btn-primary ce-btn-primary--whatsapp"
+                   onclick="ceDismissAndNavigate(this)"
+                >
+                    <i class="fab fa-whatsapp" style="font-size:1.1rem;"></i>
+                    Contacter le support WhatsApp
+                </a>
+
+                @if(!$isExpired)
+                    <button type="button"
+                            class="ce-btn-secondary"
+                            id="ceContinueBtn"
+                            onclick="ceDismiss()"
+                    >
+                        Continuer vers l'application
+                        <span id="ceCountSpan" style="margin-left:4px; opacity:0.6; font-size:0.8em;"></span>
+                    </button>
+                @else
+                    <button type="button"
+                            class="ce-btn-secondary"
+                            id="ceContinueBtn"
+                            onclick="ceDismiss()"
+                            disabled
+                    >
+                        Accès restreint — Renouvelez pour continuer
+                    </button>
+                @endif
+            </div>
+        </div>
+
+        {{-- Footer --}}
+        <div class="ce-footer">
+            <p class="ce-footer-text">
+                Ce message sera à nouveau affiché dans 12 heures.
+                &nbsp;·&nbsp; Plan actuel : <strong>{{ ucfirst($plan) }}</strong>
+            </p>
+        </div>
+
+    </div>{{-- /.ce-card --}}
+</div>{{-- /.ce-overlay --}}
+
+<script>
+(function () {
+    'use strict';
+
+    var DISMISS_URL = '{{ route('contract-expiry.dismiss') }}';
+    var IS_EXPIRED  = {{ $isExpired ? 'true' : 'false' }};
+
+    /* ── Compte à rebours avant d'autoriser "Continuer" (5 secondes) ── */
+    var continueBtn = document.getElementById('ceContinueBtn');
+    var countSpan   = document.getElementById('ceCountSpan');
+
+    if (continueBtn && !IS_EXPIRED) {
+        var sec = 5;
+        continueBtn.disabled = true;
+        countSpan.textContent = '(' + sec + 's)';
+
+        var timer = setInterval(function () {
+            sec--;
+            if (sec <= 0) {
+                clearInterval(timer);
+                continueBtn.disabled = false;
+                countSpan.textContent = '';
+            } else {
+                countSpan.textContent = '(' + sec + 's)';
+            }
+        }, 1000);
+    }
+
+    /* ── Dismiss via AJAX ── */
+    window.ceDismiss = function () {
+        var modal = document.getElementById('contractExpiryModal');
+        var token = document.querySelector('meta[name="csrf-token"]')
+                    ? document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                    : '';
+
+        fetch(DISMISS_URL, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': token,
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({}),
+        })
+        .then(function () {
+            // Fermer le modal avec animation
+            modal.style.animation = 'ce-overlay-out 0.25s ease forwards';
+            setTimeout(function () { modal.remove(); }, 280);
+
+            // Supprimer la bande urgence si présente
+            var strip = document.getElementById('ce-strip');
+            if (strip) strip.remove();
+        })
+        .catch(function () {
+            // En cas d'erreur réseau : fermer quand même
+            modal.remove();
+        });
+    };
+
+    /* ── Dismiss + navigation WhatsApp ── */
+    window.ceDismissAndNavigate = function (el) {
+        var token = document.querySelector('meta[name="csrf-token"]')
+                    ? document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                    : '';
+        fetch(DISMISS_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': token, 'Accept': 'application/json' },
+            body: JSON.stringify({}),
+        }).catch(function(){});
+        // Laisser le navigateur ouvrir le lien normalement
+    };
+
+    /* ── CSS animation out ── */
+    var style = document.createElement('style');
+    style.textContent = '@keyframes ce-overlay-out{to{opacity:0;}}';
+    document.head.appendChild(style);
+
+    /* ── Empêcher fermeture en cliquant sur l'overlay si pas expiré ── */
+    var overlay = document.getElementById('contractExpiryModal');
+    if (overlay) {
+        overlay.addEventListener('click', function (e) {
+            if (e.target === overlay && !IS_EXPIRED) {
+                // Petit shake pour indiquer que c'est bloquant
+                var card = overlay.querySelector('.ce-card');
+                card.style.animation = 'none';
+                card.style.transform = 'translateX(-8px)';
+                setTimeout(function() {
+                    card.style.transition = 'transform 0.3s ease';
+                    card.style.transform = 'translateX(0)';
+                }, 50);
+            }
+        });
+    }
+})();
+</script>

--- a/resources/views/components/contract-expiry-modal.blade.php
+++ b/resources/views/components/contract-expiry-modal.blade.php
@@ -55,7 +55,7 @@
         "Bonjour, je souhaite renouveler l'abonnement de {$tenantName} (Plan {$plan}). " .
         ($isExpired ? "Mon contrat a expiré le {$endDate}." : "Mon contrat expire le {$endDate} ({$days} jours restants).")
     );
-    $whatsappUrl = "https://wa.me/2250708080808?text={$whatsappMsg}";
+    $whatsappUrl = "https://wa.me/2250595459843?text={$whatsappMsg}";
 @endphp
 
 {{-- CSS chargé une seule fois --}}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3620,5 +3620,10 @@
     <!-- Scripts additionnels -->
     @stack('scripts')
     @stack('modals')
+
+    {{-- Compte à rebours expiration contrat (affiché max 1x/12h si ≤ 30 jours) --}}
+    @if(auth()->check())
+        @include('components.contract-expiry-modal')
+    @endif
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -175,8 +175,14 @@ Route::middleware(['auth'])->group(function () {
     })->name('settings.index');
 });
 
+// Routes contrat expiration (AJAX — pas de middleware contract.expiry pour éviter récursion)
+Route::middleware(['auth'])->prefix('contract-expiry')->name('contract-expiry.')->group(function () {
+    Route::get('/status', [\App\Http\Controllers\ContractExpiryController::class, 'status'])->name('status');
+    Route::post('/dismiss', [\App\Http\Controllers\ContractExpiryController::class, 'dismiss'])->name('dismiss');
+});
+
 // Routes accessibles uniquement après authentification
-Route::middleware(['auth', 'installed', 'force.password.change'])->group(function () {
+Route::middleware(['auth', 'installed', 'force.password.change', 'contract.expiry'])->group(function () {
     // Dashboard - Route principale qui redirige vers le tableau de bord approprié selon le rôle
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 


### PR DESCRIPTION
## Résumé

- Affiche un modal plein écran bloquant dès que l'abonnement expire dans ≤ 30 jours
- Se réaffiche toutes les 12h (cooldown en session, pas à chaque page)
- Compte à rebours SVG avec code couleur selon urgence (vert/orange/rouge/expiré)
- CTA WhatsApp pré-rempli pour réduire la friction du renouvellement
- Dismiss via AJAX POST — pas de rechargement de page

## Fichiers créés/modifiés

| Fichier | Rôle |
|---------|------|
| `app/Http/Middleware/ContractExpiryMiddleware.php` | Détection expiration via cache API Master |
| `app/Http/Controllers/ContractExpiryController.php` | Routes AJAX status + dismiss |
| `public/css/contract-expiry.css` | CSS isolé, design ACASI |
| `resources/views/components/contract-expiry-modal.blade.php` | Modal Blade avec SVG countdown |
| `app/Http/Kernel.php` | Enregistrement middleware `contract.expiry` |
| `routes/web.php` | Routes `/contract-expiry/*` + middleware sur groupe auth |
| `resources/views/layouts/app.blade.php` | Injection composant avant `</body>` |

## Plan de test

- [ ] Simuler `subscription_end_date` à J-25 → modal vert au login
- [ ] Cliquer "Continuer" → modal disparaît (AJAX dismiss)
- [ ] Recharger la page → modal ne réapparaît pas (cooldown 12h)
- [ ] Attendre 12h (ou vider session) → modal réapparaît
- [ ] Simuler J-5 → modal rouge pulsant + bande urgence en haut
- [ ] Simuler expiré → bouton "Continuer" désactivé
- [ ] Cliquer WhatsApp → lien pré-rempli correct + dismiss appelé

Closes #82