### PR TITLE
fix(frais): résumé frais temps réel + formulaire ajout formule visible

### DIFF
--- a/resources/views/esbtp/frais/optional-config.blade.php
+++ b/resources/views/esbtp/frais/optional-config.blade.php
@@ -457,14 +457,14 @@ body.modal-open * {
                                 <input type="hidden" name="category_id" value="{{ $category->id }}">
                                 <div class="row">
                                     <div class="col-md-4">
-                                        <div class="oc-add-form form-group mb-0" style="background:none;border:none;padding:0;margin-bottom:0;">
+                                        <div class="form-group mb-0">
                                             <label>Nom de la formule *</label>
                                             <input type="text" name="name" class="form-control"
                                                    placeholder="Ex : Arrêt Centre-ville" required>
                                         </div>
                                     </div>
                                     <div class="col-md-4">
-                                        <div class="oc-add-form form-group mb-0" style="background:none;border:none;padding:0;margin-bottom:0;">
+                                        <div class="form-group mb-0">
                                             <label>Montant (F CFA) *</label>
                                             <input type="number" name="additional_amount" class="form-control"
                                                    placeholder="15 000" min="0" required>
@@ -476,7 +476,7 @@ body.modal-open * {
                                         </button>
                                     </div>
                                 </div>
-                                <div class="oc-add-form form-group mt-2" style="background:none;border:none;padding:0;">
+                                <div class="form-group mt-2">
                                     <label>Description <span style="font-weight:400;color:#94a3b8;">(optionnel)</span></label>
                                     <input type="text" name="description" class="form-control"
                                            placeholder="Brève description de la formule">

--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -1383,6 +1383,7 @@ document.addEventListener('DOMContentLoaded', function() {
                            name="frais[${category.id}][variant_id]"
                            value="default"
                            id="frais_${category.id}_default"
+                           data-amount="${baseAmt}"
                            style="display:none;">
                     <div class="optional-options-label">Montant applicable</div>
                     <div class="frais-single-amount">
@@ -1403,6 +1404,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                    name="frais[${category.id}][variant_id]"
                                    value="${option.id}"
                                    id="frais_${category.id}_${option.id}"
+                                   data-amount="${totalAmt}"
                                    style="display:none;">
                             <div class="frais-option-check"><i class="fas fa-check"></i></div>
                             <div class="frais-option-name">${option.name}</div>
@@ -1475,6 +1477,7 @@ document.addEventListener('DOMContentLoaded', function() {
                            name="frais[${category.id}][variant_id]"
                            value="default"
                            id="frais_${category.id}_default"
+                           data-amount="${parseFloat(defaultAmount) || 0}"
                            checked>
                     <label class="form-check-label" for="frais_${category.id}_default">
                         ${configurationType === 'variant' ? 'Tarif configuré pour cette classe' :
@@ -1499,7 +1502,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         <input class="form-check-input frais-option" type="radio"
                                name="frais[${category.id}][variant_id]"
                                value="${option.id}"
-                               id="frais_${category.id}_${option.id}">
+                               id="frais_${category.id}_${option.id}"
+                               data-amount="${totalAmount}">
                         <label class="form-check-label" for="frais_${category.id}_${option.id}">
                             ${option.name} — <strong>${totalAmount.toLocaleString()} FCFA</strong>
                             ${option.description ? `<small class="text-muted d-block">${option.description}</small>` : ''}
@@ -1537,6 +1541,12 @@ document.addEventListener('DOMContentLoaded', function() {
 
         selectedOptions.forEach(option => {
             if (!option.value || option.value === '') return;
+
+            // Lire le montant depuis data-amount (présent sur tous les radios)
+            const amount = parseInt(option.dataset.amount) || 0;
+            if (amount <= 0) return;
+
+            // Lire le nom de la catégorie depuis le .frais-card parent
             const fraisCard = option.closest('.frais-card');
             let categoryName = 'Frais';
             if (fraisCard) {
@@ -1546,16 +1556,12 @@ document.addEventListener('DOMContentLoaded', function() {
                     categoryName = text.split('\n')[0].trim() || categoryName;
                 }
             }
-            const label = option.closest('.form-check')?.querySelector('label')?.textContent || '';
-            const match = label.match(/(\d+(?:[.,\s]\d{3})*)/);
-            if (match) {
-                const amount = parseInt(match[1].replace(/[.,\s]/g, '')) || 0;
-                totalAmount += amount;
-                resumeHTML += `<div class="d-flex justify-content-between mb-1" style="font-size:13px;">
+
+            totalAmount += amount;
+            resumeHTML += `<div class="d-flex justify-content-between mb-1" style="font-size:13px;">
                     <span>${categoryName}</span>
                     <span class="fw-bold">${amount.toLocaleString()} FCFA</span>
                 </div>`;
-            }
         });
 
         if (resumeHTML) {


### PR DESCRIPTION
## Summary
- Redesign complet de la section frais optionnels dans inscriptions/create :
  option-cards cliquables, bouton Souscrire/Désabonner, state machine visuelle
- Fix résumé des frais (bas de page) non mis à jour en temps réel lors de la
  sélection/déselection de frais optionnels
- Fix formulaire "Ajouter une formule" dans /esbtp/frais/optional-config :
  champs Nom/Montant/Description restaient invisibles après le clic
- Redesign de la page optional-config (design system KLASSCI)
- Fix boot hook ESBTPFraisConfiguration : auto-set created_by

## Changes
- `resources/views/esbtp/inscriptions/create.blade.php` — option-cards optionnelles,
  data-amount sur tous les radios, updateResumeFrais() réécrit
- `resources/views/esbtp/frais/optional-config.blade.php` — redesign complet +
  retrait de oc-add-form sur les divs internes du formulaire d'ajout
- `public/css/inscription-create.css` — styles option-cards frais optionnels
- `app/Models/ESBTPFraisConfiguration.php` — boot hook created_by

## Type of change
- [x] feat — new feature
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified (php -l) on all modified PHP files
