### PR TITLE
fix(frais): auto-set created_by in configuration boot hook

### DIFF
--- a/app/Models/ESBTPFraisConfiguration.php
+++ b/app/Models/ESBTPFraisConfiguration.php
@@ -74,6 +74,9 @@ class ESBTPFraisConfiguration extends Model
             if (empty($model->effective_date)) {
                 $model->effective_date = now()->toDateString();
             }
+            if (empty($model->created_by)) {
+                $model->created_by = auth()->id();
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- Corrige l'erreur SQL "Field 'created_by' doesn't have a default value" sur /esbtp/frais/optional-config
- Le boot hook de ESBTPFraisConfiguration initialise maintenant aussi created_by = auth()->id() si non fourni

## Changes
- `app/Models/ESBTPFraisConfiguration.php` — ajout de created_by dans le hook creating (suite du fix effective_date)

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (php -l) on all modified PHP files
