### PR TITLE
feat: Note de Conduite + absences par matière sur bulletin

### DIFF
--- a/app/Http/Controllers/ESBTP/ESBTPSettingsController.php
+++ b/app/Http/Controllers/ESBTP/ESBTPSettingsController.php
@@ -128,6 +128,31 @@ class ESBTPSettingsController extends Controller
                 );
             }
 
+            // Créer les settings de note de conduite si inexistants
+            $conduiteDefaults = [
+                'bulletin_conduite_enabled' => ['value' => '0', 'type' => 'boolean', 'description' => 'Activer la note de conduite sur le bulletin'],
+                'conduite_note_defaut' => ['value' => '16', 'type' => 'float', 'description' => 'Note de conduite par défaut (/20)'],
+                'conduite_heures_par_point' => ['value' => '4', 'type' => 'float', 'description' => 'Heures d\'absence pour retrancher 1 point'],
+                'bulletin_show_absences_par_matiere' => ['value' => '1', 'type' => 'boolean', 'description' => 'Afficher les absences par matière sur le bulletin'],
+            ];
+
+            foreach ($conduiteDefaults as $key => $attrs) {
+                Setting::firstOrCreate(
+                    ['key' => $key],
+                    [
+                        'value' => $attrs['value'],
+                        'type' => $attrs['type'],
+                        'group' => 'bulletin',
+                        'category' => 'bulletin',
+                        'description' => $attrs['description'],
+                        'is_required' => false,
+                        'default_value' => $attrs['value'],
+                        'validation_rules' => null,
+                        'sort_order' => 150,
+                    ]
+                );
+            }
+
             $allCheckboxSettings = Setting::whereIn('key', [
                 'bulletin_show_logo', 'bulletin_show_header', 'bulletin_show_republic_info',
                 'bulletin_show_ministry_info', 'bulletin_show_school_info', 'bulletin_show_cycle_info',
@@ -138,6 +163,7 @@ class ESBTPSettingsController extends Controller
                 'bulletin_show_highest_average', 'bulletin_show_lowest_average', 'bulletin_show_class_average',
                 'bulletin_auto_calculate_mention', 'bulletin_show_felicitation', 'bulletin_show_encouragement',
                 'certificat_show_classe', 'certificat_show_niveau', 'certificat_show_filiere',
+                'bulletin_conduite_enabled', 'bulletin_show_absences_par_matiere',
             ])->get();
 
             foreach ($allCheckboxSettings as $setting) {

--- a/app/Services/BulletinService.php
+++ b/app/Services/BulletinService.php
@@ -301,6 +301,26 @@ class BulletinService
         // Préparer la photo de l'étudiant en base64 pour le PDF
         $photoEtudiantBase64 = $this->preparePhotoEtudiantBase64($etudiant);
 
+        // Note de conduite (absences par matière)
+        $conduiteEnabled = SettingsHelper::get('bulletin_conduite_enabled', '0') === '1';
+        $absencesParMatiere = [];
+        $noteConduite = null;
+        $mentionConduite = '';
+        $totalHeuresAbsencesParMatiere = 0;
+
+        if ($conduiteEnabled) {
+            $absencesParMatiereData = $this->absenceService->calculerAbsencesParMatiere(
+                $etudiant->id,
+                $classe->id,
+                $anneeUniversitaire->date_debut,
+                $anneeUniversitaire->date_fin
+            );
+            $absencesParMatiere = $absencesParMatiereData['par_matiere'] ?? [];
+            $totalHeuresAbsencesParMatiere = $absencesParMatiereData['total_heures'] ?? 0;
+            $noteConduite = $this->calculerNoteConduite($totalHeuresAbsencesParMatiere);
+            $mentionConduite = $this->getMentionConduite($noteConduite);
+        }
+
         return [
             'etudiant' => $etudiant,
             'classe' => $classe,
@@ -313,7 +333,7 @@ class BulletinService
             'moyenneGlobale' => $moyenneGlobale,
             'moyenneAvecAssiduite' => $moyenneAvecAssiduite,
             'noteAssiduite' => $noteAssiduite,
-            'note_assiduite' => $noteAssiduite, // Alias pour compatibilité template
+            'note_assiduite' => $noteAssiduite,
             'rang' => $rang,
             'effectif' => $effectif,
             'meilleure_moyenne' => $statsClasse['meilleure_moyenne'],
@@ -323,8 +343,8 @@ class BulletinService
             'absences' => $absences,
             'absencesJustifiees' => $absences['justifiees'] ?? 0,
             'absencesNonJustifiees' => $absences['non_justifiees'] ?? 0,
-            'absences_justifiees' => $absences['justifiees'] ?? 0, // Alias pour compatibilité
-            'absences_non_justifiees' => $absences['non_justifiees'] ?? 0, // Alias pour compatibilité
+            'absences_justifiees' => $absences['justifiees'] ?? 0,
+            'absences_non_justifiees' => $absences['non_justifiees'] ?? 0,
             'professeurs' => $professeurs,
             'date_edition' => date('d/m/Y'),
             'settings' => $settings,
@@ -334,6 +354,10 @@ class BulletinService
             'moyenneAnnuelle' => $moyenneAnnuelle,
             'semesterWeights' => $semesterWeights,
             'warnings' => $warnings,
+            'noteConduite' => $noteConduite,
+            'mentionConduite' => $mentionConduite,
+            'absencesParMatiere' => $absencesParMatiere,
+            'totalHeuresAbsencesParMatiere' => $totalHeuresAbsencesParMatiere,
         ];
     }
 
