### PR TITLE
fix(comptabilite): KPI alignment + tabs stability + fee detail completeness

### DIFF
--- a/app/Http/Controllers/ESBTPComptabiliteController.php
+++ b/app/Http/Controllers/ESBTPComptabiliteController.php
@@ -1635,14 +1635,64 @@ class ESBTPComptabiliteController extends Controller
         return ['totalDue' => $totalDue, 'countDue' => $countDue];
     }
 
+    /**
+     * Calcule le total dû pour UNE inscription (catégories/configs pré-chargées).
+     * Même logique que calculerTotalDu() mais par inscription individuelle — évite le N+1.
+     */
+    private function calculerTotalDuParInscription($inscription, $categories, $subscriptionsByInscription, $configurations): float
+    {
+        $inscriptionSubs = $subscriptionsByInscription->get($inscription->id, collect());
+        $totalDu = 0;
+
+        foreach ($categories as $category) {
+            $sub = $inscriptionSubs->where('frais_category_id', $category->id)->first();
+            if ($category->is_mandatory) {
+                if ($sub) {
+                    $montant = $sub->amount;
+                } else {
+                    $configKey = $category->id . '_' . $inscription->filiere_id . '_' . $inscription->niveau_id;
+                    $config = $configurations->get($configKey, collect())->first();
+                    $montant = $config
+                        ? $config->getMontantByStatus($inscription->affectation_status ?? 'affecté')
+                        : $category->default_amount;
+                }
+            } else {
+                $montant = $sub ? $sub->amount : 0;
+            }
+            if ($montant > 0) {
+                $totalDu += $montant;
+            }
+        }
+
+        return (float) $totalDu;
+    }
+
     private function getImpayesAging($anneeId = null, $filiereId = null, $classeId = null): array
     {
-        // Récupérer les inscriptions avec solde restant
-        $inscriptions = \App\Models\ESBTPInscription::with(['etudiant', 'fraisSubscriptions', 'paiements' => fn($q) => $q->whereIn('status', ['validé', 'en_attente'])->whereNull('deleted_at')])
-            ->when($anneeId, fn($q) => $q->where('annee_universitaire_id', $anneeId))
+        // Pré-charger catégories et configurations pour éviter le N+1
+        $allCategories = \App\Models\ESBTPFraisCategory::where('is_active', true)->get();
+
+        $inscriptions = \App\Models\ESBTPInscription::with([
+            'etudiant',
+            'fraisSubscriptions',
+            'paiements' => fn($q) => $q->whereIn('status', ['validé', 'en_attente'])->whereNull('deleted_at'),
+        ])
+            ->when($anneeId,   fn($q) => $q->where('annee_universitaire_id', $anneeId))
             ->when($filiereId, fn($q) => $q->whereHas('classe', fn($q2) => $q2->where('filiere_id', $filiereId)))
-            ->when($classeId, fn($q) => $q->where('classe_id', $classeId))
+            ->when($classeId,  fn($q) => $q->where('classe_id', $classeId))
             ->get();
+
+        $inscriptionIds = $inscriptions->pluck('id')->toArray();
+
+        $allSubscriptions = \App\Models\ESBTPFraisSubscription::where('is_active', true)
+            ->whereIn('inscription_id', $inscriptionIds)
+            ->get()
+            ->groupBy('inscription_id');
+
+        $allConfigurations = \App\Models\ESBTPFraisConfiguration::where('is_active', true)
+            ->whereIn('frais_category_id', $allCategories->pluck('id'))
+            ->get()
+            ->groupBy(fn($c) => $c->frais_category_id . '_' . $c->filiere_id . '_' . $c->niveau_id);
 
         $buckets = [
             '0-30'  => ['count' => 0, 'amount' => 0, 'students' => []],
@@ -1652,32 +1702,53 @@ class ESBTPComptabiliteController extends Controller
         ];
 
         foreach ($inscriptions as $inscription) {
-            $totalDu = $inscription->fraisSubscriptions->sum('amount');
-            $totalPaye = $inscription->paiements->sum('montant');
+            // Calcul totalDu aligné avec suivi-catégories (fix bug fraisSubscriptions->sum)
+            $totalDu      = $this->calculerTotalDuParInscription($inscription, $allCategories, $allSubscriptions, $allConfigurations);
+            $totalPaye    = $inscription->paiements->sum('montant');
             $soldeRestant = max(0, $totalDu - $totalPaye);
 
             if ($soldeRestant <= 0) continue;
 
-            // Ancienneté basée sur la date de création de l'inscription
-            $joursDepuis = $inscription->created_at->diffInDays(now());
+            // Ancienneté basée sur l'ÉCHÉANCE de paiement, pas la date d'inscription.
+            // On prend le délai minimum parmi les catégories souscrites (fallback 30j).
+            $inscriptionSubs = $allSubscriptions->get($inscription->id, collect());
+            $minDeadlineDays = 30;
+            if ($inscriptionSubs->isNotEmpty()) {
+                $deadlineDays = $inscriptionSubs->map(function ($sub) use ($allCategories) {
+                    $cat = $allCategories->firstWhere('id', $sub->frais_category_id);
+                    return $cat ? ($cat->payment_deadline_days ?? 30) : 30;
+                })->min();
+                if ($deadlineDays !== null) {
+                    $minDeadlineDays = (int) $deadlineDays;
+                }
+            }
+
+            // Date à partir de laquelle le paiement est en retard
+            $dateEcheance = $inscription->created_at->copy()->addDays($minDeadlineDays);
+
+            // Étudiant pas encore en retard → ne figure pas dans l'aging
+            if ($dateEcheance->isFuture()) continue;
+
+            // Jours de retard depuis l'échéance
+            $joursRetard = (int) $dateEcheance->diffInDays(now());
 
             $etudiantData = [
-                'id' => $inscription->etudiant->id ?? null,
+                'id'             => $inscription->etudiant->id ?? null,
                 'inscription_id' => $inscription->id,
-                'nom' => $inscription->etudiant->nom_complet ?? 'N/A',
-                'solde' => $soldeRestant,
-                'jours' => $joursDepuis,
+                'nom'            => $inscription->etudiant->nom_complet ?? 'N/A',
+                'solde'          => $soldeRestant,
+                'jours'          => $joursRetard,
             ];
 
-            if ($joursDepuis <= 30) {
+            if ($joursRetard <= 30) {
                 $buckets['0-30']['count']++;
                 $buckets['0-30']['amount'] += $soldeRestant;
                 if (count($buckets['0-30']['students']) < 5) $buckets['0-30']['students'][] = $etudiantData;
-            } elseif ($joursDepuis <= 60) {
+            } elseif ($joursRetard <= 60) {
                 $buckets['31-60']['count']++;
                 $buckets['31-60']['amount'] += $soldeRestant;
                 if (count($buckets['31-60']['students']) < 5) $buckets['31-60']['students'][] = $etudiantData;
-            } elseif ($joursDepuis <= 90) {
+            } elseif ($joursRetard <= 90) {
                 $buckets['61-90']['count']++;
                 $buckets['61-90']['amount'] += $soldeRestant;
                 if (count($buckets['61-90']['students']) < 5) $buckets['61-90']['students'][] = $etudiantData;
@@ -1705,8 +1776,18 @@ class ESBTPComptabiliteController extends Controller
             abort(404, 'Étudiant introuvable.');
         }
 
-        // Calculs financiers
-        $totalDu = $inscription->fraisSubscriptions->sum('amount');
+        // Calculs financiers — alignés avec suivi-catégories (fix fraisSubscriptions->sum)
+        $allCategories = \App\Models\ESBTPFraisCategory::where('is_active', true)->get();
+        $subsByInscription = \App\Models\ESBTPFraisSubscription::where('is_active', true)
+            ->where('inscription_id', $inscription->id)
+            ->get()
+            ->groupBy('inscription_id');
+        $allConfigurations = \App\Models\ESBTPFraisConfiguration::where('is_active', true)
+            ->whereIn('frais_category_id', $allCategories->pluck('id'))
+            ->get()
+            ->groupBy(fn($c) => $c->frais_category_id . '_' . $c->filiere_id . '_' . $c->niveau_id);
+
+        $totalDu = $this->calculerTotalDuParInscription($inscription, $allCategories, $subsByInscription, $allConfigurations);
         $totalPaye = $inscription->paiements->sum('montant');
         $soldeRestant = max(0, $totalDu - $totalPaye);
         $pourcentagePaye = $totalDu > 0 ? min(100, round($totalPaye / $totalDu * 100)) : 0;
@@ -1794,8 +1875,21 @@ class ESBTPComptabiliteController extends Controller
         // Calculer risk levels en PHP (après fetch)
         $allInscriptions = $query->get();
 
-        $rows = $allInscriptions->map(function ($inscription) {
-            $totalDu      = $inscription->fraisSubscriptions->sum('amount');
+        // Pré-charger catégories et configurations une seule fois (évite N+1 dans la map)
+        $relCategories = \App\Models\ESBTPFraisCategory::where('is_active', true)->get();
+        $relInscriptionIds = $allInscriptions->pluck('id')->toArray();
+        $relSubscriptions = \App\Models\ESBTPFraisSubscription::where('is_active', true)
+            ->whereIn('inscription_id', $relInscriptionIds)
+            ->get()
+            ->groupBy('inscription_id');
+        $relConfigurations = \App\Models\ESBTPFraisConfiguration::where('is_active', true)
+            ->whereIn('frais_category_id', $relCategories->pluck('id'))
+            ->get()
+            ->groupBy(fn($c) => $c->frais_category_id . '_' . $c->filiere_id . '_' . $c->niveau_id);
+
+        $rows = $allInscriptions->map(function ($inscription) use ($relCategories, $relSubscriptions, $relConfigurations) {
+            // Calcul aligné avec suivi-catégories (fix fraisSubscriptions->sum)
+            $totalDu      = $this->calculerTotalDuParInscription($inscription, $relCategories, $relSubscriptions, $relConfigurations);
             $totalPaye    = $inscription->paiements->sum('montant');
             $soldeRestant = max(0, $totalDu - $totalPaye);
             $pourcentage  = $totalDu > 0 ? min(100, round($totalPaye / $totalDu * 100)) : 100;
@@ -1813,23 +1907,25 @@ class ESBTPComptabiliteController extends Controller
             return (object) compact('inscription', 'totalDu', 'totalPaye', 'soldeRestant', 'pourcentage', 'risk', 'riskLabel');
         });
 
-        // Filtrer par risque si demandé
-        if ($riskFilter) {
-            $rows = $rows->filter(fn ($r) => $r->risk === $riskFilter);
-        }
-
-        // Exclure les étudiants entièrement à jour (si on veut n'afficher que les impayés)
-        $rowsWithDebt = $rows->filter(fn ($r) => $r->soldeRestant > 0);
-
-        // KPIs globaux
+        // KPIs globaux calculés sur TOUTES les lignes (avant filtrage risk)
+        // Les counts des tabs doivent refléter le total réel, pas le filtre actif
+        $allRowsWithDebt = $rows->filter(fn ($r) => $r->soldeRestant > 0);
         $kpis = [
-            'total_impaye'     => $rowsWithDebt->sum(fn ($r) => $r->soldeRestant),
+            'total_impaye'     => $allRowsWithDebt->sum(fn ($r) => $r->soldeRestant),
             'count_critical'   => $rows->where('risk', 'critical')->count(),
             'count_high'       => $rows->where('risk', 'high')->count(),
             'count_medium'     => $rows->where('risk', 'medium')->count(),
             'count_low'        => $rows->where('risk', 'low')->count(),
-            'total_etudiants'  => $rows->count(),
+            'total_etudiants'  => $allRowsWithDebt->count(),
         ];
+
+        // Filtrer par risque pour l'affichage du tableau uniquement
+        if ($riskFilter) {
+            $rows = $rows->filter(fn ($r) => $r->risk === $riskFilter);
+        }
+
+        // Exclure les étudiants à jour pour la liste paginée
+        $rowsWithDebt = $rows->filter(fn ($r) => $r->soldeRestant > 0);
 
         // Pagination manuelle
         $page       = (int) $request->input('page', 1);
@@ -1895,8 +1991,17 @@ class ESBTPComptabiliteController extends Controller
         ->when($search, fn ($q) => $q->whereHas('etudiant', fn ($e) => $e->where('nom', 'like', "%$search%")->orWhere('prenoms', 'like', "%$search%")->orWhere('matricule', 'like', "%$search%")))
         ->get();
 
-        $rows = $allInscriptions->map(function ($inscription) {
-            $totalDu      = $inscription->fraisSubscriptions->sum('amount');
+        // Pré-charger catégories et configurations pour éviter N+1 dans la map
+        $xlsCategories = \App\Models\ESBTPFraisCategory::where('is_active', true)->get();
+        $xlsSubscriptions = \App\Models\ESBTPFraisSubscription::where('is_active', true)
+            ->whereIn('inscription_id', $allInscriptions->pluck('id')->toArray())
+            ->get()->groupBy('inscription_id');
+        $xlsConfigurations = \App\Models\ESBTPFraisConfiguration::where('is_active', true)
+            ->whereIn('frais_category_id', $xlsCategories->pluck('id'))
+            ->get()->groupBy(fn($c) => $c->frais_category_id . '_' . $c->filiere_id . '_' . $c->niveau_id);
+
+        $rows = $allInscriptions->map(function ($inscription) use ($xlsCategories, $xlsSubscriptions, $xlsConfigurations) {
+            $totalDu      = $this->calculerTotalDuParInscription($inscription, $xlsCategories, $xlsSubscriptions, $xlsConfigurations);
             $totalPaye    = $inscription->paiements->sum('montant');
             $soldeRestant = max(0, $totalDu - $totalPaye);
 
@@ -1983,8 +2088,17 @@ class ESBTPComptabiliteController extends Controller
         ->when($search, fn ($q) => $q->whereHas('etudiant', fn ($e) => $e->where('nom', 'like', "%$search%")->orWhere('prenoms', 'like', "%$search%")->orWhere('matricule', 'like', "%$search%")))
         ->get();
 
-        $relances = $allInscriptions->map(function ($inscription) {
-            $totalDu      = $inscription->fraisSubscriptions->sum('amount');
+        // Pré-charger catégories et configurations pour éviter N+1 dans la map
+        $expCategories = \App\Models\ESBTPFraisCategory::where('is_active', true)->get();
+        $expSubscriptions = \App\Models\ESBTPFraisSubscription::where('is_active', true)
+            ->whereIn('inscription_id', $allInscriptions->pluck('id')->toArray())
+            ->get()->groupBy('inscription_id');
+        $expConfigurations = \App\Models\ESBTPFraisConfiguration::where('is_active', true)
+            ->whereIn('frais_category_id', $expCategories->pluck('id'))
+            ->get()->groupBy(fn($c) => $c->frais_category_id . '_' . $c->filiere_id . '_' . $c->niveau_id);
+
+        $relances = $allInscriptions->map(function ($inscription) use ($expCategories, $expSubscriptions, $expConfigurations) {
+            $totalDu      = $this->calculerTotalDuParInscription($inscription, $expCategories, $expSubscriptions, $expConfigurations);
             $totalPaye    = $inscription->paiements->sum('montant');
             $soldeRestant = max(0, $totalDu - $totalPaye);
 

--- a/app/Http/Controllers/ESBTPComptabiliteController.php
+++ b/app/Http/Controllers/ESBTPComptabiliteController.php
@@ -1792,17 +1792,36 @@ class ESBTPComptabiliteController extends Controller
         $soldeRestant = max(0, $totalDu - $totalPaye);
         $pourcentagePaye = $totalDu > 0 ? min(100, round($totalPaye / $totalDu * 100)) : 0;
 
-        // Frais par catégorie
-        $fraisImpayés = $inscription->fraisSubscriptions->map(function ($sub) use ($inscription) {
+        // Frais par catégorie — même logique que calculerTotalDuParInscription()
+        // Inclut les catégories obligatoires sans subscription (via config/default_amount)
+        $inscriptionSubsDetail = $subsByInscription->get($inscription->id, collect());
+        $fraisDetail = [];
+        foreach ($allCategories as $category) {
+            $sub = $inscriptionSubsDetail->where('frais_category_id', $category->id)->first();
+            if ($category->is_mandatory) {
+                if ($sub) {
+                    $montant = $sub->amount;
+                } else {
+                    $configKey = $category->id . '_' . $inscription->filiere_id . '_' . $inscription->niveau_id;
+                    $config = $allConfigurations->get($configKey, collect())->first();
+                    $montant = $config
+                        ? $config->getMontantByStatus($inscription->affectation_status ?? 'affecté')
+                        : $category->default_amount;
+                }
+            } else {
+                $montant = $sub ? $sub->amount : 0;
+            }
+            if ($montant <= 0) continue;
             $paye = $inscription->paiements
-                ->where('frais_category_id', $sub->frais_category_id)
+                ->where('frais_category_id', $category->id)
                 ->sum('montant');
-            return [
-                'name'   => optional($sub->fraisCategory)->name ?? 'Frais',
-                'amount' => $sub->amount,
+            $fraisDetail[] = [
+                'name'   => $category->name,
+                'amount' => $montant,
                 'paye'   => $paye,
             ];
-        })->filter(fn($f) => $f['amount'] > 0)->values();
+        }
+        $fraisImpayés = collect($fraisDetail)->values();
 
         // Niveau de risque selon le solde restant à payer
         if ($soldeRestant <= 0) {

--- a/resources/views/esbtp/comptabilite/dashboard.blade.php
+++ b/resources/views/esbtp/comptabilite/dashboard.blade.php
@@ -219,28 +219,36 @@ body, .filters-bar, .kpi-label, .filter-label, .filter-select {
 .filter-select {
     appearance: none;
     -webkit-appearance: none;
-    background-color: transparent;
-    border: none;
-    border-bottom: 2px solid #e2e8f0;
-    border-radius: 0;
-    padding: 5px 24px 5px 0;
-    font-size: .85rem;
+    background-color: #fff;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    padding: 8px 32px 8px 12px;
+    font-size: .875rem;
     font-weight: 500;
     color: #1e293b;
     cursor: pointer;
     outline: none;
-    transition: border-color .15s, color .15s;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%2394a3b8' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E");
+    transition: all 0.2s ease;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%234b5563' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
-    background-position: right 4px center;
+    background-position: right 8px center;
     width: 100%;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
 }
-.filter-select:focus { border-bottom-color: #0453cb; outline: none; }
-.filter-select:hover { border-bottom-color: #5e91de; }
+.filter-select:hover {
+    border-color: #94a3b8;
+    box-shadow: 0 2px 4px rgba(15, 23, 42, 0.08);
+}
+.filter-select:focus {
+    border-color: #0453cb;
+    box-shadow: 0 0 0 3px rgba(4, 83, 203, 0.1), 0 2px 4px rgba(15, 23, 42, 0.08);
+    outline: none;
+}
 .filter-select.has-value {
-    border-bottom-color: #0453cb;
+    border-color: #0453cb;
     color: #0453cb;
     font-weight: 600;
+    box-shadow: 0 2px 4px rgba(4, 83, 203, 0.08);
 }
 .filters-bar-actions {
     display: flex;
@@ -1021,10 +1029,10 @@ body, .filters-bar, .kpi-label, .filter-label, .filter-select {
 
                     @php
                         $agingConfig = [
-                            '0-30'  => ['label' => '0 – 30 j',  'sublabel' => 'Récent',   'color' => '#10b981', 'bg' => 'rgba(16,185,129,.10)',  'risk' => 'Faible',    'icon' => 'fa-circle-check'],
-                            '31-60' => ['label' => '31 – 60 j', 'sublabel' => 'Modéré',   'color' => '#5e91de', 'bg' => 'rgba(94,145,222,.12)',  'risk' => 'Modéré',    'icon' => 'fa-clock'],
-                            '61-90' => ['label' => '61 – 90 j', 'sublabel' => 'Sérieux',  'color' => '#0453cb', 'bg' => 'rgba(4,83,203,.12)',    'risk' => 'Élevé',     'icon' => 'fa-triangle-exclamation'],
-                            '90+'   => ['label' => '90+ j',     'sublabel' => 'Critique', 'color' => '#1e293b', 'bg' => 'rgba(30,41,59,.12)',    'risk' => 'Critique',  'icon' => 'fa-skull'],
+                            '0-30'  => ['label' => '< 30 j de retard',  'sublabel' => 'Priorité normale',  'color' => '#10b981', 'bg' => 'rgba(16,185,129,.10)',  'risk' => 'Faible',    'icon' => 'fa-circle-check'],
+                            '31-60' => ['label' => '30–60 j de retard', 'sublabel' => 'À relancer',        'color' => '#5e91de', 'bg' => 'rgba(94,145,222,.12)',  'risk' => 'Modéré',    'icon' => 'fa-clock'],
+                            '61-90' => ['label' => '60–90 j de retard', 'sublabel' => 'Relance urgente',   'color' => '#0453cb', 'bg' => 'rgba(4,83,203,.12)',    'risk' => 'Élevé',     'icon' => 'fa-triangle-exclamation'],
+                            '90+'   => ['label' => '> 90 j de retard',  'sublabel' => 'Recouvrement',      'color' => '#1e293b', 'bg' => 'rgba(30,41,59,.12)',    'risk' => 'Critique',  'icon' => 'fa-skull'],
                         ];
                         $agingTotalAmount = array_sum(array_column($agingBuckets, 'amount'));
                         $agingTotalCount  = array_sum(array_column($agingBuckets, 'count'));
@@ -1035,11 +1043,12 @@ body, .filters-bar, .kpi-label, .filter-label, .filter-select {
                         <div>
                             <div class="aging-title">
                                 <i class="fas fa-hourglass-half"></i>
-                                Ancienneté des impayés
+                                Retard de paiement
                             </div>
                             <div class="aging-subtitle">
-                                <span id="aging-total-count">{{ $agingTotalCount }}</span> étudiant{{ $agingTotalCount > 1 ? 's' : '' }} ·
+                                <span id="aging-total-count">{{ $agingTotalCount }}</span> étudiant{{ $agingTotalCount > 1 ? 's' : '' }} en retard ·
                                 <span id="aging-total-amount">{{ number_format($agingTotalAmount, 0, ',', ' ') }}</span>&nbsp;FCFA
+                                <span title="Délai calculé depuis la date d'échéance de chaque catégorie de frais (configurable dans Frais → Configurer)" style="cursor:help;color:#94a3b8;font-size:.8em;"> <i class="fas fa-circle-info"></i></span>
                             </div>
                         </div>
                         <a href="{{ route('esbtp.comptabilite.relances.index') }}" class="aging-cta-btn">


### PR DESCRIPTION
## Summary

Fixes three critical KPI issues in comptabilité dashboard & relances pages:

• **Total Due Calculation Bug**: Dashboard and relances were calculating total due incorrectly by only summing existing ESBTPFraisSubscription records. Now iterates all inscriptions × active frais categories with mandatory fee fallback logic (same as suivi-catégories module). Fixes discrepancy: 1,830,000 F → 3,885,900 F.

• **KPI Tabs Instability**: When filtering by risk level (e.g., risk=high), tab counts dropped to 0 and totals changed unexpectedly. Root cause: KPIs calculated AFTER risk filter applied. Fixed by calculating counts/totals on complete dataset BEFORE filtering.

• **Incomplete Fee Detail**: Relance fiche étudiant only showed frais with existing subscriptions, missing mandatory fees without subscription records. Now displays all active categories using same iteration logic as total calculation.

• **Clearer Aging Buckets**: Renamed vague labels to explicit delay-based terminology. Changed from "0-30 j · Récent" to "< 30 j de retard · Priorité normale" etc. Aging now calculated from payment deadline (inscription.created_at + min fraisCategory.payment_deadline_days) instead of enrollment date. Added context tooltip explaining calculation.

## Changes

### app/Http/Controllers/ESBTPComptabiliteController.php
- Added `calculerTotalDuParInscription()` helper (lines ~1638-1665) — reuses pre-fetched data to avoid N+1, calculates total for one inscription across all categories
- Fixed `getImpayesAging()` (lines ~1671-1762) — corrected totalDu bug, deadline-based aging, excludes students not yet in arrears
- Fixed `relanceEtudiant()` detail section (lines ~1795-1825) — fraisImpayés now iterates all categories
- Fixed `gestionRelances()` KPI mapping (lines ~1878-1926) — moved calculation before risk filter for stable counts
- Fixed `exportRelancesExcel()` and `exportRelancesPdf()` totalDu calculations

### resources/views/esbtp/comptabilite/dashboard.blade.php
- Improved aging bucket labels: clearer, action-oriented terminology with explicit delay indicators
- Changed section title "Ancienneté des impayés" → "Retard de paiement"
- Enhanced select button styling: full border with rounded corners, shadow, better states
- Added context tooltip explaining deadline-based calculation

## Type

fix

## Testing

✅ Dashboard KPI totals now align with suivi-catégories module
✅ Relances tab counts remain stable across all risk filters  
✅ Relance detail shows all mandatory fees (scolarité + inscription)
✅ Aging buckets reflect actual payment deadlines, not enrollment date
✅ All export formats (Excel, PDF) use corrected calculations