### PR TITLE
Redesign PDF suivi paiements + fix 1000+ students export

### DIFF
--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -2183,6 +2183,10 @@ class ESBTPPaiementController extends Controller
      */
     public function exportStudentsPdf(Request $request, string $statut)
     {
+        // Augmenter les limites pour les gros exports (1000+ étudiants)
+        ini_set('memory_limit', '512M');
+        set_time_limit(120);
+
         $categoryId = $request->input('category_id');
         if (!$categoryId) {
             abort(400, 'category_id requis');
@@ -2269,7 +2273,7 @@ class ESBTPPaiementController extends Controller
             compact('etudiants', 'category', 'statutLabel', 'schoolInfo', 'pdfSettings', 'stats')
         )->setPaper('a4', 'portrait')
          ->setOptions([
-             'dpi'                     => 150,
+             'dpi'                     => 96,
              'defaultFont'             => 'DejaVu Sans',
              'isRemoteEnabled'         => false,
              'isHtml5ParserEnabled'    => true,

--- a/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
+++ b/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
@@ -83,23 +83,17 @@
             color-adjust: exact;
         }
 
-        .row-num-table {
-            width: 20px;
-            margin: 0 auto;
-            border-collapse: collapse;
-        }
-
-        .row-num-table td {
-            width: 20px;
-            height: 20px;
+        .row-num {
+            width: 18px;
+            height: 18px;
             background-color: {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
             color: #ffffff;
             border-radius: 50%;
             text-align: center;
-            vertical-align: middle;
-            font-size: 8px;
+            line-height: 18px;
+            font-size: 7.5px;
             font-weight: bold;
-            padding: 0;
+            margin: 0 auto;
             -webkit-print-color-adjust: exact;
             color-adjust: exact;
         }
@@ -387,7 +381,7 @@
             @endphp
             <tr>
                 <td class="text-center">
-                    <table class="row-num-table"><tr><td>{{ $i + 1 }}</td></tr></table>
+                    <div class="row-num">{{ $i + 1 }}</div>
                 </td>
                 <td>
                     <span class="student-matricule">{{ $etudiant?->matricule ?? 'N/A' }}</span>


### PR DESCRIPTION
- Add ini_set('memory_limit', '512M') and set_time_limit(120) for large exports
- Lower DPI from 150 to 96 (list document, not print-quality needed)
- Replace nested <table> per row badge with simple <div class="row-num"> (eliminates ~3000 DOM elements on 1000-row exports)

https://claude.ai/code/session_01K9jxSvWFPGMh4qTejyUFMF