### PR TITLE
fix(etudiants): fiche étudiant — certificat moyenne S1/S2, fix Browsershot et corrections UI

### DIFF
--- a/app/Http/Controllers/ESBTPEtudiantController.php
+++ b/app/Http/Controllers/ESBTPEtudiantController.php
@@ -1488,6 +1488,9 @@ class ESBTPEtudiantController extends Controller
             return back()->with('error', 'Aucune inscription trouvée pour cet étudiant.');
         }
 
+        // Calculer la moyenne générale pondérée (S1/S2) pour chaque inscription
+        $inscriptions = $this->attachMoyenneCalculee($inscriptions, $etudiant->id);
+
         // Récupérer les paramètres de l'école
         $settings = $this->getCertificateDisplaySettings();
 
@@ -1525,6 +1528,9 @@ class ESBTPEtudiantController extends Controller
                 return back()->with('error', 'Aucune inscription trouvée pour cet étudiant.');
             }
 
+            // Calculer la moyenne générale pondérée (S1/S2) pour chaque inscription
+            $inscriptions = $this->attachMoyenneCalculee($inscriptions, $etudiant->id);
+
             // Récupérer les paramètres de l'école
             $settings = $this->getCertificateDisplaySettings();
 
@@ -1560,8 +1566,74 @@ class ESBTPEtudiantController extends Controller
     }
 
     /**
+     * Attache la moyenne générale calculée (pondération S1/S2) à chaque inscription.
+     * Priorité : bulletin officiel > fallback ESBTPResultat avec pondération settings.
+     */
+    private function attachMoyenneCalculee($inscriptions, int $etudiantId)
+    {
+        $poidS1 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester1_weight', 1));
+        $poidS2 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester2_weight', 1));
+        if ($poidS1 + $poidS2 <= 0) { $poidS1 = 1; $poidS2 = 1; }
+
+        $calcSem = function ($resultats, $periode) {
+            $sp = 0; $sc = 0;
+            foreach ($resultats->where('periode', $periode) as $r) {
+                $c = $r->coefficient ?? 1;
+                $sp += $r->moyenne * $c;
+                $sc += $c;
+            }
+            return $sc > 0 ? $sp / $sc : null;
+        };
+
+        foreach ($inscriptions as $inscription) {
+            $anneeId = optional($inscription->anneeUniversitaire)->id;
+            $mg = null;
+
+            // 1. Bulletins officiels
+            if ($anneeId) {
+                $buls = \App\Models\ESBTPBulletin::where('etudiant_id', $etudiantId)
+                    ->where('annee_universitaire_id', $anneeId)
+                    ->where('moyenne_generale', '>', 0)
+                    ->get();
+                if ($buls->count()) {
+                    $mg = round($buls->avg('moyenne_generale'), 2);
+                }
+            }
+
+            // 2. Fallback : résultats bruts avec pondération S1/S2
+            if ($mg === null && $anneeId) {
+                $resultats = \App\Models\ESBTPResultat::where('etudiant_id', $etudiantId)
+                    ->where('annee_universitaire_id', $anneeId)
+                    ->whereNotNull('moyenne')
+                    ->get();
+
+                if ($resultats->count()) {
+                    $mS1 = $calcSem($resultats, 'semestre1');
+                    $mS2 = $calcSem($resultats, 'semestre2');
+
+                    if ($mS1 !== null && $mS2 !== null) {
+                        $mg = round(($mS1 * $poidS1 + $mS2 * $poidS2) / ($poidS1 + $poidS2), 2);
+                    } elseif ($mS1 !== null) {
+                        $mg = round($mS1, 2);
+                    } elseif ($mS2 !== null) {
+                        $mg = round($mS2, 2);
+                    } else {
+                        $sp = 0; $sc = 0;
+                        foreach ($resultats as $r) { $c = $r->coefficient ?? 1; $sp += $r->moyenne * $c; $sc += $c; }
+                        $mg = $sc > 0 ? round($sp / $sc, 2) : null;
+                    }
+                }
+            }
+
+            $inscription->moyenne_generale_calculee = $mg;
+        }
+
+        return $inscriptions;
+    }
+
+    /**
      * Récupère les configurations pour les certificats de scolarité
-     * 
+     *
      * @return array
      */
     public function getCertificatSettings()

