### PR TITLE
feat(pdf): optimiser le layout header et KPI de la liste complète PDF

### DIFF
--- a/resources/views/esbtp/classes/liste-complete-pdf.blade.php
+++ b/resources/views/esbtp/classes/liste-complete-pdf.blade.php
@@ -22,125 +22,13 @@
             padding: 10px;
         }
 
-        /* Header principal */
+        /* Header principal - structure table 2 colonnes */
         .header-section {
-            background: #007bff;
-            color: white;
-            padding: 15px;
             border-radius: 6px;
-            text-align: center;
             margin-bottom: 12px;
             -webkit-print-color-adjust: exact;
             color-adjust: exact;
-        }
-
-        .header-logo {
-            max-height: 35px;
-            max-width: 80px;
-            margin-bottom: 6px;
-            filter: brightness(0) invert(1);
-        }
-
-        .school-name {
-            font-size: 13px;
-            font-weight: 700;
-            margin-bottom: 3px;
-        }
-
-        .school-info {
-            font-size: 9px;
-            margin-bottom: 6px;
-            opacity: 0.9;
-        }
-
-        .document-title-section {
-            background: rgba(255,255,255,0.2);
-            padding: 6px;
-            border-radius: 4px;
-            margin-top: 6px;
-        }
-
-        .document-title {
-            font-size: 12px;
-            font-weight: 600;
-            margin-bottom: 4px;
-        }
-
-        .class-info-grid {
-            display: table;
-            width: 100%;
-            font-size: 10px;
-        }
-
-        .class-info-row {
-            display: table-row;
-        }
-
-        .class-info-cell {
-            display: table-cell;
-            width: 33.33%;
-            text-align: center;
-            padding: 2px;
-        }
-
-        .info-badge {
-            background: rgba(255,255,255,0.3);
-            padding: 1px 3px;
-            border-radius: 6px;
-            display: inline-block;
-            margin-top: 1px;
-        }
-
-        /* KPI Section */
-        .kpi-section {
-            display: table;
-            width: 100%;
-            margin-bottom: 12px;
-        }
-
-        .kpi-row {
-            display: table-row;
-        }
-
-        .kpi-card {
-            display: table-cell;
-            width: 25%;
-            padding: 5px 4px;
-            text-align: center;
-            background: #f8f9fa;
-            border: 1px solid #e9ecef;
-            vertical-align: top;
-            font-size: 9px;
-        }
-
-        .kpi-card:first-child {
-            border-radius: 4px 0 0 4px;
-        }
-
-        .kpi-card:last-child {
-            border-radius: 0 4px 4px 0;
-        }
-
-        .kpi-title {
-            font-size: 8px;
-            font-weight: 600;
-            color: #6b7280;
-            text-transform: uppercase;
-            letter-spacing: 0.1px;
-            margin-bottom: 2px;
-        }
-
-        .kpi-value {
-            font-size: 13px;
-            font-weight: bold;
-            color: #007bff;
-            margin-bottom: 2px;
-            line-height: 1.2;
-        }
-
-        .kpi-desc {
-            font-size: 7px;
-            color: #9ca3af;
+            overflow: hidden;
         }
 
         /* Table moderne */
@@ -370,70 +258,91 @@
 </head>
 <body>
     <div class="container">
-        <!-- Header Section -->
+        <!-- Header Section — 2 colonnes : Logo | Infos école + Titre document -->
         <div class="header-section">
