### PR TITLE
fix(contract): couvrir toutes les routes avec le middleware d'expiration

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -46,6 +46,7 @@ class Kernel extends HttpKernel
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\UpdateLastLogin::class,
             \App\Http\Middleware\RouteDebugMiddleware::class,
+            \App\Http\Middleware\ContractExpiryMiddleware::class,
         ],
 
         'api' => [

--- a/routes/web.php
+++ b/routes/web.php
@@ -182,7 +182,7 @@ Route::middleware(['auth'])->prefix('contract-expiry')->name('contract-expiry.')
 });
 
 // Routes accessibles uniquement après authentification
-Route::middleware(['auth', 'installed', 'force.password.change', 'contract.expiry'])->group(function () {
+Route::middleware(['auth', 'installed', 'force.password.change'])->group(function () {
     // Dashboard - Route principale qui redirige vers le tableau de bord approprié selon le rôle
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
 


### PR DESCRIPTION
## Summary
- Le modal d'expiration n'apparaissait pas sur `/esbtp/inscriptions/create`, `/dashboard`, etc.
- Le middleware `contract.expiry` était uniquement sur un seul groupe de routes

## Changes
- `app/Http/Kernel.php` — déplace `ContractExpiryMiddleware` dans le groupe `web` global (s'applique à toutes les routes web)
- `routes/web.php` — retire `contract.expiry` du groupe de routes spécifique (plus nécessaire)

Le middleware vérifie `auth()->check()` en première instruction — inactif pour les guests, zéro impact sur les routes publiques.

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Testé sur klassci.com/dashboard → modal visible si abonnement expiré
- [ ] Testé sur klassci.com/esbtp/inscriptions/create → modal visible
- [ ] Routes `/contract-expiry/*` exclues (pas de boucle infinie)

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified on all modified PHP files