### PR TITLE
fix(notifications): corriger HTML brut dans les pills de notifications

### DIFF
--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -394,10 +394,11 @@
                                                 $primaryLine = $notification->display_primary;
 
                                                 if (!$primaryLine) {
-                                                    $safeMessage = strip_tags($notification->message ?? '', '<i><strong><em><b><br>');
+                                                    // Strip ALL tags for parsing (labels must be plain text)
+                                                    $safeMessage = strip_tags($notification->message ?? '');
                                                     $primaryLine = trim(preg_split('/(Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:|Cliquez)/i', $safeMessage)[0] ?? '');
 
-                                                    if (preg_match_all('/(<i[^>]*>.*?<\\/i>\\s*)?(Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:)\\s*([^<|\\n]*)/iu', $safeMessage, $matches, PREG_SET_ORDER)) {
+                                                    if (preg_match_all('/(Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:)\s*([^|\n]*)/iu', $safeMessage, $matches, PREG_SET_ORDER)) {
                                                         foreach ($matches as $match) {
                                                             $labels[] = trim($match[0]);
                                                         }


### PR DESCRIPTION
## Summary
- Les pills affichaient `<i class='fas fa-receipt'></i> Référence:` en texte brut au lieu de rendre l'icône
- Cause : `strip_tags(..., '<i>')` conservait les balises `<i>` dans `$safeMessage`, la regex les capturait comme partie de la clé
- Fix : utiliser `strip_tags()` sans whitelist pour le parsing des labels (texte pur uniquement)

## Changes
- `resources/views/notifications/index.blade.php` — strip_tags complet + regex simplifiée sans capture de balises `<i>`

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified on all modified PHP files