### PR TITLE
fix(ui): corrections affichage année, notifications pills, boutons paiements et dropdown hauteur

### DIFF
--- a/resources/views/esbtp/bulletins/mon-bulletin.blade.php
+++ b/resources/views/esbtp/bulletins/mon-bulletin.blade.php
@@ -253,7 +253,7 @@
                 <div class="text-end">
                     <div class="badge" style="background: rgba(255, 255, 255, 0.2); color: white; padding: var(--space-sm) var(--space-md); border-radius: var(--radius-medium); font-size: var(--text-sm);">
                         <i class="fas fa-calendar me-2"></i>
-                        Année {{ date('Y') }}-{{ date('Y')+1 }}
+                        Année {{ $anneeCourante->annee_debut ?? ($anneeCourante->name ?? date('Y')) }}-{{ $anneeCourante->annee_fin ?? (isset($anneeCourante->annee_debut) ? $anneeCourante->annee_debut + 1 : date('Y')+1) }}
                     </div>
                 </div>
             </div>
@@ -312,7 +312,13 @@
                             <div>
                                 <div class="bulletin-title">
                                     <i class="fas fa-calendar-alt text-primary me-2"></i>
-                                    {{ $bulletin->anneeUniversitaire->annee_debut ?? '' }}-{{ $bulletin->anneeUniversitaire->annee_fin ?? '' }}
+                                    @if($bulletin->anneeUniversitaire && ($bulletin->anneeUniversitaire->annee_debut || $bulletin->anneeUniversitaire->annee_fin))
+                                        {{ $bulletin->anneeUniversitaire->annee_debut ?? '' }}-{{ $bulletin->anneeUniversitaire->annee_fin ?? '' }}
+                                    @elseif($bulletin->anneeUniversitaire && $bulletin->anneeUniversitaire->name)
+                                        {{ $bulletin->anneeUniversitaire->name }}
+                                    @else
+                                        Année non définie
+                                    @endif
                                 </div>
                                 <div class="bulletin-subtitle">
                                     @if($bulletin->periode == 'semestre1')

--- a/resources/views/etudiants/mes-paiements/index.blade.php
+++ b/resources/views/etudiants/mes-paiements/index.blade.php
@@ -606,6 +606,7 @@
                                             <div style="display: flex; gap: 0.4rem; flex-wrap: wrap;">
                                                 <button type="button"
                                                     class="action-btn btn-info"
+                                                    title="Voir les détails"
                                                     data-bs-toggle="modal"
                                                     data-bs-target="#paiementDetailModal"
                                                     data-paiement-id="{{ $paiement->id }}"
@@ -618,14 +619,13 @@
                                                     data-observations="{{ $paiement->observations ?? '' }}"
                                                     data-numero-recu="{{ $paiement->numero_recu ?? 'N/A' }}">
                                                     <i class="fas fa-eye"></i>
-                                                    Détails
                                                 </button>
                                                 @if($paiement->status === 'validé')
                                                     <a href="{{ route('esbtp.paiements.recu', $paiement->id) }}"
                                                        class="action-btn btn-success"
-                                                       target="_blank">
+                                                       target="_blank"
+                                                       title="Télécharger PDF">
                                                         <i class="fas fa-download"></i>
-                                                        PDF
                                                     </a>
                                                 @endif
                                             </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -196,8 +196,9 @@
         .custom-dropdown {
             min-width: 360px !important;
             max-width: 380px !important;
+            max-height: min(520px, calc(100vh - 100px)) !important;
             border: 1px solid rgba(99, 102, 241, 0.08) !important;
-            box-shadow: 
+            box-shadow:
                 0 20px 25px -5px rgba(0, 0, 0, 0.1),
                 0 10px 10px -5px rgba(0, 0, 0, 0.04) !important;
             border-radius: 20px !important;
@@ -206,6 +207,33 @@
             background: rgba(255, 255, 255, 0.98) !important;
             backdrop-filter: blur(20px) !important;
             overflow: hidden !important;
+            display: flex !important;
+            flex-direction: column !important;
+        }
+
+        #notifications-list,
+        #messages-list {
+            max-height: 320px;
+            overflow-y: auto;
+            overflow-x: hidden;
+            scrollbar-width: thin;
+            scrollbar-color: rgba(99, 102, 241, 0.3) transparent;
+        }
+
+        #notifications-list::-webkit-scrollbar,
+        #messages-list::-webkit-scrollbar {
+            width: 4px;
+        }
+
+        #notifications-list::-webkit-scrollbar-track,
+        #messages-list::-webkit-scrollbar-track {
+            background: transparent;
+        }
+
+        #notifications-list::-webkit-scrollbar-thumb,
+        #messages-list::-webkit-scrollbar-thumb {
+            background: rgba(99, 102, 241, 0.3);
+            border-radius: 4px;
         }
 
         .custom-dropdown::before {

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -395,9 +395,9 @@
 
                                                 if (!$primaryLine) {
                                                     $safeMessage = strip_tags($notification->message ?? '', '<i><strong><em><b><br>');
-                                                    $primaryLine = trim(preg_split('/(Statut:|Étape:|Paiement:|Cliquez)/i', $safeMessage)[0] ?? '');
+                                                    $primaryLine = trim(preg_split('/(Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:|Cliquez)/i', $safeMessage)[0] ?? '');
 
-                                                    if (preg_match_all('/(<i[^>]*>.*?<\\/i>\\s*)?(Statut:|Étape:|Paiement:)\\s*([^<|]*)/i', $safeMessage, $matches, PREG_SET_ORDER)) {
+                                                    if (preg_match_all('/(<i[^>]*>.*?<\\/i>\\s*)?(Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:)\\s*([^<|\\n]*)/iu', $safeMessage, $matches, PREG_SET_ORDER)) {
                                                         foreach ($matches as $match) {
                                                             $labels[] = trim($match[0]);
                                                         }
@@ -459,6 +459,12 @@
                                                                     } elseif (Str::contains($valueLower, ['rejet', 'refus'])) {
                                                                         $pillClass = 'meta-danger';
                                                                     }
+                                                                } elseif (Str::lower($key) === 'référence' || Str::lower($key) === 'reference') {
+                                                                    $icon = 'fas fa-hashtag';
+                                                                    $pillClass = 'meta-info';
+                                                                } elseif (Str::contains(Str::lower($key), ['numéro de reçu', 'numero de recu', 'numéro reçu'])) {
+                                                                    $icon = 'fas fa-receipt';
+                                                                    $pillClass = 'meta-primary';
                                                                 }
                                                             @endphp
                                                             <span class="notification-meta-pill {{ $pillClass }}">


### PR DESCRIPTION
## Summary
- Badge année sur `/esbtp/mon-bulletin` utilise `$anneeCourante` au lieu de `date('Y')` hardcodé
- Suppression des tirets orphelins quand `anneeUniversitaire` est null dans les bulletins
- Ajout de `Référence:` et `Numéro de reçu:` comme tokens pour les pills dans `/esbtp/mes-notifications`
- Boutons Détails/PDF icon-only (avec `title`) sur `/esbtp/mes-paiements` pour éviter overflow
- Dropdown notifications limité en hauteur avec scroll interne sur `#notifications-list` / `#messages-list`

## Changes
- `resources/views/esbtp/bulletins/mon-bulletin.blade.php` — année dynamique + guard tirets null
- `resources/views/notifications/index.blade.php` — regex étendu pour nouveaux pills
- `resources/views/etudiants/mes-paiements/index.blade.php` — boutons icon-only
- `resources/views/layouts/app.blade.php` — max-height + overflow-y sur dropdown

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified on all modified PHP files