--- a/app/Models/ESBTPBulletin.php
+++ b/app/Models/ESBTPBulletin.php
@@ -288,6 +288,9 @@ class ESBTPBulletin extends Model
 
     public function getAbsencesJustifieesAttribute()
     {
+        if (!$this->etudiant || !$this->classe_id) {
+            return 0;
+        }
         return $this->etudiant->absences()
             ->where('justified', true)
             ->whereHas('matiere', function ($query) {
@@ -300,6 +303,9 @@ class ESBTPBulletin extends Model
 
     public function getAbsencesNonJustifieesAttribute()
     {
+        if (!$this->etudiant || !$this->classe_id) {
+            return 0;
+        }
         return $this->etudiant->absences()
             ->where('justified', false)
             ->whereHas('matiere', function ($query) {

--- a/app/Services/ESBTPPDFService.php
+++ b/app/Services/ESBTPPDFService.php
@@ -492,14 +492,18 @@ class ESBTPPDFService
             return $pdf;
         }
 
+        // Browsershot::margins() attend des float (ex: 10.0), pas des strings (ex: '10mm')
+        // On extrait la valeur numérique en supprimant toute unité CSS éventuelle
+        $toFloat = fn($v) => (float) preg_replace('/[^0-9.]/', '', (string) $v);
+
         return \Spatie\Browsershot\Browsershot::html($html)
             ->format($options['format'])
             ->landscape($options['landscape'])
             ->margins(
-                $options['margin']['top'],
-                $options['margin']['right'],
-                $options['margin']['bottom'],
-                $options['margin']['left']
+                $toFloat($options['margin']['top']),
+                $toFloat($options['margin']['right']),
+                $toFloat($options['margin']['bottom']),
+                $toFloat($options['margin']['left'])
             )
             ->waitUntilNetworkIdle()
             ->pdf();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,7 +6,6 @@ use Illuminate\Database\Seeder;
 use Spatie\Permission\Models\Role;
 use Spatie\Permission\Models\Permission;
 use App\Models\ESBTPDepartment;
-use App\Models\ESBTPCategorieDepense;
 
 class DatabaseSeeder extends Seeder
 {
@@ -41,9 +40,6 @@ class DatabaseSeeder extends Seeder
         //     ESBTPBulletinSeeder::class,
         //     ESBTPBulletinDetailsSeeder::class,   // Migration des données bulletin vers le nouveau format
         // ]);
-
-        // Add the expense categories directly
-        $this->createBasicExpenseCategories();
 
         // Add test users with different roles (only if seeders exist)
         if (app()->environment('local', 'development', 'testing')) {
@@ -83,21 +79,6 @@ class DatabaseSeeder extends Seeder
         // Assigner toutes les permissions au superAdmin
         $superAdmin->syncPermissions($permissions);
         $admin->givePermissionTo(['manage_students', 'manage_classes', 'view_dashboard']);
-    }
-    
-    private function createBasicExpenseCategories(): void
-    {
-        $this->command->info('💰 Création des catégories de dépenses...');
-        
-        $categories = [
-            ['nom' => 'Frais de scolarité', 'code' => 'SCOLARITE', 'description' => 'Frais de scolarité annuels'],
-            ['nom' => 'Frais d\'inscription', 'code' => 'INSCRIPTION', 'description' => 'Frais d\'inscription annuels'],
-            ['nom' => 'Frais d\'examen', 'code' => 'EXAMEN', 'description' => 'Frais liés aux examens'],
-        ];
-        
-        foreach ($categories as $category) {
-            ESBTPCategorieDepense::firstOrCreate(['nom' => $category['nom']], $category);
-        }
     }
     
     private function createBasicDepartments(): void

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -224,7 +224,7 @@
                         @if($showClasse)<td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>@endif
                         @if($showNiveau)<td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>@endif
                         @if($showFiliere)<td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>@endif
-                        <td>{{ $inscription->moyenne_generale ? number_format($inscription->moyenne_generale, 2) : '—' }}</td>
+                        <td>{{ $inscription->moyenne_generale_calculee !== null ? number_format($inscription->moyenne_generale_calculee, 2) : '—' }}</td>
                     </tr>
                     @empty
                     <tr><td colspan="{{ $colCount }}">Aucune inscription trouvée</td></tr>

--- a/resources/views/esbtp/etudiants/certificat.blade.php
+++ b/resources/views/esbtp/etudiants/certificat.blade.php
@@ -327,9 +327,7 @@
                         @if($showNiveau)<td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>@endif
                         @if($showFiliere)<td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>@endif
                         <td>
-                            @if($inscription->moyenne_generale)
-                                {{ number_format($inscription->moyenne_generale, 2) }}
-                            @endif
+                            {{ $inscription->moyenne_generale_calculee !== null ? number_format($inscription->moyenne_generale_calculee, 2) : '—' }}
                         </td>
                     </tr>
                     @empty

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -1553,13 +1553,35 @@
                 : collect();
 
             if ($kpiResultats->count()) {
-                $kpiSp = 0; $kpiSc = 0;
-                foreach ($kpiResultats as $kr) {
-                    $c = $kr->coefficient ?? 1;
-                    $kpiSp += $kr->moyenne * $c;
-                    $kpiSc += $c;
+                // Pondération S1/S2 depuis les settings (même logique que les bulletins)
+                $_kpiPoidS1 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester1_weight', 1));
+                $_kpiPoidS2 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester2_weight', 1));
+                if ($_kpiPoidS1 + $_kpiPoidS2 <= 0) { $_kpiPoidS1 = 1; $_kpiPoidS2 = 1; }
+
+                $_kpiCalcSem = function($group) {
+                    $sp = 0; $sc = 0;
+                    foreach ($group as $_r) {
+                        $c = $_r->coefficient ?? 1;
+                        $sp += $_r->moyenne * $c;
+                        $sc += $c;
+                    }
+                    return $sc > 0 ? $sp / $sc : null;
+                };
+
+                $_kpiS1 = $_kpiCalcSem($kpiResultats->where('periode', 'semestre1'));
+                $_kpiS2 = $_kpiCalcSem($kpiResultats->where('periode', 'semestre2'));
+
+                if ($_kpiS1 !== null && $_kpiS2 !== null) {
+                    $_kpiTot = $_kpiPoidS1 + $_kpiPoidS2;
+                    $kpiMoyenneGen = round(($_kpiS1 * $_kpiPoidS1 + $_kpiS2 * $_kpiPoidS2) / $_kpiTot, 2);
+                } elseif ($_kpiS1 !== null) {
+                    $kpiMoyenneGen = round($_kpiS1, 2);
+                } elseif ($_kpiS2 !== null) {
+                    $kpiMoyenneGen = round($_kpiS2, 2);
+                } else {
+                    // Fallback toutes périodes confondues si periode non renseignée
+                    $kpiMoyenneGen = $_kpiCalcSem($kpiResultats) !== null ? round($_kpiCalcSem($kpiResultats), 2) : null;
                 }
-                $kpiMoyenneGen    = $kpiSc > 0 ? round($kpiSp / $kpiSc, 2) : null;
                 $kpiMoyenneIsLive = true; // Signaler que c'est provisoire
             }
         }
@@ -1873,17 +1895,33 @@
         $acadMg      = $acadMgFromBul ? round($acadMgFromBul, 2) : null;
         $acadRang    = $acadLastBul->rang;
         $acadMention = $acadLastBul->mention;
-        /* Si bulletins ont moyenne_generale=0/null, fallback aux résultats bruts */
+        /* Si bulletins ont moyenne_generale=0/null, fallback aux résultats bruts avec pondération S1/S2 */
         if ($acadMg === null) {
             $acadAllNotesForKpi = $acadResultatsRef->whereNotNull('moyenne');
             if ($acadAllNotesForKpi->count()) {
-                $sommePoints = 0; $sommeCoeffs = 0;
-                foreach ($acadAllNotesForKpi as $_r) {
-                    $coef = $_r->coefficient ?? 1;
-                    $sommePoints += $_r->moyenne * $coef;
-                    $sommeCoeffs += $coef;
+                $_fbPoidS1 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester1_weight', 1));
+                $_fbPoidS2 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester2_weight', 1));
+                if ($_fbPoidS1 + $_fbPoidS2 <= 0) { $_fbPoidS1 = 1; $_fbPoidS2 = 1; }
+
+                $_fbCalcSem = function($group) {
+                    $sp = 0; $sc = 0;
+                    foreach ($group as $_r) { $c = $_r->coefficient ?? 1; $sp += $_r->moyenne * $c; $sc += $c; }
+                    return $sc > 0 ? $sp / $sc : null;
+                };
+
+                $_fbS1 = $_fbCalcSem($acadAllNotesForKpi->where('periode', 'semestre1'));
+                $_fbS2 = $_fbCalcSem($acadAllNotesForKpi->where('periode', 'semestre2'));
+
+                if ($_fbS1 !== null && $_fbS2 !== null) {
+                    $_fbTot = $_fbPoidS1 + $_fbPoidS2;
+                    $acadMg = round(($_fbS1 * $_fbPoidS1 + $_fbS2 * $_fbPoidS2) / $_fbTot, 2);
+                } elseif ($_fbS1 !== null) {
+                    $acadMg = round($_fbS1, 2);
+                } elseif ($_fbS2 !== null) {
+                    $acadMg = round($_fbS2, 2);
+                } else {
+                    $acadMg = $_fbCalcSem($acadAllNotesForKpi) !== null ? round($_fbCalcSem($acadAllNotesForKpi), 2) : null;
                 }
-                $acadMg = $sommeCoeffs > 0 ? round($sommePoints / $sommeCoeffs, 2) : null;
             }
             if (!$acadMention && $acadMg !== null) {
                 $acadMention = match(true) {
@@ -1896,16 +1934,39 @@
             }
         }
     } else {
-        /* Cas sans bulletins : calculer moyenne pondérée depuis ESBTPResultat */
+        /* Cas sans bulletins : calculer moyenne pondérée depuis ESBTPResultat avec pondération S1/S2 */
         $acadAllNotesForKpi = $acadResultatsRef->whereNotNull('moyenne');
         if ($acadAllNotesForKpi->count()) {
-            $sommePoints = 0; $sommeCoeffs = 0;
-            foreach ($acadAllNotesForKpi as $_r) {
-                $coef = $_r->coefficient ?? 1;
-                $sommePoints += $_r->moyenne * $coef;
-                $sommeCoeffs += $coef;
+            // Pondération S1/S2 depuis les settings (même logique que les bulletins)
+            $_acadPoidS1 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester1_weight', 1));
+            $_acadPoidS2 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester2_weight', 1));
+            if ($_acadPoidS1 + $_acadPoidS2 <= 0) { $_acadPoidS1 = 1; $_acadPoidS2 = 1; }
+
+            $_acadCalcSem = function($group) {
+                $sp = 0; $sc = 0;
+                foreach ($group as $_r) {
+                    $c = $_r->coefficient ?? 1;
+                    $sp += $_r->moyenne * $c;
+                    $sc += $c;
+                }
+                return $sc > 0 ? $sp / $sc : null;
+            };
+
+            $_acadS1 = $_acadCalcSem($acadAllNotesForKpi->where('periode', 'semestre1'));
+            $_acadS2 = $_acadCalcSem($acadAllNotesForKpi->where('periode', 'semestre2'));
+
+            if ($_acadS1 !== null && $_acadS2 !== null) {
+                $_acadTot = $_acadPoidS1 + $_acadPoidS2;
+                $acadMg = round(($_acadS1 * $_acadPoidS1 + $_acadS2 * $_acadPoidS2) / $_acadTot, 2);
+            } elseif ($_acadS1 !== null) {
+                $acadMg = round($_acadS1, 2);
+            } elseif ($_acadS2 !== null) {
+                $acadMg = round($_acadS2, 2);
+            } else {
+                // Fallback toutes périodes confondues si periode non renseignée
+                $acadMg = $_acadCalcSem($acadAllNotesForKpi) !== null ? round($_acadCalcSem($acadAllNotesForKpi), 2) : null;
             }
-            $acadMg = $sommeCoeffs > 0 ? round($sommePoints / $sommeCoeffs, 2) : null;
+
             /* Mention calculée depuis la moyenne */
             $acadMention = match(true) {
                 $acadMg === null => null,
@@ -1918,7 +1979,66 @@
         } else {
             $acadMg = null; $acadMention = null;
         }
-        $acadRang = null; /* Rang non calculable sans bulletin officiel */
+
+        /* Classement : calculer le rang parmi les co-inscrits de la même classe/année */
+        $acadRang = null;
+        if ($acadMg !== null && $acadRef) {
+            // Récupérer tous les étudiants inscrits dans la même classe la même année
+            $_classeId = $acadRef->classe_id;
+            $_anneeId  = $acadRef->annee_universitaire_id;
+
+            if ($_classeId && $_anneeId) {
+                // Co-inscrits (même classe, même année, actifs, sauf cet étudiant)
+                $_coInscrits = \App\Models\ESBTPInscription::where('classe_id', $_classeId)
+                    ->where('annee_universitaire_id', $_anneeId)
+                    ->pluck('etudiant_id')
+                    ->unique();
+
+                if ($_coInscrits->count() > 1) {
+                    // Calculer la moyenne pondérée de chaque co-inscrit avec la même formule
+                    $_moyennes = [];
+                    $_resultatsClasse = \App\Models\ESBTPResultat::whereIn('etudiant_id', $_coInscrits)
+                        ->where('annee_universitaire_id', $_anneeId)
+                        ->whereNotNull('moyenne')
+                        ->get()
+                        ->groupBy('etudiant_id');
+
+                    foreach ($_coInscrits as $_eid) {
+                        $_rows = $_resultatsClasse->get($_eid, collect());
+                        if ($_rows->isEmpty()) continue;
+
+                        $_s1 = $_acadCalcSem($_rows->where('periode', 'semestre1'));
+                        $_s2 = $_acadCalcSem($_rows->where('periode', 'semestre2'));
+
+                        if ($_s1 !== null && $_s2 !== null) {
+                            $_tot = $_acadPoidS1 + $_acadPoidS2;
+                            $_moy = ($_s1 * $_acadPoidS1 + $_s2 * $_acadPoidS2) / $_tot;
+                        } elseif ($_s1 !== null) {
+                            $_moy = $_s1;
+                        } elseif ($_s2 !== null) {
+                            $_moy = $_s2;
+                        } else {
+                            $_moy = $_acadCalcSem($_rows);
+                        }
+
+                        if ($_moy !== null) {
+                            $_moyennes[$_eid] = $_moy;
+                        }
+                    }
+
+                    // Trier par moyenne décroissante et trouver la position de cet étudiant
+                    arsort($_moyennes);
+                    $_rang = 1;
+                    foreach ($_moyennes as $_eid => $_moy) {
+                        if ($_eid == $etudiant->id) {
+                            $acadRang = $_rang . '/' . count($_moyennes);
+                            break;
+                        }
+                        $_rang++;
+                    }
+                }
+            }
+        }
     }
 
     $acadAnnee  = optional($acadRef?->anneeUniversitaire)->name ?? '—';
@@ -2349,13 +2469,28 @@
         if ($autreBulsValides->count()) {
             $autreMg = round($autreBulsValides->avg('moyenne_generale'), 2);
         } elseif ($autreResultatsBruts->whereNotNull('moyenne')->count()) {
-            $_sp = 0; $_sc = 0;
-            foreach ($autreResultatsBruts->whereNotNull('moyenne') as $_ar) {
-                $_coef = $_ar->coefficient ?? $_ar->matiere?->coefficient ?? 1;
-                $_sp += $_ar->moyenne * $_coef;
-                $_sc += $_coef;
+            /* Pondération S1/S2 depuis settings (cohérence avec bulletins) */
+            $_aPoidS1 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester1_weight', 1));
+            $_aPoidS2 = max(0, (float) \App\Helpers\SettingsHelper::get('bulletin_semester2_weight', 1));
+            if ($_aPoidS1 + $_aPoidS2 <= 0) { $_aPoidS1 = 1; $_aPoidS2 = 1; }
+
+            $_aCalcSem = function($group) {
+                $_sp = 0; $_sc = 0;
+                foreach ($group as $_r) { $_c = $_r->coefficient ?? $_r->matiere?->coefficient ?? 1; $_sp += $_r->moyenne * $_c; $_sc += $_c; }
+                return $_sc > 0 ? $_sp / $_sc : null;
+            };
+            $_aS1 = $_aCalcSem($autreResultatsBruts->whereNotNull('moyenne')->where('periode', 'semestre1'));
+            $_aS2 = $_aCalcSem($autreResultatsBruts->whereNotNull('moyenne')->where('periode', 'semestre2'));
+
+            if ($_aS1 !== null && $_aS2 !== null) {
+                $autreMg = round(($_aS1 * $_aPoidS1 + $_aS2 * $_aPoidS2) / ($_aPoidS1 + $_aPoidS2), 2);
+            } elseif ($_aS1 !== null) {
+                $autreMg = round($_aS1, 2);
+            } elseif ($_aS2 !== null) {
+                $autreMg = round($_aS2, 2);
+            } else {
+                $autreMg = ($_r2 = $_aCalcSem($autreResultatsBruts->whereNotNull('moyenne'))) !== null ? round($_r2, 2) : null;
             }
-            $autreMg = $_sc > 0 ? round($_sp / $_sc, 2) : null;
         } else {
             $autreMg = null;
         }
@@ -2433,7 +2568,12 @@
                             @if($abMg !== null)
                                 <span style="font-size:.8rem; font-weight:700; color:{{ $abMgCls }};">{{ number_format($abMg, 2) }}/20</span>
                             @endif
-                            <a href="{{ route('esbtp.bulletins.download', $ab) }}" class="acad-arch-pdf-link" target="_blank">
+                            @php
+                                $_abClasseId = $autreInsc->classe_id;
+                                $_abAnneeId = optional($autreInsc->anneeUniversitaire)->id;
+                            @endphp
+                            <a href="{{ route('esbtp.bulletins.pdf-params', ['bulletin' => $ab->id, 'classe_id' => $_abClasseId, 'periode' => $ab->periode, 'annee_universitaire_id' => $_abAnneeId]) }}"
+                               class="acad-arch-pdf-link" target="_blank" title="Télécharger le bulletin PDF">
                                 <i class="fas fa-file-pdf"></i> PDF
                             </a>
                         </div>

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -36,7 +36,7 @@
     position: relative;
     background: linear-gradient(135deg, var(--k-blue) 0%, var(--k-blue-2) 100%);
     padding: 0 0 0;
-    overflow: hidden;
+    /* overflow: hidden retiré — coupait le dropdown Bootstrap */
 }
 /* SVG dot-pattern texture */
 .fiche-hero::before {
@@ -44,6 +44,8 @@
     position: absolute; inset: 0;
     background-image: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='12' cy='12' r='1.5' fill='rgba(255,255,255,0.12)'/%3E%3C/svg%3E");
     pointer-events: none;
+    overflow: hidden;
+    border-radius: inherit;
 }
 /* glass strip bottom */
 .fiche-hero::after {
@@ -53,7 +55,7 @@
 }
 
 .hero-inner {
-    position: relative; z-index: 1;
+    position: relative; z-index: 200; /* au-dessus de .fiche-tabs-wrap (z-index:100) pour que le dropdown ne soit pas masqué */
     max-width: 1280px; margin: 0 auto;
     padding: 32px 32px 28px;
     display: flex; align-items: center; gap: 24px; flex-wrap: wrap;
@@ -1248,10 +1250,17 @@
 {{-- ════════════════════════════════════════════════════════════════
      HERO
 ════════════════════════════════════════════════════════════════ --}}
+@php
+    $anneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
+    $inscCourante = $anneeCourante
+        ? $etudiant->inscriptions->first(fn($i) => $i->annee_universitaire_id === $anneeCourante->id)
+        : null;
+    // Vrai "actif" = statut actif ET inscrit pour l'année courante
+    $estInscritCetteAnnee = $inscCourante !== null;
+@endphp
 <div class="fiche-hero">
     <div class="hero-inner">
         {{-- Avatar avec badge statut --}}
-        @php $inscA = $etudiant->inscriptions->firstWhere('status', 'active') ?? $etudiant->inscriptions->first(); @endphp
         <div class="hero-avatar-wrap">
             <div class="hero-avatar">
                 @if($etudiant->photo)
@@ -1262,28 +1271,35 @@
                     {{ strtoupper(substr($etudiant->prenoms ?? 'E', 0, 1)) }}{{ strtoupper(substr($etudiant->nom, 0, 1)) }}
                 @endif
             </div>
-            <span class="hero-avatar-status {{ $etudiant->statut ?? 'inactif' }}" title="{{ ucfirst($etudiant->statut ?? 'inconnu') }}"></span>
+            {{-- Badge rond : vert seulement si inscrit cette année, sinon gris --}}
+            <span class="hero-avatar-status {{ $estInscritCetteAnnee ? 'actif' : 'inactif' }}"
+                  title="{{ $estInscritCetteAnnee ? 'Inscrit ' . ($anneeCourante->name ?? '') : 'Non inscrit pour l\'année en cours' }}"></span>
         </div>
 
         {{-- Text --}}
         <div class="hero-text">
             <h1 class="hero-name">{{ strtoupper($etudiant->nom) }} {{ $etudiant->prenoms }}</h1>
             <p class="hero-sub">
-                @if($inscA && $inscA->classe)
-                    {{ $inscA->classe->name }}
-                    @if($inscA->classe->filiere) · {{ $inscA->classe->filiere->name }} @endif
-                    @if($inscA->classe->niveau) · {{ $inscA->classe->niveau->name ?? $inscA->classe->niveau->nom ?? '' }} @endif
+                @if($inscCourante && $inscCourante->classe)
+                    {{ $inscCourante->classe->name }}
+                    @if($inscCourante->classe->filiere) · {{ $inscCourante->classe->filiere->name }} @endif
+                    @if($inscCourante->classe->niveau) · {{ $inscCourante->classe->niveau->name ?? $inscCourante->classe->niveau->nom ?? '' }} @endif
+                @elseif($anneeCourante)
+                    <span style="color:rgba(255,255,255,0.75); font-style:italic;">Non réinscrit pour {{ $anneeCourante->name }}</span>
                 @else
                     Étudiant
                 @endif
             </p>
             <div class="hero-pills">
                 <span class="hero-pill"><i class="fas fa-id-card"></i> {{ $etudiant->matricule ?? 'Non attribué' }}</span>
-                @if($etudiant->statut === 'actif')
-                    <span class="hero-pill green"><i class="fas fa-circle" style="font-size:.45rem"></i> Actif</span>
-                @elseif($etudiant->statut === 'inactif')
-                    <span class="hero-pill"><i class="fas fa-circle" style="font-size:.45rem"></i> Inactif</span>
-                @elseif($etudiant->statut === 'abandon')
+                @if($estInscritCetteAnnee)
+                    <span class="hero-pill green"><i class="fas fa-circle" style="font-size:.45rem"></i> Inscrit {{ $anneeCourante->name ?? '' }}</span>
+                @else
+                    <span class="hero-pill" style="background:rgba(255,255,255,0.15); color:#fff; border-color:rgba(255,255,255,0.4);">
+                        <i class="fas fa-exclamation-circle" style="font-size:.7rem; color:#fbbf24;"></i> Non réinscrit {{ $anneeCourante ? $anneeCourante->name : '' }}
+                    </span>
+                @endif
+                @if($etudiant->statut === 'abandon')
                     <span class="hero-pill red"><i class="fas fa-circle" style="font-size:.45rem"></i> Abandon</span>
                 @endif
                 @if($etudiant->nationalite)
@@ -1293,12 +1309,6 @@
         </div>
 
         {{-- Actions --}}
-        @php
-            $anneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
-            $inscCourante = $anneeCourante
-                ? $etudiant->inscriptions->first(fn($i) => $i->annee_universitaire_id === $anneeCourante->id)
-                : null;
-        @endphp
         <div class="hero-actions">
             @if($anneeCourante)
                 <span class="hero-pill year"><i class="fas fa-calendar-alt"></i> {{ $anneeCourante->name }}</span>
@@ -1309,6 +1319,58 @@
                     <i class="fas fa-edit"></i> <span class="d-none d-sm-inline">Modifier</span>
                 </a>
                 @endcan
+
+                {{-- Dropdown Documents — visible dès qu'il y a au moins une inscription --}}
+                @if($etudiant->inscriptions->isNotEmpty())
+                <div class="dropdown">
+                    <button class="hero-btn ghost dropdown-toggle" type="button"
+                            data-bs-toggle="dropdown" aria-expanded="false"
+                            style="gap:6px;">
+                        <i class="fas fa-file-alt"></i>
+                        <span class="d-none d-sm-inline">Documents</span>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end" style="min-width:230px;">
+                        <li><h6 class="dropdown-header" style="font-size:.72rem; letter-spacing:.04em;">CERTIFICAT DE SCOLARITÉ</h6></li>
+                        <li>
+                            <a class="dropdown-item" href="{{ route('esbtp.etudiants.certificat.preview', $etudiant) }}" target="_blank">
+                                <i class="fas fa-eye fa-fw me-2 text-muted"></i>Prévisualiser
+                            </a>
+                        </li>
+                        <li>
+                            <a class="dropdown-item" href="{{ route('esbtp.etudiants.certificat', $etudiant) }}" target="_blank">
+                                <i class="fas fa-download fa-fw me-2 text-muted"></i>Télécharger PDF
+                            </a>
+                        </li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li><h6 class="dropdown-header" style="font-size:.72rem; letter-spacing:.04em;">ATTESTATION DE FRÉQUENTATION</h6></li>
+                        <li>
+                            @if($estInscritCetteAnnee)
+                            <a class="dropdown-item" href="{{ route('esbtp.etudiants.attestation-frequentation.preview', $etudiant) }}" target="_blank">
+                                <i class="fas fa-eye fa-fw me-2 text-muted"></i>Prévisualiser
+                            </a>
+                            @else
+                            <a class="dropdown-item" href="#"
+                               onclick="openAttestationConfirm(event, '{{ route('esbtp.etudiants.attestation-frequentation.preview', $etudiant) }}')">
+                                <i class="fas fa-eye fa-fw me-2 text-muted"></i>Prévisualiser
+                            </a>
+                            @endif
+                        </li>
+                        <li>
+                            @if($estInscritCetteAnnee)
+                            <a class="dropdown-item" href="{{ route('esbtp.etudiants.attestation-frequentation', $etudiant) }}" target="_blank">
+                                <i class="fas fa-download fa-fw me-2 text-muted"></i>Télécharger PDF
+                            </a>
+                            @else
+                            <a class="dropdown-item" href="#"
+                               onclick="openAttestationConfirm(event, '{{ route('esbtp.etudiants.attestation-frequentation', $etudiant) }}')">
+                                <i class="fas fa-download fa-fw me-2 text-muted"></i>Télécharger PDF
+                            </a>
+                            @endif
+                        </li>
+                    </ul>
+                </div>
+                @endif
+
                 <a href="{{ route('esbtp.etudiants.index') }}" class="hero-btn ghost">
                     <i class="fas fa-arrow-left"></i> <span class="d-none d-sm-inline">Retour</span>
                 </a>
@@ -1327,15 +1389,17 @@
 
     {{-- KPI Strip --}}
     @php
-        $totalPaiements  = $etudiant->inscriptions->sum(fn($i) => $i->paiements->where('status','validé')->sum('montant'));
-        $totalAbsences   = $etudiant->absences->count();
+        // KPI Hero : uniquement l'année courante — si pas inscrit, tout à zéro/nul
+        $totalPaiements  = $inscCourante
+            ? $inscCourante->paiements->where('status','validé')->sum('montant')
+            : null; // null = non inscrit cette année
+        $totalAbsences   = null; // calculé après $tauxPresence (dépend de $inscCourante)
         $nbInscriptions  = $etudiant->inscriptions->count();
 
-        // taux presence depuis les absences de l'étudiant
+        // taux presence depuis les absences de l'étudiant (année courante uniquement)
         $tauxPresence = null;
-        $inscActive = $etudiant->inscriptions->firstWhere('status', 'active') ?? $etudiant->inscriptions->first();
-        if ($inscActive && $inscActive->anneeUniversitaire) {
-            $anneeId = $inscActive->anneeUniversitaire->id;
+        if ($inscCourante && $inscCourante->anneeUniversitaire) {
+            $anneeId = $inscCourante->anneeUniversitaire->id;
             $attStats = \App\Models\ESBTPAttendance::finalOnly()
                 ->where('etudiant_id', $etudiant->id)
                 ->where('annee_universitaire_id', $anneeId)
@@ -1344,6 +1408,15 @@
             if ($attStats && $attStats->total > 0) {
                 $tauxPresence = round((($attStats->nb_pres + $attStats->nb_ret) / $attStats->total) * 100, 1);
             }
+        }
+
+        // Absences de l'année courante uniquement
+        if ($inscCourante && $inscCourante->anneeUniversitaire) {
+            $totalAbsences = \App\Models\ESBTPAttendance::finalOnly()
+                ->where('etudiant_id', $etudiant->id)
+                ->where('annee_universitaire_id', $inscCourante->anneeUniversitaire->id)
+                ->where('statut', 'absent')
+                ->count();
         }
     @endphp
     <div class="hero-kpi-strip">
@@ -1364,14 +1437,14 @@
         <div class="hero-kpi">
             <i class="fas fa-user-times hero-kpi-icon"></i>
             <div>
-                <div class="hero-kpi-val">{{ $totalAbsences }}</div>
+                <div class="hero-kpi-val">{{ $totalAbsences !== null ? $totalAbsences : '—' }}</div>
                 <div class="hero-kpi-lbl">Absences</div>
             </div>
         </div>
         <div class="hero-kpi">
             <i class="fas fa-coins hero-kpi-icon"></i>
             <div>
-                <div class="hero-kpi-val">{{ number_format($totalPaiements, 0, ',', ' ') }}</div>
+                <div class="hero-kpi-val">{{ $totalPaiements !== null ? number_format($totalPaiements, 0, ',', ' ') : '—' }}</div>
                 <div class="hero-kpi-lbl">Payé (FCFA)</div>
             </div>
         </div>
@@ -1409,31 +1482,53 @@
 {{-- ─── TAB: VUE D'ENSEMBLE ─────────────────────────────────────── --}}
 <div class="tab-panel active" id="tab-overview">
 
+    {{-- Bannière : étudiant non inscrit pour l'année courante --}}
+    @if($anneeCourante && !$inscCourante)
+    <div style="
+        background: linear-gradient(135deg, #fff3cd 0%, #ffeeba 100%);
+        border: 1.5px solid #ffc107;
+        border-left: 5px solid #e65100;
+        border-radius: 10px;
+        padding: 16px 20px;
+        margin-bottom: 24px;
+        display: flex;
+        align-items: flex-start;
+        gap: 14px;
+    ">
+        <div style="flex-shrink:0; width:36px; height:36px; background:#e65100; border-radius:50%; display:flex; align-items:center; justify-content:center;">
+            <i class="fas fa-exclamation-triangle" style="color:#fff; font-size:.9rem;"></i>
+        </div>
+        <div>
+            <div style="font-weight:700; color:#b45309; font-size:.95rem; margin-bottom:4px;">
+                Cet étudiant n'est pas réinscrit pour l'année {{ $anneeCourante->name }}
+            </div>
+            <div style="color:#92400e; font-size:.85rem; line-height:1.5;">
+                Les indicateurs ci-dessous ne sont pas disponibles pour l'année en cours.
+                Pour afficher les données académiques, financières et de présence, veuillez d'abord réinscrire cet étudiant.
+            </div>
+            <a href="{{ route('esbtp.reinscription.show', $etudiant) }}"
+               style="display:inline-flex; align-items:center; gap:6px; margin-top:10px; padding:6px 14px; background:#e65100; color:#fff; border-radius:6px; font-size:.82rem; font-weight:600; text-decoration:none;">
+                <i class="fas fa-redo"></i> Réinscrire pour {{ $anneeCourante->name }}
+            </a>
+        </div>
+    </div>
+    @endif
+
     {{-- KPI Cards --}}
     @php
-        // Calcul KPI globaux depuis les vraies variables
+        // Calcul KPI globaux : uniquement depuis l'inscription courante
         $kpiMoyenneGen     = null;
-        $kpiMoyenneIsLive  = false; // true = depuis résultats bruts (bulletin non généré)
-        $kpiTauxPres       = $tauxPresence;
-        $kpiAbsTotal       = $etudiant->absences->count();
+        $kpiMoyenneIsLive  = false;
+        $kpiTauxPres       = $tauxPresence; // déjà filtré par $inscCourante
+        // Absences : uniquement année courante
+        $kpiAbsTotal       = $totalAbsences; // null si pas inscrit cette année
 
-        // Inscription de référence : prioriser is_current=true, sinon active, sinon la plus récente
-        $anneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
-        $kpiInscActive = null;
-        if ($anneeCourante) {
-            $kpiInscActive = $etudiant->inscriptions
-                ->where('annee_universitaire_id', $anneeCourante->id)
-                ->first();
-        }
-        if (!$kpiInscActive) {
-            $kpiInscActive = $inscription_active
-                ?? $etudiant->inscriptions->where('status', 'active')->first()
-                ?? $etudiant->inscriptions->sortByDesc('created_at')->first();
-        }
+        // Inscription de référence : année courante uniquement
+        $kpiInscActive = $inscCourante ?? null;
 
         $kpiPaiTotal = $kpiInscActive
             ? $kpiInscActive->paiements->where('status', 'validé')->sum('montant')
-            : 0;
+            : null; // null = pas inscrit cette année
         $kpiPaiDu = 0;
 
         // Moyenne : 1) chercher bulletins officiels de l'inscription de référence
@@ -1472,7 +1567,11 @@
 
     <div class="kpi-grid">
         {{-- Moyenne --}}
-        @php $m = $kpiMoyenneGen; $mc = $m >= 12 ? '#10b981' : ($m >= 10 ? '#f59e0b' : '#ef4444'); $mpct = min(100, ($m/20)*100); @endphp
+        @php
+            $m    = $kpiMoyenneGen;
+            $mc   = $m !== null ? ($m >= 12 ? '#10b981' : ($m >= 10 ? '#f59e0b' : '#ef4444')) : '#94a3b8';
+            $mpct = $m !== null ? min(100, ($m/20)*100) : 0;
+        @endphp
         <div class="kpi-card">
             <div class="kpi-ring">
                 <svg viewBox="0 0 52 52">
@@ -1485,7 +1584,9 @@
                 <span class="ring-icon" style="color:{{ $mc }}"><i class="fas fa-star" style="font-size:.75rem"></i></span>
             </div>
             <div class="kpi-body">
-                <div class="kpi-val" style="color:{{ $mc }}">{{ $m !== null ? number_format($m,2) : '—' }}<small style="font-size:.6em;font-weight:500">/20</small></div>
+                <div class="kpi-val" style="color:{{ $mc }}">
+                    {{ $m !== null ? number_format($m,2) : '—' }}<small style="font-size:.6em;font-weight:500">/20</small>
+                </div>
                 <div class="kpi-lbl">Moy. générale</div>
                 @if($kpiMoyenneIsLive && $m !== null)
                     <div style="font-size:.62rem; color:#f59e0b; margin-top:4px; display:flex; align-items:center; gap:3px; line-height:1.3;">
@@ -1496,7 +1597,10 @@
         </div>
 
         {{-- Présence --}}
-        @php $p = $kpiTauxPres; $pc = $p >= 80 ? '#10b981' : ($p >= 60 ? '#f59e0b' : '#ef4444'); @endphp
+        @php
+            $p  = $kpiTauxPres;
+            $pc = $p !== null ? ($p >= 80 ? '#10b981' : ($p >= 60 ? '#f59e0b' : '#ef4444')) : '#94a3b8';
+        @endphp
         <div class="kpi-card">
             <div class="kpi-ring">
                 <svg viewBox="0 0 52 52">
@@ -1515,7 +1619,10 @@
         </div>
 
         {{-- Absences --}}
-        @php $ac = $kpiAbsTotal > 20 ? '#ef4444' : ($kpiAbsTotal > 10 ? '#f59e0b' : '#10b981'); $apct = min(100, $kpiAbsTotal * 2); @endphp
+        @php
+            $ac   = $kpiAbsTotal !== null ? ($kpiAbsTotal > 20 ? '#ef4444' : ($kpiAbsTotal > 10 ? '#f59e0b' : '#10b981')) : '#94a3b8';
+            $apct = $kpiAbsTotal !== null ? min(100, $kpiAbsTotal * 2) : 0;
+        @endphp
         <div class="kpi-card">
             <div class="kpi-ring">
                 <svg viewBox="0 0 52 52">
@@ -1528,16 +1635,18 @@
                 <span class="ring-icon" style="color:{{ $ac }}"><i class="fas fa-calendar-times" style="font-size:.75rem"></i></span>
             </div>
             <div class="kpi-body">
-                <div class="kpi-val" style="color:{{ $ac }}">{{ $kpiAbsTotal }}</div>
+                <div class="kpi-val" style="color:{{ $ac }}">{{ $kpiAbsTotal !== null ? $kpiAbsTotal : '—' }}</div>
                 <div class="kpi-lbl">Absences totales</div>
             </div>
         </div>
 
         {{-- Paiements --}}
         @php
-            $totalDu2 = $kpiPaiTotal + $kpiPaiDu;
-            $ppct = $totalDu2 > 0 ? min(100, round($kpiPaiTotal/$totalDu2*100)) : 0;
-            $payc = $ppct >= 80 ? '#10b981' : ($ppct >= 50 ? '#f59e0b' : '#ef4444');
+            $kpiPaiTotalSafe = $kpiPaiTotal ?? 0;
+            $totalDu2 = $kpiPaiTotalSafe + ($kpiPaiDu ?? 0);
+            $ppct  = ($kpiPaiTotal !== null && $totalDu2 > 0) ? min(100, round($kpiPaiTotalSafe / $totalDu2 * 100)) : null;
+            $payc  = $ppct !== null ? ($ppct >= 80 ? '#10b981' : ($ppct >= 50 ? '#f59e0b' : '#ef4444')) : '#94a3b8';
+            $ppctVal = $ppct ?? 0;
         @endphp
         <div class="kpi-card">
             <div class="kpi-ring">
@@ -1546,12 +1655,12 @@
                     <circle class="ring-fg" cx="26" cy="26" r="22"
                         stroke="{{ $payc }}"
                         stroke-dasharray="{{ round(2*3.14159*22,1) }}"
-                        stroke-dashoffset="{{ round(2*3.14159*22 * (1 - $ppct/100),1) }}"/>
+                        stroke-dashoffset="{{ round(2*3.14159*22 * (1 - $ppctVal/100),1) }}"/>
                 </svg>
                 <span class="ring-icon" style="color:{{ $payc }}"><i class="fas fa-coins" style="font-size:.75rem"></i></span>
             </div>
             <div class="kpi-body">
-                <div class="kpi-val" style="color:{{ $payc }}">{{ $ppct }}%</div>
+                <div class="kpi-val" style="color:{{ $payc }}">{{ $ppct !== null ? $ppct . '%' : '—' }}</div>
                 <div class="kpi-lbl">Paiements réglés</div>
             </div>
         </div>
@@ -1578,11 +1687,11 @@
             </div>
             <div class="info-row">
                 <span class="info-lbl">Classe actuelle</span>
-                <span class="info-val">{{ $inscA?->classe?->name ?? '—' }}</span>
+                <span class="info-val">{{ $kpiInscActive?->classe?->name ?? '—' }}</span>
             </div>
             <div class="info-row">
                 <span class="info-lbl">Filière</span>
-                <span class="info-val">{{ $inscA?->classe?->filiere?->name ?? '—' }}</span>
+                <span class="info-val">{{ $kpiInscActive?->classe?->filiere?->name ?? '—' }}</span>
             </div>
             <div class="info-row">
                 <span class="info-lbl">Email</span>
@@ -1607,24 +1716,26 @@
         </div>
     </div>
 
-    {{-- Inscription année courante --}}
-    @if($kpiInscActive)
+    {{-- Toutes les inscriptions de l'étudiant --}}
     @php
-        $insc = $kpiInscActive;
-        $statInsc = $insc->status ?? 'pending';
-        $anneeLabel = $insc->anneeUniversitaire?->name ?? 'N/A';
-        $inscAccent = in_array($statInsc, ['active', 'actif', 'validé']) ? 'actif' : ($statInsc === 'abandon' ? 'abandon' : 'inactif');
-        $wfStep = $insc->workflow_step ?? null;
-        $affStatus = $insc->affectation_status ?? 'non_affecté';
+        $toutesInscs = $etudiant->inscriptions->sortByDesc(fn($i) => optional($i->anneeUniversitaire)->start_date ?? $i->created_at);
     @endphp
     <div class="s-card">
         <div class="s-card-header">
             <div class="s-card-title">
                 <div class="s-card-title-icon"><i class="fas fa-file-signature"></i></div>
-                Inscription en cours
+                Inscriptions
             </div>
         </div>
         <div class="insc-grid">
+        @forelse($toutesInscs as $insc)
+        @php
+            $statInsc = $insc->status ?? 'pending';
+            $anneeLabel = $insc->anneeUniversitaire?->name ?? 'N/A';
+            $inscAccent = in_array($statInsc, ['active', 'actif', 'validé']) ? 'actif' : ($statInsc === 'abandon' ? 'abandon' : 'inactif');
+            $wfStep = $insc->workflow_step ?? null;
+            $affStatus = $insc->affectation_status ?? 'non_affecté';
+        @endphp
         <div class="insc-card">
             <div class="insc-card-accent {{ $inscAccent }}"></div>
             <div class="insc-card-inner">
@@ -1700,6 +1811,9 @@
                 </div>
             </div>
         </div>
+        @empty
+        <div style="padding:24px;color:var(--k-gray);font-size:.9rem;">Aucune inscription enregistrée.</div>
+        @endforelse
         {{-- CTA Réinscription si pas encore inscrit pour l'année courante --}}
         @if($anneeCourante && !$inscCourante)
         <a href="{{ route('esbtp.reinscription.show', $etudiant) }}" class="insc-card insc-cta-card">
@@ -1716,29 +1830,6 @@
         @endif
         </div>{{-- /grid --}}
     </div>
-    @elseif($anneeCourante && !$inscCourante)
-    <div class="s-card">
-        <div class="s-card-header">
-            <div class="s-card-title">
-                <div class="s-card-title-icon"><i class="fas fa-file-signature"></i></div>
-                Inscription en cours
-            </div>
-        </div>
-        <div class="insc-grid">
-        <a href="{{ route('esbtp.reinscription.show', $etudiant) }}" class="insc-card insc-cta-card">
-            <div class="insc-card-accent inactif"></div>
-            <div class="insc-card-inner" style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:12px;text-align:center;">
-                <div class="insc-cta-icon"><i class="fas fa-plus"></i></div>
-                <div>
-                    <div class="insc-cta-title">Réinscrire pour {{ $anneeCourante->name }}</div>
-                    <div class="insc-cta-sub">Cet étudiant n'est pas encore inscrit pour l'année en cours</div>
-                </div>
-                <i class="fas fa-arrow-right" style="color:var(--k-blue); opacity:.6;"></i>
-            </div>
-        </a>
-        </div>{{-- /grid --}}
-    </div>
-    @endif
 
 </div>{{-- /tab-overview --}}
 
@@ -2223,15 +2314,18 @@
 
     @endif {{-- fin @else acadIsNotCurrentYear --}}
 
-    {{-- ══ ANNÉES PRÉCÉDENTES ══════════════════════════════════════ --}}
+    {{-- ══ AUTRES ANNÉES ══════════════════════════════════════ --}}
     @php
-        /* Si l'année courante n'a pas de données, TOUTES les inscriptions vont en "précédentes" */
-        $acadInscsPrec = $acadIsNotCurrentYear ? $acadInscs : $acadAutres;
+        /* Si l'année courante n'a pas de données, toutes les inscriptions vont ici
+           mais on exclut quand même l'inscription de l'année courante (sans données) */
+        $acadInscsPrec = $acadIsNotCurrentYear
+            ? $acadInscs->filter(fn($i) => $anneeCourante ? $i->annee_universitaire_id !== $anneeCourante->id : true)
+            : $acadAutres;
     @endphp
     @if($acadInscsPrec->count())
     <div class="acad-arch-sep">
         <div class="acad-arch-sep-line"></div>
-        <span class="acad-arch-sep-label"><i class="fas fa-history" style="margin-right:4px;"></i>Années précédentes</span>
+        <span class="acad-arch-sep-label"><i class="fas fa-history" style="margin-right:4px;"></i>Autres années</span>
         <div class="acad-arch-sep-line"></div>
     </div>
 
@@ -2543,7 +2637,7 @@
         @if($presInscCourante)
         <div style="display:flex; align-items:center; gap:10px; margin:8px 0 12px; opacity:.6;">
             <div style="flex:1; height:1px; background:var(--k-border);"></div>
-            <span style="font-size:.72rem; font-weight:600; color:var(--k-muted); white-space:nowrap; letter-spacing:.04em;"><i class="fas fa-history" style="margin-right:4px;"></i>ANNÉES PRÉCÉDENTES</span>
+            <span style="font-size:.72rem; font-weight:600; color:var(--k-muted); white-space:nowrap; letter-spacing:.04em;"><i class="fas fa-history" style="margin-right:4px;"></i>AUTRES ANNÉES</span>
             <div style="flex:1; height:1px; background:var(--k-border);"></div>
         </div>
         @endif
@@ -3001,7 +3095,7 @@
     @if($finAutresInscs->count())
     <div class="fin-autres-header">
         <i class="fas fa-archive"></i>
-        Années précédentes ({{ $finAutresInscs->count() }})
+        Autres années ({{ $finAutresInscs->count() }})
     </div>
 
     @foreach($finAutresInscs as $autreInsc)
@@ -3283,6 +3377,55 @@
 
 </div>{{-- /fiche-content --}}
 </div>{{-- /fiche-page --}}
+
+{{-- Modal confirmation attestation (étudiant non réinscrit cette année) --}}
+<div class="modal fade" id="attestationConfirmModal" tabindex="-1" aria-labelledby="attestationConfirmModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header border-0 pb-0">
+                <h5 class="modal-title d-flex align-items-center gap-2" id="attestationConfirmModalLabel">
+                    <i class="fas fa-exclamation-triangle text-warning"></i>
+                    Étudiant non réinscrit cette année
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body pt-2">
+                <p class="mb-1">
+                    Cet étudiant ne s'est pas réinscrit pour
+                    <strong>{{ $anneeCourante->name ?? "l'année en cours" }}</strong>.
+                </p>
+                <p class="text-muted" style="font-size:.9rem;">
+                    La dernière inscription disponible sera utilisée pour générer ce document.
+                    Voulez-vous continuer quand même ?
+                </p>
+            </div>
+            <div class="modal-footer border-0 pt-0">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary" id="attestationConfirmBtn">
+                    <i class="fas fa-check me-1"></i>Continuer quand même
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+(function () {
+    var _attestationUrl = null;
+    window.openAttestationConfirm = function (e, url) {
+        e.preventDefault();
+        _attestationUrl = url;
+        var modal = new bootstrap.Modal(document.getElementById('attestationConfirmModal'));
+        modal.show();
+    };
+    document.getElementById('attestationConfirmBtn').addEventListener('click', function () {
+        if (_attestationUrl) {
+            window.open(_attestationUrl, '_blank');
+        }
+        bootstrap.Modal.getInstance(document.getElementById('attestationConfirmModal')).hide();
+    });
+})();
+</script>
+
 @endsection
 
 @push('scripts')

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -55,44 +55,66 @@
 .hero-inner {
     position: relative; z-index: 1;
     max-width: 1280px; margin: 0 auto;
-    padding: 32px 32px 0;
-    display: flex; align-items: flex-end; gap: 28px; flex-wrap: wrap;
+    padding: 32px 32px 28px;
+    display: flex; align-items: center; gap: 24px; flex-wrap: wrap;
+}
+
+/* Avatar wrapper — permet le badge de statut */
+.hero-avatar-wrap {
+    position: relative; flex-shrink: 0;
 }
 
 /* Avatar */
 .hero-avatar {
-    width: 108px; height: 108px; flex-shrink: 0;
+    width: 96px; height: 96px;
     border-radius: 50%;
-    border: 4px solid rgba(255,255,255,.55);
+    border: 3px solid rgba(255,255,255,.6);
     background: rgba(255,255,255,.15);
     display: flex; align-items: center; justify-content: center;
-    font-size: 2.6rem; font-weight: 700; color: rgba(255,255,255,.9);
+    font-size: 2.2rem; font-weight: 700; color: rgba(255,255,255,.9);
     overflow: hidden;
-    box-shadow: 0 4px 24px rgba(0,0,0,.18);
+    box-shadow: 0 4px 20px rgba(0,0,0,.22);
     backdrop-filter: blur(4px);
-    margin-bottom: -20px;
 }
 .hero-avatar img { width: 100%; height: 100%; object-fit: cover; display: block; }
 
+/* Badge de statut — petit rond coloré en bas à droite de l'avatar */
+.hero-avatar-status {
+    position: absolute; bottom: 4px; right: 4px;
+    width: 18px; height: 18px; border-radius: 50%;
+    border: 3px solid rgba(4,83,203,.85);
+    box-shadow: 0 1px 4px rgba(0,0,0,.3);
+}
+.hero-avatar-status.actif    { background: #10b981; }
+.hero-avatar-status.inactif  { background: #94a3b8; }
+.hero-avatar-status.abandon  { background: #ef4444; }
+
 /* Text block */
-.hero-text { flex: 1; min-width: 200px; padding-bottom: 24px; color: #fff; }
-.hero-name { font-size: 1.75rem; font-weight: 800; letter-spacing: -.02em; margin: 0 0 4px; line-height: 1.2; }
-.hero-sub  { font-size: .9rem; opacity: .82; margin: 0 0 12px; }
-.hero-pills { display: flex; gap: 8px; flex-wrap: wrap; }
+.hero-text { flex: 1; min-width: 200px; color: #fff; }
+.hero-name { font-size: 1.65rem; font-weight: 800; letter-spacing: -.02em; margin: 0 0 3px; line-height: 1.2; }
+.hero-sub  { font-size: .88rem; opacity: .8; margin: 0 0 10px; }
+.hero-pills { display: flex; gap: 7px; flex-wrap: wrap; align-items: center; }
 .hero-pill {
     display: inline-flex; align-items: center; gap: 5px;
     background: rgba(255,255,255,.18); backdrop-filter: blur(6px);
-    border: 1px solid rgba(255,255,255,.3);
-    color: #fff; font-size: .78rem; font-weight: 600;
-    padding: 4px 12px; border-radius: 20px;
+    border: 1px solid rgba(255,255,255,.28);
+    color: #fff; font-size: .76rem; font-weight: 600;
+    padding: 3px 11px; border-radius: 20px;
     white-space: nowrap;
 }
 .hero-pill.green  { background: rgba(16,185,129,.25); border-color: rgba(16,185,129,.4); }
 .hero-pill.amber  { background: rgba(245,158,11,.25); border-color: rgba(245,158,11,.4); }
 .hero-pill.red    { background: rgba(239,68,68,.25);  border-color: rgba(239,68,68,.4); }
+/* Badge année intégré dans les pills */
+.hero-pill.year {
+    background: rgba(255,255,255,.12);
+    border-color: rgba(255,255,255,.22);
+    font-size: .74rem; letter-spacing: .02em;
+}
 
-/* Actions in hero */
-.hero-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; padding-bottom: 24px; }
+/* Actions in hero — poussées à droite */
+.hero-actions { display: flex; flex-direction: column; align-items: flex-end; gap: 6px; margin-left: auto; }
+.hero-btns { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end; }
 .hero-btn {
     display: inline-flex; align-items: center; gap: 6px;
     padding: 9px 18px; border-radius: 8px; font-size: .82rem; font-weight: 600;
@@ -234,7 +256,7 @@
 .info-val.mono { font-family: 'Courier New', monospace; font-size: .88rem; letter-spacing: .03em; }
 .info-val.empty { color: var(--k-muted); font-weight: 400; font-style: italic; }
 
-/* ── Semestre cards ──────────────────────────────────────────────── */
+/* ── Semestre cards (legacy, kept for other tabs) ────────────────── */
 .semestre-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
 .sem-card {
     background: var(--k-card); border: 1px solid var(--k-border);
@@ -264,6 +286,279 @@
 .mat-note.mid    { color: #d97706; }
 .mat-note.bad    { color: var(--k-danger); }
 
+/* ═══════════════════════════════════════════════════════════════════
+   TAB ACADÉMIQUE — PREMIUM REDESIGN
+═══════════════════════════════════════════════════════════════════ */
+
+/* ── Hero bilan ──────────────────────────────────────────────────── */
+.acad-hero {
+    background: linear-gradient(150deg, #0d1b3e 0%, #0a2461 45%, #0453cb 100%);
+    border-radius: var(--k-radius-lg);
+    padding: 28px 28px 0;
+    margin-bottom: 20px;
+    position: relative;
+    overflow: hidden;
+}
+.acad-hero::before {
+    content: '';
+    position: absolute; inset: 0;
+    background-image: radial-gradient(circle at 15% 50%, rgba(94,145,222,.18) 0%, transparent 55%),
+                      radial-gradient(circle at 85% 20%, rgba(255,255,255,.05) 0%, transparent 40%);
+    pointer-events: none;
+}
+.acad-hero-top {
+    display: flex; align-items: center; justify-content: space-between;
+    flex-wrap: wrap; gap: 8px;
+    margin-bottom: 24px; position: relative; z-index: 1;
+}
+.acad-hero-label {
+    font-size: .72rem; font-weight: 700; letter-spacing: .12em;
+    color: rgba(255,255,255,.55); text-transform: uppercase;
+}
+.acad-hero-title {
+    font-size: 1.05rem; font-weight: 800; color: #fff;
+    margin-top: 2px;
+}
+.acad-hero-subtitle {
+    font-size: .8rem; color: rgba(255,255,255,.6); margin-top: 2px;
+}
+.acad-hero-pdf-btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 6px 14px; border-radius: 8px;
+    background: rgba(255,255,255,.12); border: 1px solid rgba(255,255,255,.2);
+    color: rgba(255,255,255,.88); font-size: .75rem; font-weight: 600;
+    text-decoration: none; transition: background .2s;
+    white-space: nowrap;
+}
+.acad-hero-pdf-btn:hover { background: rgba(255,255,255,.2); color: #fff; }
+
+/* ── KPI 3 blocks ────────────────────────────────────────────────── */
+.acad-kpi-row {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    position: relative; z-index: 1;
+    padding-bottom: 28px;
+}
+@media (max-width: 600px) { .acad-kpi-row { grid-template-columns: 1fr 1fr; } }
+
+.acad-kpi-block {
+    display: flex; flex-direction: column; align-items: center;
+    text-align: center; padding: 18px 12px;
+    background: rgba(255,255,255,.07);
+    border: 1px solid rgba(255,255,255,.1);
+    border-radius: 14px;
+    backdrop-filter: blur(8px);
+    transition: background .2s;
+}
+.acad-kpi-block:hover { background: rgba(255,255,255,.11); }
+
+/* SVG ring */
+.acad-ring-wrap { position: relative; width: 72px; height: 72px; margin-bottom: 10px; }
+.acad-ring-wrap svg { width: 72px; height: 72px; transform: rotate(-90deg); }
+.acad-ring-wrap .acad-ring-bg { fill: none; stroke: rgba(255,255,255,.12); stroke-width: 5; }
+.acad-ring-wrap .acad-ring-fg { fill: none; stroke-width: 5; stroke-linecap: round; transition: stroke-dashoffset .8s cubic-bezier(.4,0,.2,1); }
+.acad-ring-center {
+    position: absolute; inset: 0;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+}
+.acad-ring-val {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 1.25rem; font-weight: 700; color: #fff; line-height: 1;
+}
+.acad-ring-denom { font-size: .6rem; color: rgba(255,255,255,.5); }
+
+.acad-kpi-label {
+    font-size: .68rem; font-weight: 700; letter-spacing: .08em;
+    text-transform: uppercase; color: rgba(255,255,255,.5);
+    margin-bottom: 4px;
+}
+.acad-kpi-sub {
+    font-size: .82rem; font-weight: 700; color: rgba(255,255,255,.9);
+    line-height: 1.2;
+}
+.acad-kpi-sub.small { font-size: .72rem; }
+
+/* Rang display (no ring) */
+.acad-rang-display {
+    width: 72px; height: 72px; margin-bottom: 10px;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    background: rgba(255,255,255,.08); border-radius: 50%;
+    border: 2px solid rgba(255,255,255,.15);
+}
+.acad-rang-num {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 1.4rem; font-weight: 700; color: #f59e0b; line-height: 1;
+}
+.acad-rang-icon { font-size: .7rem; color: rgba(245,158,11,.7); margin-top: 1px; }
+
+/* Mention badge (no ring) */
+.acad-mention-display {
+    width: 72px; height: 72px; margin-bottom: 10px;
+    display: flex; align-items: center; justify-content: center;
+    border-radius: 50%;
+}
+.acad-mention-badge {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 3px 10px; border-radius: 20px;
+    font-size: .72rem; font-weight: 700; letter-spacing: .02em;
+    white-space: nowrap;
+}
+.acad-mention-badge.excellent { background: rgba(16,185,129,.2); color: #34d399; border: 1px solid rgba(16,185,129,.35); }
+.acad-mention-badge.bien      { background: rgba(59,130,246,.2); color: #93c5fd; border: 1px solid rgba(59,130,246,.35); }
+.acad-mention-badge.assez     { background: rgba(245,158,11,.2); color: #fcd34d; border: 1px solid rgba(245,158,11,.35); }
+.acad-mention-badge.passable  { background: rgba(239,68,68,.2);  color: #fca5a5; border: 1px solid rgba(239,68,68,.35); }
+
+/* ── Sparkline progression ───────────────────────────────────────── */
+.acad-sparkline-section {
+    background: var(--k-card); border: 1px solid var(--k-border);
+    border-radius: var(--k-radius); padding: 16px 20px;
+    margin-bottom: 16px;
+}
+.acad-sparkline-title {
+    font-size: .72rem; font-weight: 700; color: var(--k-muted);
+    text-transform: uppercase; letter-spacing: .08em; margin-bottom: 14px;
+}
+.acad-sparkline-bars {
+    display: flex; align-items: flex-end; gap: 8px; height: 52px;
+}
+.acad-spark-bar-wrap {
+    flex: 1; display: flex; flex-direction: column; align-items: center; gap: 4px;
+}
+.acad-spark-bar {
+    width: 100%; border-radius: 4px 4px 0 0;
+    min-height: 4px;
+    transition: opacity .2s;
+}
+.acad-spark-bar:hover { opacity: .8; }
+.acad-spark-label { font-size: .62rem; color: var(--k-muted); white-space: nowrap; }
+.acad-spark-val   { font-size: .65rem; font-weight: 700; }
+
+/* ── Top/Flop matières ───────────────────────────────────────────── */
+.acad-topflop-row {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+    margin-bottom: 16px;
+}
+@media (max-width: 600px) { .acad-topflop-row { grid-template-columns: 1fr; } }
+
+.acad-topflop-card {
+    background: var(--k-card); border: 1px solid var(--k-border);
+    border-radius: var(--k-radius); padding: 14px 16px;
+}
+.acad-topflop-head {
+    display: flex; align-items: center; gap: 6px;
+    font-size: .7rem; font-weight: 700; text-transform: uppercase; letter-spacing: .07em;
+    color: var(--k-muted); margin-bottom: 10px;
+}
+.acad-topflop-item {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 5px 0; border-bottom: 1px solid var(--k-border);
+}
+.acad-topflop-item:last-child { border-bottom: none; }
+.acad-topflop-name { font-size: .78rem; color: var(--k-text); font-weight: 500; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.acad-topflop-note { font-size: .78rem; font-weight: 800; min-width: 38px; text-align: right; }
+
+/* ── Semestre accordion ──────────────────────────────────────────── */
+.acad-sem-block {
+    background: var(--k-card); border: 1px solid var(--k-border);
+    border-radius: var(--k-radius); margin-bottom: 12px;
+    overflow: hidden;
+}
+.acad-sem-header {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 14px 18px; cursor: pointer;
+    background: linear-gradient(135deg, rgba(4,83,203,.04) 0%, rgba(94,145,222,.04) 100%);
+    border-bottom: 1px solid var(--k-border);
+    user-select: none;
+    transition: background .15s;
+}
+.acad-sem-header:hover { background: linear-gradient(135deg, rgba(4,83,203,.07) 0%, rgba(94,145,222,.07) 100%); }
+.acad-sem-header-left { display: flex; align-items: center; gap: 10px; }
+.acad-sem-period {
+    font-size: .88rem; font-weight: 700; color: var(--k-text);
+}
+.acad-sem-header-right { display: flex; align-items: center; gap: 12px; }
+.acad-sem-badge {
+    font-size: .72rem; font-weight: 700; padding: 3px 10px; border-radius: 8px;
+}
+.acad-sem-badge.green { color: var(--k-success); background: rgba(16,185,129,.1); }
+.acad-sem-badge.amber { color: #d97706; background: rgba(245,158,11,.1); }
+.acad-sem-badge.red   { color: var(--k-danger); background: rgba(239,68,68,.1); }
+.acad-sem-chevron { color: var(--k-muted); font-size: .75rem; transition: transform .25s; }
+.acad-sem-header[aria-expanded="true"] .acad-sem-chevron { transform: rotate(180deg); }
+
+/* Per-matière rows */
+.acad-mat-list { padding: 8px 18px 14px; }
+.acad-mat-item {
+    padding: 9px 0; border-bottom: 1px solid var(--k-border);
+}
+.acad-mat-item:last-child { border-bottom: none; }
+.acad-mat-top {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 8px; margin-bottom: 6px;
+}
+.acad-mat-name { font-size: .82rem; color: var(--k-text); font-weight: 600; flex: 1; min-width: 0; }
+.acad-mat-coeff-pill {
+    font-size: .64rem; font-weight: 700; color: var(--k-muted);
+    background: var(--k-surface); border: 1px solid var(--k-border);
+    border-radius: 10px; padding: 1px 7px; white-space: nowrap;
+}
+.acad-mat-score {
+    font-size: .88rem; font-weight: 800; min-width: 44px; text-align: right;
+}
+.acad-mat-score.good { color: var(--k-success); }
+.acad-mat-score.mid  { color: #d97706; }
+.acad-mat-score.bad  { color: var(--k-danger); }
+.acad-mat-bar-wrap { height: 5px; background: var(--k-border); border-radius: 3px; overflow: hidden; }
+.acad-mat-bar { height: 100%; border-radius: 3px; transition: width .5s ease; }
+
+/* ── Années précédentes (accordion) ─────────────────────────────── */
+.acad-arch-sep {
+    display: flex; align-items: center; gap: 12px;
+    margin: 24px 0 14px;
+}
+.acad-arch-sep-line { flex: 1; height: 1px; background: var(--k-border); }
+.acad-arch-sep-label {
+    font-size: .7rem; font-weight: 700; color: var(--k-muted);
+    text-transform: uppercase; letter-spacing: .1em; white-space: nowrap;
+}
+
+.acad-arch-card {
+    background: var(--k-card); border: 1px solid var(--k-border);
+    border-radius: var(--k-radius); margin-bottom: 10px; overflow: hidden;
+}
+.acad-arch-toggle {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 12px 18px; cursor: pointer; width: 100%;
+    background: none; border: none; text-align: left;
+    transition: background .15s;
+}
+.acad-arch-toggle:hover { background: var(--k-surface); }
+.acad-arch-toggle-left { display: flex; align-items: center; gap: 10px; }
+.acad-arch-year { font-size: .88rem; font-weight: 700; color: var(--k-text); }
+.acad-arch-class { font-size: .75rem; color: var(--k-muted); }
+.acad-arch-toggle-right { display: flex; align-items: center; gap: 10px; }
+.acad-arch-kpi { font-size: .9rem; font-weight: 800; }
+.acad-arch-kpi-lbl { font-size: .72rem; color: var(--k-muted); }
+.acad-arch-chevron { color: var(--k-muted); font-size: .7rem; transition: transform .25s; }
+.acad-arch-toggle[aria-expanded="true"] .acad-arch-chevron { transform: rotate(180deg); }
+.acad-arch-body { padding: 16px 18px; border-top: 1px solid var(--k-border); background: var(--k-surface); }
+.acad-arch-sem-row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 8px 0; border-bottom: 1px dashed var(--k-border);
+}
+.acad-arch-sem-row:last-child { border-bottom: none; }
+.acad-arch-sem-name { font-size: .82rem; font-weight: 600; color: var(--k-text); }
+.acad-arch-sem-info { display: flex; align-items: center; gap: 10px; }
+.acad-arch-pdf-link {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-size: .72rem; color: var(--k-blue); font-weight: 600;
+    text-decoration: none; padding: 2px 8px;
+    border: 1px solid rgba(4,83,203,.2); border-radius: 6px;
+    transition: background .15s;
+}
+.acad-arch-pdf-link:hover { background: rgba(4,83,203,.06); }
+
 /* ── Presence year rows ──────────────────────────────────────────── */
 .presence-year {
     background: var(--k-card); border: 1px solid var(--k-border);
@@ -289,7 +584,10 @@
 /* Inline donut SVG for presence year */
 .py-donut { flex-shrink: 0; }
 
-.presence-year-body { padding: 16px 20px; }
+.presence-year-body { padding: 16px 20px; display: none; }
+.presence-year.open .presence-year-body { display: block; }
+.presence-year-head .fa-chevron-down { transition: transform .3s ease; }
+.presence-year.open .presence-year-head .fa-chevron-down { transform: rotate(180deg); }
 .presence-bars { display: flex; flex-direction: column; gap: 10px; }
 .pbar-row { display: flex; align-items: center; gap: 12px; }
 .pbar-lbl { font-size: .78rem; color: var(--k-muted); font-weight: 600; min-width: 80px; }
@@ -345,6 +643,366 @@
 .pmt-act-btn.del   { background: rgba(239,68,68,.1); color: var(--k-danger); }
 .pmt-act-btn.del:hover { background: var(--k-danger); color: #fff; }
 
+/* ── TAB FINANCES — Design Premium ──────────────────────────────── */
+
+/* Hero financier avec 3 blocs KPI */
+.fin-hero {
+    background: linear-gradient(135deg, #0f172a 0%, #1e293b 60%, #0c1a3a 100%);
+    border-radius: var(--k-radius-lg);
+    padding: 28px 28px 20px;
+    margin-bottom: 18px;
+    box-shadow: 0 8px 40px rgba(4,83,203,.18), 0 2px 8px rgba(0,0,0,.12);
+    position: relative;
+    overflow: hidden;
+}
+/* Texture subtile */
+.fin-hero::before {
+    content: '';
+    position: absolute; inset: 0;
+    background-image: radial-gradient(circle at 80% 20%, rgba(94,145,222,.15) 0%, transparent 60%),
+                      radial-gradient(circle at 10% 90%, rgba(4,83,203,.1) 0%, transparent 50%);
+    pointer-events: none;
+}
+
+.fin-hero-grid {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto 1fr;
+    gap: 0;
+    position: relative;
+    margin-bottom: 24px;
+}
+@media (max-width: 768px) {
+    .fin-hero-grid { grid-template-columns: 1fr; gap: 20px; }
+    .fin-sep { display: none !important; }
+}
+
+.fin-sep {
+    width: 1px;
+    background: rgba(255,255,255,.12);
+    margin: 0 24px;
+    align-self: stretch;
+}
+
+.fin-kpi-block { padding: 0 8px; }
+
+.fin-kpi-label {
+    font-size: .72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: rgba(255,255,255,.5);
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.fin-kpi-amount {
+    font-family: Georgia, 'Times New Roman', serif;
+    font-size: 2rem;
+    font-weight: 700;
+    line-height: 1;
+    letter-spacing: -.02em;
+    color: #fff;
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+.fin-kpi-amount.paid   { color: #34d399; }
+.fin-kpi-amount.due    { color: #fbbf24; }
+.fin-kpi-amount.excess { color: #f87171; }
+.fin-kpi-amount.zero   { color: #34d399; }
+.fin-kpi-amount.neutral { color: #e2e8f0; }
+
+.fin-kpi-currency {
+    font-family: system-ui, sans-serif;
+    font-size: .75rem;
+    font-weight: 600;
+    letter-spacing: .05em;
+    opacity: .7;
+    align-self: flex-end;
+    margin-bottom: 3px;
+}
+
+.fin-kpi-sub {
+    font-size: .75rem;
+    color: rgba(255,255,255,.4);
+    margin-top: 8px;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+.fin-kpi-sub-warn  { color: #fbbf24 !important; opacity: .9; }
+.fin-kpi-sub-danger { color: #f87171 !important; opacity: .9; }
+
+/* Barre de progression dans le hero */
+.fin-progress-wrap { position: relative; }
+
+.fin-progress-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+}
+.fin-progress-lbl {
+    font-size: .72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .07em;
+    color: rgba(255,255,255,.45);
+}
+.fin-progress-pct {
+    font-size: .9rem;
+    font-weight: 800;
+    font-family: Georgia, serif;
+}
+
+.fin-progress-track {
+    height: 6px;
+    background: rgba(255,255,255,.1);
+    border-radius: 3px;
+    overflow: hidden;
+    position: relative;
+    margin-bottom: 10px;
+}
+.fin-progress-segment {
+    position: absolute;
+    top: 0; left: 0;
+    height: 100%;
+    border-radius: 3px;
+    transition: width .8s cubic-bezier(.4,0,.2,1);
+}
+.fin-progress-segment.valide  { background: #34d399; }
+.fin-progress-segment.attente { background: rgba(251,191,36,.45); }
+
+.fin-progress-legend {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+.fin-progress-legend span {
+    font-size: .72rem;
+    color: rgba(255,255,255,.45);
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+.fin-legend-dot {
+    width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+}
+.fin-legend-dot.valide   { background: #34d399; }
+.fin-legend-dot.attente  { background: #fbbf24; }
+.fin-legend-dot.reliquat { background: #f87171; }
+
+/* Tableau récapitulatif par frais */
+.fin-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: .84rem;
+}
+.fin-table th {
+    padding: 10px 14px;
+    text-align: left;
+    font-size: .7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    color: var(--k-muted);
+    background: var(--k-surface);
+    border-bottom: 2px solid var(--k-border);
+}
+.fin-table td {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--k-border);
+    vertical-align: middle;
+    color: var(--k-text);
+    font-size: .84rem;
+}
+.fin-table tbody tr:last-child td { border-bottom: none; }
+.fin-table tbody tr:hover td { background: rgba(4,83,203,.03); }
+.fin-cat-name { font-weight: 600; color: var(--k-text); }
+.fin-year-badge {
+    display: inline-block;
+    font-size: .72rem;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 20px;
+    background: rgba(4,83,203,.08);
+    color: var(--k-blue);
+}
+.fin-mini-track {
+    height: 5px;
+    background: var(--k-border);
+    border-radius: 3px;
+    overflow: hidden;
+    margin: 0 auto 4px;
+    max-width: 80px;
+}
+.fin-mini-fill {
+    height: 100%;
+    border-radius: 3px;
+    transition: width .5s;
+}
+
+/* Historique paiements — card rows */
+.fin-pmt-list { display: flex; flex-direction: column; gap: 0; }
+
+.fin-pmt-row {
+    display: flex;
+    align-items: stretch;
+    border-bottom: 1px solid var(--k-border);
+    transition: background .15s;
+}
+.fin-pmt-row:last-child { border-bottom: none; }
+.fin-pmt-row:hover { background: rgba(4,83,203,.02); }
+
+.fin-pmt-accent-bar {
+    width: 3px;
+    flex-shrink: 0;
+    background: var(--pmt-accent, var(--k-border));
+    border-radius: 2px 0 0 2px;
+    margin: 10px 0;
+}
+
+.fin-pmt-content {
+    flex: 1;
+    min-width: 0;
+    padding: 14px 16px;
+}
+
+.fin-pmt-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.fin-pmt-motif {
+    font-size: .88rem;
+    font-weight: 700;
+    color: var(--k-text);
+    flex: 1;
+    min-width: 0;
+}
+
+.fin-pmt-amount {
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: var(--k-text);
+    white-space: nowrap;
+    font-family: Georgia, serif;
+    flex-shrink: 0;
+}
+.fin-pmt-amount small {
+    font-family: system-ui, sans-serif;
+    font-size: .6em;
+    font-weight: 600;
+    opacity: .6;
+    margin-left: 2px;
+}
+
+.fin-pmt-bottom {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.fin-pmt-meta-list {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.fin-pmt-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: .73rem;
+    color: var(--k-muted);
+    background: var(--k-surface);
+    padding: 2px 8px;
+    border-radius: 10px;
+    border: 1px solid var(--k-border);
+    white-space: nowrap;
+}
+.fin-pmt-chip.mono { font-family: 'Courier New', monospace; font-size: .7rem; }
+
+.fin-pmt-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+/* ── Fin hero — badge année active ─────────────────────────────── */
+.fin-hero-year-badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: .75rem; font-weight: 600; color: rgba(255,255,255,.6);
+    background: rgba(255,255,255,.08); border: 1px solid rgba(255,255,255,.12);
+    padding: 4px 12px; border-radius: 20px; margin-bottom: 18px;
+}
+.fin-hero-year-badge strong { color: rgba(255,255,255,.9); font-weight: 700; }
+
+/* ── Autres inscriptions — séparateur ──────────────────────────── */
+.fin-autres-header {
+    display: flex; align-items: center; gap: 8px;
+    font-size: .76rem; font-weight: 700; color: var(--k-muted);
+    text-transform: uppercase; letter-spacing: .08em;
+    padding: 8px 0; margin: 4px 0 10px;
+    border-top: 2px dashed var(--k-border);
+}
+
+/* ── Accordion archive inscription ─────────────────────────────── */
+.fin-arch-card {
+    border: 1px solid var(--k-border); border-radius: var(--k-radius);
+    overflow: hidden; margin-bottom: 10px;
+    background: var(--k-surface);
+}
+.fin-arch-toggle {
+    width: 100%; display: flex; align-items: center; justify-content: space-between;
+    padding: 14px 18px; background: none; border: none; cursor: pointer;
+    text-align: left; gap: 12px; transition: background .15s;
+}
+.fin-arch-toggle:hover { background: rgba(4,83,203,.04); }
+.fin-arch-toggle-left { display: flex; align-items: center; gap: 10px; flex: 1; min-width: 0; }
+.fin-arch-year {
+    font-size: .88rem; font-weight: 700; color: var(--k-text); white-space: nowrap;
+}
+.fin-arch-class {
+    font-size: .78rem; color: var(--k-muted); white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis;
+}
+.fin-arch-toggle-right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+.fin-arch-kpi { font-size: .92rem; font-weight: 800; font-family: Georgia, serif; }
+.fin-arch-kpi-lbl { font-size: .74rem; color: var(--k-muted); }
+.fin-arch-chevron {
+    font-size: .75rem; color: var(--k-muted); transition: transform .25s;
+}
+.fin-arch-toggle[aria-expanded="true"] .fin-arch-chevron { transform: rotate(180deg); }
+.fin-arch-body {
+    padding: 0 18px 18px; border-top: 1px solid var(--k-border);
+}
+.fin-arch-stats {
+    display: flex; flex-wrap: wrap; gap: 12px 20px;
+    padding: 14px 0 12px;
+}
+.fin-arch-stat { min-width: 90px; }
+.fin-arch-stat-lbl { font-size: .69rem; font-weight: 600; color: var(--k-muted); text-transform: uppercase; letter-spacing: .05em; margin-bottom: 2px; }
+.fin-arch-stat-val { font-size: 1rem; font-weight: 800; font-family: Georgia, serif; }
+.fin-arch-stat-val.neutral { color: var(--k-text); }
+.fin-arch-stat-val.paid    { color: #10b981; }
+.fin-arch-stat-val.due     { color: #f59e0b; }
+.fin-arch-stat-val.zero    { color: #10b981; }
+.fin-arch-pmt-label {
+    font-size: .72rem; font-weight: 700; color: var(--k-muted);
+    text-transform: uppercase; letter-spacing: .06em;
+    margin: 10px 0 6px; padding-top: 10px; border-top: 1px solid var(--k-border);
+}
+
 /* ── Parent accordion ────────────────────────────────────────────── */
 .parent-item {
     border: 1px solid var(--k-border); border-radius: var(--k-radius);
@@ -391,20 +1049,54 @@
 
 /* ── Inscription card ────────────────────────────────────────────── */
 .insc-card {
+    position: relative;
     background: var(--k-card); border: 1px solid var(--k-border);
-    border-left: 4px solid var(--k-blue);
-    border-radius: var(--k-radius); padding: 18px 20px;
-    margin-bottom: 14px; box-shadow: var(--k-shadow);
+    border-radius: var(--k-radius);
+    margin-bottom: 12px; box-shadow: var(--k-shadow);
+    overflow: hidden;
+    transition: box-shadow .2s, transform .2s;
 }
-.insc-card:hover { box-shadow: var(--k-shadow-lg); }
-.insc-year { font-size: 1rem; font-weight: 800; color: var(--k-blue); }
-.insc-meta { font-size: .82rem; color: var(--k-muted); margin: 6px 0 12px; display: flex; gap: 16px; flex-wrap: wrap; }
-.insc-meta span { display: inline-flex; align-items: center; gap: 5px; }
-.insc-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+.insc-card:hover { box-shadow: var(--k-shadow-lg); transform: translateY(-1px); }
+.insc-card-accent {
+    position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
+}
+.insc-card-accent.actif  { background: linear-gradient(180deg, var(--k-success) 0%, #34d399 100%); }
+.insc-card-accent.inactif { background: linear-gradient(180deg, #94a3b8 0%, #cbd5e1 100%); }
+.insc-card-accent.abandon { background: linear-gradient(180deg, var(--k-danger) 0%, #f87171 100%); }
+.insc-card-inner { padding: 16px 18px 14px 22px; }
+.insc-header {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 10px; flex-wrap: wrap; margin-bottom: 10px;
+}
+.insc-year-badge {
+    display: flex; align-items: center; gap: 8px;
+}
+.insc-year-icon {
+    width: 32px; height: 32px; border-radius: 8px;
+    background: rgba(4,83,203,.1); display: flex; align-items: center; justify-content: center;
+    color: var(--k-blue); font-size: .8rem; flex-shrink: 0;
+}
+.insc-year { font-size: .95rem; font-weight: 800; color: var(--k-text); }
+.insc-meta {
+    display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 12px;
+}
+.insc-meta-chip {
+    display: inline-flex; align-items: center; gap: 5px;
+    font-size: .75rem; color: var(--k-muted); font-weight: 500;
+    background: var(--k-surface); border: 1px solid var(--k-border);
+    padding: 3px 10px; border-radius: 20px;
+}
+.insc-meta-chip i { font-size: .7rem; color: var(--k-blue); }
+.insc-footer {
+    display: flex; align-items: center; justify-content: space-between;
+    padding-top: 10px; border-top: 1px solid var(--k-border);
+    flex-wrap: wrap; gap: 8px;
+}
+.insc-actions { display: flex; gap: 6px; flex-wrap: wrap; }
 .insc-btn {
-    font-size: .79rem; font-weight: 600; padding: 6px 14px; border-radius: 7px;
+    font-size: .77rem; font-weight: 600; padding: 5px 13px; border-radius: 7px;
     text-decoration: none; transition: all .15s;
-    display: inline-flex; align-items: center; gap: 6px; border: none; cursor: pointer;
+    display: inline-flex; align-items: center; gap: 5px; border: none; cursor: pointer;
 }
 .insc-btn.view   { background: rgba(4,83,203,.08); color: var(--k-blue); }
 .insc-btn.view:hover { background: var(--k-blue); color: #fff; }
@@ -412,13 +1104,127 @@
 .insc-btn.pdf:hover  { background: var(--k-danger); color: #fff; }
 .insc-btn.edit   { background: rgba(245,158,11,.08); color: #d97706; }
 .insc-btn.edit:hover { background: var(--k-warning); color: #fff; }
+/* workflow & affectation badges */
+.insc-header-badges { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.insc-wf-badge {
+    display: inline-flex; align-items: center; gap: 4px;
+    font-size: .7rem; font-weight: 700; padding: 3px 9px;
+    border-radius: 20px; text-transform: uppercase; letter-spacing: .03em;
+}
+.insc-wf-badge.prospect  { background: rgba(100,116,139,.1); color: #64748b; border: 1px solid rgba(100,116,139,.25); }
+.insc-wf-badge.docs      { background: rgba(59,130,246,.1); color: #3b82f6; border: 1px solid rgba(59,130,246,.25); }
+.insc-wf-badge.validation { background: rgba(245,158,11,.1); color: #d97706; border: 1px solid rgba(245,158,11,.3); }
+.insc-wf-badge.valide    { background: rgba(16,185,129,.1); color: #059669; border: 1px solid rgba(16,185,129,.3); }
+.insc-wf-badge.actif     { background: rgba(4,83,203,.1); color: var(--k-blue); border: 1px solid rgba(4,83,203,.2); }
+/* data grid inside insc-card */
+.insc-data-grid {
+    display: grid; grid-template-columns: 1fr 1fr;
+    gap: 8px 16px; margin-bottom: 12px;
+}
+.insc-data-row { display: flex; flex-direction: column; gap: 2px; }
+.insc-data-lbl {
+    font-size: .68rem; color: var(--k-muted); font-weight: 600;
+    text-transform: uppercase; letter-spacing: .04em;
+    display: flex; align-items: center; gap: 4px;
+}
+.insc-data-lbl i { font-size: .62rem; color: var(--k-blue); opacity: .7; }
+.insc-data-val { font-size: .82rem; font-weight: 600; color: var(--k-text); }
+/* affectation status */
+.insc-affectation { margin-bottom: 12px; }
+.insc-aff-badge {
+    display: inline-flex; align-items: center; gap: 5px;
+    font-size: .73rem; font-weight: 700; padding: 4px 11px; border-radius: 20px;
+}
+.insc-aff-badge.affecte    { background: rgba(16,185,129,.1); color: #059669; border: 1px solid rgba(16,185,129,.3); }
+.insc-aff-badge.non-affecte { background: rgba(239,68,68,.08); color: var(--k-danger); border: 1px solid rgba(239,68,68,.2); }
+/* reinscription CTA */
+.insc-cta-card {
+    border: 2px dashed var(--k-blue) !important;
+    background: rgba(4,83,203,.03);
+    text-decoration: none; transition: background .2s, border-color .2s;
+}
+.insc-cta-card:hover { background: rgba(4,83,203,.07); }
+.insc-cta-icon {
+    width: 40px; height: 40px; border-radius: 10px;
+    background: rgba(4,83,203,.1); color: var(--k-blue);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.1rem; flex-shrink: 0;
+}
+.insc-cta-body { flex: 1; }
+.insc-cta-title { font-size: .9rem; font-weight: 700; color: var(--k-blue); margin-bottom: 2px; }
+.insc-cta-sub   { font-size: .75rem; color: var(--k-muted); }
+/* inscriptions grid */
+.insc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+@media (max-width: 768px) { .insc-grid { grid-template-columns: 1fr; } }
+/* presence constat */
+.presence-constat {
+    margin-top: 14px; padding: 10px 14px; border-radius: 8px;
+    font-size: .78rem; font-weight: 500; line-height: 1.4;
+    display: flex; align-items: flex-start; gap: 8px;
+}
+.presence-constat.good    { background: rgba(16,185,129,.08); color: #065f46; border-left: 3px solid var(--k-success); }
+.presence-constat.warning { background: rgba(245,158,11,.08); color: #92400e; border-left: 3px solid var(--k-warning); }
+.presence-constat.bad     { background: rgba(239,68,68,.08); color: #991b1b; border-left: 3px solid var(--k-danger); }
+.presence-constat i { margin-top: 1px; flex-shrink: 0; }
+/* presence stat rows */
+.pres-stat-list { display: flex; flex-direction: column; gap: 10px; margin-bottom: 4px; }
+.pres-stat-row {
+    display: flex; align-items: center; gap: 10px;
+    padding: 8px 12px; border-radius: 8px; background: var(--k-surface);
+}
+.pres-stat-icon {
+    width: 30px; height: 30px; border-radius: 8px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: .8rem; flex-shrink: 0;
+}
+.pres-stat-icon.green { background: rgba(16,185,129,.1); color: var(--k-success); }
+.pres-stat-icon.amber { background: rgba(245,158,11,.1); color: #d97706; }
+.pres-stat-icon.red   { background: rgba(239,68,68,.08); color: var(--k-danger); }
+.pres-stat-icon.blue  { background: rgba(4,83,203,.08); color: var(--k-blue); }
+.pres-stat-lbl { flex: 1; font-size: .8rem; color: var(--k-text); font-weight: 500; }
+.pres-stat-val { font-size: .9rem; font-weight: 800; }
+.pres-stat-val.green { color: var(--k-success); }
+.pres-stat-val.amber { color: #d97706; }
+.pres-stat-val.red   { color: var(--k-danger); }
+.pres-stat-val.blue  { color: var(--k-blue); }
+.pres-stat-pct { font-size: .72rem; color: var(--k-muted); font-weight: 500; margin-left: 4px; }
+
+/* ── Overrides dark hero (fin-hero) pour contraste ──────────────── */
+.fin-hero .py-stat-val { color: #fff; }
+.fin-hero .py-stat-lbl { color: rgba(255,255,255,.65); }
+.fin-hero .pres-stat-row {
+    background: rgba(255,255,255,.07);
+    border: 1px solid rgba(255,255,255,.08);
+    border-top-color: rgba(255,255,255,.08) !important;
+}
+.fin-hero .pres-stat-lbl { color: rgba(255,255,255,.85); }
+.fin-hero .pres-stat-pct { color: rgba(255,255,255,.5); }
+.fin-hero .pres-stat-val { color: #fff; }
+.fin-hero .pres-stat-val.green { color: #34d399; }
+.fin-hero .pres-stat-val.amber { color: #fbbf24; }
+.fin-hero .pres-stat-val.red   { color: #f87171; }
+.fin-hero .pres-stat-val.blue  { color: #93c5fd; }
+.fin-hero .pres-stat-icon { background: rgba(255,255,255,.1); color: rgba(255,255,255,.7); }
+.fin-hero .pres-stat-icon.green { background: rgba(52,211,153,.15); color: #34d399; }
+.fin-hero .pres-stat-icon.amber { background: rgba(251,191,36,.15); color: #fbbf24; }
+.fin-hero .pres-stat-icon.red   { background: rgba(248,113,113,.12); color: #f87171; }
+.fin-hero .pres-stat-icon.blue  { background: rgba(147,197,253,.12); color: #93c5fd; }
+.fin-hero .pbar-lbl { color: rgba(255,255,255,.7); }
+.fin-hero .pbar-track { background: rgba(255,255,255,.1); }
+.fin-hero .presence-bars .pbar-val { color: rgba(255,255,255,.8) !important; }
+.fin-hero .presence-constat { background: rgba(255,255,255,.06); color: rgba(255,255,255,.75); }
+.fin-hero .presence-constat.good    { background: rgba(52,211,153,.12); color: #6ee7b7; border-left-color: #34d399; }
+.fin-hero .presence-constat.warning { background: rgba(251,191,36,.12); color: #fde68a; border-left-color: #fbbf24; }
+.fin-hero .presence-constat.bad     { background: rgba(248,113,113,.12); color: #fca5a5; border-left-color: #f87171; }
 
 /* ── Responsive ──────────────────────────────────────────────────── */
 @media (max-width: 768px) {
-    .hero-inner { padding: 24px 16px 0; gap: 16px; }
-    .hero-name  { font-size: 1.35rem; }
+    .hero-inner { padding: 24px 16px 20px; gap: 16px; }
+    .hero-name  { font-size: 1.3rem; }
+    .hero-avatar { width: 80px; height: 80px; font-size: 1.9rem; }
     .hero-kpi   { padding: 10px 14px; }
     .hero-kpi-val { font-size: .95rem; }
+    .hero-actions { margin-left: 0; }
     .hero-kpi-lbl { font-size: .62rem; }
     .fiche-content { padding: 20px 16px 48px; }
     .kpi-grid { grid-template-columns: repeat(2, 1fr); }
@@ -444,22 +1250,25 @@
 ════════════════════════════════════════════════════════════════ --}}
 <div class="fiche-hero">
     <div class="hero-inner">
-        {{-- Avatar --}}
-        <div class="hero-avatar">
-            @if($etudiant->photo)
-                <img src="{{ asset('storage/photos/etudiants/' . $etudiant->photo) }}"
-                     alt="{{ $etudiant->nom_complet }}"
-                     onerror="this.parentElement.innerHTML='<i class=\'fas fa-user-graduate\'></i>'">
-            @else
-                {{ strtoupper(substr($etudiant->prenoms ?? 'E', 0, 1)) }}{{ strtoupper(substr($etudiant->nom, 0, 1)) }}
-            @endif
+        {{-- Avatar avec badge statut --}}
+        @php $inscA = $etudiant->inscriptions->firstWhere('status', 'active') ?? $etudiant->inscriptions->first(); @endphp
+        <div class="hero-avatar-wrap">
+            <div class="hero-avatar">
+                @if($etudiant->photo)
+                    <img src="{{ asset('storage/photos/etudiants/' . $etudiant->photo) }}"
+                         alt="{{ $etudiant->nom_complet }}"
+                         onerror="this.parentElement.innerHTML='<i class=\'fas fa-user-graduate\'></i>'">
+                @else
+                    {{ strtoupper(substr($etudiant->prenoms ?? 'E', 0, 1)) }}{{ strtoupper(substr($etudiant->nom, 0, 1)) }}
+                @endif
+            </div>
+            <span class="hero-avatar-status {{ $etudiant->statut ?? 'inactif' }}" title="{{ ucfirst($etudiant->statut ?? 'inconnu') }}"></span>
         </div>
 
         {{-- Text --}}
         <div class="hero-text">
             <h1 class="hero-name">{{ strtoupper($etudiant->nom) }} {{ $etudiant->prenoms }}</h1>
             <p class="hero-sub">
-                @php $inscA = $etudiant->inscriptions->firstWhere('status', 'active') ?? $etudiant->inscriptions->first(); @endphp
                 @if($inscA && $inscA->classe)
                     {{ $inscA->classe->name }}
                     @if($inscA->classe->filiere) · {{ $inscA->classe->filiere->name }} @endif
@@ -471,11 +1280,11 @@
             <div class="hero-pills">
                 <span class="hero-pill"><i class="fas fa-id-card"></i> {{ $etudiant->matricule ?? 'Non attribué' }}</span>
                 @if($etudiant->statut === 'actif')
-                    <span class="hero-pill green"><i class="fas fa-circle" style="font-size:.5rem"></i> Actif</span>
+                    <span class="hero-pill green"><i class="fas fa-circle" style="font-size:.45rem"></i> Actif</span>
                 @elseif($etudiant->statut === 'inactif')
-                    <span class="hero-pill"><i class="fas fa-circle" style="font-size:.5rem"></i> Inactif</span>
+                    <span class="hero-pill"><i class="fas fa-circle" style="font-size:.45rem"></i> Inactif</span>
                 @elseif($etudiant->statut === 'abandon')
-                    <span class="hero-pill red"><i class="fas fa-circle" style="font-size:.5rem"></i> Abandon</span>
+                    <span class="hero-pill red"><i class="fas fa-circle" style="font-size:.45rem"></i> Abandon</span>
                 @endif
                 @if($etudiant->nationalite)
                     <span class="hero-pill"><i class="fas fa-flag"></i> {{ $etudiant->nationalite }}</span>
@@ -483,35 +1292,36 @@
             </div>
         </div>
 
-        {{-- Année courante — top-right --}}
-        @if($inscA && $inscA->anneeUniversitaire)
-        <div style="position:absolute; top:16px; right:16px; z-index:10">
-            <span style="display:inline-flex; align-items:center; gap:6px; background:rgba(255,255,255,.15); backdrop-filter:blur(8px); border:1px solid rgba(255,255,255,.3); color:#fff; font-size:.78rem; font-weight:700; padding:6px 14px; border-radius:20px; letter-spacing:.02em;">
-                <i class="fas fa-calendar-alt"></i>
-                {{ $inscA->anneeUniversitaire->name ?? 'N/A' }}
-            </span>
-        </div>
-        @endif
-
         {{-- Actions --}}
+        @php
+            $anneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
+            $inscCourante = $anneeCourante
+                ? $etudiant->inscriptions->first(fn($i) => $i->annee_universitaire_id === $anneeCourante->id)
+                : null;
+        @endphp
         <div class="hero-actions">
-            @can('update', $etudiant)
-            <a href="{{ route('esbtp.etudiants.edit', $etudiant) }}" class="hero-btn primary">
-                <i class="fas fa-edit"></i> <span class="d-none d-sm-inline">Modifier</span>
-            </a>
-            @endcan
-            <a href="{{ route('esbtp.etudiants.index') }}" class="hero-btn ghost">
-                <i class="fas fa-arrow-left"></i> <span class="d-none d-sm-inline">Retour</span>
-            </a>
-            @can('delete', $etudiant)
-            <form action="{{ route('esbtp.etudiants.destroy', $etudiant) }}" method="POST" style="margin:0"
-                  onsubmit="return confirm('Supprimer définitivement {{ addslashes($etudiant->nom_complet) }} ?')">
-                @csrf @method('DELETE')
-                <button type="submit" class="hero-btn danger">
-                    <i class="fas fa-trash"></i>
-                </button>
-            </form>
-            @endcan
+            @if($anneeCourante)
+                <span class="hero-pill year"><i class="fas fa-calendar-alt"></i> {{ $anneeCourante->name }}</span>
+            @endif
+            <div class="hero-btns">
+                @can('update', $etudiant)
+                <a href="{{ route('esbtp.etudiants.edit', $etudiant) }}" class="hero-btn primary">
+                    <i class="fas fa-edit"></i> <span class="d-none d-sm-inline">Modifier</span>
+                </a>
+                @endcan
+                <a href="{{ route('esbtp.etudiants.index') }}" class="hero-btn ghost">
+                    <i class="fas fa-arrow-left"></i> <span class="d-none d-sm-inline">Retour</span>
+                </a>
+                @can('delete', $etudiant)
+                <form action="{{ route('esbtp.etudiants.destroy', $etudiant) }}" method="POST" style="margin:0"
+                      onsubmit="return confirm('Supprimer définitivement {{ addslashes($etudiant->nom_complet) }} ?')">
+                    @csrf @method('DELETE')
+                    <button type="submit" class="hero-btn danger">
+                        <i class="fas fa-trash"></i>
+                    </button>
+                </form>
+                @endcan
+            </div>
         </div>
     </div>
 
@@ -526,7 +1336,8 @@
         $inscActive = $etudiant->inscriptions->firstWhere('status', 'active') ?? $etudiant->inscriptions->first();
         if ($inscActive && $inscActive->anneeUniversitaire) {
             $anneeId = $inscActive->anneeUniversitaire->id;
-            $attStats = \App\Models\ESBTPAttendance::where('etudiant_id', $etudiant->id)
+            $attStats = \App\Models\ESBTPAttendance::finalOnly()
+                ->where('etudiant_id', $etudiant->id)
                 ->where('annee_universitaire_id', $anneeId)
                 ->selectRaw("COUNT(*) as total, SUM(CASE WHEN statut='present' THEN 1 ELSE 0 END) as nb_pres, SUM(CASE WHEN statut IN ('retard','late') THEN 1 ELSE 0 END) as nb_ret")
                 ->first();
@@ -601,20 +1412,62 @@
     {{-- KPI Cards --}}
     @php
         // Calcul KPI globaux depuis les vraies variables
-        $kpiMoyenneGen = null;
-        $kpiTauxPres   = $tauxPresence;
-        $kpiAbsTotal   = $etudiant->absences->count();
-        $kpiPaiTotal   = $statistiques['paiements_valides'] ?? 0;
-        $kpiPaiDu      = 0;
+        $kpiMoyenneGen     = null;
+        $kpiMoyenneIsLive  = false; // true = depuis résultats bruts (bulletin non généré)
+        $kpiTauxPres       = $tauxPresence;
+        $kpiAbsTotal       = $etudiant->absences->count();
 
-        // Moyenne depuis bulletins de l'inscription active
-        $allMoys = [];
-        foreach($etudiant->inscriptions as $inscIt) {
-            foreach($inscIt->bulletins ?? [] as $bul) {
-                if($bul->moyenne_generale !== null) $allMoys[] = $bul->moyenne_generale;
+        // Inscription de référence : prioriser is_current=true, sinon active, sinon la plus récente
+        $anneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
+        $kpiInscActive = null;
+        if ($anneeCourante) {
+            $kpiInscActive = $etudiant->inscriptions
+                ->where('annee_universitaire_id', $anneeCourante->id)
+                ->first();
+        }
+        if (!$kpiInscActive) {
+            $kpiInscActive = $inscription_active
+                ?? $etudiant->inscriptions->where('status', 'active')->first()
+                ?? $etudiant->inscriptions->sortByDesc('created_at')->first();
+        }
+
+        $kpiPaiTotal = $kpiInscActive
+            ? $kpiInscActive->paiements->where('status', 'validé')->sum('montant')
+            : 0;
+        $kpiPaiDu = 0;
+
+        // Moyenne : 1) chercher bulletins officiels de l'inscription de référence
+        $kpiBulletins = $kpiInscActive
+            ? \App\Models\ESBTPBulletin::where('etudiant_id', $etudiant->id)
+                ->where('annee_universitaire_id', $kpiInscActive->annee_universitaire_id)
+                ->get()
+            : collect();
+
+        $kpiBulletinsCalcueles = $kpiBulletins->filter(fn($b) => $b->moyenne_generale !== null && $b->moyenne_generale > 0);
+        if ($kpiBulletinsCalcueles->count()) {
+            // Moyenne pondérée des bulletins officiels calculés
+            $kpiMoyenneGen    = round($kpiBulletinsCalcueles->avg('moyenne_generale'), 2);
+            $kpiMoyenneIsLive = false;
+        } else {
+            // Fallback : calculer depuis ESBTPResultat (résultats bruts, bulletin non généré)
+            $kpiResultats = $kpiInscActive
+                ? \App\Models\ESBTPResultat::where('etudiant_id', $etudiant->id)
+                    ->where('annee_universitaire_id', $kpiInscActive->annee_universitaire_id)
+                    ->whereNotNull('moyenne')
+                    ->get()
+                : collect();
+
+            if ($kpiResultats->count()) {
+                $kpiSp = 0; $kpiSc = 0;
+                foreach ($kpiResultats as $kr) {
+                    $c = $kr->coefficient ?? 1;
+                    $kpiSp += $kr->moyenne * $c;
+                    $kpiSc += $c;
+                }
+                $kpiMoyenneGen    = $kpiSc > 0 ? round($kpiSp / $kpiSc, 2) : null;
+                $kpiMoyenneIsLive = true; // Signaler que c'est provisoire
             }
         }
-        if(count($allMoys)) $kpiMoyenneGen = round(array_sum($allMoys)/count($allMoys), 2);
     @endphp
 
     <div class="kpi-grid">
@@ -634,6 +1487,11 @@
             <div class="kpi-body">
                 <div class="kpi-val" style="color:{{ $mc }}">{{ $m !== null ? number_format($m,2) : '—' }}<small style="font-size:.6em;font-weight:500">/20</small></div>
                 <div class="kpi-lbl">Moy. générale</div>
+                @if($kpiMoyenneIsLive && $m !== null)
+                    <div style="font-size:.62rem; color:#f59e0b; margin-top:4px; display:flex; align-items:center; gap:3px; line-height:1.3;">
+                        <i class="fas fa-clock" style="font-size:.58rem;"></i> Provisoire · Bulletin non généré
+                    </div>
+                @endif
             </div>
         </div>
 
@@ -749,47 +1607,136 @@
         </div>
     </div>
 
-    {{-- Inscriptions rapides --}}
-    @if($etudiant->inscriptions->count())
+    {{-- Inscription année courante --}}
+    @if($kpiInscActive)
+    @php
+        $insc = $kpiInscActive;
+        $statInsc = $insc->status ?? 'pending';
+        $anneeLabel = $insc->anneeUniversitaire?->name ?? 'N/A';
+        $inscAccent = in_array($statInsc, ['active', 'actif', 'validé']) ? 'actif' : ($statInsc === 'abandon' ? 'abandon' : 'inactif');
+        $wfStep = $insc->workflow_step ?? null;
+        $affStatus = $insc->affectation_status ?? 'non_affecté';
+    @endphp
     <div class="s-card">
         <div class="s-card-header">
             <div class="s-card-title">
                 <div class="s-card-title-icon"><i class="fas fa-file-signature"></i></div>
-                Inscriptions ({{ $etudiant->inscriptions->count() }})
+                Inscription en cours
             </div>
-            <a href="{{ route('esbtp.inscriptions.create', ['etudiant_id' => $etudiant->id]) }}" class="insc-btn view">
-                <i class="fas fa-plus"></i> Nouvelle
-            </a>
         </div>
-        @foreach($etudiant->inscriptions->sortByDesc(fn($i) => $i->anneeUniversitaire?->name ?? '') as $insc)
-        @php
-            $statInsc = $insc->status ?? 'pending';
-            $anneeLabel = $insc->anneeUniversitaire?->name ?? 'N/A';
-        @endphp
+        <div class="insc-grid">
         <div class="insc-card">
-            <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:10px;">
-                <div class="insc-year">{{ $anneeLabel }}</div>
-                <span class="status-chip {{ in_array($statInsc, ['active', 'actif', 'validé']) ? 'actif' : 'inactif' }}">
-                    {{ $statInsc === 'active' ? 'Active' : ucfirst($statInsc) }}
-                </span>
-            </div>
-            <div class="insc-meta">
-                @if($insc->classe) <span><i class="fas fa-chalkboard"></i> {{ $insc->classe->name }}</span> @endif
-                @if($insc->classe?->filiere) <span><i class="fas fa-project-diagram"></i> {{ $insc->classe->filiere->name }}</span> @endif
-                <span><i class="fas fa-calendar-alt"></i> {{ $insc->created_at?->format('d/m/Y') ?? '—' }}</span>
-            </div>
-            <div class="insc-actions">
-                <a href="{{ route('esbtp.inscriptions.show', $insc) }}" class="insc-btn view">
-                    <i class="fas fa-eye"></i> Voir
-                </a>
-                @can('update', $insc)
-                <a href="{{ route('esbtp.inscriptions.edit', $insc) }}" class="insc-btn edit">
-                    <i class="fas fa-edit"></i> Modifier
-                </a>
-                @endcan
+            <div class="insc-card-accent {{ $inscAccent }}"></div>
+            <div class="insc-card-inner">
+                <div class="insc-header">
+                    <div class="insc-year-badge">
+                        <div class="insc-year-icon"><i class="fas fa-graduation-cap"></i></div>
+                        <span class="insc-year">{{ $anneeLabel }}</span>
+                    </div>
+                    <div class="insc-header-badges">
+                        @if($wfStep)
+                        @switch($wfStep)
+                            @case('prospect')
+                                <span class="insc-wf-badge prospect"><i class="fas fa-clock"></i> Prospect</span>
+                                @break
+                            @case('documents_complets')
+                                <span class="insc-wf-badge docs"><i class="fas fa-folder-open"></i> Docs complets</span>
+                                @break
+                            @case('en_validation')
+                                <span class="insc-wf-badge validation"><i class="fas fa-hourglass-half"></i> En validation</span>
+                                @break
+                            @case('valide')
+                                <span class="insc-wf-badge valide"><i class="fas fa-check-circle"></i> Validé</span>
+                                @break
+                            @case('etudiant_cree')
+                                <span class="insc-wf-badge actif"><i class="fas fa-user-graduate"></i> Étudiant créé</span>
+                                @break
+                        @endswitch
+                        @endif
+                        <span class="status-chip {{ $inscAccent }}">
+                            {{ $statInsc === 'active' ? 'Active' : ucfirst($statInsc) }}
+                        </span>
+                    </div>
+                </div>
+
+                <div class="insc-data-grid">
+                    <div class="insc-data-row">
+                        <span class="insc-data-lbl"><i class="fas fa-project-diagram"></i> Filière</span>
+                        <span class="insc-data-val">{{ $insc->classe?->filiere?->name ?? '—' }}</span>
+                    </div>
+                    <div class="insc-data-row">
+                        <span class="insc-data-lbl"><i class="fas fa-layer-group"></i> Niveau</span>
+                        <span class="insc-data-val">{{ $insc->classe?->niveau?->name ?? '—' }}</span>
+                    </div>
+                    <div class="insc-data-row">
+                        <span class="insc-data-lbl"><i class="fas fa-chalkboard"></i> Classe</span>
+                        <span class="insc-data-val">{{ $insc->classe?->name ?? '—' }}</span>
+                    </div>
+                    <div class="insc-data-row">
+                        <span class="insc-data-lbl"><i class="fas fa-calendar-plus"></i> Date inscription</span>
+                        <span class="insc-data-val">{{ $insc->created_at?->format('d/m/Y') ?? '—' }}</span>
+                    </div>
+                </div>
+
+                <div class="insc-affectation">
+                    @if(in_array($affStatus, ['affecté', 'réaffecté']))
+                        <span class="insc-aff-badge affecte"><i class="fas fa-check"></i> {{ ucfirst($affStatus) }}</span>
+                    @else
+                        <span class="insc-aff-badge non-affecte"><i class="fas fa-times"></i> Non affecté</span>
+                    @endif
+                </div>
+
+                <div class="insc-footer">
+                    <div class="insc-actions">
+                        <a href="{{ route('esbtp.inscriptions.show', $insc) }}" class="insc-btn view">
+                            <i class="fas fa-eye"></i> Voir
+                        </a>
+                        @can('update', $insc)
+                        <a href="{{ route('esbtp.inscriptions.edit', $insc) }}" class="insc-btn edit">
+                            <i class="fas fa-edit"></i> Modifier
+                        </a>
+                        @endcan
+                    </div>
+                </div>
             </div>
         </div>
-        @endforeach
+        {{-- CTA Réinscription si pas encore inscrit pour l'année courante --}}
+        @if($anneeCourante && !$inscCourante)
+        <a href="{{ route('esbtp.reinscription.show', $etudiant) }}" class="insc-card insc-cta-card">
+            <div class="insc-card-accent inactif"></div>
+            <div class="insc-card-inner" style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:12px;text-align:center;">
+                <div class="insc-cta-icon"><i class="fas fa-plus"></i></div>
+                <div>
+                    <div class="insc-cta-title">Réinscrire pour {{ $anneeCourante->name }}</div>
+                    <div class="insc-cta-sub">Cet étudiant n'est pas encore inscrit pour l'année en cours</div>
+                </div>
+                <i class="fas fa-arrow-right" style="color:var(--k-blue); opacity:.6;"></i>
+            </div>
+        </a>
+        @endif
+        </div>{{-- /grid --}}
+    </div>
+    @elseif($anneeCourante && !$inscCourante)
+    <div class="s-card">
+        <div class="s-card-header">
+            <div class="s-card-title">
+                <div class="s-card-title-icon"><i class="fas fa-file-signature"></i></div>
+                Inscription en cours
+            </div>
+        </div>
+        <div class="insc-grid">
+        <a href="{{ route('esbtp.reinscription.show', $etudiant) }}" class="insc-card insc-cta-card">
+            <div class="insc-card-accent inactif"></div>
+            <div class="insc-card-inner" style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:12px;text-align:center;">
+                <div class="insc-cta-icon"><i class="fas fa-plus"></i></div>
+                <div>
+                    <div class="insc-cta-title">Réinscrire pour {{ $anneeCourante->name }}</div>
+                    <div class="insc-cta-sub">Cet étudiant n'est pas encore inscrit pour l'année en cours</div>
+                </div>
+                <i class="fas fa-arrow-right" style="color:var(--k-blue); opacity:.6;"></i>
+            </div>
+        </a>
+        </div>{{-- /grid --}}
     </div>
     @endif
 
@@ -797,133 +1744,816 @@
 
 {{-- ─── TAB: ACADÉMIQUE ────────────────────────────────────────── --}}
 <div class="tab-panel" id="tab-academique">
-    @php
-        $inscriptionsTriees = $etudiant->inscriptions->sortByDesc(fn($i) => optional($i->anneeUniversitaire)->start_date);
-    @endphp
-    @if($inscriptionsTriees->count())
-        @foreach($inscriptionsTriees as $inscAc)
-        @php
-            $anneeLabel = optional($inscAc->anneeUniversitaire)->name ?? 'Année N/A';
-            $classeLabel = optional($inscAc->classe)->name;
-            $bulletinsAc = \App\Models\ESBTPBulletin::where('etudiant_id', $etudiant->id)
-                ->where('annee_universitaire_id', optional($inscAc->anneeUniversitaire)->id)
-                ->orderBy('periode')
-                ->get();
-        @endphp
-        <div class="s-card">
-            <div class="s-card-header">
-                <div class="s-card-title">
-                    <div class="s-card-title-icon"><i class="fas fa-calendar-alt"></i></div>
-                    {{ $anneeLabel }}
-                    @if($classeLabel)
-                        <span style="font-size:.78rem; font-weight:500; color:var(--k-muted)">— {{ $classeLabel }}</span>
+@php
+    /* ── Données ─────────────────────────────────────────────────── */
+    $acadInscs = $etudiant->inscriptions->sortByDesc(fn($i) => optional($i->anneeUniversitaire)->start_date);
+
+    /* Inscription de référence : la plus récente avec bulletins CALCULÉS (moyenne_generale > 0) */
+    $acadRef = null; $acadBuls = collect();
+    foreach ($acadInscs as $_i) {
+        $_b = \App\Models\ESBTPBulletin::where('etudiant_id', $etudiant->id)
+            ->where('annee_universitaire_id', optional($_i->anneeUniversitaire)->id)
+            ->orderBy('periode')->get();
+        /* Un bulletin n'est "calculé" que si au moins un a moyenne_generale > 0 */
+        $_bCalcules = $_b->filter(fn($b) => $b->moyenne_generale !== null && $b->moyenne_generale > 0);
+        if ($_bCalcules->count()) { $acadRef = $_i; $acadBuls = $_b; break; }
+    }
+    /* Fallback : inscription la plus récente avec resultats bruts */
+    if (!$acadRef) {
+        foreach ($acadInscs as $_i) {
+            $_r = \App\Models\ESBTPResultat::where('etudiant_id', $etudiant->id)
+                ->where('annee_universitaire_id', optional($_i->anneeUniversitaire)->id)
+                ->whereNotNull('moyenne')->exists();
+            if ($_r) { $acadRef = $_i; break; }
+        }
+    }
+    if (!$acadRef && $acadInscs->count()) $acadRef = $acadInscs->first();
+
+    /* Résultats bruts de l'année de référence (pour top/flop, sparkline et KPIs si pas de bulletins) */
+    $acadResultatsRef = \App\Models\ESBTPResultat::where('etudiant_id', $etudiant->id)
+        ->where('annee_universitaire_id', optional($acadRef?->anneeUniversitaire)->id)
+        ->with(['matiere'])->get();
+
+    /* KPIs hero — depuis bulletins si dispo, sinon depuis résultats bruts */
+    $acadLastBul = $acadBuls->last();
+    if ($acadBuls->count()) {
+        /* Cas avec bulletins : moyenne pondérée des bulletins (si > 0) */
+        $acadMgFromBul = $acadBuls->filter(fn($b) => $b->moyenne_generale > 0)->avg('moyenne_generale');
+        $acadMg      = $acadMgFromBul ? round($acadMgFromBul, 2) : null;
+        $acadRang    = $acadLastBul->rang;
+        $acadMention = $acadLastBul->mention;
+        /* Si bulletins ont moyenne_generale=0/null, fallback aux résultats bruts */
+        if ($acadMg === null) {
+            $acadAllNotesForKpi = $acadResultatsRef->whereNotNull('moyenne');
+            if ($acadAllNotesForKpi->count()) {
+                $sommePoints = 0; $sommeCoeffs = 0;
+                foreach ($acadAllNotesForKpi as $_r) {
+                    $coef = $_r->coefficient ?? 1;
+                    $sommePoints += $_r->moyenne * $coef;
+                    $sommeCoeffs += $coef;
+                }
+                $acadMg = $sommeCoeffs > 0 ? round($sommePoints / $sommeCoeffs, 2) : null;
+            }
+            if (!$acadMention && $acadMg !== null) {
+                $acadMention = match(true) {
+                    $acadMg >= 16 => 'Excellent',
+                    $acadMg >= 14 => 'Très Bien',
+                    $acadMg >= 12 => 'Bien',
+                    $acadMg >= 10 => 'Assez Bien',
+                    default       => 'Passable',
+                };
+            }
+        }
+    } else {
+        /* Cas sans bulletins : calculer moyenne pondérée depuis ESBTPResultat */
+        $acadAllNotesForKpi = $acadResultatsRef->whereNotNull('moyenne');
+        if ($acadAllNotesForKpi->count()) {
+            $sommePoints = 0; $sommeCoeffs = 0;
+            foreach ($acadAllNotesForKpi as $_r) {
+                $coef = $_r->coefficient ?? 1;
+                $sommePoints += $_r->moyenne * $coef;
+                $sommeCoeffs += $coef;
+            }
+            $acadMg = $sommeCoeffs > 0 ? round($sommePoints / $sommeCoeffs, 2) : null;
+            /* Mention calculée depuis la moyenne */
+            $acadMention = match(true) {
+                $acadMg === null => null,
+                $acadMg >= 16   => 'Excellent',
+                $acadMg >= 14   => 'Très Bien',
+                $acadMg >= 12   => 'Bien',
+                $acadMg >= 10   => 'Assez Bien',
+                default         => 'Passable',
+            };
+        } else {
+            $acadMg = null; $acadMention = null;
+        }
+        $acadRang = null; /* Rang non calculable sans bulletin officiel */
+    }
+
+    $acadAnnee  = optional($acadRef?->anneeUniversitaire)->name ?? '—';
+    $acadClasse = optional($acadRef?->classe)->name ?? '—';
+
+    /* Mention CSS class */
+    $acadMentionCls = match(true) {
+        !$acadMention => 'passable',
+        str_contains(strtolower($acadMention), 'excellent') || str_contains(strtolower($acadMention), 'très bien') => 'excellent',
+        str_contains(strtolower($acadMention), 'bien') && !str_contains(strtolower($acadMention), 'assez') => 'bien',
+        str_contains(strtolower($acadMention), 'assez') => 'assez',
+        default => 'passable',
+    };
+
+    $acadAllNotes = $acadResultatsRef->whereNotNull('moyenne');
+
+    /* Top 3 / flop matières */
+    $acadTop  = $acadAllNotes->sortByDesc('moyenne')->take(3);
+    $acadFlop = $acadAllNotes->where('moyenne', '<', 10)->sortBy('moyenne')->take(3);
+
+    /* Sparkline : moyennes pondérées par période */
+    $acadSparkData = $acadResultatsRef->groupBy(fn($r) => $r->periode ?? 'N/A')
+        ->map(function($g) {
+            $sp = 0; $sc = 0;
+            foreach ($g->whereNotNull('moyenne') as $r) {
+                $c = $r->coefficient ?? 1;
+                $sp += $r->moyenne * $c;
+                $sc += $c;
+            }
+            return $sc > 0 ? round($sp / $sc, 2) : 0;
+        })
+        ->sortKeys();
+
+    /* Résultats groupés par semestre pour l'affichage détail */
+    $acadSemestres = $acadResultatsRef->groupBy(fn($r) => $r->periode ?? 'N/A')->sortKeys();
+
+    /* Années précédentes */
+    $acadAutres = $acadInscs->filter(fn($i) => !$acadRef || $i->id !== $acadRef->id);
+
+    /* Notice : données d'une année différente de l'année courante */
+    $acadAnneeCourante = $presAnneeCourante ?? \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
+    $acadIsNotCurrentYear = $acadAnneeCourante && $acadRef
+        && $acadRef->annee_universitaire_id !== $acadAnneeCourante->id;
+@endphp
+
+@if($acadInscs->count())
+
+    {{-- ══ BLOC ANNÉE EN COURS (toujours plat, jamais collapsible) ══ --}}
+    @if($acadIsNotCurrentYear)
+        {{-- Pas de données pour l'année courante --}}
+        <div class="fin-hero" style="margin-bottom:16px;">
+            <div class="fin-hero-year-badge" style="background:rgba(239,68,68,.15); border-color:rgba(239,68,68,.3);">
+                <i class="fas fa-calendar-times" style="color:#ef4444;"></i>
+                <span style="color:#ef4444;">Aucune inscription pour {{ $acadAnneeCourante?->name ?? 'l\'année en cours' }}</span>
+            </div>
+            <p style="margin:12px 0 0; font-size:.82rem; color:var(--k-muted); text-align:center;">
+                <i class="fas fa-info-circle" style="margin-right:5px;"></i>Pas encore de résultats académiques pour l'année en cours. Consultez les années précédentes ci-dessous.
+            </p>
+        </div>
+    @else
+    {{-- ══ HERO BILAN (année courante avec données) ══════════════════ --}}
+    {{-- Badge plat "Année en cours" au-dessus du hero --}}
+    <div class="fin-hero" style="margin-bottom:16px;">
+        <div class="fin-hero-year-badge">
+            <i class="fas fa-calendar-check"></i>
+            Année en cours :
+            <strong>{{ $acadAnnee }}</strong>
+            @if($acadClasse)
+                &middot; {{ $acadClasse }}
+            @endif
+        </div>
+    </div>
+    <div class="acad-hero">
+        <div class="acad-hero-top">
+            <div>
+                <div class="acad-hero-label"><i class="fas fa-graduation-cap" style="margin-right:5px;"></i>Bilan académique</div>
+                <div class="acad-hero-title">{{ $acadAnnee }}</div>
+                <div class="acad-hero-subtitle">{{ $acadClasse }}</div>
+            </div>
+            @if($acadLastBul)
+            <a href="{{ route('esbtp.bulletins.download', $acadLastBul) }}" class="acad-hero-pdf-btn" target="_blank">
+                <i class="fas fa-file-pdf"></i> Bulletin PDF
+            </a>
+            @endif
+        </div>
+
+        <div class="acad-kpi-row">
+            {{-- KPI 1 : Moyenne générale --}}
+            @php
+                $mgPct = $acadMg !== null ? min(100, round($acadMg / 20 * 100)) : 0;
+                $circumference = 2 * 3.14159 * 28; // r=28
+                $mgOffset = $circumference - ($mgPct / 100 * $circumference);
+                $mgStroke = $acadMg === null ? '#64748b' : ($acadMg >= 14 ? '#10b981' : ($acadMg >= 12 ? '#34d399' : ($acadMg >= 10 ? '#f59e0b' : '#ef4444')));
+            @endphp
+            <div class="acad-kpi-block">
+                <div class="acad-kpi-label">Moyenne</div>
+                <div class="acad-ring-wrap">
+                    <svg viewBox="0 0 64 64">
+                        <circle class="acad-ring-bg" cx="32" cy="32" r="28"/>
+                        <circle class="acad-ring-fg"
+                            cx="32" cy="32" r="28"
+                            stroke="{{ $mgStroke }}"
+                            stroke-dasharray="{{ $circumference }}"
+                            stroke-dashoffset="{{ $acadMg !== null ? $mgOffset : $circumference }}"/>
+                    </svg>
+                    <div class="acad-ring-center">
+                        <span class="acad-ring-val" style="color:{{ $mgStroke }};">
+                            {{ $acadMg !== null ? number_format($acadMg, 1) : '—' }}
+                        </span>
+                        @if($acadMg !== null)<span class="acad-ring-denom">/20</span>@endif
+                    </div>
+                </div>
+                <div class="acad-kpi-sub">
+                    @if($acadMg !== null)
+                        {{ $acadMg >= 14 ? 'Excellent' : ($acadMg >= 12 ? 'Bien' : ($acadMg >= 10 ? 'Passable' : 'Insuffisant')) }}
+                    @else
+                        Aucune moyenne
                     @endif
                 </div>
-                @if($bulletinsAc->avg('moyenne_generale') !== null)
-                    @php $ma = round($bulletinsAc->avg('moyenne_generale'), 2); @endphp
-                    <span class="sem-score {{ $ma >= 12 ? 'green' : ($ma >= 10 ? 'amber' : 'red') }}">
-                        {{ number_format($ma, 2) }}/20
-                    </span>
-                @endif
             </div>
 
-            @if($bulletinsAc->count())
-                <div class="semestre-grid">
-                @foreach($bulletinsAc as $bul)
-                @php $mg = $bul->moyenne_generale; @endphp
-                <div class="sem-card">
-                    <div class="sem-card-head">
-                        <span class="sem-card-name">{{ ucfirst(str_replace('semestre', 'Semestre ', $bul->periode)) }}</span>
-                        @if($mg !== null)
-                            <span class="sem-score {{ $mg >= 12 ? 'green' : ($mg >= 10 ? 'amber' : 'red') }}">
-                                {{ number_format($mg, 2) }}
-                            </span>
-                        @endif
-                    </div>
-                    <div class="sem-card-body">
-                        @if($bul->rang)
-                            <div class="mat-row">
-                                <span class="mat-name" style="font-weight:600">Rang</span>
-                                <span class="mat-note good">{{ $bul->rang }}</span>
-                            </div>
-                        @endif
-                        @if($bul->mention)
-                            <div class="mat-row">
-                                <span class="mat-name" style="font-weight:600">Mention</span>
-                                <span class="mat-coeff">{{ $bul->mention }}</span>
-                            </div>
-                        @endif
-                        <div class="mat-row" style="margin-top:8px">
-                            <a href="{{ route('esbtp.bulletins.download', $bul) }}" class="insc-btn pdf" style="font-size:.75rem; padding:4px 10px" target="_blank">
-                                <i class="fas fa-file-pdf"></i> Bulletin PDF
-                            </a>
-                        </div>
-                    </div>
+            {{-- KPI 2 : Rang --}}
+            <div class="acad-kpi-block">
+                <div class="acad-kpi-label">Classement</div>
+                <div class="acad-rang-display">
+                    @if($acadRang)
+                        <span class="acad-rang-num">{{ $acadRang }}</span>
+                        <span class="acad-rang-icon"><i class="fas fa-trophy"></i></span>
+                    @else
+                        <span style="font-size:1.5rem; color:rgba(255,255,255,.3);">—</span>
+                    @endif
                 </div>
-                @endforeach
+                <div class="acad-kpi-sub">
+                    @if($acadRang) Rang de classe @else Non classé @endif
                 </div>
-            @else
-                {{-- Pas de bulletin calculé — afficher les résultats bruts si dispo --}}
-                @php
-                    $resultatsAc = \App\Models\ESBTPResultat::where('etudiant_id', $etudiant->id)
-                        ->whereHas('evaluation', fn($q) => $q->where('annee_universitaire_id', optional($inscAc->anneeUniversitaire)->id))
-                        ->with(['matiere', 'evaluation'])
-                        ->get()
-                        ->groupBy(fn($r) => $r->evaluation->semestre ?? 'N/A');
-                @endphp
-                @if($resultatsAc->count())
-                    <div class="semestre-grid">
-                    @foreach($resultatsAc as $semNum => $resultsSem)
-                    <div class="sem-card">
-                        <div class="sem-card-head">
-                            <span class="sem-card-name">Semestre {{ $semNum }}</span>
-                            @php $mgR = round($resultsSem->avg('moyenne'), 2); @endphp
-                            @if($mgR)
-                                <span class="sem-score {{ $mgR >= 12 ? 'green' : ($mgR >= 10 ? 'amber' : 'red') }}">{{ number_format($mgR, 2) }}</span>
-                            @endif
-                        </div>
-                        <div class="sem-card-body">
-                            @foreach($resultsSem as $res)
-                            @php $n = $res->moyenne; @endphp
-                            <div class="mat-row">
-                                <span class="mat-name">{{ optional($res->matiere)->nom ?? '—' }}</span>
-                                <span class="mat-note {{ ($n !== null && $n >= 12) ? 'good' : (($n !== null && $n >= 10) ? 'mid' : 'bad') }}">
-                                    {{ $n !== null ? number_format($n, 2) : '—' }}
+            </div>
+
+            {{-- KPI 3 : Mention --}}
+            <div class="acad-kpi-block">
+                <div class="acad-kpi-label">Mention</div>
+                <div class="acad-mention-display">
+                    <i class="fas fa-award" style="font-size:1.8rem; color:{{ $acadMentionCls === 'excellent' ? '#34d399' : ($acadMentionCls === 'bien' ? '#93c5fd' : ($acadMentionCls === 'assez' ? '#fcd34d' : 'rgba(255,255,255,.3)')) }};"></i>
+                </div>
+                @if($acadMention)
+                    <span class="acad-mention-badge {{ $acadMentionCls }}">{{ $acadMention }}</span>
+                @else
+                    <div class="acad-kpi-sub" style="color:rgba(255,255,255,.4);">Non évalué</div>
+                @endif
+            </div>
+        </div>
+    </div>
+
+    {{-- ══ SPARKLINE : évolution par semestre ══════════════════════ --}}
+    @if($acadSparkData->count() >= 2)
+    @php
+        $sparkMax = $acadSparkData->max() ?: 20;
+    @endphp
+    <div class="acad-sparkline-section">
+        <div class="acad-sparkline-title"><i class="fas fa-chart-line" style="margin-right:5px;"></i>Progression par semestre</div>
+        <div class="acad-sparkline-bars">
+            @foreach($acadSparkData as $periode => $moy)
+            @php
+                $barH = $sparkMax > 0 ? max(8, round($moy / $sparkMax * 44)) : 8;
+                $barColor = $moy >= 14 ? '#10b981' : ($moy >= 12 ? '#3b82f6' : ($moy >= 10 ? '#f59e0b' : '#ef4444'));
+            @endphp
+            <div class="acad-spark-bar-wrap">
+                <span class="acad-spark-val" style="color:{{ $barColor }};">{{ number_format($moy, 1) }}</span>
+                <div class="acad-spark-bar" style="height:{{ $barH }}px; background:{{ $barColor }};"></div>
+                <span class="acad-spark-label">{{ ucfirst(str_replace(['semestre', '_', '-'], ['S', ' ', ' '], strtolower($periode))) }}</span>
+            </div>
+            @endforeach
+        </div>
+    </div>
+    @endif
+
+    {{-- ══ TOP / FLOP matières ══════════════════════════════════════ --}}
+    @if($acadTop->count() || $acadFlop->count())
+    <div class="acad-topflop-row">
+        @if($acadTop->count())
+        <div class="acad-topflop-card">
+            <div class="acad-topflop-head" style="color:var(--k-success);">
+                <i class="fas fa-arrow-trend-up"></i> Meilleures matières
+            </div>
+            @foreach($acadTop as $tm)
+            @php $tn = $tm->moyenne; @endphp
+            <div class="acad-topflop-item">
+                <span class="acad-topflop-name" title="{{ optional($tm->matiere)->name }}">{{ optional($tm->matiere)->name ?? '—' }}</span>
+                <span class="acad-topflop-note" style="color:var(--k-success);">{{ number_format($tn, 2) }}</span>
+            </div>
+            @endforeach
+        </div>
+        @endif
+        @if($acadFlop->count())
+        <div class="acad-topflop-card">
+            <div class="acad-topflop-head" style="color:var(--k-danger);">
+                <i class="fas fa-arrow-trend-down"></i> Matières en difficulté
+            </div>
+            @foreach($acadFlop as $fm)
+            @php $fn = $fm->moyenne; @endphp
+            <div class="acad-topflop-item">
+                <span class="acad-topflop-name" title="{{ optional($fm->matiere)->name }}">{{ optional($fm->matiere)->name ?? '—' }}</span>
+                <span class="acad-topflop-note" style="color:var(--k-danger);">{{ number_format($fn, 2) }}</span>
+            </div>
+            @endforeach
+        </div>
+        @elseif($acadTop->count())
+        {{-- Pas de matières en difficulté = message positif --}}
+        <div class="acad-topflop-card" style="display:flex; align-items:center; justify-content:center; gap:10px; color:var(--k-success);">
+            <i class="fas fa-check-circle" style="font-size:1.4rem;"></i>
+            <div>
+                <div style="font-size:.82rem; font-weight:700;">Aucune difficulté</div>
+                <div style="font-size:.72rem; color:var(--k-muted);">Toutes les notes ≥ 10</div>
+            </div>
+        </div>
+        @endif
+    </div>
+    @endif
+
+    {{-- ══ DÉTAIL PAR SEMESTRE ══════════════════════════════════════ --}}
+    @if($acadBuls->count())
+        {{-- Avec bulletins officiels --}}
+        @foreach($acadBuls as $bul)
+        @php
+            /* Résultats matières pour ce semestre */
+            $semResultats = \App\Models\ESBTPResultat::where('etudiant_id', $etudiant->id)
+                ->where('annee_universitaire_id', optional($acadRef->anneeUniversitaire)->id)
+                ->where('periode', $bul->periode)
+                ->with(['matiere'])->get()
+                ->sortBy(fn($r) => optional($r->matiere)->name);
+
+            /* Moyenne semestre : bulletin officiel, sinon calculée depuis résultats */
+            $mg = ($bul->moyenne_generale > 0) ? $bul->moyenne_generale : null;
+            if ($mg === null && $semResultats->count()) {
+                $_sp = 0; $_sc = 0;
+                foreach ($semResultats->whereNotNull('moyenne') as $_sr) {
+                    $_coef = $_sr->coefficient ?? 1;
+                    $_sp += $_sr->moyenne * $_coef;
+                    $_sc += $_coef;
+                }
+                $mg = $_sc > 0 ? round($_sp / $_sc, 2) : null;
+            }
+            $semKey = 'acad-sem-' . $bul->id;
+            $semBadgeCls = $mg === null ? '' : ($mg >= 12 ? 'green' : ($mg >= 10 ? 'amber' : 'red'));
+            $semLabel = ucfirst(str_replace(['semestre', '_', '-'], ['Semestre ', ' ', ' '], strtolower($bul->periode ?? '')));
+        @endphp
+        <div class="acad-sem-block">
+            <div class="acad-sem-header"
+                 data-bs-toggle="collapse"
+                 data-bs-target="#{{ $semKey }}"
+                 aria-expanded="{{ $loop->first ? 'true' : 'false' }}">
+                <div class="acad-sem-header-left">
+                    <i class="fas fa-book-open" style="color:var(--k-blue); font-size:.8rem;"></i>
+                    <span class="acad-sem-period">{{ $semLabel ?: 'Semestre' }}</span>
+                    @if($bul->rang)
+                        <span style="font-size:.72rem; color:var(--k-muted);">
+                            <i class="fas fa-trophy" style="color:#f59e0b; font-size:.65rem;"></i> {{ $bul->rang }}
+                        </span>
+                    @endif
+                </div>
+                <div class="acad-sem-header-right">
+                    @if($mg !== null)
+                        <span class="acad-sem-badge {{ $semBadgeCls }}">{{ number_format($mg, 2) }}/20</span>
+                    @endif
+                    @php
+                        $semMention = $bul->mention;
+                        if (!$semMention && $mg !== null) {
+                            $semMention = $mg >= 16 ? 'Excellent' : ($mg >= 14 ? 'Très Bien' : ($mg >= 12 ? 'Bien' : ($mg >= 10 ? 'Assez Bien' : 'Passable')));
+                        }
+                        $mc2 = !$semMention ? 'passable' : match(true) {
+                            str_contains(strtolower($semMention), 'excellent') || str_contains(strtolower($semMention), 'très bien') => 'excellent',
+                            str_contains(strtolower($semMention), 'bien') && !str_contains(strtolower($semMention), 'assez') => 'bien',
+                            str_contains(strtolower($semMention), 'assez') => 'assez',
+                            default => 'passable',
+                        };
+                    @endphp
+                    @if($semMention)
+                        <span class="acad-mention-badge {{ $mc2 }}" style="font-size:.65rem;">{{ $semMention }}</span>
+                    @endif
+                    <a href="{{ route('esbtp.bulletins.download', $bul) }}" class="acad-arch-pdf-link" target="_blank" onclick="event.stopPropagation()">
+                        <i class="fas fa-file-pdf"></i> PDF
+                    </a>
+                    <i class="fas fa-chevron-down acad-sem-chevron"></i>
+                </div>
+            </div>
+            <div class="collapse {{ $loop->first ? 'show' : '' }}" id="{{ $semKey }}">
+                <div class="acad-mat-list">
+                    @if($semResultats->count())
+                        @foreach($semResultats as $res)
+                        @php
+                            $rn = $res->moyenne;
+                            $rc = optional($res->matiere)->coefficient ?? optional($res->matiere)->coeff ?? null;
+                            $rnom = optional($res->matiere)->name ?? '—';
+                            $rclass = $rn === null ? '' : ($rn >= 12 ? 'good' : ($rn >= 10 ? 'mid' : 'bad'));
+                            $rcolor = $rn === null ? '#94a3b8' : ($rn >= 12 ? '#10b981' : ($rn >= 10 ? '#f59e0b' : '#ef4444'));
+                            $rpct = $rn !== null ? min(100, round($rn / 20 * 100)) : 0;
+                        @endphp
+                        <div class="acad-mat-item">
+                            <div class="acad-mat-top">
+                                <span class="acad-mat-name">{{ $rnom }}</span>
+                                @if($rc) <span class="acad-mat-coeff-pill">Coef. {{ $rc }}</span> @endif
+                                <span class="acad-mat-score {{ $rclass }}">
+                                    {{ $rn !== null ? number_format($rn, 2) : '—' }}
+                                    @if($rn !== null)<span style="font-size:.65em; font-weight:500; opacity:.6;">/20</span>@endif
                                 </span>
                             </div>
-                            @endforeach
+                            @if($rn !== null)
+                            <div class="acad-mat-bar-wrap">
+                                <div class="acad-mat-bar" style="width:{{ $rpct }}%; background:{{ $rcolor }};"></div>
+                            </div>
+                            @endif
                         </div>
+                        @endforeach
+                    @else
+                        <p style="font-size:.8rem; color:var(--k-muted); text-align:center; padding:12px 0; margin:0;">
+                            Détail des matières non disponible
+                        </p>
+                    @endif
+                </div>
+            </div>
+        </div>
+        @endforeach
+
+    @elseif($acadSemestres->count())
+        {{-- Résultats bruts sans bulletin --}}
+        @foreach($acadSemestres as $periodeKey => $semGroup)
+        @php
+            /* Moyenne pondérée par coefficient pour ce semestre */
+            $_sp = 0; $_sc = 0;
+            foreach ($semGroup->whereNotNull('moyenne') as $_sr) {
+                $_coef = $_sr->coefficient ?? 1;
+                $_sp += $_sr->moyenne * $_coef;
+                $_sc += $_coef;
+            }
+            $mgBrut = $_sc > 0 ? round($_sp / $_sc, 2) : 0;
+            $semKeyB = 'acad-sem-b-' . Str::slug($periodeKey);
+            $semBadgeClsB = $mgBrut >= 12 ? 'green' : ($mgBrut >= 10 ? 'amber' : 'red');
+            $semLabelB = ucfirst(str_replace(['semestre', '_', '-'], ['Semestre ', ' ', ' '], strtolower($periodeKey)));
+        @endphp
+        <div class="acad-sem-block">
+            <div class="acad-sem-header"
+                 data-bs-toggle="collapse"
+                 data-bs-target="#{{ $semKeyB }}"
+                 aria-expanded="{{ $loop->first ? 'true' : 'false' }}">
+                <div class="acad-sem-header-left">
+                    <i class="fas fa-book-open" style="color:var(--k-blue); font-size:.8rem;"></i>
+                    <span class="acad-sem-period">{{ $semLabelB ?: 'Semestre' }}</span>
+                </div>
+                <div class="acad-sem-header-right">
+                    @if($mgBrut)
+                        <span class="acad-sem-badge {{ $semBadgeClsB }}">{{ number_format($mgBrut, 2) }}/20</span>
+                    @endif
+                    <i class="fas fa-chevron-down acad-sem-chevron"></i>
+                </div>
+            </div>
+            <div class="collapse {{ $loop->first ? 'show' : '' }}" id="{{ $semKeyB }}">
+                <div class="acad-mat-list">
+                    @foreach($semGroup->sortBy(fn($r) => optional($r->matiere)->name) as $res)
+                    @php
+                        $rn = $res->moyenne;
+                        $rc = optional($res->matiere)->coefficient ?? optional($res->matiere)->coeff ?? null;
+                        $rnom = optional($res->matiere)->name ?? '—';
+                        $rclass = $rn === null ? '' : ($rn >= 12 ? 'good' : ($rn >= 10 ? 'mid' : 'bad'));
+                        $rcolor = $rn === null ? '#94a3b8' : ($rn >= 12 ? '#10b981' : ($rn >= 10 ? '#f59e0b' : '#ef4444'));
+                        $rpct = $rn !== null ? min(100, round($rn / 20 * 100)) : 0;
+                    @endphp
+                    <div class="acad-mat-item">
+                        <div class="acad-mat-top">
+                            <span class="acad-mat-name">{{ $rnom }}</span>
+                            @if($rc) <span class="acad-mat-coeff-pill">Coef. {{ $rc }}</span> @endif
+                            <span class="acad-mat-score {{ $rclass }}">
+                                {{ $rn !== null ? number_format($rn, 2) : '—' }}
+                                @if($rn !== null)<span style="font-size:.65em; font-weight:500; opacity:.6;">/20</span>@endif
+                            </span>
+                        </div>
+                        @if($rn !== null)
+                        <div class="acad-mat-bar-wrap">
+                            <div class="acad-mat-bar" style="width:{{ $rpct }}%; background:{{ $rcolor }};"></div>
+                        </div>
+                        @endif
                     </div>
                     @endforeach
-                    </div>
-                @else
-                    <p style="font-size:.82rem; color:var(--k-muted); text-align:center; padding:16px 0; margin:0">Aucune note enregistrée pour cette année</p>
-                @endif
-            @endif
+                </div>
+            </div>
         </div>
         @endforeach
     @else
         <div class="s-card">
-            <div class="empty-state">
-                <i class="fas fa-graduation-cap"></i>
-                <p>Aucun résultat académique disponible</p>
-            </div>
+            <p style="text-align:center; color:var(--k-muted); font-size:.85rem; padding:16px 0; margin:0;">
+                <i class="fas fa-info-circle" style="margin-right:6px;"></i>Aucune note enregistrée pour cette année
+            </p>
         </div>
     @endif
+
+    @endif {{-- fin @else acadIsNotCurrentYear --}}
+
+    {{-- ══ ANNÉES PRÉCÉDENTES ══════════════════════════════════════ --}}
+    @php
+        /* Si l'année courante n'a pas de données, TOUTES les inscriptions vont en "précédentes" */
+        $acadInscsPrec = $acadIsNotCurrentYear ? $acadInscs : $acadAutres;
+    @endphp
+    @if($acadInscsPrec->count())
+    <div class="acad-arch-sep">
+        <div class="acad-arch-sep-line"></div>
+        <span class="acad-arch-sep-label"><i class="fas fa-history" style="margin-right:4px;"></i>Années précédentes</span>
+        <div class="acad-arch-sep-line"></div>
+    </div>
+
+    @foreach($acadInscsPrec as $autreInsc)
+    @php
+        $autreBuls = \App\Models\ESBTPBulletin::where('etudiant_id', $etudiant->id)
+            ->where('annee_universitaire_id', optional($autreInsc->anneeUniversitaire)->id)
+            ->orderBy('periode')->get();
+        $autreMention = $autreBuls->last()?->mention;
+        $autreAnneeLabel = optional($autreInsc->anneeUniversitaire)->name ?? 'Année N/A';
+        $autreClasseLabel = optional($autreInsc->classe)->name ?? '';
+        $autreArchKey = 'acad-arch-' . $autreInsc->id;
+
+        /* Résultats bruts pour calcul pondéré : utilisés si bulletins sans moyenne_generale */
+        $autreResultatsBruts = \App\Models\ESBTPResultat::where('etudiant_id', $etudiant->id)
+            ->where('annee_universitaire_id', optional($autreInsc->anneeUniversitaire)->id)
+            ->with(['matiere'])->get();
+
+        /* Calcul moyenne générale : bulletins officiels si disponibles, sinon pondéré depuis ESBTPResultat */
+        $autreBulsValides = $autreBuls->filter(fn($b) => ($b->moyenne_generale ?? 0) > 0);
+        if ($autreBulsValides->count()) {
+            $autreMg = round($autreBulsValides->avg('moyenne_generale'), 2);
+        } elseif ($autreResultatsBruts->whereNotNull('moyenne')->count()) {
+            $_sp = 0; $_sc = 0;
+            foreach ($autreResultatsBruts->whereNotNull('moyenne') as $_ar) {
+                $_coef = $_ar->coefficient ?? $_ar->matiere?->coefficient ?? 1;
+                $_sp += $_ar->moyenne * $_coef;
+                $_sc += $_coef;
+            }
+            $autreMg = $_sc > 0 ? round($_sp / $_sc, 2) : null;
+        } else {
+            $autreMg = null;
+        }
+
+        $autreMgColor = $autreMg === null ? 'var(--k-muted)' : ($autreMg >= 12 ? 'var(--k-success)' : ($autreMg >= 10 ? '#d97706' : 'var(--k-danger)'));
+
+        /* Résultats groupés par période pour affichage dans le body */
+        $autreResultats = !$autreBuls->count()
+            ? $autreResultatsBruts->groupBy(fn($r) => $r->periode ?? 'N/A')
+            : collect();
+    @endphp
+    <div class="acad-arch-card">
+        <button class="acad-arch-toggle"
+                data-bs-toggle="collapse"
+                data-bs-target="#{{ $autreArchKey }}"
+                aria-expanded="false">
+            <div class="acad-arch-toggle-left">
+                <span class="acad-arch-year">{{ $autreAnneeLabel }}</span>
+                @if($autreClasseLabel)
+                    <span class="acad-arch-class">{{ $autreClasseLabel }}</span>
+                @endif
+            </div>
+            <div class="acad-arch-toggle-right">
+                @if($autreMg !== null)
+                    <span class="acad-arch-kpi" style="color:{{ $autreMgColor }};">{{ number_format($autreMg, 2) }}/20</span>
+                @endif
+                @if($autreMention)
+                    @php
+                        $amCls = match(true) {
+                            str_contains(strtolower($autreMention), 'excellent') || str_contains(strtolower($autreMention), 'très bien') => 'excellent',
+                            str_contains(strtolower($autreMention), 'bien') && !str_contains(strtolower($autreMention), 'assez') => 'bien',
+                            str_contains(strtolower($autreMention), 'assez') => 'assez',
+                            default => 'passable',
+                        };
+                    @endphp
+                    <span class="acad-mention-badge {{ $amCls }}" style="font-size:.65rem;">{{ $autreMention }}</span>
+                @endif
+                <i class="fas fa-chevron-down acad-arch-chevron"></i>
+            </div>
+        </button>
+        <div class="collapse" id="{{ $autreArchKey }}">
+            <div class="acad-arch-body">
+                @if($autreBuls->count())
+                    @foreach($autreBuls as $ab)
+                    @php
+                        $abMgRaw = $ab->moyenne_generale;
+                        /* Si le bulletin n'a pas de moyenne_generale, calculer depuis ESBTPResultat pondéré */
+                        if (!$abMgRaw && $ab->periode) {
+                            $_abResultats = $autreResultatsBruts->where('periode', $ab->periode)->whereNotNull('moyenne');
+                            if ($_abResultats->count()) {
+                                $_abSp = 0; $_abSc = 0;
+                                foreach ($_abResultats as $_abR) {
+                                    $_abCoef = $_abR->coefficient ?? $_abR->matiere?->coefficient ?? 1;
+                                    $_abSp += $_abR->moyenne * $_abCoef;
+                                    $_abSc += $_abCoef;
+                                }
+                                $abMg = $_abSc > 0 ? round($_abSp / $_abSc, 2) : null;
+                            } else {
+                                $abMg = null;
+                            }
+                        } else {
+                            $abMg = $abMgRaw ?: null;
+                        }
+                        $abLabel = ucfirst(str_replace(['semestre', '_', '-'], ['Semestre ', ' ', ' '], strtolower($ab->periode ?? '')));
+                        $abMgCls = $abMg === null ? 'var(--k-muted)' : ($abMg >= 12 ? 'var(--k-success)' : ($abMg >= 10 ? '#d97706' : 'var(--k-danger)'));
+                    @endphp
+                    <div class="acad-arch-sem-row">
+                        <span class="acad-arch-sem-name">{{ $abLabel ?: 'Semestre' }}</span>
+                        <div class="acad-arch-sem-info">
+                            @if($ab->rang)
+                                <span style="font-size:.75rem; color:var(--k-muted);">
+                                    <i class="fas fa-trophy" style="color:#f59e0b; font-size:.65rem;"></i> {{ $ab->rang }}
+                                </span>
+                            @endif
+                            @if($abMg !== null)
+                                <span style="font-size:.8rem; font-weight:700; color:{{ $abMgCls }};">{{ number_format($abMg, 2) }}/20</span>
+                            @endif
+                            <a href="{{ route('esbtp.bulletins.download', $ab) }}" class="acad-arch-pdf-link" target="_blank">
+                                <i class="fas fa-file-pdf"></i> PDF
+                            </a>
+                        </div>
+                    </div>
+                    @endforeach
+                @elseif($autreResultats->count())
+                    @foreach($autreResultats as $arPeriode => $arGroup)
+                    @php
+                        /* Calcul pondéré par coefficient */
+                        $_arSp = 0; $_arSc = 0;
+                        foreach ($arGroup->whereNotNull('moyenne') as $_arR) {
+                            $_arCoef = $_arR->coefficient ?? $_arR->matiere?->coefficient ?? 1;
+                            $_arSp += $_arR->moyenne * $_arCoef;
+                            $_arSc += $_arCoef;
+                        }
+                        $arMg = $_arSc > 0 ? round($_arSp / $_arSc, 2) : 0;
+                        $arLabel = ucfirst(str_replace(['semestre', '_', '-'], ['Semestre ', ' ', ' '], strtolower($arPeriode)));
+                        $arColor = $arMg >= 12 ? 'var(--k-success)' : ($arMg >= 10 ? '#d97706' : 'var(--k-danger)');
+                    @endphp
+                    <div class="acad-arch-sem-row">
+                        <span class="acad-arch-sem-name">{{ $arLabel ?: 'Semestre' }}</span>
+                        <div class="acad-arch-sem-info">
+                            @if($arMg)
+                                <span style="font-size:.8rem; font-weight:700; color:{{ $arColor }};">{{ number_format($arMg, 2) }}/20</span>
+                            @endif
+                            <span style="font-size:.72rem; color:var(--k-muted);">{{ $arGroup->count() }} matière(s)</span>
+                        </div>
+                    </div>
+                    @endforeach
+                @else
+                    <p style="font-size:.8rem; color:var(--k-muted); margin:0;">Aucune donnée disponible</p>
+                @endif
+            </div>
+        </div>
+    </div>
+    @endforeach
+    @endif
+
+@else
+    <div class="s-card">
+        <div class="empty-state">
+            <i class="fas fa-graduation-cap"></i>
+            <p>Aucun résultat académique disponible</p>
+        </div>
+    </div>
+@endif
 </div>{{-- /tab-academique --}}
 
 {{-- ─── TAB: PRÉSENCES ─────────────────────────────────────────── --}}
 <div class="tab-panel" id="tab-presences">
     @php
+        $presAnneeCourante    = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
         $inscriptionsPresences = $etudiant->inscriptions->sortByDesc(fn($i) => optional($i->anneeUniversitaire)->start_date);
+        $presInscCourante     = $presAnneeCourante
+            ? $inscriptionsPresences->first(fn($i) => $i->annee_universitaire_id === $presAnneeCourante->id)
+            : null;
+        $presInscsPrecedentes = $presInscCourante
+            ? $inscriptionsPresences->filter(fn($i) => $i->id !== $presInscCourante->id)
+            : $inscriptionsPresences;
     @endphp
-    @if($inscriptionsPresences->count())
-        @foreach($inscriptionsPresences as $inscPres)
+
+    @if($inscriptionsPresences->isEmpty())
+        <div class="s-card">
+            <div class="empty-state">
+                <i class="fas fa-calendar-check"></i>
+                <p>Aucune donnée de présence disponible</p>
+            </div>
+        </div>
+    @else
+
+    {{-- ── Année en cours : bloc FLAT (toujours visible) ── --}}
+    @if($presAnneeCourante)
+    @php
+        if ($presInscCourante) {
+            $anneePresId    = $presAnneeCourante->id;
+            $attRowCur = \App\Models\ESBTPAttendance::finalOnly()
+                ->where('etudiant_id', $etudiant->id)
+                ->where('annee_universitaire_id', $anneePresId)
+                ->selectRaw("COUNT(*) as total, SUM(CASE WHEN statut='present' THEN 1 ELSE 0 END) as nb_presences, SUM(CASE WHEN statut='absent' THEN 1 ELSE 0 END) as nb_absences, SUM(CASE WHEN statut='excuse' THEN 1 ELSE 0 END) as nb_absences_just, SUM(CASE WHEN statut IN ('retard','late') THEN 1 ELSE 0 END) as nb_retards")
+                ->first();
+            $totalCur  = (int)($attRowCur->total ?? 0);
+            $presCur   = (int)($attRowCur->nb_presences ?? 0);
+            $retardCur = (int)($attRowCur->nb_retards ?? 0);
+            $absCur    = (int)($attRowCur->nb_absences ?? 0);
+            $justCur   = (int)($attRowCur->nb_absences_just ?? 0);
+            $tauxCur   = $totalCur > 0 ? round(($presCur + $retardCur) / $totalCur * 100, 1) : null;
+        }
+    @endphp
+    <div class="fin-hero" style="margin-bottom:16px;">
+        <div class="fin-hero-year-badge">
+            <i class="fas fa-calendar-check"></i>
+            Année en cours :
+            <strong>{{ $presAnneeCourante->name }}</strong>
+            @if($presInscCourante?->classe)
+                &middot; {{ $presInscCourante->classe->name }}
+            @endif
+        </div>
+
+        @if(!$presInscCourante)
+            <div style="display:flex; align-items:center; gap:10px; padding:14px 16px; background:rgba(239,68,68,.06); border-radius:10px; border-left:3px solid #ef4444;">
+                <i class="fas fa-exclamation-circle" style="color:#ef4444; font-size:1.1rem; flex-shrink:0;"></i>
+                <span style="font-size:.84rem; color:#991b1b; font-weight:500;">Aucune inscription pour {{ $presAnneeCourante->name }} — données de présence indisponibles.</span>
+            </div>
+        @elseif($totalCur === 0)
+            <div style="text-align:center; padding:28px 16px; color:var(--k-muted);">
+                <i class="fas fa-calendar-times" style="font-size:2rem; opacity:.25; display:block; margin-bottom:12px;"></i>
+                <p style="font-size:.84rem; margin:0; font-weight:500;">Aucune séance de présence enregistrée pour cette année.</p>
+            </div>
+        @else
+            @php
+                $presConstatClassCur = ($tauxCur ?? 0) >= 80 ? 'good' : (($tauxCur ?? 0) >= 60 ? 'warning' : 'bad');
+                $presConstatIconCur  = ($tauxCur ?? 0) >= 80 ? 'fa-thumbs-up' : (($tauxCur ?? 0) >= 60 ? 'fa-exclamation-circle' : 'fa-times-circle');
+                if (($tauxCur ?? 0) >= 90) {
+                    $presConstatTextCur = "Excellent — taux de présence de {$tauxCur}%. L'étudiant est très assidu.";
+                } elseif (($tauxCur ?? 0) >= 80) {
+                    $presConstatTextCur = "Bon — taux de présence de {$tauxCur}%. Quelques absences ponctuelles sans impact notable.";
+                } elseif (($tauxCur ?? 0) >= 70) {
+                    $presConstatTextCur = "Acceptable — taux de {$tauxCur}%. Une vigilance est recommandée pour maintenir la régularité.";
+                } elseif (($tauxCur ?? 0) >= 60) {
+                    $presConstatTextCur = "Insuffisant — taux de {$tauxCur}%. Les absences fréquentes risquent d'affecter les résultats académiques.";
+                } else {
+                    $presConstatTextCur = "Critique — taux de " . ($tauxCur ?? 0) . "%. Une intervention urgente est nécessaire.";
+                }
+                $rCur = 18; $circumCur = round(2*3.14159*$rCur, 1);
+                $presRatioCur   = $totalCur > 0 ? ($presCur+$retardCur)/$totalCur : 0;
+                $presOffsetCur  = round($circumCur * (1 - $presRatioCur), 1);
+                $presColorCur   = ($tauxCur ?? 0) >= 80 ? '#10b981' : (($tauxCur ?? 0) >= 60 ? '#f59e0b' : '#ef4444');
+            @endphp
+            <div style="display:flex; align-items:center; gap:20px; margin-bottom:16px; flex-wrap:wrap;">
+                <div class="py-stats">
+                    <div class="py-stat"><div class="py-stat-val green">{{ $presCur + $retardCur }}</div><div class="py-stat-lbl">Présents</div></div>
+                    <div class="py-stat"><div class="py-stat-val red">{{ $absCur }}</div><div class="py-stat-lbl">Absences</div></div>
+                    <div class="py-stat"><div class="py-stat-val amber">{{ $justCur }}</div><div class="py-stat-lbl">Justifiés</div></div>
+                    <div class="py-stat">
+                        <div class="py-stat-val {{ ($tauxCur??0) >= 80 ? 'green' : (($tauxCur??0) >= 60 ? 'amber' : 'red') }}">{{ $tauxCur !== null ? $tauxCur . '%' : '—' }}</div>
+                        <div class="py-stat-lbl">Taux</div>
+                    </div>
+                </div>
+                <svg width="44" height="44" viewBox="0 0 44 44" style="transform:rotate(-90deg); flex-shrink:0;">
+                    <circle cx="22" cy="22" r="{{ $rCur }}" fill="none" stroke="var(--k-border)" stroke-width="4"/>
+                    <circle cx="22" cy="22" r="{{ $rCur }}" fill="none" stroke="{{ $presColorCur }}" stroke-width="4" stroke-linecap="round" stroke-dasharray="{{ $circumCur }}" stroke-dashoffset="{{ $presOffsetCur }}"/>
+                </svg>
+            </div>
+            <div class="pres-stat-list">
+                <div class="pres-stat-row">
+                    <div class="pres-stat-icon green"><i class="fas fa-check"></i></div>
+                    <span class="pres-stat-lbl">Présences</span>
+                    <span class="pres-stat-val green">{{ $presCur + $retardCur }}</span>
+                    <span class="pres-stat-pct">{{ $totalCur > 0 ? round(($presCur+$retardCur)/$totalCur*100) : 0 }}%</span>
+                </div>
+                @if($retardCur > 0)
+                <div class="pres-stat-row" style="padding-left:20px; opacity:.85;">
+                    <div class="pres-stat-icon amber" style="width:24px;height:24px;font-size:.65rem;"><i class="fas fa-clock"></i></div>
+                    <span class="pres-stat-lbl" style="font-size:.78rem;">dont {{ $retardCur }} retard(s)</span>
+                    <span class="pres-stat-val amber">{{ $retardCur }}</span>
+                    <span class="pres-stat-pct" style="font-size:.75rem;">{{ $totalCur > 0 ? round($retardCur/$totalCur*100) : 0 }}%</span>
+                </div>
+                @endif
+                <div class="pres-stat-row">
+                    <div class="pres-stat-icon red"><i class="fas fa-times"></i></div>
+                    <span class="pres-stat-lbl">Absences injustifiées</span>
+                    <span class="pres-stat-val red">{{ $absCur }}</span>
+                    <span class="pres-stat-pct">{{ $totalCur > 0 ? round($absCur/$totalCur*100) : 0 }}%</span>
+                </div>
+                @if($justCur > 0)
+                <div class="pres-stat-row">
+                    <div class="pres-stat-icon blue"><i class="fas fa-file-alt"></i></div>
+                    <span class="pres-stat-lbl">Absences justifiées</span>
+                    <span class="pres-stat-val blue">{{ $justCur }}</span>
+                    <span class="pres-stat-pct">{{ $totalCur > 0 ? round($justCur/$totalCur*100) : 0 }}%</span>
+                </div>
+                @endif
+                <div class="pres-stat-row" style="border-top:1px solid rgba(255,255,255,.1); padding-top:10px; margin-top:2px;">
+                    <div class="pres-stat-icon"><i class="fas fa-list"></i></div>
+                    <span class="pres-stat-lbl">Total séances</span>
+                    <span class="pres-stat-val">{{ $totalCur }}</span>
+                </div>
+            </div>
+            <div class="presence-bars" style="margin-top:14px;">
+                <div class="pbar-row">
+                    <span class="pbar-lbl">Présent</span>
+                    <div class="pbar-track"><div class="pbar-fill green" style="width:{{ $totalCur > 0 ? round(($presCur+$retardCur)/$totalCur*100) : 0 }}%"></div></div>
+                    <span class="pbar-val" style="color:var(--k-success)">{{ $totalCur > 0 ? round(($presCur+$retardCur)/$totalCur*100) : 0 }}%</span>
+                </div>
+                <div class="pbar-row">
+                    <span class="pbar-lbl">Absent</span>
+                    <div class="pbar-track"><div class="pbar-fill red" style="width:{{ $totalCur > 0 ? round(($absCur+$justCur)/$totalCur*100) : 0 }}%"></div></div>
+                    <span class="pbar-val" style="color:var(--k-danger)">{{ $totalCur > 0 ? round(($absCur+$justCur)/$totalCur*100) : 0 }}%</span>
+                </div>
+            </div>
+            <div class="presence-constat {{ $presConstatClassCur }}" style="margin-top:14px;">
+                <i class="fas {{ $presConstatIconCur }}"></i>
+                <span>{{ $presConstatTextCur }}</span>
+            </div>
+        @endif
+    </div>
+    @endif
+
+    {{-- ── Années précédentes : accordéons ── --}}
+    @if($presInscsPrecedentes->count())
+        @if($presInscCourante)
+        <div style="display:flex; align-items:center; gap:10px; margin:8px 0 12px; opacity:.6;">
+            <div style="flex:1; height:1px; background:var(--k-border);"></div>
+            <span style="font-size:.72rem; font-weight:600; color:var(--k-muted); white-space:nowrap; letter-spacing:.04em;"><i class="fas fa-history" style="margin-right:4px;"></i>ANNÉES PRÉCÉDENTES</span>
+            <div style="flex:1; height:1px; background:var(--k-border);"></div>
+        </div>
+        @endif
+        @foreach($presInscsPrecedentes as $inscPres)
         @php
             $anneePresId = optional($inscPres->anneeUniversitaire)->id;
             $anneePresLabel = optional($inscPres->anneeUniversitaire)->name ?? 'Année N/A';
             $attRow = $anneePresId
-                ? \App\Models\ESBTPAttendance::where('etudiant_id', $etudiant->id)
+                ? \App\Models\ESBTPAttendance::finalOnly()
+                    ->where('etudiant_id', $etudiant->id)
                     ->where('annee_universitaire_id', $anneePresId)
                     ->selectRaw("COUNT(*) as total, SUM(CASE WHEN statut='present' THEN 1 ELSE 0 END) as nb_presences, SUM(CASE WHEN statut='absent' THEN 1 ELSE 0 END) as nb_absences, SUM(CASE WHEN statut='excuse' THEN 1 ELSE 0 END) as nb_absences_just, SUM(CASE WHEN statut IN ('retard','late') THEN 1 ELSE 0 END) as nb_retards")
                     ->first()
@@ -978,136 +2608,296 @@
                     <i class="fas fa-chevron-down" style="color:var(--k-muted); font-size:.75rem"></i>
                 </div>
             </div>
+            @php
+                $presConstatClass = ($taux ?? 0) >= 80 ? 'good' : (($taux ?? 0) >= 60 ? 'warning' : 'bad');
+                $presConstatIcon  = ($taux ?? 0) >= 80 ? 'fa-thumbs-up' : (($taux ?? 0) >= 60 ? 'fa-exclamation-circle' : 'fa-times-circle');
+                if (($taux ?? 0) >= 90) {
+                    $presConstatText = "Excellent — taux de présence de {$taux}%. L'étudiant est très assidu.";
+                } elseif (($taux ?? 0) >= 80) {
+                    $presConstatText = "Bon — taux de présence de {$taux}%. Quelques absences ponctuelles sans impact notable.";
+                } elseif (($taux ?? 0) >= 70) {
+                    $presConstatText = "Acceptable — taux de {$taux}%. Une vigilance est recommandée pour maintenir la régularité.";
+                } elseif (($taux ?? 0) >= 60) {
+                    $presConstatText = "Insuffisant — taux de {$taux}%. Les absences fréquentes risquent d'affecter les résultats académiques.";
+                } else {
+                    $presConstatText = "Critique — taux de " . ($taux ?? 0) . "%. Une intervention urgente est nécessaire.";
+                }
+            @endphp
             @if($total > 0)
             <div class="presence-year-body">
-                <div class="presence-bars">
-                    <div class="pbar-row">
-                        <span class="pbar-lbl">Présences</span>
-                        <div class="pbar-track"><div class="pbar-fill green" style="width:{{ $total > 0 ? round($pres/$total*100) : 0 }}%"></div></div>
-                        <span class="pbar-val" style="color:var(--k-success)">{{ $pres }}</span>
+                <div class="pres-stat-list">
+                    <div class="pres-stat-row">
+                        <div class="pres-stat-icon green"><i class="fas fa-check"></i></div>
+                        <span class="pres-stat-lbl">Présences</span>
+                        <span class="pres-stat-val green">{{ $pres + $retard }}</span>
+                        <span class="pres-stat-pct">{{ $total > 0 ? round(($pres+$retard)/$total*100) : 0 }}%</span>
                     </div>
-                    <div class="pbar-row">
-                        <span class="pbar-lbl">Retards</span>
-                        <div class="pbar-track"><div class="pbar-fill amber" style="width:{{ $total > 0 ? round($retard/$total*100) : 0 }}%"></div></div>
-                        <span class="pbar-val" style="color:#d97706">{{ $retard }}</span>
-                    </div>
-                    <div class="pbar-row">
-                        <span class="pbar-lbl">Absences</span>
-                        <div class="pbar-track"><div class="pbar-fill red" style="width:{{ $total > 0 ? round($abs/$total*100) : 0 }}%"></div></div>
-                        <span class="pbar-val" style="color:var(--k-danger)">{{ $abs }}</span>
-                    </div>
-                    @if($just > 0)
-                    <div class="pbar-row">
-                        <span class="pbar-lbl">Justifiés</span>
-                        <div class="pbar-track"><div class="pbar-fill blue" style="width:{{ $total > 0 ? round($just/$total*100) : 0 }}%"></div></div>
-                        <span class="pbar-val" style="color:var(--k-blue-2)">{{ $just }}</span>
+                    @if($retard > 0)
+                    <div class="pres-stat-row" style="padding-left:20px; opacity:.85;">
+                        <div class="pres-stat-icon amber" style="width:24px;height:24px;font-size:.65rem;"><i class="fas fa-clock"></i></div>
+                        <span class="pres-stat-lbl" style="font-size:.78rem;">dont {{ $retard }} retard(s)</span>
+                        <span class="pres-stat-val amber">{{ $retard }}</span>
+                        <span class="pres-stat-pct" style="font-size:.75rem;">{{ $total > 0 ? round($retard/$total*100) : 0 }}%</span>
                     </div>
                     @endif
+                    <div class="pres-stat-row">
+                        <div class="pres-stat-icon red"><i class="fas fa-times"></i></div>
+                        <span class="pres-stat-lbl">Absences injustifiées</span>
+                        <span class="pres-stat-val red">{{ $abs }}</span>
+                        <span class="pres-stat-pct">{{ $total > 0 ? round($abs/$total*100) : 0 }}%</span>
+                    </div>
+                    @if($just > 0)
+                    <div class="pres-stat-row">
+                        <div class="pres-stat-icon blue"><i class="fas fa-file-alt"></i></div>
+                        <span class="pres-stat-lbl">Absences justifiées</span>
+                        <span class="pres-stat-val blue">{{ $just }}</span>
+                        <span class="pres-stat-pct">{{ $total > 0 ? round($just/$total*100) : 0 }}%</span>
+                    </div>
+                    @endif
+                    <div class="pres-stat-row" style="border-top:1px solid rgba(255,255,255,.1); padding-top:10px; margin-top:2px;">
+                        <div class="pres-stat-icon"><i class="fas fa-list"></i></div>
+                        <span class="pres-stat-lbl">Total séances</span>
+                        <span class="pres-stat-val">{{ $total }}</span>
+                    </div>
                 </div>
-                <p style="font-size:.75rem; color:var(--k-muted); margin-top:12px; margin-bottom:0">
-                    Total séances enregistrées : <strong>{{ $total }}</strong>
-                </p>
+                <div class="presence-bars" style="margin-top:14px;">
+                    <div class="pbar-row">
+                        <span class="pbar-lbl">Présent</span>
+                        <div class="pbar-track"><div class="pbar-fill green" style="width:{{ $total > 0 ? round(($pres+$retard)/$total*100) : 0 }}%"></div></div>
+                        <span class="pbar-val" style="color:var(--k-success)">{{ $total > 0 ? round(($pres+$retard)/$total*100) : 0 }}%</span>
+                    </div>
+                    <div class="pbar-row">
+                        <span class="pbar-lbl">Absent</span>
+                        <div class="pbar-track"><div class="pbar-fill red" style="width:{{ $total > 0 ? round(($abs+$just)/$total*100) : 0 }}%"></div></div>
+                        <span class="pbar-val" style="color:var(--k-danger)">{{ $total > 0 ? round(($abs+$just)/$total*100) : 0 }}%</span>
+                    </div>
+                </div>
+                <div class="presence-constat {{ $presConstatClass }}">
+                    <i class="fas {{ $presConstatIcon }}"></i>
+                    <span>{{ $presConstatText }}</span>
+                </div>
+            </div>
+            @else
+            <div class="presence-year-body">
+                <div style="text-align:center; padding:28px 16px; color:var(--k-muted);">
+                    <i class="fas fa-calendar-times" style="font-size:2rem; opacity:.25; display:block; margin-bottom:12px;"></i>
+                    <p style="font-size:.84rem; margin:0; font-weight:500;">Aucune séance de présence enregistrée pour cette année.</p>
+                </div>
             </div>
             @endif
         </div>
         @endforeach
-    @else
-        <div class="s-card">
-            <div class="empty-state">
-                <i class="fas fa-calendar-check"></i>
-                <p>Aucune donnée de présence disponible</p>
-            </div>
-        </div>
-    @endif
+    @endif {{-- /if presInscsPrecedentes->count() --}}
+@endif {{-- /else: inscriptionsPresences not empty --}}
 </div>{{-- /tab-presences --}}
 
 {{-- ─── TAB: FINANCES ──────────────────────────────────────────── --}}
 <div class="tab-panel" id="tab-finances">
     @php
-        // Collect all paiements across inscriptions
-        $allPaiements = collect();
-        foreach($etudiant->inscriptions as $insc) {
-            foreach($insc->paiements ?? [] as $pai) {
-                $pai->_annee = $insc->anneeUniversitaire?->name ?? 'N/A';
-                $allPaiements->push($pai);
+        /* ── Inscription de l'année courante (priorité absolue) ── */
+        $finAnneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
+        $finInscActive = $finAnneeCourante
+            ? $etudiant->inscriptions->first(fn($i) => $i->annee_universitaire_id === $finAnneeCourante->id)
+            : null;
+        /* ── Autres inscriptions (toutes sauf l'active courante) ── */
+        $finAutresInscs  = $etudiant->inscriptions->filter(fn($i) => !$finInscActive || $i->id !== $finInscActive->id)->sortByDesc('created_at');
+
+        /* ── Collect paiements de l'inscription active ── */
+        $finPaiementsActive = collect();
+        if($finInscActive) {
+            foreach($finInscActive->paiements ?? [] as $pai) {
+                $pai->_annee = $finInscActive->anneeUniversitaire?->name ?? 'N/A';
+                $finPaiementsActive->push($pai);
             }
         }
-        $allPaiements = $allPaiements->sortByDesc('date_paiement');
+        $finPaiementsActive = $finPaiementsActive->sortByDesc('date_paiement');
+
+        /* ── Calculs pour inscription active ── */
+        $finTotalPaye    = $finPaiementsActive->filter(fn($p) => str_contains(strtolower($p->status ?? $p->statut ?? ''), 'valid'))->sum('montant');
+        $finEnAttente    = $finPaiementsActive->filter(fn($p) => str_contains(strtolower($p->status ?? $p->statut ?? ''), 'attente'))->sum('montant');
+        $finNbPaiements  = $finPaiementsActive->count();
+        $finReliquats    = $statistiques['total_reliquats_entrants'] ?? 0;
+
+        $finTotalAttendu = 0;
+        if($finInscActive) {
+            try { $finTotalAttendu = $finInscActive->fraisSubscriptions->sum('amount'); } catch(\Exception $e) {}
+        }
+
+        $finSolde  = $finTotalAttendu - $finTotalPaye;
+        $finTaux   = $finTotalAttendu > 0 ? min(100, round($finTotalPaye / $finTotalAttendu * 100)) : 0;
     @endphp
 
-    {{-- Financial summary --}}
-    @php
-        $finTotalPaye   = $statistiques['paiements_valides'] ?? 0;
-        $finEnAttente   = $statistiques['paiements_en_attente'] ?? 0;
-        $finNbPaiements = $statistiques['nombre_paiements'] ?? $allPaiements->count();
-        $finReliquats   = $statistiques['total_reliquats_entrants'] ?? 0;
-        $finTotal       = $finTotalPaye + $finEnAttente;
-    @endphp
-    <div class="kpi-grid" style="margin-bottom:20px">
-        <div class="kpi-card">
-            <div class="kpi-ring">
-                <svg viewBox="0 0 52 52">
-                    <circle class="ring-bg" cx="26" cy="26" r="22"/>
-                    <circle class="ring-fg" cx="26" cy="26" r="22" stroke="#10b981"
-                        stroke-dasharray="{{ round(2*3.14159*22,1) }}"
-                        stroke-dashoffset="{{ round(2*3.14159*22 * (1 - min(1, $finTotalPaye / max(1, $finTotal))), 1) }}"/>
-                </svg>
-                <span class="ring-icon" style="color:#10b981"><i class="fas fa-check" style="font-size:.7rem"></i></span>
-            </div>
-            <div class="kpi-body">
-                <div class="kpi-val" style="color:#10b981">{{ number_format($finTotalPaye, 0, ',', ' ') }}</div>
-                <div class="kpi-lbl">Total validé (FCFA)</div>
-            </div>
+    {{-- ── HERO FINANCIER ─────────────────────────────────────── --}}
+    <div class="fin-hero">
+        @if($finInscActive)
+        <div class="fin-hero-year-badge">
+            <i class="fas fa-calendar-check"></i>
+            Année en cours :
+            <strong>{{ $finInscActive->anneeUniversitaire?->name ?? 'N/A' }}</strong>
+            @if($finInscActive->classe)
+                &middot; {{ $finInscActive->classe->name }}
+            @endif
         </div>
-        @if($finEnAttente > 0)
-        <div class="kpi-card">
-            <div class="kpi-ring">
-                <svg viewBox="0 0 52 52">
-                    <circle class="ring-bg" cx="26" cy="26" r="22"/>
-                    <circle class="ring-fg" cx="26" cy="26" r="22" stroke="#f59e0b"
-                        stroke-dasharray="{{ round(2*3.14159*22,1) }}" stroke-dashoffset="{{ round(2*3.14159*22*.35,1) }}"/>
-                </svg>
-                <span class="ring-icon" style="color:#f59e0b"><i class="fas fa-clock" style="font-size:.7rem"></i></span>
-            </div>
-            <div class="kpi-body">
-                <div class="kpi-val" style="color:#f59e0b">{{ number_format($finEnAttente, 0, ',', ' ') }}</div>
-                <div class="kpi-lbl">En attente (FCFA)</div>
-            </div>
+        @else
+        <div class="fin-hero-year-badge" style="background:rgba(239,68,68,.15); border-color:rgba(239,68,68,.3);">
+            <i class="fas fa-calendar-times" style="color:#ef4444;"></i>
+            <span style="color:#ef4444;">Aucune inscription pour {{ $finAnneeCourante?->name ?? 'l\'année en cours' }}</span>
         </div>
         @endif
-        @if($finReliquats > 0)
-        <div class="kpi-card">
-            <div class="kpi-ring">
-                <svg viewBox="0 0 52 52">
-                    <circle class="ring-bg" cx="26" cy="26" r="22"/>
-                    <circle class="ring-fg" cx="26" cy="26" r="22" stroke="#ef4444"
-                        stroke-dasharray="{{ round(2*3.14159*22,1) }}" stroke-dashoffset="{{ round(2*3.14159*22*.5,1) }}"/>
-                </svg>
-                <span class="ring-icon" style="color:#ef4444"><i class="fas fa-exclamation" style="font-size:.8rem"></i></span>
+        <div class="fin-hero-grid">
+            {{-- KPI 1 : Total attendu --}}
+            <div class="fin-kpi-block">
+                <div class="fin-kpi-label">
+                    <i class="fas fa-file-invoice-dollar"></i>
+                    Total attendu
+                </div>
+                <div class="fin-kpi-amount neutral">
+                    {{ number_format($finTotalAttendu, 0, ',', ' ') }}
+                    <span class="fin-kpi-currency">FCFA</span>
+                </div>
+                <div class="fin-kpi-sub">
+                    {{ $finNbPaiements }} transaction(s) enregistrée(s)
+                </div>
             </div>
-            <div class="kpi-body">
-                <div class="kpi-val" style="color:#ef4444">{{ number_format($finReliquats, 0, ',', ' ') }}</div>
-                <div class="kpi-lbl">Reliquats (FCFA)</div>
+
+            {{-- Séparateur vertical --}}
+            <div class="fin-sep"></div>
+
+            {{-- KPI 2 : Total payé --}}
+            <div class="fin-kpi-block">
+                <div class="fin-kpi-label">
+                    <i class="fas fa-check-circle"></i>
+                    Total payé
+                </div>
+                <div class="fin-kpi-amount paid">
+                    {{ number_format($finTotalPaye, 0, ',', ' ') }}
+                    <span class="fin-kpi-currency">FCFA</span>
+                </div>
+                @if($finEnAttente > 0)
+                <div class="fin-kpi-sub fin-kpi-sub-warn">
+                    <i class="fas fa-clock"></i>
+                    + {{ number_format($finEnAttente, 0, ',', ' ') }} FCFA en attente
+                </div>
+                @else
+                <div class="fin-kpi-sub">
+                    Paiements validés uniquement
+                </div>
+                @endif
+            </div>
+
+            {{-- Séparateur vertical --}}
+            <div class="fin-sep"></div>
+
+            {{-- KPI 3 : Solde --}}
+            <div class="fin-kpi-block">
+                <div class="fin-kpi-label">
+                    <i class="fas fa-balance-scale"></i>
+                    Solde restant
+                </div>
+                <div class="fin-kpi-amount {{ $finSolde > 0 ? 'due' : ($finSolde < 0 ? 'excess' : 'zero') }}">
+                    {{ $finSolde > 0 ? '' : ($finSolde < 0 ? '-' : '') }}{{ number_format(abs($finSolde), 0, ',', ' ') }}
+                    <span class="fin-kpi-currency">FCFA</span>
+                </div>
+                <div class="fin-kpi-sub {{ $finSolde > 0 ? 'fin-kpi-sub-danger' : '' }}">
+                    @if($finSolde > 0)
+                        <i class="fas fa-exclamation-circle"></i> Reste à régler
+                    @elseif($finSolde < 0)
+                        <i class="fas fa-info-circle"></i> Trop-perçu
+                    @else
+                        <i class="fas fa-check"></i> Situation apurée
+                    @endif
+                </div>
             </div>
         </div>
-        @endif
-        <div class="kpi-card">
-            <div class="kpi-ring">
-                <svg viewBox="0 0 52 52">
-                    <circle class="ring-bg" cx="26" cy="26" r="22"/>
-                    <circle class="ring-fg" cx="26" cy="26" r="22" stroke="var(--k-blue)"
-                        stroke-dasharray="{{ round(2*3.14159*22,1) }}" stroke-dashoffset="{{ round(2*3.14159*22*.5,1) }}"/>
-                </svg>
-                <span class="ring-icon" style="color:var(--k-blue)"><i class="fas fa-list" style="font-size:.7rem"></i></span>
+
+        {{-- Barre de progression globale --}}
+        <div class="fin-progress-wrap">
+            <div class="fin-progress-header">
+                <span class="fin-progress-lbl">Progression du paiement</span>
+                <span class="fin-progress-pct" style="color:{{ $finTaux >= 100 ? '#10b981' : ($finTaux >= 50 ? '#f59e0b' : '#ef4444') }}">{{ $finTaux }}%</span>
             </div>
-            <div class="kpi-body">
-                <div class="kpi-val" style="color:var(--k-blue)">{{ $finNbPaiements }}</div>
-                <div class="kpi-lbl">Transactions</div>
+            <div class="fin-progress-track">
+                {{-- Segment en attente --}}
+                @php
+                    $finAttenteW = $finTotalAttendu > 0 ? min(100, round(($finTotalPaye + $finEnAttente) / $finTotalAttendu * 100)) : 0;
+                @endphp
+                @if($finEnAttente > 0 && $finTotalAttendu > 0)
+                <div class="fin-progress-segment attente" style="width:{{ $finAttenteW }}%"></div>
+                @endif
+                {{-- Segment validé --}}
+                <div class="fin-progress-segment valide" style="width:{{ $finTaux }}%"></div>
+            </div>
+            <div class="fin-progress-legend">
+                <span><span class="fin-legend-dot valide"></span>Validé ({{ number_format($finTotalPaye, 0, ',', ' ') }} FCFA)</span>
+                @if($finEnAttente > 0)<span><span class="fin-legend-dot attente"></span>En attente ({{ number_format($finEnAttente, 0, ',', ' ') }} FCFA)</span>@endif
+                @if($finReliquats > 0)<span><span class="fin-legend-dot reliquat"></span>Reliquat ({{ number_format($finReliquats, 0, ',', ' ') }} FCFA)</span>@endif
             </div>
         </div>
     </div>
 
-    {{-- Payment timeline --}}
+    {{-- ── TABLEAU RÉCAPITULATIF PAR INSCRIPTION (année active) ── --}}
+    @php
+        $finHasSubscriptions = false;
+        if($finInscActive) {
+            try {
+                if($finInscActive->fraisSubscriptions->count() > 0) { $finHasSubscriptions = true; }
+            } catch(\Exception $e) {}
+        }
+    @endphp
+
+    @if($finHasSubscriptions)
+    <div class="s-card" style="margin-bottom:16px;">
+        <div class="s-card-header">
+            <div class="s-card-title">
+                <div class="s-card-title-icon"><i class="fas fa-table"></i></div>
+                Détail par frais
+            </div>
+        </div>
+        <div style="overflow-x:auto;">
+            <table class="fin-table">
+                <thead>
+                    <tr>
+                        <th>Catégorie</th>
+                        <th style="text-align:right;">Attendu</th>
+                        <th style="text-align:right;">Payé</th>
+                        <th style="text-align:right;">Solde</th>
+                        <th style="text-align:center;">Avancement</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @foreach($finInscActive->fraisSubscriptions as $sub)
+                    @php
+                        $subPaye  = $finPaiementsActive->filter(fn($p) =>
+                            ($p->frais_category_id ?? null) == ($sub->frais_category_id ?? null) &&
+                            str_contains(strtolower($p->status ?? $p->statut ?? ''), 'valid')
+                        )->sum('montant');
+                        $subSolde = $sub->amount - $subPaye;
+                        $subTaux  = $sub->amount > 0 ? min(100, round($subPaye / $sub->amount * 100)) : 0;
+                    @endphp
+                    <tr>
+                        <td>
+                            <span class="fin-cat-name">{{ $sub->fraisCategory->name ?? '—' }}</span>
+                        </td>
+                        <td style="text-align:right; font-weight:600; color:var(--k-text);">{{ number_format($sub->amount, 0, ',', ' ') }}</td>
+                        <td style="text-align:right; font-weight:700; color:#10b981;">{{ number_format($subPaye, 0, ',', ' ') }}</td>
+                        <td style="text-align:right; font-weight:700; color:{{ $subSolde > 0 ? '#f59e0b' : '#10b981' }};">
+                            {{ $subSolde > 0 ? number_format($subSolde, 0, ',', ' ') : '✓' }}
+                        </td>
+                        <td style="text-align:center; min-width:100px;">
+                            <div class="fin-mini-track">
+                                <div class="fin-mini-fill" style="width:{{ $subTaux }}%; background:{{ $subTaux >= 100 ? '#10b981' : ($subTaux >= 50 ? '#f59e0b' : '#ef4444') }};"></div>
+                            </div>
+                            <span style="font-size:.72rem; color:var(--k-muted);">{{ $subTaux }}%</span>
+                        </td>
+                    </tr>
+                @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+    @endif
+
+    {{-- ── HISTORIQUE PAIEMENTS (année active) ────────────────── --}}
     <div class="s-card">
         <div class="s-card-header">
             <div class="s-card-title">
@@ -1116,9 +2906,9 @@
             </div>
         </div>
 
-        @if($allPaiements->count())
-        <div class="pmt-timeline">
-            @foreach($allPaiements as $loop_idx => $pai)
+        @if($finPaiementsActive->count())
+        <div class="fin-pmt-list">
+            @foreach($finPaiementsActive as $pai)
             @php
                 $status = $pai->status ?? $pai->statut ?? 'en_attente';
                 $statusKey = match(true) {
@@ -1133,44 +2923,67 @@
                     'rejete'  => 'Rejeté',
                     default   => ucfirst($status)
                 };
-                $isLast = $loop_idx === $allPaiements->count() - 1;
+                $borderCol = match($statusKey) {
+                    'valide'  => '#10b981',
+                    'attente' => '#f59e0b',
+                    'rejete'  => '#ef4444',
+                    default   => '#94a3b8'
+                };
             @endphp
-            <div class="pmt-item">
-                <div class="pmt-dot-wrap">
-                    <div class="pmt-dot {{ $statusKey }}"></div>
-                    @if(!$isLast) <div class="pmt-line"></div> @endif
-                </div>
-                <div class="pmt-body">
-                    <div class="pmt-motif">{{ $pai->motif ?? 'Paiement' }}</div>
-                    <div class="pmt-meta">
-                        @if($pai->date_paiement)
-                        <span><i class="fas fa-calendar"></i> {{ \Carbon\Carbon::parse($pai->date_paiement)->format('d/m/Y') }}</span>
-                        @endif
-                        @if($pai->mode_paiement)
-                        <span><i class="fas fa-credit-card"></i> {{ $pai->mode_paiement }}</span>
-                        @endif
-                        @if($pai->numero_recu)
-                        <span><i class="fas fa-receipt"></i> {{ $pai->numero_recu }}</span>
-                        @endif
-                        <span><i class="fas fa-folder"></i> {{ $pai->_annee }}</span>
+            <div class="fin-pmt-row" style="--pmt-accent:{{ $borderCol }}">
+                <div class="fin-pmt-accent-bar"></div>
+                <div class="fin-pmt-content">
+                    <div class="fin-pmt-top">
+                        <div class="fin-pmt-motif">{{ $pai->motif ?? ($pai->fraisCategory->name ?? 'Paiement') }}</div>
+                        <div class="fin-pmt-amount">
+                            {{ number_format($pai->montant, 0, ',', ' ') }}
+                            <small>FCFA</small>
+                        </div>
                     </div>
-                </div>
-                <div class="pmt-right">
-                    <div class="pmt-amount">{{ number_format($pai->montant, 0, ',', ' ') }} <small style="font-size:.65em;font-weight:500">FCFA</small></div>
-                    <span class="pmt-badge {{ $statusKey }}">{{ $statusLabel }}</span>
-                    <div class="pmt-actions">
-                        @if(isset($pai->inscription_id))
-                        <a href="{{ route('esbtp.paiements.show', $pai) }}" class="pmt-act-btn view">
-                            <i class="fas fa-eye"></i>
-                        </a>
-                        @endif
-                        @can('delete', $pai)
-                        <form action="{{ route('esbtp.paiements.destroy', $pai) }}" method="POST" style="margin:0"
-                              onsubmit="return confirm('Supprimer ce paiement ?')">
-                            @csrf @method('DELETE')
-                            <button type="submit" class="pmt-act-btn del"><i class="fas fa-trash"></i></button>
-                        </form>
-                        @endcan
+                    <div class="fin-pmt-bottom">
+                        <div class="fin-pmt-meta-list">
+                            @if($pai->date_paiement)
+                            <span class="fin-pmt-chip">
+                                <i class="fas fa-calendar-day"></i>
+                                {{ \Carbon\Carbon::parse($pai->date_paiement)->format('d/m/Y') }}
+                            </span>
+                            @endif
+                            @if($pai->mode_paiement)
+                            <span class="fin-pmt-chip">
+                                <i class="fas fa-credit-card"></i>
+                                {{ $pai->mode_paiement }}
+                            </span>
+                            @endif
+                            @if($pai->numero_recu)
+                            <span class="fin-pmt-chip mono">
+                                <i class="fas fa-receipt"></i>
+                                {{ $pai->numero_recu }}
+                            </span>
+                            @endif
+                            @if($pai->_annee ?? null)
+                            <span class="fin-pmt-chip">
+                                <i class="fas fa-layer-group"></i>
+                                {{ $pai->_annee }}
+                            </span>
+                            @endif
+                        </div>
+                        <div class="fin-pmt-right">
+                            <span class="pmt-badge {{ $statusKey }}">{{ $statusLabel }}</span>
+                            <div class="pmt-actions">
+                                @if(isset($pai->inscription_id))
+                                <a href="{{ route('esbtp.paiements.show', $pai) }}" class="pmt-act-btn view">
+                                    <i class="fas fa-eye"></i>
+                                </a>
+                                @endif
+                                @can('delete', $pai)
+                                <form action="{{ route('esbtp.paiements.destroy', $pai) }}" method="POST" style="margin:0"
+                                      onsubmit="return confirm('Supprimer ce paiement ?')">
+                                    @csrf @method('DELETE')
+                                    <button type="submit" class="pmt-act-btn del"><i class="fas fa-trash"></i></button>
+                                </form>
+                                @endcan
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -1179,10 +2992,169 @@
         @else
             <div class="empty-state">
                 <i class="fas fa-wallet"></i>
-                <p>Aucun paiement enregistré</p>
+                <p>Aucun paiement enregistré pour cette année</p>
             </div>
         @endif
     </div>
+
+    {{-- ── AUTRES INSCRIPTIONS (années précédentes) ────────────── --}}
+    @if($finAutresInscs->count())
+    <div class="fin-autres-header">
+        <i class="fas fa-archive"></i>
+        Années précédentes ({{ $finAutresInscs->count() }})
+    </div>
+
+    @foreach($finAutresInscs as $autreInsc)
+    @php
+        /* calculs pour cette inscription archivée */
+        $autrePaiements = collect();
+        foreach($autreInsc->paiements ?? [] as $p) { $autrePaiements->push($p); }
+        $autrePaye    = $autrePaiements->filter(fn($p) => str_contains(strtolower($p->status ?? $p->statut ?? ''), 'valid'))->sum('montant');
+        $autreAttente = $autrePaiements->filter(fn($p) => str_contains(strtolower($p->status ?? $p->statut ?? ''), 'attente'))->sum('montant');
+        $autreAttendu = 0;
+        try { $autreAttendu = $autreInsc->fraisSubscriptions->sum('amount'); } catch(\Exception $e) {}
+        $autreSolde   = $autreAttendu - $autrePaye;
+        $autreTaux    = $autreAttendu > 0 ? min(100, round($autrePaye / $autreAttendu * 100)) : 0;
+        $autreAccordionId = 'fin-arch-' . $autreInsc->id;
+    @endphp
+    <div class="fin-arch-card">
+        <button class="fin-arch-toggle" type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#{{ $autreAccordionId }}"
+                aria-expanded="false">
+            <div class="fin-arch-toggle-left">
+                <span class="fin-arch-year">{{ $autreInsc->anneeUniversitaire?->name ?? 'N/A' }}</span>
+                @if($autreInsc->classe)
+                <span class="fin-arch-class">{{ $autreInsc->classe->name }}</span>
+                @endif
+            </div>
+            <div class="fin-arch-toggle-right">
+                <span class="fin-arch-kpi" style="color:{{ $autreTaux >= 100 ? '#10b981' : ($autreTaux >= 50 ? '#f59e0b' : '#ef4444') }}">
+                    {{ $autreTaux }}%
+                </span>
+                <span class="fin-arch-kpi-lbl">{{ number_format($autrePaye, 0, ',', ' ') }} / {{ number_format($autreAttendu, 0, ',', ' ') }} FCFA</span>
+                <i class="fas fa-chevron-down fin-arch-chevron"></i>
+            </div>
+        </button>
+
+        <div class="collapse" id="{{ $autreAccordionId }}">
+            <div class="fin-arch-body">
+                {{-- Mini hero stats --}}
+                <div class="fin-arch-stats">
+                    <div class="fin-arch-stat">
+                        <div class="fin-arch-stat-lbl">Attendu</div>
+                        <div class="fin-arch-stat-val neutral">{{ number_format($autreAttendu, 0, ',', ' ') }}</div>
+                    </div>
+                    <div class="fin-arch-stat">
+                        <div class="fin-arch-stat-lbl">Payé</div>
+                        <div class="fin-arch-stat-val paid">{{ number_format($autrePaye, 0, ',', ' ') }}</div>
+                    </div>
+                    <div class="fin-arch-stat">
+                        <div class="fin-arch-stat-lbl">Solde</div>
+                        <div class="fin-arch-stat-val {{ $autreSolde > 0 ? 'due' : 'zero' }}">
+                            {{ $autreSolde > 0 ? number_format($autreSolde, 0, ',', ' ') : '✓ Apuré' }}
+                        </div>
+                    </div>
+                    @if($autreAttente > 0)
+                    <div class="fin-arch-stat">
+                        <div class="fin-arch-stat-lbl">En attente</div>
+                        <div class="fin-arch-stat-val" style="color:#f59e0b;">{{ number_format($autreAttente, 0, ',', ' ') }}</div>
+                    </div>
+                    @endif
+                </div>
+
+                {{-- Détail frais --}}
+                @if($autreInsc->fraisSubscriptions->count())
+                <div style="overflow-x:auto; margin-bottom:12px;">
+                    <table class="fin-table" style="font-size:.82rem;">
+                        <thead>
+                            <tr>
+                                <th>Catégorie</th>
+                                <th style="text-align:right;">Attendu</th>
+                                <th style="text-align:right;">Payé</th>
+                                <th style="text-align:right;">Solde</th>
+                                <th style="text-align:center;">%</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($autreInsc->fraisSubscriptions as $sub)
+                            @php
+                                $aSubPaye  = $autrePaiements->filter(fn($p) =>
+                                    ($p->frais_category_id ?? null) == ($sub->frais_category_id ?? null) &&
+                                    str_contains(strtolower($p->status ?? $p->statut ?? ''), 'valid')
+                                )->sum('montant');
+                                $aSubSolde = $sub->amount - $aSubPaye;
+                                $aSubTaux  = $sub->amount > 0 ? min(100, round($aSubPaye / $sub->amount * 100)) : 0;
+                            @endphp
+                            <tr>
+                                <td><span class="fin-cat-name">{{ $sub->fraisCategory->name ?? '—' }}</span></td>
+                                <td style="text-align:right; color:var(--k-text);">{{ number_format($sub->amount, 0, ',', ' ') }}</td>
+                                <td style="text-align:right; color:#10b981; font-weight:700;">{{ number_format($aSubPaye, 0, ',', ' ') }}</td>
+                                <td style="text-align:right; color:{{ $aSubSolde > 0 ? '#f59e0b' : '#10b981' }}; font-weight:700;">
+                                    {{ $aSubSolde > 0 ? number_format($aSubSolde, 0, ',', ' ') : '✓' }}
+                                </td>
+                                <td style="text-align:center; color:var(--k-muted); font-size:.75rem;">{{ $aSubTaux }}%</td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+                @endif
+
+                {{-- Paiements archivés --}}
+                @if($autrePaiements->count())
+                <div class="fin-arch-pmt-label">Paiements ({{ $autrePaiements->count() }})</div>
+                <div class="fin-pmt-list" style="margin-top:0;">
+                    @foreach($autrePaiements->sortByDesc('date_paiement') as $pai)
+                    @php
+                        $aStatus = $pai->status ?? $pai->statut ?? 'en_attente';
+                        $aStatusKey = match(true) {
+                            str_contains(strtolower($aStatus), 'valid') => 'valide',
+                            str_contains(strtolower($aStatus), 'rejet') => 'rejete',
+                            default => 'attente'
+                        };
+                        $aBorderCol = match($aStatusKey) { 'valide' => '#10b981', 'rejete' => '#ef4444', default => '#f59e0b' };
+                        $aStatusLabel = match($aStatusKey) { 'valide' => 'Validé', 'rejete' => 'Rejeté', default => 'En attente' };
+                    @endphp
+                    <div class="fin-pmt-row" style="--pmt-accent:{{ $aBorderCol }}">
+                        <div class="fin-pmt-accent-bar"></div>
+                        <div class="fin-pmt-content">
+                            <div class="fin-pmt-top">
+                                <div class="fin-pmt-motif">{{ $pai->motif ?? ($pai->fraisCategory->name ?? 'Paiement') }}</div>
+                                <div class="fin-pmt-amount">{{ number_format($pai->montant, 0, ',', ' ') }} <small>FCFA</small></div>
+                            </div>
+                            <div class="fin-pmt-bottom">
+                                <div class="fin-pmt-meta-list">
+                                    @if($pai->date_paiement)
+                                    <span class="fin-pmt-chip"><i class="fas fa-calendar-day"></i> {{ \Carbon\Carbon::parse($pai->date_paiement)->format('d/m/Y') }}</span>
+                                    @endif
+                                    @if($pai->mode_paiement)
+                                    <span class="fin-pmt-chip"><i class="fas fa-credit-card"></i> {{ $pai->mode_paiement }}</span>
+                                    @endif
+                                    @if($pai->numero_recu)
+                                    <span class="fin-pmt-chip mono"><i class="fas fa-receipt"></i> {{ $pai->numero_recu }}</span>
+                                    @endif
+                                </div>
+                                <div class="fin-pmt-right">
+                                    <span class="pmt-badge {{ $aStatusKey }}">{{ $aStatusLabel }}</span>
+                                    @if(isset($pai->inscription_id))
+                                    <a href="{{ route('esbtp.paiements.show', $pai) }}" class="pmt-act-btn view"><i class="fas fa-eye"></i></a>
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    @endforeach
+                </div>
+                @else
+                <div style="text-align:center; padding:16px; color:var(--k-muted); font-size:.83rem;">Aucun paiement</div>
+                @endif
+            </div>
+        </div>
+    </div>
+    @endforeach
+    @endif
+
 </div>{{-- /tab-finances --}}
 
 {{-- ─── TAB: PROFIL ─────────────────────────────────────────────── --}}

--- a/resources/views/esbtp/resultats/partials/lignes-etudiants.blade.php
+++ b/resources/views/esbtp/resultats/partials/lignes-etudiants.blade.php
@@ -87,12 +87,30 @@
                 <i class="fas fa-chart-line"></i>
             </a>
             @if(isset($bulletins[$etudiant->id]))
-                <a href="{{ route('esbtp.bulletins.show', $bulletins[$etudiant->id]) }}" class="btn btn-sm btn-secondary" title="Voir bulletin">
+                <button type="button"
+                        class="btn btn-sm btn-secondary btn-bulletin-periode"
+                        title="Voir bulletin"
+                        data-bs-toggle="modal"
+                        data-bs-target="#modalChoixPeriodeBulletin"
+                        data-etudiant-id="{{ $etudiant->id }}"
+                        data-bulletin-id="{{ $bulletins[$etudiant->id] }}"
+                        data-classe-id="{{ $actualClasseId }}"
+                        data-annee-id="{{ $annee_id }}"
+                        data-action="show">
                     <i class="fas fa-file-alt"></i>
-                </a>
-                <a href="{{ route('esbtp.bulletins.pdf-params', ['bulletin' => $etudiant->id, 'classe_id' => $actualClasseId, 'periode' => request('semestre'), 'annee_universitaire_id' => $annee_id]) }}" class="btn btn-sm btn-danger" target="_blank" title="Télécharger PDF">
+                </button>
+                <button type="button"
+                        class="btn btn-sm btn-danger btn-bulletin-periode"
+                        title="Télécharger PDF"
+                        data-bs-toggle="modal"
+                        data-bs-target="#modalChoixPeriodeBulletin"
+                        data-etudiant-id="{{ $etudiant->id }}"
+                        data-bulletin-id="{{ $bulletins[$etudiant->id] }}"
+                        data-classe-id="{{ $actualClasseId }}"
+                        data-annee-id="{{ $annee_id }}"
+                        data-action="pdf">
                     <i class="fas fa-file-pdf"></i>
-                </a>
+                </button>
             @else
                 <button class="btn btn-sm btn-outline-secondary" disabled title="Bulletin non généré">
                     <i class="fas fa-exclamation-triangle"></i>

--- a/resources/views/esbtp/resultats/partials/liste-etudiants.blade.php
+++ b/resources/views/esbtp/resultats/partials/liste-etudiants.blade.php
@@ -108,12 +108,30 @@
                                 <i class="fas fa-chart-line"></i>
                             </a>
                             @if(isset($bulletins[$etudiant->id]))
-                                <a href="{{ route('esbtp.bulletins.show', $bulletins[$etudiant->id]) }}" class="btn btn-sm btn-secondary" title="Voir bulletin">
+                                <button type="button"
+                                        class="btn btn-sm btn-secondary btn-bulletin-periode"
+                                        title="Voir bulletin"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#modalChoixPeriodeBulletin"
+                                        data-etudiant-id="{{ $etudiant->id }}"
+                                        data-bulletin-id="{{ $bulletins[$etudiant->id] }}"
+                                        data-classe-id="{{ $actualClasseId }}"
+                                        data-annee-id="{{ $annee_id }}"
+                                        data-action="show">
                                     <i class="fas fa-file-alt"></i>
-                                </a>
-                                <a href="{{ route('esbtp.bulletins.pdf-params', ['bulletin' => $etudiant->id, 'classe_id' => $actualClasseId, 'periode' => request('semestre'), 'annee_universitaire_id' => $annee_id]) }}" class="btn btn-sm btn-danger" target="_blank" title="Télécharger PDF">
+                                </button>
+                                <button type="button"
+                                        class="btn btn-sm btn-danger btn-bulletin-periode"
+                                        title="Télécharger PDF"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#modalChoixPeriodeBulletin"
+                                        data-etudiant-id="{{ $etudiant->id }}"
+                                        data-bulletin-id="{{ $bulletins[$etudiant->id] }}"
+                                        data-classe-id="{{ $actualClasseId }}"
+                                        data-annee-id="{{ $annee_id }}"
+                                        data-action="pdf">
                                     <i class="fas fa-file-pdf"></i>
-                                </a>
+                                </button>
                             @else
                                 <button class="btn btn-sm btn-outline-secondary" disabled title="Bulletin non généré">
                                     <i class="fas fa-exclamation-triangle"></i>
@@ -126,3 +144,67 @@
         </tbody>
     </table>
 </div>
+
+{{-- Modal choix de période pour bulletin --}}
+<div class="modal fade" id="modalChoixPeriodeBulletin" tabindex="-1" aria-labelledby="modalChoixPeriodeBulletinLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalChoixPeriodeBulletinLabel">
+                    <i class="fas fa-calendar-alt me-2"></i>Choisir la période
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body text-center">
+                <p class="text-muted mb-3">Sélectionnez le semestre pour ce bulletin :</p>
+                <div class="d-grid gap-2">
+                    <a href="#" id="btnBulletinS1" class="btn btn-outline-primary">
+                        <i class="fas fa-calendar me-2"></i>Semestre 1
+                    </a>
+                    <a href="#" id="btnBulletinS2" class="btn btn-outline-primary">
+                        <i class="fas fa-calendar me-2"></i>Semestre 2
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+(function() {
+    var modal = document.getElementById('modalChoixPeriodeBulletin');
+    if (!modal) return;
+
+    modal.addEventListener('show.bs.modal', function(event) {
+        var btn = event.relatedTarget;
+        if (!btn) return;
+
+        var bulletinId = btn.getAttribute('data-bulletin-id');
+        var classeId   = btn.getAttribute('data-classe-id');
+        var anneeId    = btn.getAttribute('data-annee-id');
+        var action     = btn.getAttribute('data-action'); // 'show' or 'pdf'
+
+        var btnS1 = document.getElementById('btnBulletinS1');
+        var btnS2 = document.getElementById('btnBulletinS2');
+
+        if (action === 'show') {
+            // Route: esbtp.bulletins.show → /esbtp/bulletins/{id}
+            var baseUrl = '{{ url("/esbtp/bulletins") }}/' + bulletinId;
+            btnS1.href = baseUrl + '?periode=semestre_1';
+            btnS2.href = baseUrl + '?periode=semestre_2';
+            btnS1.target = '';
+            btnS2.target = '';
+        } else {
+            // Route: esbtp.bulletins.pdf-params → /esbtp-special/bulletins-pdf?bulletin=X&...
+            var baseUrl = '{{ url("/esbtp-special/bulletins-pdf") }}'
+                + '?bulletin=' + bulletinId
+                + '&classe_id=' + classeId
+                + '&annee_universitaire_id=' + anneeId;
+            btnS1.href = baseUrl + '&periode=semestre_1';
+            btnS2.href = baseUrl + '&periode=semestre_2';
+            btnS1.target = '_blank';
+            btnS2.target = '_blank';
+        }
+    });
+})();
+</script>

--- a/resources/views/esbtp/resultats/partials/liste-etudiants.blade.php
+++ b/resources/views/esbtp/resultats/partials/liste-etudiants.blade.php
@@ -179,7 +179,7 @@
         var btn = event.relatedTarget;
         if (!btn) return;
 
-        var bulletinId = btn.getAttribute('data-bulletin-id');
+        var etudiantId = btn.getAttribute('data-etudiant-id');
         var classeId   = btn.getAttribute('data-classe-id');
         var anneeId    = btn.getAttribute('data-annee-id');
         var action     = btn.getAttribute('data-action'); // 'show' or 'pdf'
@@ -188,20 +188,20 @@
         var btnS2 = document.getElementById('btnBulletinS2');
 
         if (action === 'show') {
-            // Route: esbtp.bulletins.show → /esbtp/bulletins/{id}
-            var baseUrl = '{{ url("/esbtp/bulletins") }}/' + bulletinId;
-            btnS1.href = baseUrl + '?periode=semestre_1';
-            btnS2.href = baseUrl + '?periode=semestre_2';
+            // Route: esbtp.resultats.etudiant.preview → /esbtp/resultats/etudiant/{id}/preview
+            var baseUrl = '{{ url("/esbtp/resultats/etudiant") }}/' + etudiantId + '/preview';
+            btnS1.href = baseUrl + '?classe_id=' + classeId + '&annee_universitaire_id=' + anneeId + '&periode=semestre1';
+            btnS2.href = baseUrl + '?classe_id=' + classeId + '&annee_universitaire_id=' + anneeId + '&periode=semestre2';
             btnS1.target = '';
             btnS2.target = '';
         } else {
-            // Route: esbtp.bulletins.pdf-params → /esbtp-special/bulletins-pdf?bulletin=X&...
+            // Route: esbtp.bulletins.pdf-params → /esbtp-special/bulletins-pdf?bulletin={etudiant_id}&...
             var baseUrl = '{{ url("/esbtp-special/bulletins-pdf") }}'
-                + '?bulletin=' + bulletinId
+                + '?bulletin=' + etudiantId
                 + '&classe_id=' + classeId
                 + '&annee_universitaire_id=' + anneeId;
-            btnS1.href = baseUrl + '&periode=semestre_1';
-            btnS2.href = baseUrl + '&periode=semestre_2';
+            btnS1.href = baseUrl + '&periode=semestre1';
+            btnS2.href = baseUrl + '&periode=semestre2';
             btnS1.target = '_blank';
             btnS2.target = '_blank';
         }


### PR DESCRIPTION
## Résumé

Suite de l'issue #99 — corrections et améliorations sur la fiche étudiant complète.

### Commits inclus

- **fix(certificat)** : Calcul de la moyenne générale pondérée S1/S2 dans les certificats de scolarité
  - Nouvelle méthode `attachMoyenneCalculee()` dans `ESBTPEtudiantController`
  - Priorité aux bulletins officiels, fallback aux `ESBTPResultat` avec pondération settings
  - Fix `ESBTPPDFService` : marges converties en float pour `Browsershot::margins()`
- **fix(etudiants)** : KPI de la fiche étudiant utilise la même pondération S1/S2 que les bulletins
- **fix(etudiants)** : Dropdown Documents — routes, overflow et z-index
- **fix(resultats)** : Liens bulletin/PDF dans modal choix période
- **fix(etudiants)** : Contraste tab Présences sur fond dark hero
- **chore(seeder)** : Suppression référence ESBTPCategorieDepense obsolète

## Test plan

- [ ] Générer un certificat de scolarité pour un étudiant avec des résultats → la moyenne doit s'afficher
- [ ] Générer un certificat via Browserless.io (BROWSERLESS_ENABLED=true dans .env) → pas d'erreur de marges
- [ ] Vérifier la fiche étudiant — KPI moyenne cohérente avec les bulletins
- [ ] Vérifier dropdown Documents — pas de débordement ou z-index cassé
- [ ] Vérifier tab Présences — texte lisible sur fond dark