### PR TITLE
fix(pdf): corriger les marges A4 du PDF suivi-categories (18mm/15mm)

### DIFF
--- a/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
+++ b/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
@@ -9,7 +9,7 @@
 
         @page {
             size: A4 portrait;
-            margin: 12mm 10mm 12mm 10mm;
+            margin: 18mm 15mm 18mm 15mm;
         }
 
         body {


### PR DESCRIPTION
## Summary
- Correction des marges du PDF d'export liste étudiants par statut de paiement
- Les marges `@page` passent de 12mm/10mm → 18mm/15mm (standard A4 professionnel)

## Changes
- `resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php` — marges `@page` augmentées pour un espace blanc visible autour du contenu

## Type of change
- [x] fix — bug fix

## Testing
- [ ] Aller sur `/esbtp/paiements/suivi-categories`
- [ ] Sélectionner une catégorie et un onglet (Aucun paiement / Partiels / À jour)
- [ ] Cliquer PDF → vérifier marges blanches visibles sur les 4 côtés

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified on all modified PHP files