@@ -777,6 +801,12 @@ class BulletinService
             'bulletin_show_lowest_average' => \App\Helpers\SettingsHelper::get('bulletin_show_lowest_average', '1'),
             'bulletin_show_class_average' => \App\Helpers\SettingsHelper::get('bulletin_show_class_average', '1'),
             'bulletin_include_attendance_in_stats' => \App\Helpers\SettingsHelper::get('bulletin_include_attendance_in_stats', '1'),
+
+            // Note de conduite
+            'bulletin_conduite_enabled' => \App\Helpers\SettingsHelper::get('bulletin_conduite_enabled', '0'),
+            'conduite_note_defaut' => \App\Helpers\SettingsHelper::get('conduite_note_defaut', '16'),
+            'conduite_heures_par_point' => \App\Helpers\SettingsHelper::get('conduite_heures_par_point', '4'),
+            'bulletin_show_absences_par_matiere' => \App\Helpers\SettingsHelper::get('bulletin_show_absences_par_matiere', '1'),
 
             // Décision et signatures
             'bulletin_show_council_decision' => \App\Helpers\SettingsHelper::get('bulletin_show_council_decision', '1'),
@@ -1810,23 +1840,58 @@ class BulletinService
 
     public function getAppreciation($moyenne)
     {
-        if ($moyenne >= 16) {
-            return 'Excellent';
-        }
-        if ($moyenne >= 14) {
-            return 'Très Bien';
-        }
-        if ($moyenne >= 12) {
-            return 'Bien';
-        }
-        if ($moyenne >= 10) {
-            return 'Assez Bien';
-        }
-        if ($moyenne >= 8) {
-            return 'Passable';
+        $useCustomAppreciations = SettingsHelper::get('bulletin_conduite_enabled', '0') === '1';
+
+        if ($useCustomAppreciations) {
+            if ($moyenne >= 18) return 'Excellent';
+            if ($moyenne >= 16) return 'Très Bien';
+            if ($moyenne >= 14) return 'Bien';
+            if ($moyenne >= 12) return 'Assez-bien';
+            if ($moyenne >= 9.99) return 'Passable';
+            if ($moyenne >= 7) return 'Insuffisant';
+            if ($moyenne >= 1) return 'Médiocre';
+            return 'Nul';
         }
 
+        if ($moyenne >= 16) return 'Excellent';
+        if ($moyenne >= 14) return 'Très Bien';
+        if ($moyenne >= 12) return 'Bien';
+        if ($moyenne >= 10) return 'Assez Bien';
+        if ($moyenne >= 8) return 'Passable';
         return 'Insuffisant';
+    }
+
+    /**
+     * Calcule la note de conduite basée sur les absences totales
+     * Note par défaut - (total_heures_absences / heures_par_point)
+     */
+    public function calculerNoteConduite($totalHeuresAbsences)
+    {
+        $noteDefaut = floatval(SettingsHelper::get('conduite_note_defaut', '16'));
+        $heuresParPoint = floatval(SettingsHelper::get('conduite_heures_par_point', '4'));
+
+        if ($heuresParPoint <= 0) {
+            $heuresParPoint = 4;
+        }
+
+        $deduction = floor($totalHeuresAbsences / $heuresParPoint);
+        $noteConduite = max(0, $noteDefaut - $deduction);
+
+        return round($noteConduite, 2);
+    }
+
+    /**
+     * Retourne la mention conduite selon la note
+     */
+    public function getMentionConduite($noteConduite)
+    {
+        if ($noteConduite <= 0) {
+            return 'Blâme';
+        }
+        if ($noteConduite <= 10) {
+            return 'Avertissement';
+        }
+        return '';
     }
 
 

--- a/app/Services/ESBTP/ESBTPAbsenceService.php
+++ b/app/Services/ESBTP/ESBTPAbsenceService.php
@@ -74,4 +74,56 @@ class ESBTPAbsenceService
             ]
         ];
     }
