### PR TITLE
fix(etudiants): corriger tabs et eager loading classe dans fiche étudiant

### DIFF
--- a/app/Http/Controllers/ESBTPEtudiantController.php
+++ b/app/Http/Controllers/ESBTPEtudiantController.php
@@ -401,7 +401,8 @@ class ESBTPEtudiantController extends Controller
                 $q->with('etudiants'); // Pour afficher les autres étudiants du même parent
             },
             'inscriptions' => function($q) {
-                $q->with(['filiere', 'niveauEtude', 'classe', 'anneeUniversitaire', 'paiements'])
+                $q->with(['filiere', 'niveauEtude', 'anneeUniversitaire', 'paiements',
+                          'classe' => fn($cq) => $cq->with(['filiere', 'niveauEtude'])])
                   ->orderBy('created_at', 'desc');
             },
             'paiements' => function($q) {

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -1313,7 +1313,7 @@
 </div>{{-- /fiche-page --}}
 @endsection
 
-@section('scripts')
+@push('scripts')
 <script>
 (function () {
     // Tab switching
@@ -1339,4 +1339,4 @@
     }
 })();
 </script>
-@endsection
+@endpush


### PR DESCRIPTION
## Résumé

- **Fix eager loading** : La classe était chargée sans ses sous-relations (`filiere`, `niveauEtude`), causant l'affichage de "—" pour Classe actuelle et Filière dans la fiche étudiant
- **Fix tabs** : La vue utilisait `@section('scripts')` mais le layout utilise `@stack('scripts')` — le JS des tabs n'était jamais injecté. Corrigé avec `@push`/`@endpush`

## Détail des corrections

### 1. Eager loading (`ESBTPEtudiantController.php`)
```php
// Avant
'inscriptions' => fn($q) => $q->with(['filiere', 'niveauEtude', 'classe', ...])

// Après
'inscriptions' => fn($q) => $q->with(['filiere', 'niveauEtude', ...,
    'classe' => fn($cq) => $cq->with(['filiere', 'niveauEtude'])])
```

### 2. Injection script tabs (`show.blade.php`)
```blade
{{-- Avant (ignoré par le layout) --}}
@section('scripts') ... @endsection

{{-- Après (compatible avec @stack dans app.blade.php) --}}
@push('scripts') ... @endpush
```

## Test plan
- [ ] Vérifier que Classe actuelle et Filière s'affichent correctement (plus de "—")
- [ ] Vérifier que cliquer sur les tabs Académique / Présences / Finances / Profil change bien le contenu affiché

🤖 Generated with [Claude Code](https://claude.com/claude-code)