-            @if($etablissement['logo'] && file_exists(storage_path('app/public/' . $etablissement['logo'])))
-                <img src="data:image/{{ pathinfo($etablissement['logo'], PATHINFO_EXTENSION) }};base64,{{ base64_encode(file_get_contents(storage_path('app/public/' . $etablissement['logo']))) }}" class="header-logo" alt="Logo">
-            @endif
-
-            <div class="school-name">{{ $etablissement['nom'] ?? 'KLASSCI' }}</div>
-
-            @if($etablissement['adresse'] || $etablissement['telephone'] || $etablissement['email'])
-            <div class="school-info">
-                @if($etablissement['adresse']){{ $etablissement['adresse'] }}@endif
-                @if($etablissement['telephone'] && $etablissement['adresse']) | @endif
-                @if($etablissement['telephone'])Tel: {{ $etablissement['telephone'] }}@endif
-                @if($etablissement['email'] && ($etablissement['adresse'] || $etablissement['telephone'])) | @endif
-                @if($etablissement['email'])Email: {{ $etablissement['email'] }}@endif
-            </div>
-            @endif
-
-            <div class="document-title-section">
-                <div class="document-title">LISTE COMPLÈTE DES ÉTUDIANTS</div>
-                <div class="class-info-grid">
-                    <div class="class-info-row">
-                        <div class="class-info-cell">
-                            <strong>Classe:</strong><br>
-                            <span class="info-badge">{{ $classe->name }}</span>
+            <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                    <!-- Colonne gauche : Logo -->
+                    <td width="18%" style="background-color: #0453cb; padding: 14px 10px; text-align: center; vertical-align: middle; border-right: 2px solid rgba(255,255,255,0.25);">
+                        @if($etablissement['logo'] && file_exists(storage_path('app/public/' . $etablissement['logo'])))
+                            <img src="data:image/{{ pathinfo($etablissement['logo'], PATHINFO_EXTENSION) }};base64,{{ base64_encode(file_get_contents(storage_path('app/public/' . $etablissement['logo']))) }}"
+                                 style="max-height: 55px; max-width: 100px; filter: brightness(0) invert(1);" alt="Logo">
+                        @else
+                            <div style="font-size: 30px; font-weight: 900; color: white; opacity: 0.4; letter-spacing: -2px;">K</div>
+                        @endif
+                    </td>
+                    <!-- Colonne droite : Nom école + contact + titre document -->
+                    <td width="82%" style="background-color: #0453cb; padding: 12px 16px; vertical-align: middle;">
+                        <!-- Nom établissement -->
+                        <div style="font-size: 15px; font-weight: 700; color: white; margin-bottom: 2px;">{{ $etablissement['nom'] ?? 'KLASSCI' }}</div>
+                        <!-- Adresse | Tél | Email -->
+                        @if($etablissement['adresse'] || $etablissement['telephone'] || $etablissement['email'])
+                        <div style="font-size: 8.5px; color: white; opacity: 0.85; margin-bottom: 8px;">
+                            @if($etablissement['adresse']){{ $etablissement['adresse'] }}@endif
+                            @if($etablissement['telephone'])
+                                @if($etablissement['adresse']) &nbsp;|&nbsp; @endif
+                                Tél: {{ $etablissement['telephone'] }}
+                            @endif
+                            @if($etablissement['email'])
+                                @if($etablissement['adresse'] || $etablissement['telephone']) &nbsp;|&nbsp; @endif
+                                Email: {{ $etablissement['email'] }}
+                            @endif
                         </div>
-                        <div class="class-info-cell">
-                            <strong>Date:</strong><br>
-                            <span class="info-badge">{{ now()->format('d/m/Y') }}</span>
+                        @endif
+                        <!-- Séparateur + titre document + infos classe -->
+                        <div style="border-top: 1px solid rgba(255,255,255,0.35); padding-top: 7px;">
+                            <div style="font-size: 12px; font-weight: 700; color: white; letter-spacing: 0.5px; margin-bottom: 5px;">LISTE COMPLÈTE DES ÉTUDIANTS</div>
+                            <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                                <tr>
+                                    <td width="33%" style="font-size: 9px; color: white;">
+                                        <span style="color: white; opacity: 0.75;">Classe :</span>
+                                        <strong style="color: white;">{{ $classe->name }}</strong>
+                                    </td>
+                                    <td width="33%" style="font-size: 9px; color: white; text-align: center;">
+                                        <span style="color: white; opacity: 0.75;">Date :</span>
+                                        <strong style="color: white;">{{ now()->format('d/m/Y') }}</strong>
+                                    </td>
+                                    <td width="34%" style="font-size: 9px; color: white; text-align: right;">
+                                        <span style="color: white; opacity: 0.75;">Code :</span>
+                                        <strong style="color: white;">{{ $classe->code ?? 'N/A' }}</strong>
+                                    </td>
+                                </tr>
+                            </table>
                         </div>
-                        <div class="class-info-cell">
-                            <strong>Code:</strong><br>
-                            <span class="info-badge">{{ $classe->code ?? 'N/A' }}</span>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                    </td>
+                </tr>
+            </table>
         </div>
 
