### PR TITLE
fix(navbar+notifications): dropdowns toujours visibles et labels notification fusionnés

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -207,8 +207,11 @@
             background: rgba(255, 255, 255, 0.98) !important;
             backdrop-filter: blur(20px) !important;
             overflow: hidden !important;
-            display: flex !important;
             flex-direction: column !important;
+        }
+
+        .custom-dropdown.show {
+            display: flex !important;
         }
 
         #notifications-list,

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -398,7 +398,7 @@
                                                     $safeMessage = strip_tags($notification->message ?? '');
                                                     $primaryLine = trim(preg_split('/(Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:|Cliquez)/i', $safeMessage)[0] ?? '');
 
-                                                    if (preg_match_all('/(Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:)\s*([^|\n]*)/iu', $safeMessage, $matches, PREG_SET_ORDER)) {
+                                                    if (preg_match_all('/(Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:)\s*((?:(?!Statut:|Étape:|Paiement:|Référence:|Numéro de reçu:|Cliquez)[^|\n])*)/iu', $safeMessage, $matches, PREG_SET_ORDER)) {
                                                         foreach ($matches as $match) {
                                                             $labels[] = trim($match[0]);
                                                         }


### PR DESCRIPTION
## Summary
- **Bug 1** : Les dropdowns navbar (Notifications, Messages, Actions, Profil) s'affichaient tous ouverts au chargement de la page
- **Bug 2** : Les labels "Référence:" et "Numéro de reçu:" étaient fusionnés en un seul pill dans les notifications

## Changes
- `resources/views/layouts/app.blade.php` — déplace `display: flex !important` de `.custom-dropdown` vers `.custom-dropdown.show` pour ne pas écraser le `display: none` de Bootstrap
- `resources/views/notifications/index.blade.php` — regex avec lookahead négatif pour stopper la capture avant le prochain keyword

## Root causes
**Dropdown** : `.custom-dropdown { display: flex !important }` overridait le `display: none` que Bootstrap applique aux menus fermés → tous les menus étaient toujours visibles.

**Labels** : Le regex `([^|\n]*)` capturait tout jusqu'à `|` ou newline. Comme "Référence: Numéro de reçu: REC-00007" est sur une seule ligne sans `|`, "Référence:" avalait toute la suite.

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [ ] No secrets or sensitive data committed
- [ ] PHP syntax verified (php -l) on all modified PHP files