### PR TITLE
fix(comptable): auto-generate username/password like coordinateur

### DIFF
--- a/app/Http/Controllers/ESBTPComptableController.php
+++ b/app/Http/Controllers/ESBTPComptableController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use App\Services\UserService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -10,9 +11,12 @@ use Spatie\Permission\Models\Role;
 
 class ESBTPComptableController extends Controller
 {
-    public function __construct()
+    protected $userService;
+
+    public function __construct(UserService $userService)
     {
         $this->middleware(['auth', 'role:superAdmin']);
+        $this->userService = $userService;
     }
 
     public function index()
@@ -30,30 +34,41 @@ class ESBTPComptableController extends Controller
     {
         $validated = $request->validate([
             'name'       => 'required|string|max:255',
-            'email'      => 'required|email|unique:users,email',
+            'email'      => 'nullable|string|email|max:255|unique:users,email',
             'telephone'  => 'nullable|string|max:20',
             'department' => 'nullable|string|max:100',
-            'password'   => 'required|string|min:8|confirmed',
         ]);
 
         DB::beginTransaction();
         try {
-            $user = User::create([
-                'name'       => $validated['name'],
-                'email'      => $validated['email'],
-                'telephone'  => $validated['telephone'] ?? null,
+            // Créer l'utilisateur avec username et password automatiques
+            $user = $this->userService->createUserWithAutoCredentials([
+                'name' => $validated['name'],
+                'email' => $validated['email'] ?? null,
+                'phone' => $validated['telephone'] ?? null,
+            ], 'comptable');
+
+            // Mettre à jour les champs supplémentaires
+            $user->update([
+                'telephone' => $validated['telephone'] ?? null,
                 'department' => $validated['department'] ?? null,
-                'password'   => Hash::make($validated['password']),
-                'is_active'  => true,
             ]);
 
+            // Assigner le rôle comptable
             $user->assignRole('comptable');
 
             DB::commit();
 
+            // Obtenir les informations de connexion pour affichage
+            $credentials = $this->userService->getCredentialsInfo(
+                $user->username,
+                $this->userService->generateDefaultPassword()
+            );
+
             return redirect()
-                ->route('esbtp.comptables.show', $user)
-                ->with('success', "Comptable {$user->name} créé avec succès.");
+                ->route('esbtp.personnel.unified.index')
+                ->with('success', "Comptable {$user->name} créé avec succès.")
+                ->with('credentials', $credentials);
         } catch (\Exception $e) {
             DB::rollBack();
             return redirect()->back()

--- a/app/Services/UserService.php
+++ b/app/Services/UserService.php
@@ -36,6 +36,15 @@ class UserService
     }
 
     /**
+     * Génère un username unique pour un comptable
+     */
+    public function generateComptableUsername(string $prenom, string $nom): string
+    {
+        $baseUsername = $this->createBaseUsername('compta', $prenom, $nom);
+        return $this->ensureUniqueUsername($baseUsername);
+    }
+
+    /**
      * Génère le mot de passe générique de l'année courante
      */
     public function generateDefaultPassword(): string
@@ -61,6 +70,9 @@ class UserService
                 break;
             case 'secretaire':
                 $username = $this->generateSecretaireUsername($nameParts['prenom'], $nameParts['nom']);
+                break;
+            case 'comptable':
+                $username = $this->generateComptableUsername($nameParts['prenom'], $nameParts['nom']);
                 break;
             default:
                 throw new \InvalidArgumentException("Type de rôle non supporté: {$roleType}");

--- a/resources/views/esbtp/comptables/create.blade.php
+++ b/resources/views/esbtp/comptables/create.blade.php
@@ -73,9 +73,9 @@
                             @error('name')<div class="invalid-feedback">{{ $message }}</div>@enderror
                         </div>
                         <div>
-                            <label class="form-label fw-semibold">Email <span class="text-danger">*</span></label>
+                            <label class="form-label fw-semibold">Email</label>
                             <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                                   value="{{ old('email') }}" placeholder="comptable@ecole.ci" required>
+                                   value="{{ old('email') }}" placeholder="comptable@ecole.ci">
                             @error('email')<div class="invalid-feedback">{{ $message }}</div>@enderror
                         </div>
                         <div>
@@ -96,25 +96,15 @@
                         </div>
                     </div>
 
-                    <h5 class="text-success fw-bold mb-3 mt-4"><i class="fas fa-lock me-2"></i>Accès & Sécurité</h5>
-                    <div class="form-grid">
-                        <div>
-                            <label class="form-label fw-semibold">Mot de passe <span class="text-danger">*</span></label>
-                            <input type="password" name="password" class="form-control @error('password') is-invalid @enderror"
-                                   placeholder="Minimum 8 caractères" required>
-                            @error('password')<div class="invalid-feedback">{{ $message }}</div>@enderror
-                        </div>
-                        <div>
-                            <label class="form-label fw-semibold">Confirmer le mot de passe <span class="text-danger">*</span></label>
-                            <input type="password" name="password_confirmation" class="form-control"
-                                   placeholder="Répéter le mot de passe" required>
-                        </div>
-                    </div>
-
                     <div class="alert alert-info rounded-3 mt-3">
                         <i class="fas fa-info-circle me-2"></i>
                         Ce compte aura le rôle <strong>comptable</strong> avec accès complet à la comptabilité (paiements, frais, relances, rapports) mais <strong>sans pouvoir supprimer</strong> des données.
                         Les permissions peuvent être ajustées depuis <a href="{{ route('esbtp.roles-permissions.index') }}" class="alert-link">Gestion des Permissions</a>.
+                    </div>
+
+                    <div class="alert alert-success rounded-3 mt-3">
+                        <i class="fas fa-key me-2"></i>
+                        Le <strong>nom d'utilisateur</strong> et le <strong>mot de passe</strong> seront générés automatiquement. Ils vous seront affichés après la création du compte.
                     </div>
 
                     <div class="d-flex justify-content-end gap-3 mt-4">


### PR DESCRIPTION
## Summary
- Fix SQL error 'Field username doesn't have a default value' when creating a comptable
- Use `UserService.createUserWithAutoCredentials()` with prefix `compta` (e.g. `compta.jean.martin`) — same pattern as coordinateur
- Remove password fields from create form; credentials are auto-generated and shown in a modal after creation
- Email field is now optional (matching coordinateur behavior)

## Test plan
- [ ] Go to `/esbtp/comptables/create`, fill name + optional fields, submit
- [ ] Verify credentials modal appears with auto-generated username (`compta.prenom.nom`) and password (`Bonjour@2026`)
- [ ] Verify the comptable appears in the unified personnel list
- [ ] Verify login works with the generated credentials
