### PR TITLE
fix(dashboard): aging row overflow — label width + sublabel

### DIFF
--- a/resources/views/esbtp/comptabilite/dashboard.blade.php
+++ b/resources/views/esbtp/comptabilite/dashboard.blade.php
@@ -446,7 +446,7 @@ body, .filters-bar, .kpi-label, .filter-label, .filter-select {
     display: flex;
     align-items: center;
     gap: 10px;
-    flex: 0 0 110px;
+    flex: 0 0 165px;
     min-width: 0;
 }
 
@@ -1032,7 +1032,7 @@ body, .filters-bar, .kpi-label, .filter-label, .filter-select {
                             '0-30'  => ['label' => '< 30 j de retard',  'sublabel' => 'Priorité normale',  'color' => '#10b981', 'bg' => 'rgba(16,185,129,.10)',  'risk' => 'Faible',    'icon' => 'fa-circle-check'],
                             '31-60' => ['label' => '30–60 j de retard', 'sublabel' => 'À relancer',        'color' => '#5e91de', 'bg' => 'rgba(94,145,222,.12)',  'risk' => 'Modéré',    'icon' => 'fa-clock'],
                             '61-90' => ['label' => '60–90 j de retard', 'sublabel' => 'Relance urgente',   'color' => '#0453cb', 'bg' => 'rgba(4,83,203,.12)',    'risk' => 'Élevé',     'icon' => 'fa-triangle-exclamation'],
-                            '90+'   => ['label' => '> 90 j de retard',  'sublabel' => 'Recouvrement',      'color' => '#1e293b', 'bg' => 'rgba(30,41,59,.12)',    'risk' => 'Critique',  'icon' => 'fa-skull'],
+                            '90+'   => ['label' => '> 90 j de retard',  'sublabel' => 'Critique',           'color' => '#1e293b', 'bg' => 'rgba(30,41,59,.12)',    'risk' => 'Critique',  'icon' => 'fa-skull'],
                         ];
                         $agingTotalAmount = array_sum(array_column($agingBuckets, 'amount'));
                         $agingTotalCount  = array_sum(array_column($agingBuckets, 'count'));


### PR DESCRIPTION
## Summary

• **Chevauchement texte corrigé** : `.aging-row-left` passé de `flex: 0 0 110px` à `165px` pour les labels longs ("< 30 j de retard", "> 90 j de retard")
• **Sublabel raccourci** : "RECOUVREMENT" → "Critique" pour éviter la troncature dans la bucket "> 90 j de retard"

## Type

fix