### PR TITLE
fix(dashboard): année courante depuis DB + encaissements mensuels + KPI alignés

### DIFF
--- a/app/Http/Controllers/ESBTPComptabiliteController.php
+++ b/app/Http/Controllers/ESBTPComptabiliteController.php
@@ -1439,7 +1439,7 @@ class ESBTPComptabiliteController extends Controller
             ->when($anneeId, fn($q) => $q->where('annee_universitaire_id', $anneeId))
             ->when($filiereId, fn($q) => $q->whereHas('classe', fn($q2) => $q2->where('filiere_id', $filiereId)))
             ->when($classeId, fn($q) => $q->where('classe_id', $classeId))
-            ->whereHas('fraisSubscriptions', fn($q) => $q->where('amount', '>', 0))
+            ->whereIn('status', ['active', 'en_attente', 'validée'])
             ->count();
         $countDue = (clone $subscriptionsQuery)->count();
 
@@ -1452,9 +1452,9 @@ class ESBTPComptabiliteController extends Controller
         $labelsMoisDepenses = [];
         $dataDepensesMensuelles = [];
 
-        if ($annee && isset($annee->date_debut)) {
-            $debut = \Carbon\Carbon::parse($annee->date_debut);
-            $fin = \Carbon\Carbon::parse($annee->date_fin ?? now());
+        if ($annee && $annee->start_date) {
+            $debut = \Carbon\Carbon::parse($annee->start_date);
+            $fin = \Carbon\Carbon::parse($annee->end_date ?? now());
             for ($date = $debut->copy(); $date->lte($fin); $date->addMonth()) {
                 $labelsMois[] = $date->translatedFormat('M Y');
                 $labelsMoisDepenses[] = $date->translatedFormat('M Y');
@@ -1533,16 +1533,16 @@ class ESBTPComptabiliteController extends Controller
             ->when($anneeId,   fn($q) => $q->where('annee_universitaire_id', $anneeId))
             ->when($filiereId, fn($q) => $q->whereHas('classe', fn($q2) => $q2->where('filiere_id', $filiereId)))
             ->when($classeId,  fn($q) => $q->where('classe_id', $classeId))
-            ->whereHas('fraisSubscriptions', fn($q) => $q->where('amount', '>', 0))
+            ->whereIn('status', ['active', 'en_attente', 'validée'])
             ->count();
         $countDue = (clone $subscriptionsQuery)->count();
 
         // Graphique mensuel
         $labelsMois = [];
         $dataEncaissements = [];
-        if ($annee && isset($annee->date_debut)) {
-            $debut = \Carbon\Carbon::parse($annee->date_debut);
-            $fin   = \Carbon\Carbon::parse($annee->date_fin ?? now());
+        if ($annee && $annee->start_date) {
+            $debut = \Carbon\Carbon::parse($annee->start_date);
+            $fin   = \Carbon\Carbon::parse($annee->end_date ?? now());
             for ($date = $debut->copy(); $date->lte($fin); $date->addMonth()) {
                 $labelsMois[] = $date->translatedFormat('M Y');
                 $dataEncaissements[] = (float) \App\Models\ESBTPPaiement::where('status', 'validé')

--- a/resources/views/esbtp/attendances/mes-absences.blade.php
+++ b/resources/views/esbtp/attendances/mes-absences.blade.php
@@ -310,7 +310,7 @@
                 <div class="text-end">
                     <div class="badge" style="background: rgba(255, 255, 255, 0.2); color: white; padding: var(--space-sm) var(--space-md); border-radius: var(--radius-medium); font-size: var(--text-sm);">
                         <i class="fas fa-calendar me-2"></i>
-                        Année {{ date('Y') }}-{{ date('Y')+1 }}
+                        Année {{ $anneeCourante->name ?? (date('Y').'-'.(date('Y')+1)) }}
                     </div>
                 </div>
             </div>

--- a/resources/views/esbtp/etudiants/notes.blade.php
+++ b/resources/views/esbtp/etudiants/notes.blade.php
@@ -387,7 +387,7 @@
                 <div class="text-end">
                     <div class="badge" style="background: rgba(255, 255, 255, 0.2); color: white; padding: var(--space-sm) var(--space-md); border-radius: var(--radius-medium); font-size: var(--text-sm);">
                         <i class="fas fa-chart-line me-2"></i>
-                        Année {{ date('Y') }}-{{ date('Y')+1 }}
+                        Année {{ $anneeCourante->name ?? (date('Y').'-'.(date('Y')+1)) }}
                     </div>
                 </div>
             </div>

--- a/resources/views/esbtp/notes/mes-notes.blade.php
+++ b/resources/views/esbtp/notes/mes-notes.blade.php
@@ -251,7 +251,7 @@
                 <div class="text-end">
                     <div class="badge" style="background: rgba(255, 255, 255, 0.2); color: white; padding: var(--space-sm) var(--space-md); border-radius: var(--radius-medium); font-size: var(--text-sm);">
                         <i class="fas fa-calendar me-2"></i>
-                        Année {{ date('Y') }}-{{ date('Y')+1 }}
+                        Année @php echo \App\Models\ESBTPAnneeUniversitaire::where('is_current',true)->value('name') ?? (date('Y').'-'.(date('Y')+1)); @endphp
                     </div>
                 </div>
             </div>

--- a/resources/views/esbtp/paiements/index.blade.php
+++ b/resources/views/esbtp/paiements/index.blade.php
@@ -98,8 +98,9 @@
                     <div style="flex: 1; max-width: 300px;">
                         <label for="annee_academique" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Année Académique Courante</label>
                         <select name="annee_academique" id="annee_academique" class="year-selector" style="width: 100%; background-color: #f8f9fa; cursor: not-allowed;" disabled>
-                            <option value="{{ date('Y') . '-' . (date('Y') + 1) }}" selected>
-                                {{ date('Y') . '-' . (date('Y') + 1) }} (Année en cours)
+                            @php $anneeNom = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->value('name') ?? (date('Y').'-'.(date('Y')+1)); @endphp
+                            <option value="{{ $anneeNom }}" selected>
+                                {{ $anneeNom }} (Année en cours)
                             </option>
                         </select>
                     </div>

--- a/resources/views/esbtp/paiements/suivi-categories.blade.php
+++ b/resources/views/esbtp/paiements/suivi-categories.blade.php
@@ -422,8 +422,9 @@
                     <div style="flex: 1; max-width: 300px;">
                         <label for="annee_academique" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Année Académique Courante</label>
                         <select name="annee_academique" id="annee_academique" class="year-selector" style="width: 100%; background-color: #f8f9fa; cursor: not-allowed;" disabled>
-                            <option value="{{ date('Y') . '-' . (date('Y') + 1) }}" selected>
-                                {{ date('Y') . '-' . (date('Y') + 1) }} (Année en cours)
+                            @php $anneeNom = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->value('name') ?? (date('Y').'-'.(date('Y')+1)); @endphp
+                            <option value="{{ $anneeNom }}" selected>
+                                {{ $anneeNom }} (Année en cours)
                             </option>
                         </select>
                     </div>

--- a/resources/views/etudiants/attendances.blade.php
+++ b/resources/views/etudiants/attendances.blade.php
@@ -477,7 +477,7 @@
                 <div class="text-end">
                     <div class="badge" style="background: rgba(255, 255, 255, 0.2); color: white; padding: var(--space-sm) var(--space-md); border-radius: var(--radius-medium); font-size: var(--text-sm);">
                         <i class="fas fa-calendar me-2"></i>
-                        Année {{ date('Y') }}-{{ date('Y')+1 }}
+                        Année {{ $anneeCourante->name ?? (date('Y').'-'.(date('Y')+1)) }}
                     </div>
                 </div>
             </div>

--- a/resources/views/etudiants/bulletins.blade.php
+++ b/resources/views/etudiants/bulletins.blade.php
@@ -253,7 +253,7 @@
                 <div class="text-end">
                     <div class="badge" style="background: rgba(255, 255, 255, 0.2); color: white; padding: var(--space-sm) var(--space-md); border-radius: var(--radius-medium); font-size: var(--text-sm);">
                         <i class="fas fa-calendar me-2"></i>
-                        Année {{ date('Y') }}-{{ date('Y')+1 }}
+                        Année @php echo \App\Models\ESBTPAnneeUniversitaire::where('is_current',true)->value('name') ?? (date('Y').'-'.(date('Y')+1)); @endphp
                     </div>
                 </div>
             </div>

--- a/resources/views/etudiants/evaluations.blade.php
+++ b/resources/views/etudiants/evaluations.blade.php
@@ -358,7 +358,7 @@
                 <div class="text-end">
                     <div class="badge" style="background: rgba(255, 255, 255, 0.2); color: white; padding: var(--space-sm) var(--space-md); border-radius: var(--radius-medium); font-size: var(--text-sm);">
                         <i class="fas fa-calendar me-2"></i>
-                        Année {{ date('Y') }}-{{ date('Y')+1 }}
+                        Année {{ $anneeCourante->name ?? (date('Y').'-'.(date('Y')+1)) }}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

• **Bug 1 — Année affichée incorrecte** : 9 vues affichaient `date('Y')` hardcodé (2026-2027) au lieu de l'année courante en BDD. Corrigé via `ESBTPAnneeUniversitaire::where('is_current', true)`. Pour les vues étudiants qui reçoivent déjà `$anneeCourante` du contrôleur, on utilise directement `$anneeCourante->name` (zéro requête supplémentaire).

• **Bug 2 — KPI discordants** : Le dashboard comptabilité comptait les étudiants via `whereHas('fraisSubscriptions', amount > 0)` alors que suivi-catégories utilisait les statuts d'inscription. Aligné sur `whereIn('status', ['active', 'en_attente', 'validée'])` dans `dashboard()` et `dashboardData()`.

• **Bug 3 — Graphique "Encaissements mensuels" vide** : Le contrôleur vérifiait `isset($annee->date_debut)` mais le modèle `ESBTPAnneeUniversitaire` expose `start_date`/`end_date`. Corrigé dans les deux méthodes.

## Type

fix

## Closes

closes #146