### PR TITLE
fix(excel): corriger affichage school info dans export Excel suivi paiements

### DIFF
--- a/app/Exports/SuiviPaiementsExport.php
+++ b/app/Exports/SuiviPaiementsExport.php
@@ -143,8 +143,12 @@ class SuiviPaiementsExport implements FromCollection, WithHeadings, WithMapping,
         $sheet->getRowDimension(1)->setRowHeight(26);
 
         // Row 2 : coordonnées
-        $contactParts = array_filter([
+        $addressParts = array_filter([
             $this->settings['school_address'] ?? null,
+            $this->settings['school_city'] ?? null,
+        ]);
+        $contactParts = array_filter([
+            !empty($addressParts) ? implode(', ', $addressParts) : null,
             isset($this->settings['school_phone']) && $this->settings['school_phone'] ? 'Tél : ' . $this->settings['school_phone'] : null,
             isset($this->settings['school_email']) && $this->settings['school_email'] ? 'Email : ' . $this->settings['school_email'] : null,
         ]);

--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -2155,10 +2155,15 @@ class ESBTPPaiementController extends Controller
             'niveau'  => $niveau?->name,
         ];
 
-        $settings = array_merge(
-            \App\Helpers\SettingsHelper::getSchoolInfo(),
-            ['primary_color' => \App\Helpers\SettingsHelper::getPdfSettings()['primary_color'] ?? '#0453cb']
-        );
+        $schoolInfo = \App\Helpers\SettingsHelper::getSchoolInfo();
+        $settings = [
+            'school_name'    => $schoolInfo['name'],
+            'school_address' => $schoolInfo['address'],
+            'school_phone'   => $schoolInfo['phone'] ?: $schoolInfo['mobile'],
+            'school_email'   => $schoolInfo['email'],
+            'school_city'    => $schoolInfo['city'],
+            'primary_color'  => \App\Helpers\SettingsHelper::getPdfSettings()['primary_color'] ?? '#0453cb',
+        ];
 
         $filename = 'suivi-' . $statut . '-' . ($category->name ? \Illuminate\Support\Str::slug($category->name) . '-' : '') . now()->format('Ymd') . '.xlsx';
 

--- a/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
+++ b/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
@@ -9,62 +9,86 @@
 
         @page {
             size: A4 portrait;
-            margin: 18mm 15mm 18mm 15mm;
+            margin: 0;
         }
 
         body {
             font-family: DejaVu Sans, Arial, sans-serif;
             font-size: 10px;
             color: #1f2937;
-            line-height: 1.3;
+            line-height: 1.4;
             background: #ffffff;
+        }
+
+        /* Wrapper principal — remplace les marges @page */
+        .page-wrapper {
+            padding: 22mm 18mm 20mm 18mm;
+        }
+
+        /* ── Barre accent décorative ── */
+        .accent-bar {
+            height: 5px;
+            margin-bottom: 10px;
+            border-radius: 2px;
+            -webkit-print-color-adjust: exact;
         }
 
         /* ── Header ── */
         .header-section {
-            background-color: #0453cb;
-            color: #ffffff;
-            padding: 8px 10px 6px;
-            border-radius: 4px;
-            margin-bottom: 6px;
+            border-radius: 6px;
+            margin-bottom: 10px;
+            overflow: hidden;
             -webkit-print-color-adjust: exact;
         }
 
+        .header-main {
+            padding: 12px 14px 10px;
+        }
+
         .header-logo {
-            max-height: 32px;
-            max-width: 80px;
-            filter: brightness(0) invert(1);
+            max-height: 40px;
+            max-width: 90px;
         }
 
         .school-name {
-            font-size: 13px;
+            font-size: 15px;
             font-weight: bold;
-            margin-bottom: 1px;
+            letter-spacing: 0.5px;
+            margin-bottom: 3px;
         }
 
         .school-info {
-            font-size: 8px;
-            opacity: 0.9;
+            font-size: 8.5px;
+            opacity: 0.88;
+        }
+
+        .header-date {
+            font-size: 8.5px;
+            opacity: 0.85;
+            text-align: right;
         }
 
         /* ── Title band ── */
         .title-band {
-            margin-bottom: 6px;
+            margin-bottom: 10px;
+            border-radius: 3px;
+            overflow: hidden;
+            -webkit-print-color-adjust: exact;
         }
 
-        .title-band td {
-            background-color: #e8edfd;
-            border-left: 4px solid #0453cb;
-            padding: 5px 10px;
-            border-radius: 0 3px 3px 0;
-            font-size: 11px;
+        .title-band-inner {
+            padding: 7px 12px;
+        }
+
+        .title-text {
+            font-size: 11.5px;
             font-weight: bold;
             color: #0f172a;
         }
 
         .statut-badge {
             display: inline-block;
-            padding: 2px 8px;
+            padding: 3px 10px;
             border-radius: 10px;
             font-size: 9px;
             font-weight: bold;
@@ -90,40 +114,31 @@
 
         /* ── KPI cards ── */
         .kpi-section {
-            margin-bottom: 8px;
+            margin-bottom: 12px;
         }
-
-        .kpi-section td {
-            vertical-align: top;
-            padding: 0 3px;
-        }
-
-        .kpi-section td:first-child { padding-left: 0; }
-        .kpi-section td:last-child  { padding-right: 0; }
 
         .kpi-card {
             border: 1px solid #e5e7eb;
-            border-radius: 4px;
+            border-radius: 5px;
             overflow: hidden;
-        }
-
-        .kpi-card-header {
-            background-color: #f8fafc;
-            padding: 4px 8px;
-            font-size: 8px;
-            color: #6b7280;
-            text-transform: uppercase;
-            letter-spacing: 0.3px;
-            font-weight: bold;
-            border-bottom: 1px solid #e5e7eb;
             -webkit-print-color-adjust: exact;
         }
 
-        .kpi-card-value {
-            padding: 5px 8px;
-            font-size: 13px;
+        .kpi-card-header {
+            background-color: #f1f5f9;
+            padding: 5px 10px;
+            font-size: 7.5px;
+            color: #64748b;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
             font-weight: bold;
-            color: #0453cb;
+            border-bottom: 1px solid #e2e8f0;
+        }
+
+        .kpi-card-value {
+            padding: 7px 10px 8px;
+            font-size: 14px;
+            font-weight: bold;
         }
 
         /* ── Table ── */
@@ -131,16 +146,14 @@
             width: 100%;
             border-collapse: collapse;
             font-size: 9px;
-            margin-bottom: 10px;
+            margin-bottom: 12px;
         }
 
         .students-table thead td {
-            background-color: #0453cb;
             color: #ffffff;
-            padding: 5px 6px;
+            padding: 6px 7px;
             font-weight: bold;
             font-size: 8.5px;
-            border-bottom: 2px solid #0343ab;
             -webkit-print-color-adjust: exact;
         }
 
@@ -150,7 +163,7 @@
         }
 
         .students-table tbody td {
-            padding: 4px 6px;
+            padding: 5px 7px;
             border-bottom: 1px solid #e5e7eb;
             vertical-align: middle;
         }
@@ -158,19 +171,17 @@
         .students-table tfoot td {
             background-color: #eff6ff;
             font-weight: bold;
-            padding: 5px 6px;
-            border-top: 2px solid #0453cb;
+            padding: 6px 7px;
             font-size: 9px;
             -webkit-print-color-adjust: exact;
         }
 
         .row-num {
-            width: 22px;
-            background-color: #0453cb;
-            color: #ffffff;
-            border-radius: 10px;
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
             text-align: center;
-            padding: 1px 4px;
+            line-height: 20px;
             font-size: 8px;
             font-weight: bold;
             display: inline-block;
@@ -185,18 +196,26 @@
             text-align: center;
             color: #9ca3af;
             font-style: italic;
-            padding: 20px;
+            padding: 28px;
             font-size: 10px;
         }
 
         /* ── Footer ── */
         .pdf-footer {
-            margin-top: 10px;
-            padding-top: 6px;
-            border-top: 1px solid #e5e7eb;
-            text-align: center;
+            margin-top: 12px;
+            padding-top: 8px;
+            border-top: 1px solid #e2e8f0;
+        }
+
+        .pdf-footer-left {
             font-size: 8px;
-            color: #9ca3af;
+            color: #94a3b8;
+        }
+
+        .pdf-footer-right {
+            text-align: right;
+            font-size: 8px;
+            color: #94a3b8;
         }
     </style>
     @include('pdf.partials.theme')
@@ -209,9 +228,12 @@
     $headerText     = $pdfSettings['header_text_color'] ?? '#ffffff';
     $schoolName     = $schoolInfo['name']    ?? config('app.name');
     $schoolAddress  = $schoolInfo['address'] ?? '';
-    $schoolPhone    = $schoolInfo['phone']   ?? '';
+    $schoolPhone    = $schoolInfo['phone']   ?? $schoolInfo['mobile'] ?? '';
     $schoolEmail    = $schoolInfo['email']   ?? '';
     $schoolLogo     = $schoolInfo['logo']    ?? '';
+
+    // Calcul couleur accent (version légèrement plus claire du primary)
+    $accentColor = $primaryColor;
 
     $logoBase64 = null;
     if ($schoolLogo) {
@@ -235,7 +257,6 @@
     $taux         = $stats['taux_recouvrement']  ?? ($montantDu > 0 ? round(($montantPaye / $montantDu) * 100, 1) : 0);
     $soldeTotal   = $montantDu - $montantPaye;
 
-    // Badge CSS class based on statut
     $statut = $stats['statut'] ?? '';
     $badgeClass = match($statut) {
         'non_payes' => 'badge-non-payes',
@@ -243,259 +264,234 @@
         'a_jour'    => 'badge-a-jour',
         default     => 'badge-en-retard',
     };
+
+    $contactParts = array_filter([
+        $schoolAddress ?: null,
+        $schoolPhone ? 'Tél : ' . $schoolPhone : null,
+        $schoolEmail ?: null,
+    ]);
 @endphp
 
-{{-- ── HEADER ── --}}
-<table width="100%" border="0" cellspacing="0" cellpadding="0"
-       style="background-color: {{ $headerBg }}; border-radius: 4px; margin-bottom: 6px; -webkit-print-color-adjust: exact;">
-    <tr>
-        {{-- Logo --}}
-        <td width="15%" style="padding: 8px 6px 6px 10px; vertical-align: middle;">
-            @if($logoBase64)
-                <img src="{{ $logoBase64 }}"
-                     style="max-height: 36px; max-width: 90px; filter: brightness(0) invert(1);"
-                     alt="Logo">
-            @endif
-        </td>
+{{-- ── BARRE ACCENT (fixed, top) ── --}}
+<div class="accent-bar" style="background-color: {{ $accentColor }};"></div>
 
-        {{-- School name & info --}}
-        <td width="70%" style="padding: 8px 6px 6px; text-align: center; vertical-align: middle;">
-            <div style="font-size: 14px; font-weight: bold; color: {{ $headerText }}; margin-bottom: 2px;">
-                {{ strtoupper($schoolName) }}
-            </div>
-            @if($schoolAddress || $schoolPhone || $schoolEmail)
-            <div style="font-size: 8px; color: {{ $headerText }}; opacity: 0.9;">
-                {{ implode(' • ', array_filter([$schoolAddress, $schoolPhone ? 'Tél : '.$schoolPhone : null, $schoolEmail])) }}
-            </div>
-            @endif
-        </td>
+{{-- ── WRAPPER ── --}}
+<div class="page-wrapper">
 
-        {{-- Date --}}
-        <td width="15%" style="padding: 8px 10px 6px 6px; text-align: right; vertical-align: top;">
-            <div style="font-size: 8px; color: {{ $headerText }}; opacity: 0.85;">
-                {{ now()->format('d/m/Y') }}
-            </div>
-        </td>
-    </tr>
-</table>
+    {{-- ── HEADER ── --}}
+    <div class="header-section" style="background-color: {{ $headerBg }};">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="header-main">
+            <tr>
+                {{-- Logo --}}
+                <td width="14%" style="vertical-align: middle; padding-right: 8px;">
+                    @if($logoBase64)
+                        <img src="{{ $logoBase64 }}"
+                             style="max-height: 40px; max-width: 90px; filter: brightness(0) invert(1);"
+                             alt="Logo">
+                    @endif
+                </td>
 
-{{-- ── TITLE BAND ── --}}
-<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 7px;">
-    <tr>
-        <td style="background-color: #e8edfd;
-                   border-left: 4px solid {{ $primaryColor }};
-                   padding: 5px 10px;
-                   -webkit-print-color-adjust: exact;">
-            <table width="100%" border="0" cellspacing="0" cellpadding="0">
-                <tr>
-                    <td style="vertical-align: middle;">
-                        <span style="font-size: 11px; font-weight: bold; color: #0f172a;">
-                            Suivi Paiements —
-                            <span style="color: {{ $primaryColor }};">{{ $category->name ?? 'Catégorie' }}</span>
-                        </span>
-                    </td>
-                    <td style="text-align: right; vertical-align: middle;">
-                        <span class="statut-badge {{ $badgeClass }}">
-                            {{ $statutLabel }}
-                        </span>
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
+                {{-- Nom + coordonnées --}}
+                <td width="72%" style="text-align: center; vertical-align: middle;">
+                    <div class="school-name" style="color: {{ $headerText }};">
+                        {{ strtoupper($schoolName) }}
+                    </div>
+                    @if(!empty($contactParts))
+                    <div class="school-info" style="color: {{ $headerText }};">
+                        {{ implode(' • ', $contactParts) }}
+                    </div>
+                    @endif
+                </td>
 
-{{-- ── KPI CARDS ── --}}
-<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 8px;">
-    <tr>
-        <td width="25%" style="padding-right: 4px;">
-            <table width="100%" border="0" cellspacing="0" cellpadding="0"
-                   style="border: 1px solid #e5e7eb; border-radius: 4px;">
-                <tr>
-                    <td style="background-color: #f8fafc; padding: 4px 8px;
-                               font-size: 8px; color: #6b7280; text-transform: uppercase;
-                               font-weight: bold; border-bottom: 1px solid #e5e7eb;
-                               -webkit-print-color-adjust: exact;">
-                        TOTAL ÉTUDIANTS
-                    </td>
-                </tr>
-                <tr>
-                    <td style="padding: 5px 8px; font-size: 15px; font-weight: bold; color: {{ $primaryColor }};">
-                        {{ $total }}
-                    </td>
-                </tr>
-            </table>
-        </td>
-        <td width="25%" style="padding: 0 4px;">
-            <table width="100%" border="0" cellspacing="0" cellpadding="0"
-                   style="border: 1px solid #e5e7eb; border-radius: 4px;">
-                <tr>
-                    <td style="background-color: #f8fafc; padding: 4px 8px;
-                               font-size: 8px; color: #6b7280; text-transform: uppercase;
-                               font-weight: bold; border-bottom: 1px solid #e5e7eb;
-                               -webkit-print-color-adjust: exact;">
-                        MONTANT DÛ
-                    </td>
-                </tr>
-                <tr>
-                    <td style="padding: 5px 8px; font-size: 11px; font-weight: bold; color: #0f172a;">
+                {{-- Date --}}
+                <td width="14%" style="vertical-align: top; text-align: right;">
+                    <div class="header-date" style="color: {{ $headerText }};">
+                        {{ now()->format('d/m/Y') }}
+                    </div>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    {{-- ── TITLE BAND ── --}}
+    <div class="title-band" style="background-color: #e8edfd; border-left: 4px solid {{ $primaryColor }};">
+        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="title-band-inner">
+            <tr>
+                <td style="vertical-align: middle;">
+                    <span class="title-text">
+                        Suivi Paiements —
+                        <span style="color: {{ $primaryColor }};">{{ $category->name ?? 'Catégorie' }}</span>
+                    </span>
+                </td>
+                <td style="text-align: right; vertical-align: middle;">
+                    <span class="statut-badge {{ $badgeClass }}">{{ $statutLabel }}</span>
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    {{-- ── KPI CARDS ── --}}
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" class="kpi-section">
+        <tr>
+            {{-- Total étudiants --}}
+            <td width="25%" style="padding-right: 5px;">
+                <div class="kpi-card">
+                    <div class="kpi-card-header">TOTAL ÉTUDIANTS</div>
+                    <div class="kpi-card-value" style="color: {{ $primaryColor }};">{{ $total }}</div>
+                </div>
+            </td>
+            {{-- Montant dû --}}
+            <td width="25%" style="padding: 0 5px;">
+                <div class="kpi-card">
+                    <div class="kpi-card-header">MONTANT DÛ</div>
+                    <div class="kpi-card-value" style="color: #0f172a; font-size: 11px;">
                         {{ number_format($montantDu, 0, ',', ' ') }} FCFA
-                    </td>
-                </tr>
-            </table>
-        </td>
-        <td width="25%" style="padding: 0 4px;">
-            <table width="100%" border="0" cellspacing="0" cellpadding="0"
-                   style="border: 1px solid #e5e7eb; border-radius: 4px;">
-                <tr>
-                    <td style="background-color: #f8fafc; padding: 4px 8px;
-                               font-size: 8px; color: #6b7280; text-transform: uppercase;
-                               font-weight: bold; border-bottom: 1px solid #e5e7eb;
-                               -webkit-print-color-adjust: exact;">
-                        MONTANT PAYÉ
-                    </td>
-                </tr>
-                <tr>
-                    <td style="padding: 5px 8px; font-size: 11px; font-weight: bold; color: #059669;">
+                    </div>
+                </div>
+            </td>
+            {{-- Montant payé --}}
+            <td width="25%" style="padding: 0 5px;">
+                <div class="kpi-card">
+                    <div class="kpi-card-header">MONTANT PAYÉ</div>
+                    <div class="kpi-card-value" style="color: #059669; font-size: 11px;">
                         {{ number_format($montantPaye, 0, ',', ' ') }} FCFA
-                    </td>
-                </tr>
-            </table>
-        </td>
-        <td width="25%" style="padding-left: 4px;">
-            <table width="100%" border="0" cellspacing="0" cellpadding="0"
-                   style="border: 1px solid #e5e7eb; border-radius: 4px;">
-                <tr>
-                    <td style="background-color: #f8fafc; padding: 4px 8px;
-                               font-size: 8px; color: #6b7280; text-transform: uppercase;
-                               font-weight: bold; border-bottom: 1px solid #e5e7eb;
-                               -webkit-print-color-adjust: exact;">
-                        TAUX RECOUVREMENT
-                    </td>
-                </tr>
-                <tr>
-                    <td style="padding: 5px 8px; font-size: 15px; font-weight: bold;
-                               color: {{ $taux >= 80 ? '#059669' : ($taux >= 50 ? '#d97706' : '#dc2626') }};">
+                    </div>
+                </div>
+            </td>
+            {{-- Taux recouvrement --}}
+            <td width="25%" style="padding-left: 5px;">
+                <div class="kpi-card">
+                    <div class="kpi-card-header">TAUX RECOUVREMENT</div>
+                    <div class="kpi-card-value"
+                         style="color: {{ $taux >= 80 ? '#059669' : ($taux >= 50 ? '#d97706' : '#dc2626') }};">
                         {{ $taux }}%
-                    </td>
-                </tr>
-            </table>
-        </td>
-    </tr>
-</table>
+                    </div>
+                </div>
+            </td>
+        </tr>
+    </table>
 
-{{-- ── STUDENT TABLE ── --}}
-<table class="students-table">
-    <thead>
-        <tr>
-            <td class="text-center" style="width: 28px;">N°</td>
-            <td style="width: 70px;">Matricule</td>
-            <td>Nom & Prénom(s)</td>
-            <td style="width: 80px;">Classe</td>
-            <td style="width: 60px;">Filière</td>
-            <td class="text-right" style="width: 80px;">Montant Dû</td>
-            <td class="text-right" style="width: 80px;">Payé</td>
-            <td class="text-right" style="width: 80px;">Solde</td>
-            <td class="text-center" style="width: 36px;">%</td>
-        </tr>
-    </thead>
-    <tbody>
-        @forelse($etudiants as $i => $item)
-        @php
-            $inscription = $item['inscription'];
-            $etudiant    = $inscription->etudiant ?? null;
-            $pct         = $item['pourcentage'] ?? 0;
-            $pctColor    = $pct >= 100 ? '#059669' : ($pct > 0 ? '#d97706' : '#dc2626');
-        @endphp
-        <tr>
-            <td class="text-center">
-                <span class="row-num">{{ $i + 1 }}</span>
-            </td>
-            <td style="font-size: 8.5px; color: #374151;">
-                {{ $etudiant?->matricule ?? 'N/A' }}
-            </td>
-            <td style="font-weight: bold; font-size: 9px;">
-                {{ $etudiant ? strtoupper($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '') : '—' }}
-            </td>
-            <td style="font-size: 8.5px; color: #374151;">
-                {{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? '—') }}
-            </td>
-            <td style="font-size: 8.5px; color: #374151;">
-                {{ $inscription->filiere->name ?? '—' }}
-            </td>
-            <td class="text-right" style="font-size: 8.5px;">
-                {{ number_format($item['montant_attendu'] ?? 0, 0, ',', ' ') }}
-            </td>
-            <td class="text-right" style="font-size: 8.5px; color: #059669; font-weight: bold;">
-                {{ number_format($item['montant_paye'] ?? 0, 0, ',', ' ') }}
-            </td>
-            <td class="text-right" style="font-size: 8.5px; color: {{ ($item['solde'] ?? 0) > 0 ? '#dc2626' : '#059669' }}; font-weight: bold;">
-                {{ number_format($item['solde'] ?? 0, 0, ',', ' ') }}
-            </td>
-            <td class="text-center" style="font-weight: bold; font-size: 8.5px; color: {{ $pctColor }};">
-                {{ $pct }}%
-            </td>
-        </tr>
-        @empty
-        <tr class="empty-state">
-            <td colspan="9" style="text-align: center; color: #9ca3af; font-style: italic; padding: 20px; font-size: 10px;">
-                Aucun étudiant dans cette liste.
-            </td>
-        </tr>
-        @endforelse
-    </tbody>
-    @if($etudiants->count() > 0)
-    <tfoot>
-        <tr>
-            <td colspan="5" style="text-align: right; font-size: 9px; background-color: #eff6ff; padding: 5px 6px;
-                                    border-top: 2px solid #0453cb; font-weight: bold; -webkit-print-color-adjust: exact;">
-                TOTAUX
-            </td>
-            <td class="text-right" style="background-color: #eff6ff; padding: 5px 6px;
-                                          border-top: 2px solid #0453cb; font-weight: bold; font-size: 9px;
-                                          -webkit-print-color-adjust: exact;">
-                {{ number_format($montantDu, 0, ',', ' ') }}
-            </td>
-            <td class="text-right" style="background-color: #eff6ff; padding: 5px 6px;
-                                          border-top: 2px solid #0453cb; font-weight: bold; font-size: 9px;
-                                          color: #059669; -webkit-print-color-adjust: exact;">
-                {{ number_format($montantPaye, 0, ',', ' ') }}
-            </td>
-            <td class="text-right" style="background-color: #eff6ff; padding: 5px 6px;
-                                          border-top: 2px solid #0453cb; font-weight: bold; font-size: 9px;
-                                          color: {{ $soldeTotal > 0 ? '#dc2626' : '#059669' }};
-                                          -webkit-print-color-adjust: exact;">
-                {{ number_format($soldeTotal, 0, ',', ' ') }}
-            </td>
-            <td class="text-center" style="background-color: #eff6ff; padding: 5px 6px;
-                                           border-top: 2px solid #0453cb; font-weight: bold; font-size: 9px;
-                                           -webkit-print-color-adjust: exact;">
-                {{ $taux }}%
-            </td>
-        </tr>
-    </tfoot>
-    @endif
-</table>
+    {{-- ── STUDENT TABLE ── --}}
+    <table class="students-table">
+        <thead>
+            <tr style="background-color: {{ $primaryColor }}; -webkit-print-color-adjust: exact;">
+                <td class="text-center" style="width: 26px; border-radius: 3px 0 0 0;">N°</td>
+                <td style="width: 72px;">Matricule</td>
+                <td>Nom & Prénom(s)</td>
+                <td style="width: 82px;">Classe</td>
+                <td style="width: 62px;">Filière</td>
+                <td class="text-right" style="width: 82px;">Montant Dû</td>
+                <td class="text-right" style="width: 72px;">Payé</td>
+                <td class="text-right" style="width: 72px;">Solde</td>
+                <td class="text-center" style="width: 34px; border-radius: 0 3px 0 0;">%</td>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($etudiants as $i => $item)
+            @php
+                $inscription = $item['inscription'];
+                $etudiant    = $inscription->etudiant ?? null;
+                $pct         = $item['pourcentage'] ?? 0;
+                $pctColor    = $pct >= 100 ? '#059669' : ($pct > 0 ? '#d97706' : '#dc2626');
+            @endphp
+            <tr>
+                <td class="text-center">
+                    <span class="row-num"
+                          style="background-color: {{ $primaryColor }}; color: #ffffff; -webkit-print-color-adjust: exact;">
+                        {{ $i + 1 }}
+                    </span>
+                </td>
+                <td style="font-size: 8.5px; color: #374151;">
+                    {{ $etudiant?->matricule ?? 'N/A' }}
+                </td>
+                <td style="font-weight: bold; font-size: 9px;">
+                    {{ $etudiant ? strtoupper($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '') : '—' }}
+                </td>
+                <td style="font-size: 8.5px; color: #374151;">
+                    {{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? '—') }}
+                </td>
+                <td style="font-size: 8.5px; color: #374151;">
+                    {{ $inscription->filiere->name ?? '—' }}
+                </td>
+                <td class="text-right" style="font-size: 8.5px;">
+                    {{ number_format($item['montant_attendu'] ?? 0, 0, ',', ' ') }}
+                </td>
+                <td class="text-right" style="font-size: 8.5px; color: #059669; font-weight: bold;">
+                    {{ number_format($item['montant_paye'] ?? 0, 0, ',', ' ') }}
+                </td>
+                <td class="text-right"
+                    style="font-size: 8.5px; font-weight: bold;
+                           color: {{ ($item['solde'] ?? 0) > 0 ? '#dc2626' : '#059669' }};">
+                    {{ number_format($item['solde'] ?? 0, 0, ',', ' ') }}
+                </td>
+                <td class="text-center" style="font-weight: bold; font-size: 8.5px; color: {{ $pctColor }};">
+                    {{ $pct }}%
+                </td>
+            </tr>
+            @empty
+            <tr class="empty-state">
+                <td colspan="9">Aucun étudiant dans cette liste.</td>
+            </tr>
+            @endforelse
+        </tbody>
+        @if($etudiants->count() > 0)
+        <tfoot>
+            <tr>
+                <td colspan="5"
+                    style="text-align: right; background-color: #eff6ff; padding: 6px 7px;
+                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
+                           -webkit-print-color-adjust: exact;">
+                    TOTAUX
+                </td>
+                <td class="text-right"
+                    style="background-color: #eff6ff; padding: 6px 7px;
+                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
+                           -webkit-print-color-adjust: exact;">
+                    {{ number_format($montantDu, 0, ',', ' ') }}
+                </td>
+                <td class="text-right"
+                    style="background-color: #eff6ff; padding: 6px 7px;
+                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
+                           color: #059669; -webkit-print-color-adjust: exact;">
+                    {{ number_format($montantPaye, 0, ',', ' ') }}
+                </td>
+                <td class="text-right"
+                    style="background-color: #eff6ff; padding: 6px 7px;
+                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
+                           color: {{ $soldeTotal > 0 ? '#dc2626' : '#059669' }};
+                           -webkit-print-color-adjust: exact;">
+                    {{ number_format($soldeTotal, 0, ',', ' ') }}
+                </td>
+                <td class="text-center"
+                    style="background-color: #eff6ff; padding: 6px 7px;
+                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
+                           -webkit-print-color-adjust: exact;">
+                    {{ $taux }}%
+                </td>
+            </tr>
+        </tfoot>
+        @endif
+    </table>
 
-{{-- ── FOOTER ── --}}
-<table width="100%" border="0" cellspacing="0" cellpadding="0"
-       style="margin-top: 8px; padding-top: 6px; border-top: 1px solid #e5e7eb;">
-    <tr>
-        <td style="font-size: 8px; color: #9ca3af;">
-            Catégorie : <strong>{{ $category->name ?? '—' }}</strong>
-            @if(!empty($stats['filiere_name']))
-                — Filière : <strong>{{ $stats['filiere_name'] }}</strong>
-            @endif
-            @if(!empty($stats['niveau_name']))
-                — Niveau : <strong>{{ $stats['niveau_name'] }}</strong>
-            @endif
-        </td>
-        <td style="text-align: right; font-size: 8px; color: #9ca3af;">
-            Généré le {{ now()->format('d/m/Y à H:i') }}
-            — {{ $schoolName }}
-        </td>
-    </tr>
-</table>
+    {{-- ── FOOTER ── --}}
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" class="pdf-footer">
+        <tr>
+            <td class="pdf-footer-left">
+                Catégorie : <strong>{{ $category->name ?? '—' }}</strong>
+                @if(!empty($stats['filiere_name']))
+                    — Filière : <strong>{{ $stats['filiere_name'] }}</strong>
+                @endif
+                @if(!empty($stats['niveau_name']))
+                    — Niveau : <strong>{{ $stats['niveau_name'] }}</strong>
+                @endif
+            </td>
+            <td class="pdf-footer-right">
+                Généré le {{ now()->format('d/m/Y à H:i') }} — {{ $schoolName }}
+            </td>
+        </tr>
+    </table>
+
+</div>{{-- end .page-wrapper --}}
 
 </body>
 </html>

--- a/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
+++ b/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
@@ -9,75 +9,47 @@
 
         @page {
             size: A4 portrait;
-            margin: 0;
+            margin: {{ $pdfSettings['margin_top'] ?? 18 }}mm
+                    {{ $pdfSettings['margin_right'] ?? 15 }}mm
+                    {{ $pdfSettings['margin_bottom'] ?? 18 }}mm
+                    {{ $pdfSettings['margin_left'] ?? 15 }}mm;
         }
 
         body {
             font-family: DejaVu Sans, Arial, sans-serif;
             font-size: 10px;
-            color: #1f2937;
+            color: {{ $pdfSettings['text_color'] ?? '#1f2937' }};
             line-height: 1.4;
             background: #ffffff;
         }
 
-        /* Wrapper principal — remplace les marges @page */
-        .page-wrapper {
-            padding: 22mm 18mm 20mm 18mm;
-        }
-
-        /* ── Barre accent décorative ── */
-        .accent-bar {
-            height: 5px;
-            margin-bottom: 10px;
-            border-radius: 2px;
-            -webkit-print-color-adjust: exact;
-        }
-
         /* ── Header ── */
-        .header-section {
-            border-radius: 6px;
-            margin-bottom: 10px;
-            overflow: hidden;
-            -webkit-print-color-adjust: exact;
-        }
-
-        .header-main {
+        .header-table td {
+            background-color: {{ $pdfSettings['header_bg_color'] ?? '#0453cb' }};
             padding: 12px 14px 10px;
-        }
-
-        .header-logo {
-            max-height: 40px;
-            max-width: 90px;
+            -webkit-print-color-adjust: exact;
         }
 
         .school-name {
             font-size: 15px;
             font-weight: bold;
             letter-spacing: 0.5px;
+            color: {{ $pdfSettings['header_text_color'] ?? '#ffffff' }};
             margin-bottom: 3px;
         }
 
         .school-info {
             font-size: 8.5px;
             opacity: 0.88;
-        }
-
-        .header-date {
-            font-size: 8.5px;
-            opacity: 0.85;
-            text-align: right;
+            color: {{ $pdfSettings['header_text_color'] ?? '#ffffff' }};
         }
 
         /* ── Title band ── */
-        .title-band {
-            margin-bottom: 10px;
-            border-radius: 3px;
-            overflow: hidden;
-            -webkit-print-color-adjust: exact;
-        }
-
-        .title-band-inner {
+        .title-band td {
+            background-color: #e8edfd;
+            border-left: 4px solid {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
             padding: 7px 12px;
+            -webkit-print-color-adjust: exact;
         }
 
         .title-text {
@@ -113,30 +85,20 @@
         }
 
         /* ── KPI cards ── */
-        .kpi-section {
-            margin-bottom: 12px;
-        }
-
-        .kpi-card {
-            border: 1px solid #e5e7eb;
-            border-radius: 5px;
-            overflow: hidden;
-            -webkit-print-color-adjust: exact;
-        }
-
-        .kpi-card-header {
+        .kpi-header td {
             background-color: #f1f5f9;
-            padding: 5px 10px;
+            padding: 6px 10px;
             font-size: 7.5px;
             color: #64748b;
             text-transform: uppercase;
             letter-spacing: 0.4px;
             font-weight: bold;
             border-bottom: 1px solid #e2e8f0;
+            -webkit-print-color-adjust: exact;
         }
 
-        .kpi-card-value {
-            padding: 7px 10px 8px;
+        .kpi-value td {
+            padding: 8px 10px 9px;
             font-size: 14px;
             font-weight: bold;
         }
@@ -146,12 +108,13 @@
             width: 100%;
             border-collapse: collapse;
             font-size: 9px;
-            margin-bottom: 12px;
+            margin-bottom: 14px;
         }
 
         .students-table thead td {
+            background-color: {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
             color: #ffffff;
-            padding: 6px 7px;
+            padding: 7px 7px;
             font-weight: bold;
             font-size: 8.5px;
             -webkit-print-color-adjust: exact;
@@ -162,8 +125,12 @@
             -webkit-print-color-adjust: exact;
         }
 
+        .students-table tbody tr:nth-child(odd) td {
+            background-color: #ffffff;
+        }
+
         .students-table tbody td {
-            padding: 5px 7px;
+            padding: 6px 7px;
             border-bottom: 1px solid #e5e7eb;
             vertical-align: middle;
         }
@@ -171,7 +138,8 @@
         .students-table tfoot td {
             background-color: #eff6ff;
             font-weight: bold;
-            padding: 6px 7px;
+            padding: 7px 7px;
+            border-top: 2px solid {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
             font-size: 9px;
             -webkit-print-color-adjust: exact;
         }
@@ -179,6 +147,8 @@
         .row-num {
             width: 20px;
             height: 20px;
+            background-color: {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
+            color: #ffffff;
             border-radius: 50%;
             text-align: center;
             line-height: 20px;
@@ -191,29 +161,10 @@
         .text-right  { text-align: right; }
         .text-center { text-align: center; }
 
-        /* ── Empty state ── */
-        .empty-state td {
-            text-align: center;
-            color: #9ca3af;
-            font-style: italic;
-            padding: 28px;
-            font-size: 10px;
-        }
-
         /* ── Footer ── */
-        .pdf-footer {
-            margin-top: 12px;
+        .pdf-footer td {
             padding-top: 8px;
             border-top: 1px solid #e2e8f0;
-        }
-
-        .pdf-footer-left {
-            font-size: 8px;
-            color: #94a3b8;
-        }
-
-        .pdf-footer-right {
-            text-align: right;
             font-size: 8px;
             color: #94a3b8;
         }
@@ -223,17 +174,14 @@
 <body>
 
 @php
-    $primaryColor   = $pdfSettings['primary_color']   ?? '#0453cb';
-    $headerBg       = $pdfSettings['header_bg_color'] ?? $primaryColor;
-    $headerText     = $pdfSettings['header_text_color'] ?? '#ffffff';
-    $schoolName     = $schoolInfo['name']    ?? config('app.name');
-    $schoolAddress  = $schoolInfo['address'] ?? '';
-    $schoolPhone    = $schoolInfo['phone']   ?? $schoolInfo['mobile'] ?? '';
-    $schoolEmail    = $schoolInfo['email']   ?? '';
-    $schoolLogo     = $schoolInfo['logo']    ?? '';
-
-    // Calcul couleur accent (version légèrement plus claire du primary)
-    $accentColor = $primaryColor;
+    $primaryColor  = $pdfSettings['primary_color']    ?? '#0453cb';
+    $headerBg      = $pdfSettings['header_bg_color']  ?? $primaryColor;
+    $headerText    = $pdfSettings['header_text_color'] ?? '#ffffff';
+    $schoolName    = $schoolInfo['name']    ?? config('app.name');
+    $schoolAddress = $schoolInfo['address'] ?? '';
+    $schoolPhone   = $schoolInfo['phone']   ?? $schoolInfo['mobile'] ?? '';
+    $schoolEmail   = $schoolInfo['email']   ?? '';
+    $schoolLogo    = $schoolInfo['logo']    ?? '';
 
     $logoBase64 = null;
     if ($schoolLogo) {
@@ -244,20 +192,20 @@
         ];
         foreach ($paths as $p) {
             if (file_exists($p)) {
-                $mime = mime_content_type($p);
+                $mime       = mime_content_type($p);
                 $logoBase64 = 'data:' . $mime . ';base64,' . base64_encode(file_get_contents($p));
                 break;
             }
         }
     }
 
-    $total        = $stats['total']              ?? $etudiants->count();
-    $montantDu    = $stats['montant_total_du']   ?? $etudiants->sum(fn($e) => $e['montant_attendu'] ?? 0);
-    $montantPaye  = $stats['montant_total_paye'] ?? $etudiants->sum(fn($e) => $e['montant_paye'] ?? 0);
-    $taux         = $stats['taux_recouvrement']  ?? ($montantDu > 0 ? round(($montantPaye / $montantDu) * 100, 1) : 0);
-    $soldeTotal   = $montantDu - $montantPaye;
+    $total       = $stats['total']              ?? $etudiants->count();
+    $montantDu   = $stats['montant_total_du']   ?? $etudiants->sum(fn($e) => $e['montant_attendu'] ?? 0);
+    $montantPaye = $stats['montant_total_paye'] ?? $etudiants->sum(fn($e) => $e['montant_paye'] ?? 0);
+    $taux        = $stats['taux_recouvrement']  ?? ($montantDu > 0 ? round(($montantPaye / $montantDu) * 100, 1) : 0);
+    $soldeTotal  = $montantDu - $montantPaye;
 
-    $statut = $stats['statut'] ?? '';
+    $statut     = $stats['statut'] ?? '';
     $badgeClass = match($statut) {
         'non_payes' => 'badge-non-payes',
         'en_retard' => 'badge-en-retard',
@@ -267,231 +215,217 @@
 
     $contactParts = array_filter([
         $schoolAddress ?: null,
-        $schoolPhone ? 'Tél : ' . $schoolPhone : null,
-        $schoolEmail ?: null,
+        $schoolPhone   ? 'Tél : ' . $schoolPhone : null,
+        $schoolEmail   ?: null,
     ]);
 @endphp
 
-{{-- ── BARRE ACCENT (fixed, top) ── --}}
-<div class="accent-bar" style="background-color: {{ $accentColor }};"></div>
+{{-- ── HEADER ── --}}
+<table class="header-table" width="100%" border="0" cellspacing="0" cellpadding="0"
+       style="border-radius: 6px; margin-bottom: 10px; overflow: hidden;">
+    <tr>
+        {{-- Logo --}}
+        <td width="14%" style="text-align: left; vertical-align: middle;
+                                background-color: {{ $headerBg }}; padding: 12px 8px 10px 14px;">
+            @if($logoBase64)
+                <img src="{{ $logoBase64 }}"
+                     style="max-height: 40px; max-width: 90px; filter: brightness(0) invert(1);"
+                     alt="Logo">
+            @endif
+        </td>
 
-{{-- ── WRAPPER ── --}}
-<div class="page-wrapper">
+        {{-- Nom + coordonnées --}}
+        <td width="72%" style="text-align: center; vertical-align: middle;
+                                background-color: {{ $headerBg }}; padding: 12px 6px 10px;">
+            <div class="school-name">{{ strtoupper($schoolName) }}</div>
+            @if(!empty($contactParts))
+                <div class="school-info">{{ implode(' • ', $contactParts) }}</div>
+            @endif
+        </td>
 
-    {{-- ── HEADER ── --}}
-    <div class="header-section" style="background-color: {{ $headerBg }};">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="header-main">
-            <tr>
-                {{-- Logo --}}
-                <td width="14%" style="vertical-align: middle; padding-right: 8px;">
-                    @if($logoBase64)
-                        <img src="{{ $logoBase64 }}"
-                             style="max-height: 40px; max-width: 90px; filter: brightness(0) invert(1);"
-                             alt="Logo">
-                    @endif
-                </td>
+        {{-- Date --}}
+        <td width="14%" style="text-align: right; vertical-align: top;
+                                background-color: {{ $headerBg }}; padding: 12px 14px 10px 6px;">
+            <div style="font-size: 8.5px; color: {{ $headerText }}; opacity: 0.85;">
+                {{ now()->format('d/m/Y') }}
+            </div>
+        </td>
+    </tr>
+</table>
 
-                {{-- Nom + coordonnées --}}
-                <td width="72%" style="text-align: center; vertical-align: middle;">
-                    <div class="school-name" style="color: {{ $headerText }};">
-                        {{ strtoupper($schoolName) }}
-                    </div>
-                    @if(!empty($contactParts))
-                    <div class="school-info" style="color: {{ $headerText }};">
-                        {{ implode(' • ', $contactParts) }}
-                    </div>
-                    @endif
-                </td>
+{{-- ── TITLE BAND ── --}}
+<table class="title-band" width="100%" border="0" cellspacing="0" cellpadding="0"
+       style="margin-bottom: 10px; border-radius: 3px;">
+    <tr>
+        <td>
+            <table width="100%" border="0" cellspacing="0" cellpadding="0">
+                <tr>
+                    <td style="vertical-align: middle;">
+                        <span class="title-text">
+                            Suivi Paiements —
+                            <span style="color: {{ $primaryColor }};">{{ $category->name ?? 'Catégorie' }}</span>
+                        </span>
+                    </td>
+                    <td style="text-align: right; vertical-align: middle;">
+                        <span class="statut-badge {{ $badgeClass }}">{{ $statutLabel }}</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
 
-                {{-- Date --}}
-                <td width="14%" style="vertical-align: top; text-align: right;">
-                    <div class="header-date" style="color: {{ $headerText }};">
-                        {{ now()->format('d/m/Y') }}
-                    </div>
-                </td>
-            </tr>
-        </table>
-    </div>
-
-    {{-- ── TITLE BAND ── --}}
-    <div class="title-band" style="background-color: #e8edfd; border-left: 4px solid {{ $primaryColor }};">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0" class="title-band-inner">
-            <tr>
-                <td style="vertical-align: middle;">
-                    <span class="title-text">
-                        Suivi Paiements —
-                        <span style="color: {{ $primaryColor }};">{{ $category->name ?? 'Catégorie' }}</span>
-                    </span>
-                </td>
-                <td style="text-align: right; vertical-align: middle;">
-                    <span class="statut-badge {{ $badgeClass }}">{{ $statutLabel }}</span>
-                </td>
-            </tr>
-        </table>
-    </div>
-
-    {{-- ── KPI CARDS ── --}}
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" class="kpi-section">
-        <tr>
-            {{-- Total étudiants --}}
-            <td width="25%" style="padding-right: 5px;">
-                <div class="kpi-card">
-                    <div class="kpi-card-header">TOTAL ÉTUDIANTS</div>
-                    <div class="kpi-card-value" style="color: {{ $primaryColor }};">{{ $total }}</div>
-                </div>
-            </td>
-            {{-- Montant dû --}}
-            <td width="25%" style="padding: 0 5px;">
-                <div class="kpi-card">
-                    <div class="kpi-card-header">MONTANT DÛ</div>
-                    <div class="kpi-card-value" style="color: #0f172a; font-size: 11px;">
+{{-- ── KPI CARDS ── --}}
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 12px;">
+    <tr>
+        {{-- Total étudiants --}}
+        <td width="25%" style="padding-right: 5px; vertical-align: top;">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0"
+                   style="border: 1px solid #e5e7eb; border-radius: 5px; overflow: hidden;">
+                <tr class="kpi-header"><td>TOTAL ÉTUDIANTS</td></tr>
+                <tr class="kpi-value">
+                    <td style="color: {{ $primaryColor }};">{{ $total }}</td>
+                </tr>
+            </table>
+        </td>
+        {{-- Montant dû --}}
+        <td width="25%" style="padding: 0 5px; vertical-align: top;">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0"
+                   style="border: 1px solid #e5e7eb; border-radius: 5px; overflow: hidden;">
+                <tr class="kpi-header"><td>MONTANT DÛ</td></tr>
+                <tr class="kpi-value">
+                    <td style="color: #0f172a; font-size: 11px;">
                         {{ number_format($montantDu, 0, ',', ' ') }} FCFA
-                    </div>
-                </div>
-            </td>
-            {{-- Montant payé --}}
-            <td width="25%" style="padding: 0 5px;">
-                <div class="kpi-card">
-                    <div class="kpi-card-header">MONTANT PAYÉ</div>
-                    <div class="kpi-card-value" style="color: #059669; font-size: 11px;">
+                    </td>
+                </tr>
+            </table>
+        </td>
+        {{-- Montant payé --}}
+        <td width="25%" style="padding: 0 5px; vertical-align: top;">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0"
+                   style="border: 1px solid #e5e7eb; border-radius: 5px; overflow: hidden;">
+                <tr class="kpi-header"><td>MONTANT PAYÉ</td></tr>
+                <tr class="kpi-value">
+                    <td style="color: #059669; font-size: 11px;">
                         {{ number_format($montantPaye, 0, ',', ' ') }} FCFA
-                    </div>
-                </div>
-            </td>
-            {{-- Taux recouvrement --}}
-            <td width="25%" style="padding-left: 5px;">
-                <div class="kpi-card">
-                    <div class="kpi-card-header">TAUX RECOUVREMENT</div>
-                    <div class="kpi-card-value"
-                         style="color: {{ $taux >= 80 ? '#059669' : ($taux >= 50 ? '#d97706' : '#dc2626') }};">
+                    </td>
+                </tr>
+            </table>
+        </td>
+        {{-- Taux recouvrement --}}
+        <td width="25%" style="padding-left: 5px; vertical-align: top;">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0"
+                   style="border: 1px solid #e5e7eb; border-radius: 5px; overflow: hidden;">
+                <tr class="kpi-header"><td>TAUX RECOUVREMENT</td></tr>
+                <tr class="kpi-value">
+                    <td style="color: {{ $taux >= 80 ? '#059669' : ($taux >= 50 ? '#d97706' : '#dc2626') }};">
                         {{ $taux }}%
-                    </div>
-                </div>
-            </td>
-        </tr>
-    </table>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
 
-    {{-- ── STUDENT TABLE ── --}}
-    <table class="students-table">
-        <thead>
-            <tr style="background-color: {{ $primaryColor }}; -webkit-print-color-adjust: exact;">
-                <td class="text-center" style="width: 26px; border-radius: 3px 0 0 0;">N°</td>
-                <td style="width: 72px;">Matricule</td>
-                <td>Nom & Prénom(s)</td>
-                <td style="width: 82px;">Classe</td>
-                <td style="width: 62px;">Filière</td>
-                <td class="text-right" style="width: 82px;">Montant Dû</td>
-                <td class="text-right" style="width: 72px;">Payé</td>
-                <td class="text-right" style="width: 72px;">Solde</td>
-                <td class="text-center" style="width: 34px; border-radius: 0 3px 0 0;">%</td>
-            </tr>
-        </thead>
-        <tbody>
-            @forelse($etudiants as $i => $item)
-            @php
-                $inscription = $item['inscription'];
-                $etudiant    = $inscription->etudiant ?? null;
-                $pct         = $item['pourcentage'] ?? 0;
-                $pctColor    = $pct >= 100 ? '#059669' : ($pct > 0 ? '#d97706' : '#dc2626');
-            @endphp
-            <tr>
-                <td class="text-center">
-                    <span class="row-num"
-                          style="background-color: {{ $primaryColor }}; color: #ffffff; -webkit-print-color-adjust: exact;">
-                        {{ $i + 1 }}
-                    </span>
-                </td>
-                <td style="font-size: 8.5px; color: #374151;">
-                    {{ $etudiant?->matricule ?? 'N/A' }}
-                </td>
-                <td style="font-weight: bold; font-size: 9px;">
-                    {{ $etudiant ? strtoupper($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '') : '—' }}
-                </td>
-                <td style="font-size: 8.5px; color: #374151;">
-                    {{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? '—') }}
-                </td>
-                <td style="font-size: 8.5px; color: #374151;">
-                    {{ $inscription->filiere->name ?? '—' }}
-                </td>
-                <td class="text-right" style="font-size: 8.5px;">
-                    {{ number_format($item['montant_attendu'] ?? 0, 0, ',', ' ') }}
-                </td>
-                <td class="text-right" style="font-size: 8.5px; color: #059669; font-weight: bold;">
-                    {{ number_format($item['montant_paye'] ?? 0, 0, ',', ' ') }}
-                </td>
-                <td class="text-right"
-                    style="font-size: 8.5px; font-weight: bold;
-                           color: {{ ($item['solde'] ?? 0) > 0 ? '#dc2626' : '#059669' }};">
-                    {{ number_format($item['solde'] ?? 0, 0, ',', ' ') }}
-                </td>
-                <td class="text-center" style="font-weight: bold; font-size: 8.5px; color: {{ $pctColor }};">
-                    {{ $pct }}%
-                </td>
-            </tr>
-            @empty
-            <tr class="empty-state">
-                <td colspan="9">Aucun étudiant dans cette liste.</td>
-            </tr>
-            @endforelse
-        </tbody>
-        @if($etudiants->count() > 0)
-        <tfoot>
-            <tr>
-                <td colspan="5"
-                    style="text-align: right; background-color: #eff6ff; padding: 6px 7px;
-                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
-                           -webkit-print-color-adjust: exact;">
-                    TOTAUX
-                </td>
-                <td class="text-right"
-                    style="background-color: #eff6ff; padding: 6px 7px;
-                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
-                           -webkit-print-color-adjust: exact;">
-                    {{ number_format($montantDu, 0, ',', ' ') }}
-                </td>
-                <td class="text-right"
-                    style="background-color: #eff6ff; padding: 6px 7px;
-                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
-                           color: #059669; -webkit-print-color-adjust: exact;">
-                    {{ number_format($montantPaye, 0, ',', ' ') }}
-                </td>
-                <td class="text-right"
-                    style="background-color: #eff6ff; padding: 6px 7px;
-                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
-                           color: {{ $soldeTotal > 0 ? '#dc2626' : '#059669' }};
-                           -webkit-print-color-adjust: exact;">
-                    {{ number_format($soldeTotal, 0, ',', ' ') }}
-                </td>
-                <td class="text-center"
-                    style="background-color: #eff6ff; padding: 6px 7px;
-                           border-top: 2px solid {{ $primaryColor }}; font-weight: bold; font-size: 9px;
-                           -webkit-print-color-adjust: exact;">
-                    {{ $taux }}%
-                </td>
-            </tr>
-        </tfoot>
-        @endif
-    </table>
-
-    {{-- ── FOOTER ── --}}
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" class="pdf-footer">
+{{-- ── STUDENT TABLE ── --}}
+<table class="students-table">
+    <thead>
         <tr>
-            <td class="pdf-footer-left">
-                Catégorie : <strong>{{ $category->name ?? '—' }}</strong>
-                @if(!empty($stats['filiere_name']))
-                    — Filière : <strong>{{ $stats['filiere_name'] }}</strong>
-                @endif
-                @if(!empty($stats['niveau_name']))
-                    — Niveau : <strong>{{ $stats['niveau_name'] }}</strong>
-                @endif
+            <td class="text-center" style="width: 26px;">N°</td>
+            <td style="width: 72px;">Matricule</td>
+            <td>Nom & Prénom(s)</td>
+            <td style="width: 82px;">Classe</td>
+            <td style="width: 62px;">Filière</td>
+            <td class="text-right" style="width: 82px;">Montant Dû</td>
+            <td class="text-right" style="width: 72px;">Payé</td>
+            <td class="text-right" style="width: 72px;">Solde</td>
+            <td class="text-center" style="width: 34px;">%</td>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($etudiants as $i => $item)
+        @php
+            $inscription = $item['inscription'];
+            $etudiant    = $inscription->etudiant ?? null;
+            $pct         = $item['pourcentage'] ?? 0;
+            $pctColor    = $pct >= 100 ? '#059669' : ($pct > 0 ? '#d97706' : '#dc2626');
+        @endphp
+        <tr>
+            <td class="text-center">
+                <span class="row-num">{{ $i + 1 }}</span>
             </td>
-            <td class="pdf-footer-right">
-                Généré le {{ now()->format('d/m/Y à H:i') }} — {{ $schoolName }}
+            <td style="font-size: 8.5px; color: #374151;">
+                {{ $etudiant?->matricule ?? 'N/A' }}
+            </td>
+            <td style="font-weight: bold; font-size: 9px;">
+                {{ $etudiant ? strtoupper($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '') : '—' }}
+            </td>
+            <td style="font-size: 8.5px; color: #374151;">
+                {{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? '—') }}
+            </td>
+            <td style="font-size: 8.5px; color: #374151;">
+                {{ $inscription->filiere->name ?? '—' }}
+            </td>
+            <td class="text-right" style="font-size: 8.5px;">
+                {{ number_format($item['montant_attendu'] ?? 0, 0, ',', ' ') }}
+            </td>
+            <td class="text-right" style="font-size: 8.5px; color: #059669; font-weight: bold;">
+                {{ number_format($item['montant_paye'] ?? 0, 0, ',', ' ') }}
+            </td>
+            <td class="text-right"
+                style="font-size: 8.5px; font-weight: bold;
+                       color: {{ ($item['solde'] ?? 0) > 0 ? '#dc2626' : '#059669' }};">
+                {{ number_format($item['solde'] ?? 0, 0, ',', ' ') }}
+            </td>
+            <td class="text-center" style="font-weight: bold; font-size: 8.5px; color: {{ $pctColor }};">
+                {{ $pct }}%
             </td>
         </tr>
-    </table>
+        @empty
+        <tr>
+            <td colspan="9"
+                style="text-align: center; color: #9ca3af; font-style: italic; padding: 28px; font-size: 10px;">
+                Aucun étudiant dans cette liste.
+            </td>
+        </tr>
+        @endforelse
+    </tbody>
+    @if($etudiants->count() > 0)
+    <tfoot>
+        <tr>
+            <td colspan="5" style="text-align: right;">TOTAUX</td>
+            <td class="text-right">{{ number_format($montantDu, 0, ',', ' ') }}</td>
+            <td class="text-right" style="color: #059669;">
+                {{ number_format($montantPaye, 0, ',', ' ') }}
+            </td>
+            <td class="text-right" style="color: {{ $soldeTotal > 0 ? '#dc2626' : '#059669' }};">
+                {{ number_format($soldeTotal, 0, ',', ' ') }}
+            </td>
+            <td class="text-center">{{ $taux }}%</td>
+        </tr>
+    </tfoot>
+    @endif
+</table>
 
-</div>{{-- end .page-wrapper --}}
+{{-- ── FOOTER ── --}}
+<table class="pdf-footer" width="100%" border="0" cellspacing="0" cellpadding="0"
+       style="margin-top: 12px;">
+    <tr>
+        <td style="padding-top: 8px; border-top: 1px solid #e2e8f0; font-size: 8px; color: #94a3b8;">
+            Catégorie : <strong>{{ $category->name ?? '—' }}</strong>
+            @if(!empty($stats['filiere_name']))
+                — Filière : <strong>{{ $stats['filiere_name'] }}</strong>
+            @endif
+            @if(!empty($stats['niveau_name']))
+                — Niveau : <strong>{{ $stats['niveau_name'] }}</strong>
+            @endif
+        </td>
+        <td style="padding-top: 8px; border-top: 1px solid #e2e8f0; text-align: right;
+                   font-size: 8px; color: #94a3b8;">
+            Généré le {{ now()->format('d/m/Y à H:i') }} — {{ $schoolName }}
+        </td>
+    </tr>
+</table>
 
 </body>
 </html>


### PR DESCRIPTION
Les clés retournées par getSchoolInfo() (name, address, phone, email)
ne correspondaient pas aux clés attendues par renderHeader() dans
SuiviPaiementsExport (school_name, school_address, school_phone, school_email).
Le header Excel affichait "ESBTP" (app.name) au lieu du nom complet
et la ligne coordonnées était vide.

- Contrôleur: mapper explicitement les clés getSchoolInfo() → school_name, etc.
- Inclure school_city dans les coordonnées (Row 2)
- Fallback phone → mobile si phone vide

https://claude.ai/code/session_01TN8S3MWriVtdX1exntvbtY