### PR TITLE
fix: add comptable role to route middlewares + improve dashboard UI (#138)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -88,6 +88,11 @@ class DashboardController extends Controller
             return $this->etudiantDashboard();
         }
 
+        // Vérifier si l'utilisateur est un comptable
+        if ($user->hasRole('comptable')) {
+            return redirect()->route('esbtp.comptabilite.dashboard');
+        }
+
         // Si aucun rôle spécifique n'est trouvé, afficher un tableau de bord générique
         return view('dashboard.index', compact('user'));
     }

--- a/resources/views/esbtp/comptabilite/dashboard.blade.php
+++ b/resources/views/esbtp/comptabilite/dashboard.blade.php
@@ -842,7 +842,7 @@
         {{-- ── KPI STRIP ── --}}
         <div class="kpi-strip" id="kpi-strip">
             @php
-                $tauxRecouvrement = $totalDue > 0 ? round(($totalPaid / $totalDue) * 100, 1) : 0;
+                $tauxRecouvrement = $totalDue > 0 ? min(100, round(($totalPaid / $totalDue) * 100, 1)) : 0;
             @endphp
             {{-- KPI 1 : Total frais dus --}}
             <div class="kpi-card">

--- a/routes/web.php
+++ b/routes/web.php
@@ -234,7 +234,7 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
     });
 
     // Routes pour la gestion du profil admin, enseignants et coordinateurs
-    Route::middleware(['role:superAdmin|secretaire|serviceTechnique|enseignant|teacher|coordinateur'])->group(function () {
+    Route::middleware(['role:superAdmin|secretaire|serviceTechnique|enseignant|teacher|coordinateur|comptable'])->group(function () {
         Route::get('/admin/profile', [AdminProfileController::class, 'index'])->name('admin.profile');
         Route::put('/admin/profile/update', [AdminProfileController::class, 'update'])->name('admin.profile.update');
         Route::put('/admin/profile/update-professional', [AdminProfileController::class, 'updateProfessionalInfo'])->name('admin.profile.update.professional');
@@ -257,7 +257,7 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
     // Routes pour les fonctionnalités ESBTP
     Route::prefix('esbtp')->name('esbtp.')->group(function () {
         // Routes protégées pour les super-administrateurs, secrétaires, coordinateurs et enseignants
-        Route::middleware(['auth', 'role:superAdmin|secretaire|coordinateur|enseignant|teacher', 'paywall'])->group(function () {
+        Route::middleware(['auth', 'role:superAdmin|secretaire|coordinateur|enseignant|teacher|comptable', 'paywall'])->group(function () {
             // Routes pour les paiements
             Route::resource('payments', \App\Http\Controllers\ESBTP\PaymentController::class);
             Route::get('payments/{payment}/receipt', [\App\Http\Controllers\ESBTP\PaymentController::class, 'generateReceipt'])
@@ -426,7 +426,7 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
         });
 
         // Routes accessibles aux superAdmin, secrétaires, coordinateurs et enseignants
-        Route::middleware(['auth', 'role:superAdmin|secretaire|coordinateur|enseignant|teacher', 'paywall'])->group(function () {
+        Route::middleware(['auth', 'role:superAdmin|secretaire|coordinateur|enseignant|teacher|comptable', 'paywall'])->group(function () {
             // Routes pour les classes ESBTP - index et show avec permission view_classes
             Route::get('classes', [ESBTPClasseController::class, 'index'])
                 ->name('classes.index')


### PR DESCRIPTION
## Changes
- Add comptable role to 3 route middleware groups (profile L237, frais L260, paiements L429)
- Add comptable redirect in DashboardController (before generic fallback)
- Cap taux de recouvrement at 100% in dashboard blade

Closes #138