### PR TITLE
feat(inscriptions): refaire l'UI des frais optionnels pour la rendre …

### DIFF
--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -1078,6 +1078,7 @@ class ESBTPInscriptionController extends Controller
         )
             ->active()
             ->ordered()
+            ->with(['options' => fn($q) => $q->where('is_active', true)->orderBy('sort_order')])
             ->get();
 
         // Récupérer les souscriptions actives pour cette inscription

--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -1364,16 +1364,98 @@ document.addEventListener('DOMContentLoaded', function() {
             configBadge = `<div class="alert-kl alert-kl-warning mb-3" style="font-size:12px;padding:8px 12px;"><i class="fas fa-info-circle"></i><span>Montant par défaut utilisé (non configuré pour cette classe)</span></div>`;
         }
 
+        // ── FRAIS OPTIONNELS : toggle switch + options révélées ────────────────
+        if (!isMandatory) {
+            const baseAmt = parseFloat(defaultAmount) || 0;
+
+            // Radios des options (visibles quand le toggle est ON)
+            let optionRadios = `
+                <div class="form-check mb-2">
+                    <input class="form-check-input frais-option optional-variant" type="radio"
+                           name="frais[${category.id}][variant_id]"
+                           value="default"
+                           id="frais_${category.id}_default">
+                    <label class="form-check-label" for="frais_${category.id}_default">
+                        Montant de base — <strong>${baseAmt.toLocaleString()} FCFA</strong>
+                    </label>
+                </div>`;
+
+            if (options.length > 0) {
+                options.forEach(option => {
+                    const addAmt   = parseFloat(option.additional_amount) || parseFloat(option.amount) || 0;
+                    let totalAmt   = baseAmt + addAmt;
+                    if (isNaN(totalAmt) || totalAmt < 0) totalAmt = baseAmt;
+                    optionRadios += `
+                        <div class="form-check mb-2">
+                            <input class="form-check-input frais-option optional-variant" type="radio"
+                                   name="frais[${category.id}][variant_id]"
+                                   value="${option.id}"
+                                   id="frais_${category.id}_${option.id}">
+                            <label class="form-check-label" for="frais_${category.id}_${option.id}">
+                                ${option.name} — <strong>${totalAmt.toLocaleString()} FCFA</strong>
+                                ${option.description ? `<small class="text-muted d-block">${option.description}</small>` : ''}
+                            </label>
+                        </div>`;
+                });
+            }
+
+            return `
+                <div class="frais-card optional-frais-card" data-category-id="${category.id}">
+                    <!-- Radio "non souscrit" caché — état par défaut -->
+                    <input type="radio" class="frais-option"
+                           name="frais[${category.id}][variant_id]"
+                           value="" id="frais_${category.id}_none"
+                           checked style="display:none;">
+
+                    <!-- En-tête avec toggle -->
+                    <div class="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                        <div style="flex:1;min-width:0;">
+                            <h6 class="fw-bold mb-0" style="font-size:14px;">
+                                <i class="fas fa-${icon} me-2" style="color:var(--kl-primary-light);"></i>
+                                ${category.name}
+                            </h6>
+                            ${category.description ? `<p class="text-muted mb-0 mt-1" style="font-size:12px;">${category.description}</p>` : ''}
+                        </div>
+                        <div class="d-flex align-items-center gap-2 flex-shrink-0">
+                            <span class="badge bg-info" style="font-size:10px;">Optionnel</span>
+                            <div class="form-check form-switch mb-0 d-flex align-items-center gap-1">
+                                <input class="form-check-input optional-frais-toggle" type="checkbox"
+                                       id="toggle_frais_${category.id}"
+                                       data-category-id="${category.id}"
+                                       role="switch"
+                                       style="width:2.5em;height:1.3em;cursor:pointer;margin-top:0;">
+                                <label class="form-check-label small fw-semibold" for="toggle_frais_${category.id}"
+                                       style="cursor:pointer;user-select:none;">
+                                    Souscrire
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <!-- Zone options — masquée par défaut, révélée au toggle ON -->
+                    <div class="optional-frais-options mt-3 pt-3"
+                         id="options_frais_${category.id}"
+                         style="display:none;border-top:1px solid rgba(0,0,0,0.08);">
+                        <p class="small text-muted mb-2">
+                            <i class="fas fa-list-ul me-1"></i>
+                            ${options.length > 0 ? 'Choisissez une option :' : 'Montant applicable :'}
+                        </p>
+                        ${optionRadios}
+                    </div>
+                </div>`;
+        }
+
+        // ── FRAIS OBLIGATOIRES : comportement existant ──────────────────────────
         let optionsHTML = '';
 
-        if (isMandatory || configurationType === 'rule' || configurationType === 'variant' || configurationType === 'configuration') {
+        if (configurationType === 'rule' || configurationType === 'variant' || configurationType === 'configuration' || isMandatory) {
             optionsHTML += `
                 <div class="form-check mb-2">
                     <input class="form-check-input frais-option" type="radio"
                            name="frais[${category.id}][variant_id]"
                            value="default"
                            id="frais_${category.id}_default"
-                           ${isMandatory ? 'checked' : ''}>
+                           checked>
                     <label class="form-check-label" for="frais_${category.id}_default">
                         ${configurationType === 'variant' ? 'Tarif configuré pour cette classe' :
                           configurationType === 'rule' ? 'Tarif configuré' :
@@ -1406,20 +1488,6 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
 
-        if (!isMandatory) {
-            optionsHTML += `
-                <div class="form-check mb-2">
-                    <input class="form-check-input frais-option" type="radio"
-                           name="frais[${category.id}][variant_id]"
-                           value=""
-                           id="frais_${category.id}_none"
-                           checked>
-                    <label class="form-check-label" for="frais_${category.id}_none">
-                        <em>Ne pas souscrire à ce service</em>
-                    </label>
-                </div>`;
-        }
-
         return `
             <div class="frais-card ${!isConfigured ? 'border-warning' : ''}">
                 <div class="d-flex justify-content-between align-items-start mb-2">
@@ -1429,9 +1497,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         ${!isConfigured ? '<i class="fas fa-exclamation-triangle text-warning ms-1" title="Pas d\'options configurées"></i>' : ''}
                     </h6>
                     <div class="d-flex gap-1">
-                        ${isMandatory
-                            ? '<span class="badge bg-danger" style="font-size:10px;">Obligatoire</span>'
-                            : '<span class="badge bg-info" style="font-size:10px;">Optionnel</span>'}
+                        <span class="badge bg-danger" style="font-size:10px;">Obligatoire</span>
                         <span class="badge bg-secondary" style="font-size:10px;">${categoryType.charAt(0).toUpperCase() + categoryType.slice(1)}</span>
                     </div>
                 </div>
@@ -1485,6 +1551,25 @@ document.addEventListener('DOMContentLoaded', function() {
 
     document.addEventListener('change', function(e) {
         if (e.target.classList.contains('frais-option')) updateResumeFrais();
+
+        // Toggle souscription frais optionnel
+        if (e.target.classList.contains('optional-frais-toggle')) {
+            const categoryId = e.target.dataset.categoryId;
+            const optionsDiv = document.getElementById('options_frais_' + categoryId);
+            const noneRadio  = document.getElementById('frais_' + categoryId + '_none');
+            const variants   = document.querySelectorAll('input[name="frais[' + categoryId + '][variant_id]"].optional-variant');
+
+            if (e.target.checked) {
+                if (optionsDiv) optionsDiv.style.display = 'block';
+                if (variants.length > 0) variants[0].checked = true;
+                if (noneRadio) noneRadio.checked = false;
+            } else {
+                if (optionsDiv) optionsDiv.style.display = 'none';
+                variants.forEach(v => v.checked = false);
+                if (noneRadio) noneRadio.checked = true;
+            }
+            updateResumeFrais();
+        }
     });
 
     // =============================================

--- a/resources/views/esbtp/inscriptions/show.blade.php
+++ b/resources/views/esbtp/inscriptions/show.blade.php
@@ -1876,24 +1876,44 @@ body:has(#editSubscriptionModal.show) .modal-backdrop {
                             <div class="row g-3">
                                 @foreach($availableOptionalCategories as $category)
                                     <div class="col-md-6">
-                                        <div class="optional-fee-card">
-                                            <div class="optional-fee-icon">
-                                                <i class="{{ $category->icon ?? 'fas fa-concierge-bell' }}"></i>
+                                        <div class="optional-fee-card" style="flex-direction:column;align-items:stretch;gap:0.75rem;">
+                                            <div class="d-flex align-items-center gap-3">
+                                                <div class="optional-fee-icon" style="flex-shrink:0;">
+                                                    <i class="{{ $category->icon ?? 'fas fa-concierge-bell' }}"></i>
+                                                </div>
+                                                <div class="optional-fee-body" style="flex:1;min-width:0;">
+                                                    <div class="optional-fee-name">{{ $category->name }}</div>
+                                                    @if($category->description)
+                                                        <div class="optional-fee-desc" title="{{ $category->description }}">{{ $category->description }}</div>
+                                                    @endif
+                                                    @if($category->options->count() > 0)
+                                                        <div class="mt-1">
+                                                            @foreach($category->options->take(3) as $opt)
+                                                                <span class="badge bg-light text-dark border me-1" style="font-size:10px;">{{ $opt->name }}</span>
+                                                            @endforeach
+                                                            @if($category->options->count() > 3)
+                                                                <span class="text-muted" style="font-size:10px;">+{{ $category->options->count() - 3 }} options</span>
+                                                            @endif
+                                                        </div>
+                                                    @endif
+                                                </div>
+                                                <div class="optional-fee-price" style="flex-shrink:0;text-align:right;">
+                                                    <span class="badge-optionnel">Optionnel</span>
+                                                    <strong>{{ number_format($category->default_amount, 0, ',', ' ') }}<small> FCFA</small></strong>
+                                                </div>
                                             </div>
-                                            <div class="optional-fee-body">
-                                                <div class="optional-fee-name">{{ $category->name }}</div>
-                                                @if($category->description)
-                                                    <div class="optional-fee-desc" title="{{ $category->description }}">{{ $category->description }}</div>
-                                                @endif
-                                            </div>
-                                            <div class="optional-fee-price">
-                                                <span class="badge-optionnel">Optionnel</span>
-                                                <strong>{{ number_format($category->default_amount, 0, ',', ' ') }}<small> FCFA</small></strong>
-                                            </div>
+                                            @can('inscriptions.edit')
+                                            <button type="button"
+                                                    class="btn btn-sm btn-outline-primary w-100"
+                                                    onclick="openSubscribeModal({{ $category->id }}, '{{ addslashes($category->name) }}', {{ $category->default_amount }}, {{ $category->options->map(fn($o) => ['id' => $o->id, 'name' => $o->name, 'additional_amount' => (float)$o->additional_amount, 'description' => $o->description]) ->values()->toJson() }})">
+                                                <i class="fas fa-plus-circle me-1"></i>Souscrire l'étudiant
+                                            </button>
+                                            @endcan
                                         </div>
                                     </div>
                                 @endforeach
                             </div>
+
                         </div>
                     </div>
                     @endif
@@ -2803,11 +2823,13 @@ body:has(#editSubscriptionModal.show) .modal-backdrop {
                         <div class="col-md-6">
                             <div class="mb-3">
                                 <label for="optional_category_id" class="form-label">Frais optionnel <span class="text-danger">*</span></label>
-                                <select class="form-select" id="optional_category_id" name="category_id" required>
+                                <select class="form-select" id="optional_category_id" name="frais_category_id" required>
                                     <option value="">Sélectionnez un frais</option>
                                     @if(isset($availableOptionalCategories))
                                         @foreach($availableOptionalCategories as $category)
-                                            <option value="{{ $category->id }}" data-default-amount="{{ $category->default_amount }}">
+                                            <option value="{{ $category->id }}"
+                                                    data-default-amount="{{ $category->default_amount }}"
+                                                    data-options="{{ json_encode($category->options->map(fn($o) => ['id' => $o->id, 'name' => $o->name, 'additional_amount' => (float)$o->additional_amount, 'description' => $o->description])->values()) }}">
                                                 {{ $category->name }} - {{ number_format($category->default_amount, 0, ',', ' ') }} FCFA
                                             </option>
                                         @endforeach
@@ -2818,10 +2840,19 @@ body:has(#editSubscriptionModal.show) .modal-backdrop {
                         <div class="col-md-6">
                             <div class="mb-3">
                                 <label for="subscription_amount" class="form-label">Montant <span class="text-danger">*</span></label>
-                                <input type="number" class="form-control" id="subscription_amount" name="amount" min="0" step="0.01" required readonly>
+                                <input type="number" class="form-control" id="subscription_amount" name="amount" min="0" step="1" required>
+                                <small class="text-muted" id="subscription_amount_hint"></small>
                             </div>
                         </div>
                     </div>
+
+                    <!-- Zone options dynamique (affichée si la catégorie a des options) -->
+                    <div id="subscription_options_zone" class="mb-3" style="display:none;">
+                        <label class="form-label">Option <span class="text-danger">*</span></label>
+                        <div id="subscription_options_list"></div>
+                        <small class="text-muted">Le montant se met à jour automatiquement selon l'option choisie.</small>
+                    </div>
+
                     <div class="mb-3">
                         <label for="subscription_notes" class="form-label">Notes</label>
                         <textarea class="form-control" id="subscription_notes" name="notes" rows="3" placeholder="Commentaires sur la souscription..."></textarea>
@@ -3914,20 +3945,89 @@ body:has(#editSubscriptionModal.show) .modal-backdrop {
             });
         }
 
-        // Auto-remplir le montant pour la souscription
-        const optionalCategorySelect = document.getElementById('optional_category_id');
+        // ── Souscription frais optionnel : gestion modal ──────────────────────
+        const optionalCategorySelect  = document.getElementById('optional_category_id');
         const subscriptionAmountInput = document.getElementById('subscription_amount');
-        
-        if (optionalCategorySelect && subscriptionAmountInput) {
-            optionalCategorySelect.addEventListener('change', function() {
-                const selectedOption = this.options[this.selectedIndex];
-                const defaultAmount = selectedOption.getAttribute('data-default-amount');
-                if (defaultAmount) {
+        const subscriptionOptionsZone = document.getElementById('subscription_options_zone');
+        const subscriptionOptionsList = document.getElementById('subscription_options_list');
+        const subscriptionAmountHint  = document.getElementById('subscription_amount_hint');
+
+        function renderSubscriptionOptions(options, defaultAmount) {
+            if (!subscriptionOptionsList || !subscriptionOptionsZone) return;
+
+            if (!options || options.length === 0) {
+                subscriptionOptionsZone.style.display = 'none';
+                if (subscriptionAmountInput) {
                     subscriptionAmountInput.value = defaultAmount;
-                    debugLog('💰 Montant souscription auto-rempli:', defaultAmount);
+                    subscriptionAmountInput.readOnly = false;
                 }
+                if (subscriptionAmountHint) subscriptionAmountHint.textContent = 'Montant par défaut pré-rempli. Vous pouvez l\'ajuster.';
+                return;
+            }
+
+            subscriptionOptionsZone.style.display = 'block';
+            if (subscriptionAmountHint) subscriptionAmountHint.textContent = '';
+
+            let html = '';
+            // Default amount option
+            html += `<div class="form-check mb-2">
+                <input class="form-check-input subscription-option-radio" type="radio"
+                       name="subscription_option" value="default"
+                       id="subs_opt_default" data-amount="${defaultAmount}" checked>
+                <label class="form-check-label" for="subs_opt_default">
+                    Montant de base — <strong>${parseFloat(defaultAmount).toLocaleString('fr-FR')} FCFA</strong>
+                </label>
+            </div>`;
+            options.forEach((opt, idx) => {
+                const total = parseFloat(defaultAmount) + parseFloat(opt.additional_amount || 0);
+                html += `<div class="form-check mb-2">
+                    <input class="form-check-input subscription-option-radio" type="radio"
+                           name="subscription_option" value="${opt.id}"
+                           id="subs_opt_${opt.id}" data-amount="${total}">
+                    <label class="form-check-label" for="subs_opt_${opt.id}">
+                        ${opt.name} — <strong>${total.toLocaleString('fr-FR')} FCFA</strong>
+                        ${opt.description ? `<small class="text-muted d-block">${opt.description}</small>` : ''}
+                    </label>
+                </div>`;
+            });
+            subscriptionOptionsList.innerHTML = html;
+
+            // Set initial amount from checked option
+            if (subscriptionAmountInput) subscriptionAmountInput.value = defaultAmount;
+            subscriptionAmountInput.readOnly = true;
+
+            // On option change → update amount
+            subscriptionOptionsList.querySelectorAll('.subscription-option-radio').forEach(radio => {
+                radio.addEventListener('change', function() {
+                    if (subscriptionAmountInput) subscriptionAmountInput.value = this.dataset.amount;
+                });
             });
         }
+
+        if (optionalCategorySelect) {
+            optionalCategorySelect.addEventListener('change', function() {
+                const selectedOption = this.options[this.selectedIndex];
+                const defaultAmount  = parseFloat(selectedOption.getAttribute('data-default-amount')) || 0;
+                let   options        = [];
+                try { options = JSON.parse(selectedOption.getAttribute('data-options') || '[]'); } catch(e) {}
+                renderSubscriptionOptions(options, defaultAmount);
+            });
+        }
+
+        // Ouvrir le modal depuis un bouton de carte — pré-sélectionne la catégorie
+        window.openSubscribeModal = function(categoryId, categoryName, defaultAmount, options) {
+            if (!optionalCategorySelect) return;
+            // Sélectionner la catégorie correspondante
+            for (let i = 0; i < optionalCategorySelect.options.length; i++) {
+                if (parseInt(optionalCategorySelect.options[i].value) === parseInt(categoryId)) {
+                    optionalCategorySelect.selectedIndex = i;
+                    break;
+                }
+            }
+            renderSubscriptionOptions(options, defaultAmount);
+            const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('subscriptionModal'));
+            modal.show();
+        };
 
         // Fonction pour préparer le modal de paiement de reliquat
         window.prepareReliquatPaymentModal = function(reliquatId, montantRestant, nomFrais) {


### PR DESCRIPTION
…intuitive

- create.blade.php : remplacer les radio confus par un toggle switch "Souscrire"
  - OFF par défaut (non souscrit) → zone options masquée
  - ON → révèle les options + sélectionne la première automatiquement
  - Corrige le bug "impossible de souscrire si aucune option configurée"
  - Résumé frais mis à jour via le même gestionnaire d'événements

- show.blade.php : amélioration du modal et des cartes optionnelles
  - Fix bug critique : name="category_id" → name="frais_category_id"
  - Bouton "Souscrire" direct sur chaque carte (openSubscribeModal)
  - Modal affiche les options de la catégorie avec sélection radio
  - Montant se met à jour automatiquement selon l'option choisie
  - options récupérées depuis data-options (JSON injecté côté Blade)

- ESBTPInscriptionController : eager-load options sur optionalCategories
  - Évite les N+1 queries et permet l'injection JSON des options dans la vue

https://claude.ai/code/session_01WgRC4DBGbjfNRwAFJ9o8NA