+
+    /**
+     * Calcule les absences par matière pour un étudiant (en heures)
+     */
+    public function calculerAbsencesParMatiere($etudiantId, $classeId, $dateDebut = null, $dateFin = null)
+    {
+        if (!$dateDebut) {
+            $dateDebut = Carbon::now()->startOfYear()->format('Y-m-d');
+        }
+        if (!$dateFin) {
+            $dateFin = Carbon::now()->format('Y-m-d');
+        }
+
+        $absences = ESBTPAttendance::where('etudiant_id', $etudiantId)
+            ->whereNotNull('matiere_id')
+            ->whereIn('statut', ['absent', 'absent_excuse'])
+            ->whereBetween('date', [$dateDebut, $dateFin])
+            ->get();
+
+        $parMatiere = [];
+        $totalHeures = 0;
+
+        foreach ($absences as $absence) {
+            $matiereId = $absence->matiere_id;
+            $heureDebut = Carbon::parse($absence->heure_debut);
+            $heureFin = Carbon::parse($absence->heure_fin);
+            $duree = max(1, $heureDebut->diffInHours($heureFin));
+
+            if (!isset($parMatiere[$matiereId])) {
+                $parMatiere[$matiereId] = [
+                    'matiere_id' => $matiereId,
+                    'total_heures' => 0,
+                    'justifiees' => 0,
+                    'non_justifiees' => 0,
+                ];
+            }
+
+            $parMatiere[$matiereId]['total_heures'] += $duree;
+            $totalHeures += $duree;
+
+            if ($absence->statut === 'absent_excuse' || $absence->justified_at) {
+                $parMatiere[$matiereId]['justifiees'] += $duree;
+            } else {
+                $parMatiere[$matiereId]['non_justifiees'] += $duree;
+            }
+        }
+
+        return [
+            'par_matiere' => $parMatiere,
+            'total_heures' => $totalHeures,
+        ];
+    }
 }

--- a/database/seeders/SettingsSeeder.php
+++ b/database/seeders/SettingsSeeder.php
@@ -1017,6 +1017,56 @@ class SettingsSeeder extends Seeder
                 'sort_order' => 37
             ],
 
