### PR TITLE
fix(frais): auto-set effective_date to today on configuration create

### DIFF
--- a/app/Models/ESBTPFraisConfiguration.php
+++ b/app/Models/ESBTPFraisConfiguration.php
@@ -65,6 +65,19 @@ class ESBTPFraisConfiguration extends Model
     ];
 
     /**
+     * Boot
+     */
+    protected static function boot()
+    {
+        parent::boot();
+        static::creating(function ($model) {
+            if (empty($model->effective_date)) {
+                $model->effective_date = now()->toDateString();
+            }
+        });
+    }
+
+    /**
      * Relations
      */
     public function fraisCategory()


### PR DESCRIPTION
Le champ effective_date est NOT NULL sans valeur par défaut en BDD. Plusieurs appels create/updateOrCreate ne le fournissaient pas, causant une erreur SQL sur /frais/optional-config → Ajouter option.

Ajout d'un boot hook `creating` dans ESBTPFraisConfiguration qui initialise effective_date = today() si non fourni.