### PR TITLE
Fix PDF export 1000+ étudiants + barre de recherche suivi paiements

### DIFF
--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -2033,6 +2033,26 @@ class ESBTPPaiementController extends Controller
                 break;
         }
 
+        // Filtre de recherche texte (nom, prénom, matricule)
+        $search = $request->input('search');
+        if ($search && trim($search) !== '') {
+            $searchLower = mb_strtolower(trim($search));
+            $etudiants = $etudiants->filter(function ($item) use ($searchLower) {
+                $etudiant = $item['inscription']->etudiant ?? null;
+                if (!$etudiant) return false;
+
+                $nom = mb_strtolower($etudiant->nom ?? '');
+                $prenoms = mb_strtolower($etudiant->prenoms ?? '');
+                $matricule = mb_strtolower($etudiant->matricule ?? '');
+
+                return str_contains($nom, $searchLower)
+                    || str_contains($prenoms, $searchLower)
+                    || str_contains($matricule, $searchLower)
+                    || str_contains($nom . ' ' . $prenoms, $searchLower)
+                    || str_contains($prenoms . ' ' . $nom, $searchLower);
+            })->values();
+        }
+
         // Paginer les résultats
         $total = $etudiants->count();
         $offset = ($page - 1) * $perPage;
@@ -2180,12 +2200,15 @@ class ESBTPPaiementController extends Controller
 
     /**
      * Export PDF — liste étudiants par statut de paiement (suivi-categories)
+     *
+     * Pour 1000+ étudiants, utilise une stratégie de chunk+merge avec FPDI :
+     * chaque chunk de 200 lignes est rendu comme un PDF séparé puis fusionné.
+     * Cela évite le crash mémoire de DomPDF qui charge tout le HTML d'un coup.
      */
     public function exportStudentsPdf(Request $request, string $statut)
     {
-        // Augmenter les limites pour les gros exports (1000+ étudiants)
         ini_set('memory_limit', '512M');
-        set_time_limit(120);
+        set_time_limit(300);
 
         $categoryId = $request->input('category_id');
         if (!$categoryId) {
@@ -2268,22 +2291,91 @@ class ESBTPPaiementController extends Controller
         $schoolInfo  = \App\Helpers\SettingsHelper::getSchoolInfo();
         $pdfSettings = \App\Helpers\SettingsHelper::getPdfSettings();
 
-        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView(
-            'esbtp.paiements.pdf.suivi-liste-etudiants',
-            compact('etudiants', 'category', 'statutLabel', 'schoolInfo', 'pdfSettings', 'stats')
-        )->setPaper('a4', 'portrait')
-         ->setOptions([
-             'dpi'                     => 96,
-             'defaultFont'             => 'DejaVu Sans',
-             'isRemoteEnabled'         => false,
-             'isHtml5ParserEnabled'    => true,
-             'isPhpEnabled'            => false,
-             'isFontSubsettingEnabled' => true,
-         ]);
-
         $filename = 'suivi-' . $statut . '-' . (\Illuminate\Support\Str::slug($category->name ?? $statut)) . '-' . now()->format('Ymd') . '.pdf';
 
-        return $pdf->download($filename);
+        $pdfOptions = [
+            'dpi'                     => 72,
+            'defaultFont'             => 'DejaVu Sans',
+            'isRemoteEnabled'         => false,
+            'isHtml5ParserEnabled'    => true,
+            'isPhpEnabled'            => false,
+            'isFontSubsettingEnabled' => true,
+        ];
+
+        $chunkSize = 200;
+
+        // Pour les petits exports (< 500), rendu direct sans FPDI
+        if ($etudiants->count() <= 500) {
+            $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView(
+                'esbtp.paiements.pdf.suivi-liste-etudiants',
+                compact('etudiants', 'category', 'statutLabel', 'schoolInfo', 'pdfSettings', 'stats')
+            )->setPaper('a4', 'portrait')->setOptions($pdfOptions);
+
+            return $pdf->download($filename);
+        }
+
+        // Pour les gros exports (500+), chunk + merge avec FPDI
+        $tempDir = storage_path('app/temp');
+        if (!is_dir($tempDir)) {
+            mkdir($tempDir, 0755, true);
+        }
+
+        $chunks = $etudiants->chunk($chunkSize);
+        $tempFiles = [];
+        $totalChunks = $chunks->count();
+
+        foreach ($chunks as $chunkIndex => $chunk) {
+            $isFirstChunk = ($chunkIndex === 0);
+            $isLastChunk  = ($chunkIndex === $totalChunks - 1);
+            $rowOffset    = $chunkIndex * $chunkSize;
+
+            $chunkPdf = \Barryvdh\DomPDF\Facade\Pdf::loadView(
+                'esbtp.paiements.pdf.suivi-liste-etudiants',
+                [
+                    'etudiants'    => $chunk,
+                    'category'     => $category,
+                    'statutLabel'  => $statutLabel,
+                    'schoolInfo'   => $schoolInfo,
+                    'pdfSettings'  => $pdfSettings,
+                    'stats'        => $stats,
+                    'isFirstChunk' => $isFirstChunk,
+                    'isLastChunk'  => $isLastChunk,
+                    'rowOffset'    => $rowOffset,
+                    'chunkIndex'   => $chunkIndex,
+                ]
+            )->setPaper('a4', 'portrait')->setOptions($pdfOptions);
+
+            $tempPath = $tempDir . '/suivi_chunk_' . uniqid() . '_' . $chunkIndex . '.pdf';
+            file_put_contents($tempPath, $chunkPdf->output());
+            $tempFiles[] = $tempPath;
+
+            // Libérer la mémoire entre chaque chunk
+            unset($chunkPdf);
+        }
+
+        // Fusionner tous les chunks avec FPDI
+        $merger = new \setasign\Fpdi\Fpdi();
+        foreach ($tempFiles as $file) {
+            $pageCount = $merger->setSourceFile($file);
+            for ($p = 1; $p <= $pageCount; $p++) {
+                $tpl = $merger->importPage($p);
+                $size = $merger->getTemplateSize($tpl);
+                $merger->AddPage($size['orientation'], [$size['width'], $size['height']]);
+                $merger->useTemplate($tpl);
+            }
+        }
+
+        $finalPath = $tempDir . '/suivi_final_' . uniqid() . '.pdf';
+        $merger->Output('F', $finalPath);
+        unset($merger);
+
+        // Nettoyer les fichiers temporaires de chunks
+        foreach ($tempFiles as $file) {
+            @unlink($file);
+        }
+
+        // Retourner le PDF fusionné et nettoyer après envoi
+        return response()->download($finalPath, $filename)->deleteFileAfterSend(true);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "maatwebsite/excel": "^3.1",
         "mpdf/mpdf": "^8.2",
         "owen-it/laravel-auditing": "^13.0",
+        "setasign/fpdi": "^2.6",
         "spatie/browsershot": "^5.0",
         "spatie/laravel-permission": "^5.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a20fde9067918fc1ccbc44717f386b1a",
+    "content-hash": "bb431dcb53fbd00138c0560317a434e1",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -10599,5 +10599,5 @@
         "php": "^7.4|^8.0|^8.1|^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/resources/views/esbtp/paiements/partials/suivi-content.blade.php
+++ b/resources/views/esbtp/paiements/partials/suivi-content.blade.php
@@ -179,6 +179,26 @@
                 </div>
             </div>
 
+            {{-- Barre de recherche intelligente --}}
+            <div class="suivi-search-container" style="margin-bottom: 16px; position: relative;">
+                <div style="display: flex; align-items: center; gap: 12px; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 10px; padding: 10px 16px;">
+                    <i class="fas fa-search" style="color: #9ca3af; font-size: 14px;"></i>
+                    <input type="text"
+                           id="suivi-search-input"
+                           class="suivi-search-field"
+                           placeholder="Rechercher par nom, prénom ou matricule..."
+                           data-category-id="{{ $detailsCategorie['category']->id }}"
+                           style="border: none; background: transparent; outline: none; flex: 1; font-size: 14px; color: #1f2937; font-weight: 400;"
+                    >
+                    <span id="suivi-search-count" style="font-size: 12px; color: #6b7280; white-space: nowrap; display: none;">
+                        <i class="fas fa-filter me-1"></i><span id="suivi-search-count-value">0</span> résultat(s)
+                    </span>
+                    <button type="button" id="suivi-search-clear" style="display: none; border: none; background: #e5e7eb; border-radius: 50%; width: 24px; height: 24px; cursor: pointer; color: #6b7280; font-size: 12px; padding: 0; line-height: 24px; text-align: center;">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+            </div>
+
             {{-- Navigation par onglets avec lazy loading --}}
             <div class="student-tabs-container">
                 <ul class="nav nav-tabs students-tabs" id="myTab_{{ $detailsCategorie['category']->id }}" role="tablist" style="border: none; display: flex; gap: var(--space-md);">

--- a/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
+++ b/resources/views/esbtp/paiements/pdf/suivi-liste-etudiants.blade.php
@@ -5,7 +5,6 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <title>Suivi Paiements – {{ $category->name ?? '' }} – {{ $statutLabel ?? '' }}</title>
     <style>
-        /* ── Reset ── */
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         @page {
@@ -19,22 +18,6 @@
             color: {{ $pdfSettings['text_color'] ?? '#1f2937' }};
             line-height: 1.4;
             background: #ffffff;
-            padding: 8px;
-        }
-
-        .container {
-            max-width: 100%;
-            background: white;
-            padding: 10px;
-        }
-
-        /* ── Header ── */
-        .header-section {
-            border-radius: 6px;
-            margin-bottom: 12px;
-            -webkit-print-color-adjust: exact;
-            color-adjust: exact;
-            overflow: hidden;
         }
 
         /* ── Table data ── */
@@ -42,13 +25,13 @@
             width: 100%;
             border-collapse: collapse;
             font-size: 9px;
-            margin-bottom: 14px;
+            margin-bottom: 10px;
         }
 
         .students-table thead td {
             background-color: {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
             color: #ffffff;
-            padding: 7px 7px;
+            padding: 6px 6px;
             font-weight: bold;
             font-size: 8.5px;
             text-transform: uppercase;
@@ -63,12 +46,8 @@
             color-adjust: exact;
         }
 
-        .students-table tbody tr:nth-child(odd) td {
-            background-color: #ffffff;
-        }
-
         .students-table tbody td {
-            padding: 6px 7px;
+            padding: 5px 6px;
             border-bottom: 1px solid #e5e7eb;
             vertical-align: middle;
         }
@@ -76,75 +55,41 @@
         .students-table tfoot td {
             background-color: #eff6ff;
             font-weight: bold;
-            padding: 8px 7px;
+            padding: 7px 6px;
             border-top: 2px solid {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
             font-size: 9px;
             -webkit-print-color-adjust: exact;
             color-adjust: exact;
         }
 
-        .row-num {
-            width: 18px;
-            height: 18px;
-            background-color: {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
-            color: #ffffff;
+        /* Row number — same pattern as liste-complete-pdf.blade.php (works in DomPDF) */
+        .student-number {
+            background: {{ $pdfSettings['primary_color'] ?? '#0453cb' }};
+            color: white;
+            padding: 2px 4px;
             border-radius: 50%;
-            text-align: center;
-            line-height: 18px;
-            font-size: 7.5px;
             font-weight: bold;
-            margin: 0 auto;
+            font-size: 8px;
+            min-width: 16px;
+            display: inline-block;
+            text-align: center;
             -webkit-print-color-adjust: exact;
             color-adjust: exact;
         }
 
         .student-matricule {
             font-family: 'Courier New', monospace;
-            background: #f3f4f6;
-            padding: 2px 3px;
-            border-radius: 2px;
             font-size: 8px;
             color: #374151;
-            -webkit-print-color-adjust: exact;
-            color-adjust: exact;
         }
 
-        /* ── Badges ── */
-        .statut-badge {
-            display: inline-block;
-            padding: 3px 10px;
-            border-radius: 10px;
-            font-size: 9px;
-            font-weight: bold;
-        }
-
-        .badge-non-payes {
-            background-color: #fee2e2;
-            color: #991b1b;
-            border: 1px solid #fca5a5;
-        }
-
-        .badge-en-retard {
-            background-color: #fef3c7;
-            color: #92400e;
-            border: 1px solid #fcd34d;
-        }
-
-        .badge-a-jour {
-            background-color: #d1fae5;
-            color: #065f46;
-            border: 1px solid #6ee7b7;
-        }
-
-        /* ── Footer ── */
-        .footer-section {
-            margin-top: 12px;
-        }
+        /* ── Utilities ── */
+        .text-right  { text-align: right; }
+        .text-center { text-align: center; }
 
         .summary-card {
             background: #f8f9fa;
             border: 1px solid #e5e7eb;
-            border-radius: 4px;
             padding: 9px;
         }
 
@@ -160,7 +105,6 @@
         .info-card {
             background: #f8f9fa;
             border: 1px solid #e5e7eb;
-            border-radius: 4px;
             padding: 9px;
         }
 
@@ -174,27 +118,6 @@
             font-size: 9px;
             font-weight: 600;
             color: #374151;
-        }
-
-        .generation-info {
-            text-align: center;
-            font-size: 8px;
-            color: #6b7280;
-            margin-top: 10px;
-            padding-top: 6px;
-            border-top: 1px solid #e5e7eb;
-        }
-
-        /* ── Utilities ── */
-        .text-right  { text-align: right; }
-        .text-center { text-align: center; }
-
-        /* ── Print optimizations ── */
-        @media print {
-            body { background: white; padding: 4px; }
-            .container { padding: 8px; }
-            .header-section { margin-bottom: 10px; }
-            .footer-section { margin-top: 10px; }
         }
     </style>
     @include('pdf.partials.theme')
@@ -211,8 +134,13 @@
     $schoolEmail   = $schoolInfo['email']   ?? '';
     $schoolLogo    = $schoolInfo['logo']    ?? '';
 
+    // Chunk support: variables passées par le controller pour les gros exports
+    $isFirstChunk = $isFirstChunk ?? true;
+    $isLastChunk  = $isLastChunk ?? true;
+    $rowOffset    = $rowOffset ?? 0;
+
     $logoBase64 = null;
-    if ($schoolLogo) {
+    if ($isFirstChunk && $schoolLogo) {
         $paths = [
             storage_path('app/public/' . $schoolLogo),
             public_path('storage/' . $schoolLogo),
@@ -234,287 +162,235 @@
     $soldeTotal  = $montantDu - $montantPaye;
 
     $statut     = $stats['statut'] ?? '';
-    $badgeClass = match($statut) {
-        'non_payes' => 'badge-non-payes',
-        'en_retard' => 'badge-en-retard',
-        'a_jour'    => 'badge-a-jour',
-        default     => 'badge-en-retard',
-    };
 @endphp
 
-<div class="container">
-
-    {{-- ── HEADER SECTION — Logo | Infos école + Titre document ── --}}
-    <div class="header-section">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <tr>
-                {{-- Logo --}}
-                <td width="18%" style="background-color: {{ $headerBg }}; padding: 14px 10px; text-align: center; vertical-align: middle; border-right: 2px solid rgba(255,255,255,0.25);">
-                    @if($logoBase64)
-                        <img src="{{ $logoBase64 }}"
-                             style="max-height: 55px; max-width: 100px; filter: brightness(0) invert(1);"
-                             alt="Logo">
-                    @else
-                        <div style="font-size: 30px; font-weight: 900; color: {{ $headerText }}; opacity: 0.4; letter-spacing: -2px;">K</div>
-                    @endif
-                </td>
-
-                {{-- Nom + coordonnées + titre document --}}
-                <td width="82%" style="background-color: {{ $headerBg }}; padding: 12px 16px; vertical-align: middle;">
-                    {{-- Nom établissement --}}
-                    <div style="font-size: 15px; font-weight: 700; color: {{ $headerText }}; margin-bottom: 2px;">
-                        {{ strtoupper($schoolName) }}
-                    </div>
-
-                    {{-- Adresse | Tél | Email --}}
-                    @if($schoolAddress || $schoolPhone || $schoolEmail)
-                    <div style="font-size: 8.5px; color: {{ $headerText }}; opacity: 0.85; margin-bottom: 8px;">
-                        @if($schoolAddress){{ $schoolAddress }}@endif
-                        @if($schoolPhone)
-                            @if($schoolAddress) &nbsp;|&nbsp; @endif
-                            Tél: {{ $schoolPhone }}
-                        @endif
-                        @if($schoolEmail)
-                            @if($schoolAddress || $schoolPhone) &nbsp;|&nbsp; @endif
-                            Email: {{ $schoolEmail }}
-                        @endif
-                    </div>
-                    @endif
-
-                    {{-- Séparateur + titre document + sous-infos --}}
-                    <div style="border-top: 1px solid rgba(255,255,255,0.35); padding-top: 7px;">
-                        <div style="font-size: 12px; font-weight: 700; color: {{ $headerText }}; letter-spacing: 0.5px; margin-bottom: 5px;">
-                            SUIVI DES PAIEMENTS
-                        </div>
+{{-- ── HEADER + KPI — Only on first chunk ── --}}
+@if($isFirstChunk)
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 12px;">
+    <tr>
+        <td width="18%" style="background-color: {{ $headerBg }}; padding: 14px 10px; text-align: center; vertical-align: middle; border-right: 2px solid rgba(255,255,255,0.25); -webkit-print-color-adjust: exact; color-adjust: exact;">
+            @if($logoBase64)
+                <img src="{{ $logoBase64 }}"
+                     style="max-height: 55px; max-width: 100px; filter: brightness(0) invert(1);"
+                     alt="Logo">
+            @else
+                <span style="font-size: 30px; font-weight: 900; color: {{ $headerText }}; opacity: 0.4; letter-spacing: -2px;">K</span>
+            @endif
+        </td>
+        <td width="82%" style="background-color: {{ $headerBg }}; padding: 12px 16px; vertical-align: middle; -webkit-print-color-adjust: exact; color-adjust: exact;">
+            <span style="font-size: 15px; font-weight: 700; color: {{ $headerText }};">{{ strtoupper($schoolName) }}</span>
+            @if($schoolAddress || $schoolPhone || $schoolEmail)
+            <br><span style="font-size: 8.5px; color: {{ $headerText }}; opacity: 0.85;">@if($schoolAddress){{ $schoolAddress }}@endif @if($schoolPhone)@if($schoolAddress) | @endif Tel: {{ $schoolPhone }}@endif @if($schoolEmail)@if($schoolAddress || $schoolPhone) | @endif Email: {{ $schoolEmail }}@endif</span>
+            @endif
+            <br><span style="font-size: 1px; color: {{ $headerBg }};">.</span>
+            <table width="100%" border="0" cellspacing="0" cellpadding="0" style="border-top: 1px solid rgba(255,255,255,0.35); margin-top: 4px; padding-top: 4px;">
+                <tr>
+                    <td style="font-size: 12px; font-weight: 700; color: {{ $headerText }}; padding-top: 5px;">SUIVI DES PAIEMENTS</td>
+                </tr>
+                <tr>
+                    <td>
                         <table width="100%" border="0" cellspacing="0" cellpadding="0">
                             <tr>
                                 <td width="33%" style="font-size: 9px; color: {{ $headerText }};">
-                                    <span style="color: {{ $headerText }}; opacity: 0.75;">Catégorie :</span>
-                                    <strong style="color: {{ $headerText }};">{{ $category->name ?? 'N/A' }}</strong>
+                                    <span style="opacity: 0.75;">Catégorie :</span> <strong>{{ $category->name ?? 'N/A' }}</strong>
                                 </td>
                                 <td width="33%" style="font-size: 9px; color: {{ $headerText }}; text-align: center;">
-                                    <span style="color: {{ $headerText }}; opacity: 0.75;">Statut :</span>
-                                    <strong style="color: {{ $headerText }};">{{ $statutLabel }}</strong>
+                                    <span style="opacity: 0.75;">Statut :</span> <strong>{{ $statutLabel }}</strong>
                                 </td>
                                 <td width="34%" style="font-size: 9px; color: {{ $headerText }}; text-align: right;">
-                                    <span style="color: {{ $headerText }}; opacity: 0.75;">Date :</span>
-                                    <strong style="color: {{ $headerText }};">{{ now()->format('d/m/Y') }}</strong>
+                                    <span style="opacity: 0.75;">Date :</span> <strong>{{ now()->format('d/m/Y') }}</strong>
                                 </td>
                             </tr>
                         </table>
-                    </div>
-                </td>
-            </tr>
-        </table>
-    </div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
 
-    {{-- ── KPI SECTION — 4 cellules uniformes fond bleu ── --}}
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 12px;">
+{{-- KPI --}}
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 12px;">
+    <tr>
+        <td width="25%" style="background-color: {{ $primaryColor }}; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25); -webkit-print-color-adjust: exact; color-adjust: exact;">
+            <span style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8;">TOTAL ÉTUDIANTS</span><br>
+            <span style="font-size: 18px; font-weight: 700; color: white;">{{ $total }}</span><br>
+            <span style="font-size: 7px; color: white; opacity: 0.65;">{{ $statutLabel }}</span>
+        </td>
+        <td width="25%" style="background-color: {{ $primaryColor }}; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25); -webkit-print-color-adjust: exact; color-adjust: exact;">
+            <span style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8;">MONTANT DÛ</span><br>
+            <span style="font-size: 11px; font-weight: 700; color: white;">{{ number_format($montantDu, 0, ',', ' ') }} F</span><br>
+            <span style="font-size: 7px; color: white; opacity: 0.65;">Total attendu</span>
+        </td>
+        <td width="25%" style="background-color: {{ $primaryColor }}; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25); -webkit-print-color-adjust: exact; color-adjust: exact;">
+            <span style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8;">MONTANT PAYÉ</span><br>
+            <span style="font-size: 11px; font-weight: 700; color: white;">{{ number_format($montantPaye, 0, ',', ' ') }} F</span><br>
+            <span style="font-size: 7px; color: white; opacity: 0.65;">Total reçu</span>
+        </td>
+        <td width="25%" style="background-color: {{ $primaryColor }}; padding: 9px 8px; text-align: center; vertical-align: middle; -webkit-print-color-adjust: exact; color-adjust: exact;">
+            <span style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8;">RECOUVREMENT</span><br>
+            <span style="font-size: 18px; font-weight: 700; color: white;">{{ $taux }}%</span><br>
+            <span style="font-size: 7px; color: white; opacity: 0.65;">Taux de paiement</span>
+        </td>
+    </tr>
+</table>
+
+{{-- Filtres actifs --}}
+@if(!empty($stats['filiere_name']) || !empty($stats['niveau_name']))
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 10px;">
+    <tr>
+        <td style="background-color: #f0f9ff; border-left: 3px solid {{ $primaryColor }}; padding: 6px 10px; font-size: 9px; color: #1e40af; -webkit-print-color-adjust: exact; color-adjust: exact;">
+            <strong>Filtres :</strong>
+            @if(!empty($stats['filiere_name']))
+                Filière : <strong>{{ $stats['filiere_name'] }}</strong>
+            @endif
+            @if(!empty($stats['niveau_name']))
+                @if(!empty($stats['filiere_name'])) — @endif
+                Niveau : <strong>{{ $stats['niveau_name'] }}</strong>
+            @endif
+        </td>
+    </tr>
+</table>
+@endif
+@else
+{{-- Non-first chunk: light continuation header --}}
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 8px;">
+    <tr>
+        <td style="font-size: 9px; color: #6b7280; padding: 4px 0; border-bottom: 1px solid #e5e7eb;">
+            {{ $category->name ?? '' }} — {{ $statutLabel }} — <strong>{{ $total }}</strong> étudiants (suite)
+        </td>
+    </tr>
+</table>
+@endif
+
+{{-- ── TABLE DES ÉTUDIANTS ── --}}
+<table class="students-table">
+    <thead>
         <tr>
-            {{-- Total étudiants --}}
-            <td width="25%" style="background-color: {{ $primaryColor }}; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25); -webkit-print-color-adjust: exact; color-adjust: exact;">
-                <div style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8; margin-bottom: 4px;">TOTAL ÉTUDIANTS</div>
-                <div style="font-size: 18px; font-weight: 700; color: white; line-height: 1.1; margin-bottom: 4px;">{{ $total }}</div>
-                <div style="font-size: 7px; color: white; opacity: 0.65;">{{ $statutLabel }}</div>
+            <td class="text-center" style="width: 26px;">N°</td>
+            <td style="width: 72px;">Matricule</td>
+            <td>Nom & Prénom(s)</td>
+            <td style="width: 80px;">Classe</td>
+            <td style="width: 60px;">Filière</td>
+            <td class="text-right" style="width: 80px;">Montant Dû</td>
+            <td class="text-right" style="width: 72px;">Payé</td>
+            <td class="text-right" style="width: 72px;">Solde</td>
+            <td class="text-center" style="width: 34px;">%</td>
+        </tr>
+    </thead>
+    <tbody>
+        @forelse($etudiants as $i => $item)
+        @php
+            $inscription = $item['inscription'];
+            $etudiant    = $inscription->etudiant ?? null;
+            $pct         = $item['pourcentage'] ?? 0;
+            $pctColor    = $pct >= 100 ? '#059669' : ($pct > 0 ? '#d97706' : '#dc2626');
+            $rowNum      = $rowOffset + $i + 1;
+        @endphp
+        <tr>
+            <td class="text-center">
+                <span class="student-number">{{ $rowNum }}</span>
             </td>
-            {{-- Montant dû --}}
-            <td width="25%" style="background-color: {{ $primaryColor }}; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25); -webkit-print-color-adjust: exact; color-adjust: exact;">
-                <div style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8; margin-bottom: 4px;">MONTANT DÛ</div>
-                <div style="font-size: 11px; font-weight: 700; color: white; line-height: 1.25; margin-bottom: 4px;">{{ number_format($montantDu, 0, ',', ' ') }} F</div>
-                <div style="font-size: 7px; color: white; opacity: 0.65;">Total attendu</div>
+            <td>
+                <span class="student-matricule">{{ $etudiant?->matricule ?? 'N/A' }}</span>
             </td>
-            {{-- Montant payé --}}
-            <td width="25%" style="background-color: {{ $primaryColor }}; padding: 9px 8px; text-align: center; vertical-align: middle; border-right: 1px solid rgba(255,255,255,0.25); -webkit-print-color-adjust: exact; color-adjust: exact;">
-                <div style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8; margin-bottom: 4px;">MONTANT PAYÉ</div>
-                <div style="font-size: 11px; font-weight: 700; color: white; line-height: 1.25; margin-bottom: 4px;">{{ number_format($montantPaye, 0, ',', ' ') }} F</div>
-                <div style="font-size: 7px; color: white; opacity: 0.65;">Total reçu</div>
+            <td style="font-weight: bold; font-size: 9px;">
+                {{ $etudiant ? strtoupper($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '') : '—' }}
             </td>
-            {{-- Taux recouvrement --}}
-            <td width="25%" style="background-color: {{ $primaryColor }}; padding: 9px 8px; text-align: center; vertical-align: middle; -webkit-print-color-adjust: exact; color-adjust: exact;">
-                <div style="font-size: 7.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: white; opacity: 0.8; margin-bottom: 4px;">RECOUVREMENT</div>
-                <div style="font-size: 18px; font-weight: 700; color: white; line-height: 1.1; margin-bottom: 4px;">{{ $taux }}%</div>
-                <div style="font-size: 7px; color: white; opacity: 0.65;">Taux de paiement</div>
+            <td style="font-size: 8.5px; color: #374151;">
+                {{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? '—') }}
+            </td>
+            <td style="font-size: 8.5px; color: #374151;">
+                {{ $inscription->filiere->name ?? '—' }}
+            </td>
+            <td class="text-right" style="font-size: 8.5px;">
+                {{ number_format($item['montant_attendu'] ?? 0, 0, ',', ' ') }}
+            </td>
+            <td class="text-right" style="font-size: 8.5px; color: #059669; font-weight: bold;">
+                {{ number_format($item['montant_paye'] ?? 0, 0, ',', ' ') }}
+            </td>
+            <td class="text-right" style="font-size: 8.5px; font-weight: bold; color: {{ ($item['solde'] ?? 0) > 0 ? '#dc2626' : '#059669' }};">
+                {{ number_format($item['solde'] ?? 0, 0, ',', ' ') }}
+            </td>
+            <td class="text-center" style="font-weight: bold; font-size: 8.5px; color: {{ $pctColor }};">
+                {{ $pct }}%
             </td>
         </tr>
-    </table>
-
-    {{-- ── Filtres actifs (si filière ou niveau spécifié) ── --}}
-    @if(!empty($stats['filiere_name']) || !empty($stats['niveau_name']))
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-bottom: 10px;">
+        @empty
         <tr>
-            <td style="background-color: #f0f9ff; border-left: 3px solid {{ $primaryColor }}; padding: 6px 10px; font-size: 9px; color: #1e40af; border-radius: 3px; -webkit-print-color-adjust: exact; color-adjust: exact;">
-                <strong>Filtres :</strong>
-                @if(!empty($stats['filiere_name']))
-                    Filière : <strong>{{ $stats['filiere_name'] }}</strong>
-                @endif
-                @if(!empty($stats['niveau_name']))
-                    @if(!empty($stats['filiere_name'])) — @endif
-                    Niveau : <strong>{{ $stats['niveau_name'] }}</strong>
-                @endif
+            <td colspan="9" style="text-align: center; color: #9ca3af; font-style: italic; padding: 28px; font-size: 10px;">
+                Aucun étudiant dans cette liste.
             </td>
         </tr>
-    </table>
+        @endforelse
+    </tbody>
+    @if($isLastChunk && $etudiants->count() > 0)
+    <tfoot>
+        <tr>
+            <td colspan="5" style="text-align: right;">TOTAUX</td>
+            <td class="text-right">{{ number_format($montantDu, 0, ',', ' ') }}</td>
+            <td class="text-right" style="color: #059669;">{{ number_format($montantPaye, 0, ',', ' ') }}</td>
+            <td class="text-right" style="color: {{ $soldeTotal > 0 ? '#dc2626' : '#059669' }};">{{ number_format($soldeTotal, 0, ',', ' ') }}</td>
+            <td class="text-center">{{ $taux }}%</td>
+        </tr>
+    </tfoot>
     @endif
+</table>
 
-    {{-- ── TABLE DES ÉTUDIANTS ── --}}
-    <table class="students-table">
-        <thead>
-            <tr>
-                <td class="text-center" style="width: 26px;">N°</td>
-                <td style="width: 72px;">Matricule</td>
-                <td>Nom & Prénom(s)</td>
-                <td style="width: 80px;">Classe</td>
-                <td style="width: 60px;">Filière</td>
-                <td class="text-right" style="width: 80px;">Montant Dû</td>
-                <td class="text-right" style="width: 72px;">Payé</td>
-                <td class="text-right" style="width: 72px;">Solde</td>
-                <td class="text-center" style="width: 34px;">%</td>
-            </tr>
-        </thead>
-        <tbody>
-            @forelse($etudiants as $i => $item)
-            @php
-                $inscription = $item['inscription'];
-                $etudiant    = $inscription->etudiant ?? null;
-                $pct         = $item['pourcentage'] ?? 0;
-                $pctColor    = $pct >= 100 ? '#059669' : ($pct > 0 ? '#d97706' : '#dc2626');
-            @endphp
-            <tr>
-                <td class="text-center">
-                    <div class="row-num">{{ $i + 1 }}</div>
-                </td>
-                <td>
-                    <span class="student-matricule">{{ $etudiant?->matricule ?? 'N/A' }}</span>
-                </td>
-                <td style="font-weight: bold; font-size: 9px; text-align: left;">
-                    {{ $etudiant ? strtoupper($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '') : '—' }}
-                </td>
-                <td style="font-size: 8.5px; color: #374151;">
-                    {{ $inscription->classe->name ?? ($inscription->niveauEtude->name ?? '—') }}
-                </td>
-                <td style="font-size: 8.5px; color: #374151;">
-                    {{ $inscription->filiere->name ?? '—' }}
-                </td>
-                <td class="text-right" style="font-size: 8.5px;">
-                    {{ number_format($item['montant_attendu'] ?? 0, 0, ',', ' ') }}
-                </td>
-                <td class="text-right" style="font-size: 8.5px; color: #059669; font-weight: bold;">
-                    {{ number_format($item['montant_paye'] ?? 0, 0, ',', ' ') }}
-                </td>
-                <td class="text-right"
-                    style="font-size: 8.5px; font-weight: bold;
-                           color: {{ ($item['solde'] ?? 0) > 0 ? '#dc2626' : '#059669' }};">
-                    {{ number_format($item['solde'] ?? 0, 0, ',', ' ') }}
-                </td>
-                <td class="text-center" style="font-weight: bold; font-size: 8.5px; color: {{ $pctColor }};">
-                    {{ $pct }}%
-                </td>
-            </tr>
-            @empty
-            <tr>
-                <td colspan="9"
-                    style="text-align: center; color: #9ca3af; font-style: italic; padding: 28px; font-size: 10px;">
-                    Aucun étudiant dans cette liste.
-                </td>
-            </tr>
-            @endforelse
-        </tbody>
-        @if($etudiants->count() > 0)
-        <tfoot>
-            <tr>
-                <td colspan="5" style="text-align: right;">TOTAUX</td>
-                <td class="text-right">{{ number_format($montantDu, 0, ',', ' ') }}</td>
-                <td class="text-right" style="color: #059669;">
-                    {{ number_format($montantPaye, 0, ',', ' ') }}
-                </td>
-                <td class="text-right" style="color: {{ $soldeTotal > 0 ? '#dc2626' : '#059669' }};">
-                    {{ number_format($soldeTotal, 0, ',', ' ') }}
-                </td>
-                <td class="text-center">{{ $taux }}%</td>
-            </tr>
-        </tfoot>
-        @endif
-    </table>
+{{-- ── FOOTER — Only on last chunk ── --}}
+@if($isLastChunk && $etudiants->count() > 0)
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-top: 12px;">
+    <tr>
+        <td width="48%" style="vertical-align: top; padding-right: 6px;">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0" style="background: #f8f9fa; border: 1px solid #e5e7eb;">
+                <tr>
+                    <td colspan="2" style="padding: 8px 9px 4px; font-size: 10px; font-weight: 600; color: #374151; text-transform: uppercase; letter-spacing: 0.2px;">Résumé financier</td>
+                </tr>
+                <tr>
+                    <td width="50%" style="text-align: center; padding: 6px;">
+                        <span style="font-size: 13px; font-weight: bold; color: {{ $primaryColor }};">{{ number_format($montantDu, 0, ',', ' ') }}</span><br>
+                        <span style="font-size: 8px; color: #6b7280;">Montant total dû (FCFA)</span>
+                    </td>
+                    <td width="50%" style="text-align: center; padding: 6px;">
+                        <span style="font-size: 13px; font-weight: bold; color: #059669;">{{ number_format($montantPaye, 0, ',', ' ') }}</span><br>
+                        <span style="font-size: 8px; color: #6b7280;">Montant total payé (FCFA)</span>
+                    </td>
+                </tr>
+                <tr>
+                    <td style="text-align: center; padding: 6px;">
+                        <span style="font-size: 13px; font-weight: bold; color: {{ $soldeTotal > 0 ? '#dc2626' : '#059669' }};">{{ number_format($soldeTotal, 0, ',', ' ') }}</span><br>
+                        <span style="font-size: 8px; color: #6b7280;">Solde restant (FCFA)</span>
+                    </td>
+                    <td style="text-align: center; padding: 6px;">
+                        <span style="font-size: 13px; font-weight: bold; color: {{ $taux >= 80 ? '#059669' : ($taux >= 50 ? '#d97706' : '#dc2626') }};">{{ $taux }}%</span><br>
+                        <span style="font-size: 8px; color: #6b7280;">Taux de recouvrement</span>
+                    </td>
+                </tr>
+            </table>
+        </td>
+        <td width="4%"></td>
+        <td width="48%" style="vertical-align: top; padding-left: 6px;">
+            <table width="100%" border="0" cellspacing="0" cellpadding="0" style="background: #f8f9fa; border: 1px solid #e5e7eb;">
+                <tr>
+                    <td style="padding: 8px 9px 4px; font-size: 10px; font-weight: 600; color: #374151; text-transform: uppercase; letter-spacing: 0.2px;">Informations document</td>
+                </tr>
+                <tr><td style="padding: 4px 9px;"><span class="info-label">Généré le :</span> <span class="info-value">{{ now()->format('d/m/Y à H:i') }}</span></td></tr>
+                <tr><td style="padding: 4px 9px;"><span class="info-label">Par :</span> <span class="info-value">{{ auth()->user()->name ?? 'Système' }}</span></td></tr>
+                <tr><td style="padding: 4px 9px;"><span class="info-label">Établissement :</span> <span class="info-value">{{ $schoolName }}</span></td></tr>
+                <tr><td style="padding: 4px 9px 8px;"><span class="info-label">Catégorie :</span> <span class="info-value">{{ $category->name ?? '—' }}</span></td></tr>
+            </table>
+        </td>
+    </tr>
+</table>
 
-    {{-- ── FOOTER SECTION — 2 colonnes : Résumé | Infos document ── --}}
-    @if($etudiants->count() > 0)
-    <div class="footer-section">
-        <table width="100%" border="0" cellspacing="0" cellpadding="0">
-            <tr>
-                {{-- Résumé financier --}}
-                <td width="48%" style="vertical-align: top; padding-right: 6px;">
-                    <div class="summary-card">
-                        <div class="summary-title">Résumé financier</div>
-                        <table width="100%" border="0" cellspacing="0" cellpadding="3">
-                            <tr>
-                                <td width="50%" style="text-align: center; vertical-align: top;">
-                                    <div style="font-size: 13px; font-weight: bold; color: {{ $primaryColor }};">{{ number_format($montantDu, 0, ',', ' ') }}</div>
-                                    <div style="font-size: 8px; color: #6b7280;">Montant total dû (FCFA)</div>
-                                </td>
-                                <td width="50%" style="text-align: center; vertical-align: top;">
-                                    <div style="font-size: 13px; font-weight: bold; color: #059669;">{{ number_format($montantPaye, 0, ',', ' ') }}</div>
-                                    <div style="font-size: 8px; color: #6b7280;">Montant total payé (FCFA)</div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td style="text-align: center; vertical-align: top; padding-top: 6px;">
-                                    <div style="font-size: 13px; font-weight: bold; color: {{ $soldeTotal > 0 ? '#dc2626' : '#059669' }};">{{ number_format($soldeTotal, 0, ',', ' ') }}</div>
-                                    <div style="font-size: 8px; color: #6b7280;">Solde restant (FCFA)</div>
-                                </td>
-                                <td style="text-align: center; vertical-align: top; padding-top: 6px;">
-                                    <div style="font-size: 13px; font-weight: bold; color: {{ $taux >= 80 ? '#059669' : ($taux >= 50 ? '#d97706' : '#dc2626') }};">{{ $taux }}%</div>
-                                    <div style="font-size: 8px; color: #6b7280;">Taux de recouvrement</div>
-                                </td>
-                            </tr>
-                        </table>
-                    </div>
-                </td>
-
-                {{-- Infos document --}}
-                <td width="4%"></td>
-                <td width="48%" style="vertical-align: top; padding-left: 6px;">
-                    <div class="info-card">
-                        <div class="summary-title">Informations document</div>
-                        <table width="100%" border="0" cellspacing="0" cellpadding="2">
-                            <tr>
-                                <td>
-                                    <div class="info-label">Document généré le :</div>
-                                    <div class="info-value">{{ now()->format('d/m/Y à H:i') }}</div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td style="padding-top: 4px;">
-                                    <div class="info-label">Par :</div>
-                                    <div class="info-value">{{ auth()->user()->name ?? 'Système' }}</div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td style="padding-top: 4px;">
-                                    <div class="info-label">Établissement :</div>
-                                    <div class="info-value">{{ $schoolName }}</div>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td style="padding-top: 4px;">
-                                    <div class="info-label">Catégorie :</div>
-                                    <div class="info-value">{{ $category->name ?? '—' }}</div>
-                                </td>
-                            </tr>
-                        </table>
-                    </div>
-                </td>
-            </tr>
-        </table>
-    </div>
-    @endif
-
-    {{-- ── GENERATION INFO ── --}}
-    <div class="generation-info">
-        <strong>Document généré automatiquement le {{ now()->format('d/m/Y à H:i') }}</strong><br>
-        {{ $schoolName }} — Système de Gestion KLASSCI
-    </div>
-
-</div>
+<table width="100%" border="0" cellspacing="0" cellpadding="0" style="margin-top: 10px; border-top: 1px solid #e5e7eb; padding-top: 6px;">
+    <tr>
+        <td style="text-align: center; font-size: 8px; color: #6b7280;">
+            <strong>Document généré automatiquement le {{ now()->format('d/m/Y à H:i') }}</strong> — {{ $schoolName }} — Système de Gestion KLASSCI
+        </td>
+    </tr>
+</table>
+@endif
 
 </body>
 </html>

--- a/resources/views/esbtp/paiements/suivi-categories.blade.php
+++ b/resources/views/esbtp/paiements/suivi-categories.blade.php
@@ -756,21 +756,50 @@
             }
         }
 
-        function loadStudentsByStatut(statut, categoryId, targetPane) {
+        // Variable globale pour la recherche active
+        let currentSearchQuery = '';
+
+        function loadStudentsByStatut(statut, categoryId, targetPane, resetPage) {
             const container = targetPane.querySelector('.students-list-container');
+
+            // Si resetPage demandé (ex: nouvelle recherche), repartir de 0
+            if (resetPage) {
+                targetPane.setAttribute('data-current-page', '0');
+                targetPane.setAttribute('data-loaded', 'false');
+            }
+
             const currentPage = parseInt(targetPane.getAttribute('data-current-page') || '0');
             const nextPage = currentPage + 1;
 
-            // Construire l'URL avec les filtres actuels
+            // Construire l'URL avec les filtres actuels + recherche
             const urlParams = new URLSearchParams(window.location.search);
-            const url = `/esbtp/paiements/suivi-categories/load/${statut}?` + new URLSearchParams({
+            const params = {
                 category_id: categoryId,
                 page: nextPage,
                 per_page: 20,
                 filiere_id: urlParams.get('filiere_id') || '',
                 niveau_id: urlParams.get('niveau_id') || '',
                 annee_id: urlParams.get('annee_id') || ''
-            }).toString();
+            };
+
+            // Ajouter le paramètre de recherche si présent
+            if (currentSearchQuery) {
+                params.search = currentSearchQuery;
+            }
+
+            const url = `/esbtp/paiements/suivi-categories/load/${statut}?` + new URLSearchParams(params).toString();
+
+            // Afficher un indicateur de chargement si première page
+            if (nextPage === 1) {
+                container.innerHTML = `
+                    <div class="text-center" style="padding: 40px 0;">
+                        <div class="spinner-border text-primary" role="status" style="width: 2rem; height: 2rem;">
+                            <span class="visually-hidden">Chargement...</span>
+                        </div>
+                        <p style="margin-top: 12px; color: #6b7280; font-size: 13px;">Chargement...</p>
+                    </div>
+                `;
+            }
 
             fetch(url, {
                 method: 'GET',
@@ -794,13 +823,35 @@
                     // Pages suivantes : ajouter à la fin
                     const tempDiv = document.createElement('div');
                     tempDiv.innerHTML = data.html;
-                    container.querySelector('.students-list').appendChild(...tempDiv.children);
+                    const list = container.querySelector('.students-list');
+                    if (list) {
+                        list.appendChild(...tempDiv.children);
+                    }
                 }
 
                 // Mettre à jour l'état
                 targetPane.setAttribute('data-loaded', 'true');
                 targetPane.setAttribute('data-current-page', data.current_page);
                 targetPane.setAttribute('data-has-more', data.has_more);
+
+                // Mettre à jour le compteur de recherche
+                const searchCountEl = document.getElementById('suivi-search-count');
+                const searchCountValueEl = document.getElementById('suivi-search-count-value');
+                if (currentSearchQuery && searchCountEl && searchCountValueEl) {
+                    searchCountValueEl.textContent = data.total;
+                    searchCountEl.style.display = 'inline';
+                } else if (searchCountEl) {
+                    searchCountEl.style.display = 'none';
+                }
+
+                // Mettre à jour le nombre dans l'onglet actif
+                const activeTab = document.querySelector('.students-tabs a.active[data-statut]');
+                if (activeTab && currentSearchQuery) {
+                    const countSpan = activeTab.querySelector('.student-count');
+                    if (countSpan) {
+                        countSpan.textContent = data.total;
+                    }
+                }
 
                 // Ajouter bouton "Charger plus" si nécessaire
                 if (data.has_more) {
@@ -845,6 +896,65 @@
         // Initialiser après le premier chargement
         initStudentTabsLazyLoading();
 
+        // ===== BARRE DE RECHERCHE — debounce 300ms =====
+        function initSearchHandler() {
+            const searchInput = document.getElementById('suivi-search-input');
+            const searchClear = document.getElementById('suivi-search-clear');
+            const searchCount = document.getElementById('suivi-search-count');
+
+            if (!searchInput) return;
+
+            let searchTimeout = null;
+
+            searchInput.addEventListener('input', function() {
+                const query = this.value.trim();
+
+                // Afficher/masquer le bouton clear
+                if (searchClear) {
+                    searchClear.style.display = query ? 'block' : 'none';
+                }
+
+                // Debounce 300ms
+                clearTimeout(searchTimeout);
+                searchTimeout = setTimeout(() => {
+                    currentSearchQuery = query;
+
+                    // Recharger l'onglet actif avec le filtre de recherche
+                    const activeTab = document.querySelector('.students-tabs a.active[data-statut]');
+                    if (activeTab) {
+                        const statut = activeTab.getAttribute('data-statut');
+                        const categoryId = activeTab.getAttribute('data-category-id');
+                        const targetId = activeTab.getAttribute('href');
+                        const targetPane = document.querySelector(targetId);
+
+                        if (targetPane) {
+                            loadStudentsByStatut(statut, categoryId, targetPane, true);
+                        }
+                    }
+
+                    // Marquer les autres onglets comme non chargés pour forcer le rechargement
+                    document.querySelectorAll('.students-tabs a[data-statut]:not(.active)').forEach(tab => {
+                        const tabTargetId = tab.getAttribute('href');
+                        const tabPane = document.querySelector(tabTargetId);
+                        if (tabPane) {
+                            tabPane.setAttribute('data-loaded', 'false');
+                            tabPane.setAttribute('data-current-page', '0');
+                        }
+                    });
+                }, 300);
+            });
+
+            // Bouton clear
+            if (searchClear) {
+                searchClear.addEventListener('click', function() {
+                    searchInput.value = '';
+                    searchInput.dispatchEvent(new Event('input'));
+                    searchInput.focus();
+                });
+            }
+        }
+        initSearchHandler();
+
         // Réinitialiser après chaque refresh AJAX
         const originalFetchSuiviData = fetchSuiviData;
         fetchSuiviData = function(url, options = {}) {
@@ -852,6 +962,9 @@
                 // Attendre que le DOM soit mis à jour
                 setTimeout(() => {
                     initStudentTabsLazyLoading();
+                    initSearchHandler();
+                    // Reset la recherche lors d'un changement de catégorie
+                    currentSearchQuery = '';
                 }, 100);
             });
         };
@@ -986,6 +1099,11 @@ $(function() {
             page: page,
             per_page: 20
         };
+
+        // Ajouter la recherche si active (variable partagée avec le système vanilla JS)
+        if (typeof currentSearchQuery !== 'undefined' && currentSearchQuery) {
+            params.search = currentSearchQuery;
+        }
 
         debugLog(`📡 DEBUG PAIEMENTS: AJAX vers ${ajaxUrl} avec params:`, params);
 


### PR DESCRIPTION
## Summary
- **Fix export PDF 1000+ étudiants** : Stratégie chunk+merge avec FPDI — chaque groupe de 200 lignes est rendu comme un PDF séparé puis fusionné, évitant le crash mémoire DomPDF
- **Fix centrage numéros de ligne** dans le PDF (pattern `<span>` au lieu de `<div>`)
- **Barre de recherche** dans les onglets suivi paiements : recherche par nom, prénom ou matricule avec debounce 300ms

## Détails techniques

### PDF Export (FPDI)
- Exports >500 étudiants : chunks de 200, rendu DomPDF séparé, merge FPDI
- Exports ≤500 : rendu direct pour la vitesse
- DPI réduit à 72, timeout 300s, CSS simplifié
- Header/KPIs sur le premier chunk, footer sur le dernier
- Numérotation continue via `rowOffset`

### Recherche
- Backend : filtre collection par nom/prenoms/matricule (case-insensitive)
- Frontend : input debounced (300ms), bouton clear, compteur résultats
- Compatible avec les 2 systèmes JS (vanilla + jQuery lazy loading)

## Test plan
- [ ] Exporter PDF avec <100 étudiants → rendu direct rapide
- [ ] Exporter PDF avec 1000+ étudiants → chunk/merge sans crash
- [ ] Vérifier centrage des numéros circulaires dans le PDF
- [ ] Taper un nom dans la barre de recherche → filtrage après 300ms
- [ ] Cliquer le bouton X → réinitialisation recherche
- [ ] Changer d'onglet après recherche → rechargement avec filtre

https://claude.ai/code/session_01K9jxSvWFPGMh4qTejyUFMF
