### PR TITLE
fix(bulletins): supprimer max-width qui causait espaces blancs

### DIFF
--- a/resources/views/esbtp/bulletins/mon-bulletin.blade.php
+++ b/resources/views/esbtp/bulletins/mon-bulletin.blade.php
@@ -20,8 +20,7 @@
 
 /* ---- Layout ---- */
 .bulletins-page .main-content {
-    max-width: 860px;
-    margin: 0 auto;
+    max-width: 100%;
 }
 
 /* ---- Hero header ---- */


### PR DESCRIPTION
## Summary
- Supprime `max-width: 860px; margin: 0 auto` sur `.bulletins-page .main-content` qui centrait le contenu et laissait de grands espaces blancs sur les côtés

## Changes
- `resources/views/esbtp/bulletins/mon-bulletin.blade.php` — `max-width: 100%` au lieu de `860px`

## Type of change
- [x] fix — bug fix

## Checklist
- [x] No secrets or sensitive data committed