-        <!-- KPI Section -->
-        <div class="kpi-section">
-            <div class="kpi-row">
-                <div class="kpi-card">
-                    <div class="kpi-title">Total</div>
-                    <div class="kpi-value">{{ $etudiants->count() }}</div>
-                    <div class="kpi-desc">Etudiants</div>
-                </div>
-                <div class="kpi-card">
-                    <div class="kpi-title">Filiere</div>
-                    <div class="kpi-value" style="font-size: 9px; line-height: 1.2;">{{ $classe->filiere->name ?? 'N/A' }}</div>
-                    <div class="kpi-desc">Specialisation</div>
-                </div>
-                <div class="kpi-card">
-                    <div class="kpi-title">Niveau</div>
-                    <div class="kpi-value" style="font-size: 9px; line-height: 1.2;">{{ $classe->niveau->name ?? 'N/A' }}</div>
-                    <div class="kpi-desc">Annee d'etudes</div>
-                </div>
-                <div class="kpi-card">
-                    <div class="kpi-title">Repartition</div>
-                    <div class="kpi-value" style="font-size: 9px; line-height: 1.2;">{{ $etudiants->where('genre', 'M')->count() }}H/{{ $etudiants->where('genre', 'F')->count() }}F</div>
-                    <div class="kpi-desc">Hommes/Femmes</div>
-                </div>
-            </div>
-        </div>
+        <!-- KPI Section — 4 cellules uniformes fond bleu (pas de .kpi-value/.kpi-title pour éviter override theme) -->
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 12px;">
+            <tr>
+                <!-- TOTAL -->
+                <td width="25%" style="background-color: #0453cb; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25);">
+                    <div style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8; margin-bottom: 4px;">TOTAL</div>
+                    <div style="font-size: 18px; font-weight: 700; color: white; line-height: 1.1; margin-bottom: 4px;">{{ $etudiants->count() }}</div>
+                    <div style="font-size: 7px; color: white; opacity: 0.65;">Étudiants</div>
+                </td>
+                <!-- FILIÈRE -->
+                <td width="25%" style="background-color: #0453cb; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25);">
+                    <div style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8; margin-bottom: 4px;">FILIÈRE</div>
+                    <div style="font-size: 10px; font-weight: 700; color: white; line-height: 1.25; margin-bottom: 4px;">{{ $classe->filiere->name ?? 'N/A' }}</div>
+                    <div style="font-size: 7px; color: white; opacity: 0.65;">Spécialisation</div>
+                </td>
+                <!-- NIVEAU -->
+                <td width="25%" style="background-color: #0453cb; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25);">
+                    <div style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8; margin-bottom: 4px;">NIVEAU</div>
+                    <div style="font-size: 10px; font-weight: 700; color: white; line-height: 1.25; margin-bottom: 4px;">{{ $classe->niveau->name ?? 'N/A' }}</div>
+                    <div style="font-size: 7px; color: white; opacity: 0.65;">Année d'études</div>
+                </td>
+                <!-- RÉPARTITION -->
+                <td width="25%" style="background-color: #0453cb; padding: 9px 8px; text-align: center; vertical-align: middle;">
+                    <div style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8; margin-bottom: 4px;">RÉPARTITION</div>
+                    <div style="font-size: 13px; font-weight: 700; color: white; line-height: 1.25; margin-bottom: 4px;">{{ $etudiants->where('genre', 'M')->count() }}H / {{ $etudiants->where('genre', 'F')->count() }}F</div>
+                    <div style="font-size: 7px; color: white; opacity: 0.65;">Hommes / Femmes</div>
+                </td>
+            </tr>
+        </table>
 
         <!-- Liste des étudiants -->
         @if($etudiants->count() > 0)


### PR DESCRIPTION
- Header redessiné en 2 colonnes (logo gauche | infos école + titre droite)
  au lieu du layout centré vertical : les infos sont maintenant empilées
  à droite du logo (nom, adresse, tél, email, puis titre document)
- KPI bar redessiné avec vraie table HTML (plus de display:table CSS)
  et styles inline uniformes : fond bleu uniforme sur les 4 cellules,
  suppression des classes .kpi-value/.kpi-title qui causaient des blocs
  colorés incohérents via l'override de theme.blade.php
- Séparateurs internes semi-transparents entre cellules KPI

https://claude.ai/code/session_01BnCmF5ykVeC8DxDyBWdfK7