+            // Note de conduite
+            [
+                'key' => 'bulletin_conduite_enabled',
+                'value' => '0',
+                'type' => 'boolean',
+                'group' => 'bulletin',
+                'category' => 'bulletin',
+                'description' => 'Activer la note de conduite sur le bulletin',
+                'is_required' => false,
+                'default_value' => '0',
+                'validation_rules' => ['string'],
+                'sort_order' => 38
+            ],
+            [
+                'key' => 'conduite_note_defaut',
+                'value' => '16',
+                'type' => 'float',
+                'group' => 'bulletin',
+                'category' => 'bulletin',
+                'description' => 'Note de conduite par défaut (/20)',
+                'is_required' => false,
+                'default_value' => '16',
+                'validation_rules' => ['nullable', 'numeric', 'min:0', 'max:20'],
+                'sort_order' => 39
+            ],
+            [
+                'key' => 'conduite_heures_par_point',
+                'value' => '4',
+                'type' => 'float',
+                'group' => 'bulletin',
+                'category' => 'bulletin',
+                'description' => 'Nombre d\'heures d\'absence pour retrancher 1 point de conduite',
+                'is_required' => false,
+                'default_value' => '4',
+                'validation_rules' => ['nullable', 'numeric', 'min:1'],
+                'sort_order' => 40
+            ],
+            [
+                'key' => 'bulletin_show_absences_par_matiere',
+                'value' => '1',
+                'type' => 'boolean',
+                'group' => 'bulletin',
+                'category' => 'bulletin',
+                'description' => 'Afficher les absences par matière sur le bulletin',
+                'is_required' => false,
+                'default_value' => '1',
+                'validation_rules' => ['string'],
+                'sort_order' => 41
+            ],
+
             // Statistiques
             [
                 'key' => 'bulletin_show_statistics',

--- a/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php
@@ -530,6 +530,7 @@
                         @if(($settings['bulletin_show_coefficient'] ?? '1') == '1')<th>Coef C</th>@endif
                         @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<th>Moy Pondérée M×C</th>@endif
                         @if(($settings['bulletin_show_rank_per_subject'] ?? '1') == '1')<th>Rang</th>@endif
+                        @if(($settings['bulletin_show_absences_par_matiere'] ?? '0') == '1' && ($settings['bulletin_conduite_enabled'] ?? '0') == '1')<th>Abs. (h)</th>@endif
                         @if(($settings['bulletin_show_teachers'] ?? '1') == '1')<th>Professeurs</th>@endif
                         @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<th>Appréciations</th>@endif
                     </tr>
@@ -549,13 +550,14 @@
                                     @if(($settings['bulletin_show_coefficient'] ?? '1') == '1')<td class="center">{{ $resultat->coefficient }}</td>@endif
                                     @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<td class="center">{{ number_format($resultat->moyenne * $resultat->coefficient, 2) }}</td>@endif
                                     @if(($settings['bulletin_show_rank_per_subject'] ?? '1') == '1')<td class="center">{{ $resultat->rang ?: '-' }}</td>@endif
+                                    @if(($settings['bulletin_show_absences_par_matiere'] ?? '0') == '1' && ($settings['bulletin_conduite_enabled'] ?? '0') == '1')<td class="center">{{ isset($absencesParMatiere[$resultat->matiere_id]) ? $absencesParMatiere[$resultat->matiere_id]['total_heures'] : 0 }}</td>@endif
                                     @if(($settings['bulletin_show_teachers'] ?? '1') == '1')<td>{{ $professeurs[$resultat->matiere_id] ?? 'M.' }}</td>@endif
                                     @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<td>{{ $resultat->appreciation ?? 'Nul' }}</td>@endif
                                 </tr>
                             @endforeach
                         @else
                             <tr>
-                                <td colspan="7" class="center">Aucune matière d'enseignement général</td>
+                                <td colspan="8" class="center">Aucune matière d'enseignement général</td>
                             </tr>
                         @endif
                         @if(($settings['bulletin_show_section_averages'] ?? '1') == '1')
@@ -579,13 +581,14 @@
                                     @if(($settings['bulletin_show_coefficient'] ?? '1') == '1')<td class="center">{{ $resultat->coefficient }}</td>@endif
                                     @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<td class="center">{{ number_format($resultat->moyenne * $resultat->coefficient, 2) }}</td>@endif
                                     @if(($settings['bulletin_show_rank_per_subject'] ?? '1') == '1')<td class="center">{{ $resultat->rang ?: '-' }}</td>@endif
+                                    @if(($settings['bulletin_show_absences_par_matiere'] ?? '0') == '1' && ($settings['bulletin_conduite_enabled'] ?? '0') == '1')<td class="center">{{ isset($absencesParMatiere[$resultat->matiere_id]) ? $absencesParMatiere[$resultat->matiere_id]['total_heures'] : 0 }}</td>@endif
                                     @if(($settings['bulletin_show_teachers'] ?? '1') == '1')<td>{{ $professeurs[$resultat->matiere_id] ?? 'M.' }}</td>@endif
                                     @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<td>{{ $resultat->appreciation ?? 'Nul' }}</td>@endif
                                 </tr>
                             @endforeach
                         @else
                             <tr>
-                                <td colspan="7" class="center">Aucune matière d'enseignement technique</td>
+                                <td colspan="8" class="center">Aucune matière d'enseignement technique</td>
                             </tr>
                         @endif
                         @if(($settings['bulletin_show_section_averages'] ?? '1') == '1')
@@ -620,6 +623,33 @@
                             <td>Absences non justifiées</td>
                             <td class="center">{{ isset($absencesNonJustifiees) ? $absencesNonJustifiees : (isset($absences_non_justifiees) ? $absences_non_justifiees : (isset($bulletin->absences_non_justifiees) ? $bulletin->absences_non_justifiees : '00')) }} Heure(s)</td>
                         </tr>
+                    @endif
+                </tbody>
+            </table>
+        @endif
+
+        {{-- Note de Conduite --}}
+        @if(($settings['bulletin_conduite_enabled'] ?? '0') == '1' && isset($noteConduite))
+            <table class="absences-table">
+                <thead>
+                    <tr class="section-header">
+                        <td colspan="2">Note de Conduite</td>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Total heures d'absences</td>
+                        <td class="center" style="width: 50%;">{{ $totalHeuresAbsencesParMatiere ?? 0 }} Heure(s)</td>
+                    </tr>
+                    <tr>
+                        <td>Note de conduite</td>
+                        <td class="center"><strong>{{ number_format($noteConduite, 2) }} / 20</strong></td>
+                    </tr>
+                    @if(!empty($mentionConduite))
+                    <tr>
+                        <td>Mention conduite</td>
+                        <td class="center"><strong style="color: #c0392b;">{{ $mentionConduite }}</strong></td>
+                    </tr>
                     @endif
                 </tbody>
             </table>

--- a/resources/views/esbtp/bulletins/pdf-configurable.blade.php
+++ b/resources/views/esbtp/bulletins/pdf-configurable.blade.php
@@ -515,6 +515,7 @@
                     @if(($settings['bulletin_show_coefficient'] ?? '1') == '1')<th>Coef C</th>@endif
                     @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<th>Moy Pondérée M×C</th>@endif
                     @if(($settings['bulletin_show_rank_per_subject'] ?? '1') == '1')<th>Rang</th>@endif
+                    @if(($settings['bulletin_show_absences_par_matiere'] ?? '0') == '1' && ($settings['bulletin_conduite_enabled'] ?? '0') == '1')<th>Abs. (h)</th>@endif
                     @if(($settings['bulletin_show_teachers'] ?? '1') == '1')<th>Professeurs</th>@endif
                     @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<th>Appréciations</th>@endif
                 </tr>
@@ -534,12 +535,13 @@
                                 @if(($settings['bulletin_show_coefficient'] ?? '1') == '1')<td class="center">{{ $resultat->coefficient }}</td>@endif
                                 @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<td class="center">{{ number_format($resultat->moyenne * $resultat->coefficient, 2) }}</td>@endif
                                 @if(($settings['bulletin_show_rank_per_subject'] ?? '1') == '1')<td class="center">{{ $resultat->rang ?: '-' }}</td>@endif
+                                @if(($settings['bulletin_show_absences_par_matiere'] ?? '0') == '1' && ($settings['bulletin_conduite_enabled'] ?? '0') == '1')<td class="center">{{ isset($absencesParMatiere[$resultat->matiere_id]) ? $absencesParMatiere[$resultat->matiere_id]['total_heures'] : 0 }}</td>@endif
                                 @if(($settings['bulletin_show_teachers'] ?? '1') == '1')<td>{{ $professeurs[$resultat->matiere_id] ?? 'M.' }}</td>@endif
                                 @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<td>{{ $resultat->appreciation ?? 'Nul' }}</td>@endif
                             </tr>
                         @endforeach
                     @else
-                        <tr><td colspan="7" class="center">Aucune matière d'enseignement général</td></tr>
+                        <tr><td colspan="8" class="center">Aucune matière d'enseignement général</td></tr>
                     @endif
                     @if(($settings['bulletin_show_section_averages'] ?? '1') == '1')
                     <tr class="summary-row">
@@ -562,12 +564,13 @@
                             @if(($settings['bulletin_show_coefficient'] ?? '1') == '1')<td class="center">{{ $resultat->coefficient }}</td>@endif
                             @if(($settings['bulletin_show_weighted_average'] ?? '1') == '1')<td class="center">{{ number_format($resultat->moyenne * $resultat->coefficient, 2) }}</td>@endif
                             @if(($settings['bulletin_show_rank_per_subject'] ?? '1') == '1')<td class="center">{{ $resultat->rang ?: '-' }}</td>@endif
+                            @if(($settings['bulletin_show_absences_par_matiere'] ?? '0') == '1' && ($settings['bulletin_conduite_enabled'] ?? '0') == '1')<td class="center">{{ isset($absencesParMatiere[$resultat->matiere_id]) ? $absencesParMatiere[$resultat->matiere_id]['total_heures'] : 0 }}</td>@endif
                             @if(($settings['bulletin_show_teachers'] ?? '1') == '1')<td>{{ $professeurs[$resultat->matiere_id] ?? 'M.' }}</td>@endif
                             @if(($settings['bulletin_show_appreciations'] ?? '1') == '1')<td>{{ $resultat->appreciation ?? 'Nul' }}</td>@endif
                         </tr>
                     @endforeach
                 @else
-                    <tr><td colspan="7" class="center">Aucune matière d'enseignement technique</td></tr>
+                    <tr><td colspan="8" class="center">Aucune matière d'enseignement technique</td></tr>
                 @endif
                 @if(($settings['bulletin_show_section_averages'] ?? '1') == '1')
                 <tr class="summary-row">
@@ -600,6 +603,33 @@
                 <tr>
                     <td>Absences non justifiées</td>
                     <td class="center">{{ isset($absencesNonJustifiees) ? $absencesNonJustifiees : (isset($absences_non_justifiees) ? $absences_non_justifiees : (isset($bulletin->absences_non_justifiees) ? $bulletin->absences_non_justifiees : '00')) }} Heure(s)</td>
+                </tr>
+                @endif
+            </tbody>
+        </table>
+        @endif
+
+        {{-- Note de Conduite --}}
+        @if(($settings['bulletin_conduite_enabled'] ?? '0') == '1' && isset($noteConduite))
+        <table class="absences-table">
+            <thead>
+                <tr class="section-header">
+                    <td colspan="2">Note de Conduite</td>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Total heures d'absences</td>
+                    <td class="center" style="width: 50%;">{{ $totalHeuresAbsencesParMatiere ?? 0 }} Heure(s)</td>
+                </tr>
+                <tr>
+                    <td>Note de conduite</td>
+                    <td class="center"><strong>{{ number_format($noteConduite, 2) }} / 20</strong></td>
+                </tr>
+                @if(!empty($mentionConduite))
+                <tr>
+                    <td>Mention conduite</td>
+                    <td class="center"><strong style="color: #c0392b;">{{ $mentionConduite }}</strong></td>
                 </tr>
                 @endif
             </tbody>

--- a/resources/views/esbtp/settings/index.blade.php
+++ b/resources/views/esbtp/settings/index.blade.php
@@ -1129,6 +1129,84 @@
                 </small>
             </div>
 
+            <!-- Section: Note de Conduite -->
+            <div class="settings-section">
+                <div class="section-header">
+                    <div class="section-icon" style="background: linear-gradient(135deg, #e74c3c, #c0392b);">
+                        <i class="fas fa-user-shield"></i>
+                    </div>
+                    <div>
+                        <h3 class="section-title">Note de Conduite</h3>
+                        <p class="section-description">Configuration de la note de conduite basée sur les absences</p>
+                    </div>
+                </div>
+
+                <div class="settings-grid-3">
+                    <div class="form-group">
+                        <label class="form-label-modern">
+                            <i class="fas fa-toggle-on text-success"></i>
+                            Activer la note de conduite
+                        </label>
+                        <label class="form-switch-modern">
+                            <input type="checkbox" name="bulletin_conduite_enabled" value="1"
+                                   {{ \App\Helpers\SettingsHelper::get('bulletin_conduite_enabled', '0') == '1' ? 'checked' : '' }}>
+                            <span class="slider"></span>
+                        </label>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label-modern">
+                            <i class="fas fa-list-ol text-info"></i>
+                            Absences par matière sur bulletin
+                        </label>
+                        <label class="form-switch-modern">
+                            <input type="checkbox" name="bulletin_show_absences_par_matiere" value="1"
+                                   {{ \App\Helpers\SettingsHelper::get('bulletin_show_absences_par_matiere', '1') == '1' ? 'checked' : '' }}>
+                            <span class="slider"></span>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="settings-grid-2" style="margin-top: var(--space-md);">
+                    <div class="form-group">
+                        <label class="form-label-modern">
+                            <i class="fas fa-star text-warning"></i>
+                            Note par défaut (/20)
+                        </label>
+                        <input type="number" class="form-control form-control-modern threshold-input"
+                               name="setting_conduite_note_defaut"
+                               value="{{ \App\Helpers\SettingsHelper::get('conduite_note_defaut', '16') }}"
+                               min="0" max="20" step="0.5">
+                        <small class="text-muted">Note de départ avant déduction des absences</small>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="form-label-modern">
+                            <i class="fas fa-clock text-danger"></i>
+                            Heures d'absence par point retiré
+                        </label>
+                        <input type="number" class="form-control form-control-modern threshold-input"
+                               name="setting_conduite_heures_par_point"
+                               value="{{ \App\Helpers\SettingsHelper::get('conduite_heures_par_point', '4') }}"
+                               min="1" max="20" step="1">
+                        <small class="text-muted">Chaque X heures d'absences = -1 point sur la note de conduite</small>
+                    </div>
+                </div>
+
+                <div style="margin-top: var(--space-md); padding: var(--space-md); background: #fef3cd; border-radius: var(--radius-medium); border: 1px solid #ffc107;">
+                    <strong><i class="fas fa-info-circle"></i> Barème des mentions de conduite :</strong>
+                    <ul style="margin: 8px 0 0 16px; padding: 0;">
+                        <li><strong>0/20</strong> → Blâme</li>
+                        <li><strong>05/20 à 10/20</strong> → Avertissement</li>
+                    </ul>
+                    <strong style="display: block; margin-top: 8px;"><i class="fas fa-book"></i> Appréciations des notes :</strong>
+                    <ul style="margin: 8px 0 0 16px; padding: 0;">
+                        <li>00/20 = Nul · 01-06 = Médiocre · 07-09.98 = Insuffisant · 9.99-11.99 = Passable</li>
+                        <li>12-13.99 = Assez-bien · 14-15.99 = Bien · 16-17.99 = Très Bien · 18-20 = Excellent</li>
+                    </ul>
+                </div>
+            </div>
+
             <!-- Section: Mentions et Seuils -->
             <div class="settings-section">
                 <div class="section-header">


### PR DESCRIPTION
## Summary
- **Note de conduite** calculée automatiquement : note défaut 16/20, chaque 4h d'absences = -1 point
- **Mentions conduite** : Blâme (0/20), Avertissement (5-10/20)
- **Absences par matière** (colonne "Abs. (h)") affichées dans le tableau des matières du bulletin
- **Appréciations ESBTP Abidjan** : barème complet (Nul → Excellent) activé quand conduite est ON
- **Settings configurables** dans esbtp/settings : toggle ON/OFF, note par défaut, heures par point retiré

## Fichiers modifiés
- `app/Services/BulletinService.php` — `calculerNoteConduite()`, `getMentionConduite()`, `getAppreciation()` mis à jour
- `app/Services/ESBTP/ESBTPAbsenceService.php` — `calculerAbsencesParMatiere()` (nouvelle méthode)
- `app/Http/Controllers/ESBTP/ESBTPSettingsController.php` — checkboxes + firstOrCreate conduite settings
- `database/seeders/SettingsSeeder.php` — 4 nouveaux settings conduite
- `resources/views/esbtp/bulletins/pdf-configurable.blade.php` — section conduite + colonne abs. par matière
- `resources/views/esbtp/bulletins/pdf-configurable-abidjan.blade.php` — idem template Abidjan
- `resources/views/esbtp/settings/index.blade.php` — section "Note de Conduite" dans tab bulletin

## Test plan
- [ ] Activer "Note de conduite" dans Paramètres > Configuration Bulletin
- [ ] Vérifier que la note par défaut (16) et heures par point (4) sont sauvegardées
- [ ] Générer un bulletin PDF → vérifier la section "Note de Conduite" (total heures, note, mention)
- [ ] Vérifier la colonne "Abs. (h)" dans le tableau des matières
- [ ] Désactiver la conduite → vérifier que le bulletin revient à l'ancien format
- [ ] Tester avec un étudiant ayant des absences pour vérifier le calcul (ex: 8h → note 14/20)

Closes #161