### PR TITLE
feat(inscriptions): inscription sous réserve pour année future + documents adaptatifs

### DIFF
--- a/app/Http/Controllers/ESBTPAnneeUniversitaireController.php
+++ b/app/Http/Controllers/ESBTPAnneeUniversitaireController.php
@@ -59,6 +59,17 @@ class ESBTPAnneeUniversitaireController extends Controller
         // Si cette année est définie comme l'année en cours, mettre à jour les autres années
         if ($request->has('is_current') && $request->is_current) {
             $anneeUniversitaire->setAsCurrent();
+
+            // Vérifier s'il y a des inscriptions sous réserve pour cette année
+            $sousReserveCount = \App\Models\ESBTPInscription::where('annee_universitaire_id', $anneeUniversitaire->id)
+                ->where('is_sous_reserve', true)
+                ->count();
+
+            if ($sousReserveCount > 0) {
+                return redirect()->route('esbtp.inscriptions.sous-reserve', ['annee_id' => $anneeUniversitaire->id])
+                    ->with('success', 'L\'année universitaire a été créée et définie comme l\'année en cours.')
+                    ->with('warning', $sousReserveCount . ' inscription(s) sous réserve détectée(s) pour cette année.');
+            }
         }
 
         // Rediriger avec un message de succès
@@ -116,6 +127,17 @@ class ESBTPAnneeUniversitaireController extends Controller
         // Si cette année est définie comme l'année en cours, mettre à jour les autres années
         if ($request->has('is_current') && $request->is_current) {
             $anneesUniversitaire->setAsCurrent();
+
+            // Vérifier s'il y a des inscriptions sous réserve pour cette année
+            $sousReserveCount = \App\Models\ESBTPInscription::where('annee_universitaire_id', $anneesUniversitaire->id)
+                ->where('is_sous_reserve', true)
+                ->count();
+
+            if ($sousReserveCount > 0) {
+                return redirect()->route('esbtp.inscriptions.sous-reserve', ['annee_id' => $anneesUniversitaire->id])
+                    ->with('success', 'L\'année universitaire a été mise à jour et définie comme l\'année en cours.')
+                    ->with('warning', $sousReserveCount . ' inscription(s) sous réserve détectée(s) pour cette année.');
+            }
         }
 
         // Rediriger avec un message de succès
@@ -155,18 +177,29 @@ class ESBTPAnneeUniversitaireController extends Controller
     {
         try {
             $result = $anneesUniversitaire->setAsCurrent();
-            
+
             if (!$result) {
                 return redirect()->route('esbtp.annees-universitaires.index')
                     ->with('error', 'Erreur lors de la définition de l\'année en cours.');
             }
-            
+
+            // Vérifier s'il y a des inscriptions sous réserve pour cette année
+            $sousReserveCount = \App\Models\ESBTPInscription::where('annee_universitaire_id', $anneesUniversitaire->id)
+                ->where('is_sous_reserve', true)
+                ->count();
+
+            if ($sousReserveCount > 0) {
+                return redirect()->route('esbtp.inscriptions.sous-reserve', ['annee_id' => $anneesUniversitaire->id])
+                    ->with('success', 'L\'année universitaire a été définie comme l\'année en cours.')
+                    ->with('warning', $sousReserveCount . ' inscription(s) sous réserve détectée(s) pour cette année. Veuillez confirmer ou annuler ces inscriptions.');
+            }
+
             return redirect()->route('esbtp.annees-universitaires.index')
                 ->with('success', 'L\'année universitaire a été définie comme l\'année en cours.');
-                
+
         } catch (\Exception $e) {
             \Log::error("setCurrent: Exception = " . $e->getMessage());
-            
+
             return redirect()->route('esbtp.annees-universitaires.index')
                 ->with('error', 'Erreur: ' . $e->getMessage());
         }

--- a/app/Http/Controllers/ESBTPAnneeUniversitaireController.php
+++ b/app/Http/Controllers/ESBTPAnneeUniversitaireController.php
@@ -60,19 +60,13 @@ class ESBTPAnneeUniversitaireController extends Controller
         if ($request->has('is_current') && $request->is_current) {
             $anneeUniversitaire->setAsCurrent();
 
-            // Vérifier s'il y a des inscriptions sous réserve pour cette année
-            $sousReserveCount = \App\Models\ESBTPInscription::where('annee_universitaire_id', $anneeUniversitaire->id)
-                ->where('is_sous_reserve', true)
-                ->count();
-
-            if ($sousReserveCount > 0) {
-                return redirect()->route('esbtp.inscriptions.sous-reserve', ['annee_id' => $anneeUniversitaire->id])
-                    ->with('success', 'L\'année universitaire a été créée et définie comme l\'année en cours.')
-                    ->with('warning', $sousReserveCount . ' inscription(s) sous réserve détectée(s) pour cette année.');
-            }
+            $redirect = $this->redirectIfSousReservesExist(
+                $anneeUniversitaire,
+                'L\'année universitaire a été créée et définie comme l\'année en cours.'
+            );
+            if ($redirect) return $redirect;
         }
 
-        // Rediriger avec un message de succès
         return redirect()->route('esbtp.annees-universitaires.index')
             ->with('success', 'L\'année universitaire a été créée avec succès.');
     }
@@ -128,19 +122,13 @@ class ESBTPAnneeUniversitaireController extends Controller
         if ($request->has('is_current') && $request->is_current) {
             $anneesUniversitaire->setAsCurrent();
 
-            // Vérifier s'il y a des inscriptions sous réserve pour cette année
-            $sousReserveCount = \App\Models\ESBTPInscription::where('annee_universitaire_id', $anneesUniversitaire->id)
-                ->where('is_sous_reserve', true)
-                ->count();
-
-            if ($sousReserveCount > 0) {
-                return redirect()->route('esbtp.inscriptions.sous-reserve', ['annee_id' => $anneesUniversitaire->id])
-                    ->with('success', 'L\'année universitaire a été mise à jour et définie comme l\'année en cours.')
-                    ->with('warning', $sousReserveCount . ' inscription(s) sous réserve détectée(s) pour cette année.');
-            }
+            $redirect = $this->redirectIfSousReservesExist(
+                $anneesUniversitaire,
+                'L\'année universitaire a été mise à jour et définie comme l\'année en cours.'
+            );
+            if ($redirect) return $redirect;
         }
 
-        // Rediriger avec un message de succès
         return redirect()->route('esbtp.annees-universitaires.index')
             ->with('success', 'L\'année universitaire a été mise à jour avec succès.');
     }
@@ -183,16 +171,11 @@ class ESBTPAnneeUniversitaireController extends Controller
                     ->with('error', 'Erreur lors de la définition de l\'année en cours.');
             }
 
-            // Vérifier s'il y a des inscriptions sous réserve pour cette année
-            $sousReserveCount = \App\Models\ESBTPInscription::where('annee_universitaire_id', $anneesUniversitaire->id)
-                ->where('is_sous_reserve', true)
-                ->count();
-
-            if ($sousReserveCount > 0) {
-                return redirect()->route('esbtp.inscriptions.sous-reserve', ['annee_id' => $anneesUniversitaire->id])
-                    ->with('success', 'L\'année universitaire a été définie comme l\'année en cours.')
-                    ->with('warning', $sousReserveCount . ' inscription(s) sous réserve détectée(s) pour cette année. Veuillez confirmer ou annuler ces inscriptions.');
-            }
+            $redirect = $this->redirectIfSousReservesExist(
+                $anneesUniversitaire,
+                'L\'année universitaire a été définie comme l\'année en cours.'
+            );
+            if ($redirect) return $redirect;
 
             return redirect()->route('esbtp.annees-universitaires.index')
                 ->with('success', 'L\'année universitaire a été définie comme l\'année en cours.');
@@ -203,6 +186,22 @@ class ESBTPAnneeUniversitaireController extends Controller
             return redirect()->route('esbtp.annees-universitaires.index')
                 ->with('error', 'Erreur: ' . $e->getMessage());
         }
+    }
+
+    /**
+     * Redirige vers la page sous-reserve si des inscriptions conditionnelles existent pour cette année.
+     */
+    private function redirectIfSousReservesExist(ESBTPAnneeUniversitaire $annee, string $successMessage): ?\Illuminate\Http\RedirectResponse
+    {
+        $count = $annee->inscriptions()->where('is_sous_reserve', true)->count();
+
+        if ($count > 0) {
+            return redirect()->route('esbtp.inscriptions.sous-reserve', ['annee_id' => $annee->id])
+                ->with('success', $successMessage)
+                ->with('warning', $count . ' inscription(s) sous réserve détectée(s) pour cette année. Veuillez confirmer ou annuler ces inscriptions.');
+        }
+
+        return null;
     }
 
     /**

--- a/app/Http/Controllers/ESBTPEtudiantController.php
+++ b/app/Http/Controllers/ESBTPEtudiantController.php
@@ -1523,10 +1523,13 @@ class ESBTPEtudiantController extends Controller
         // Récupérer les paramètres de l'école
         $settings = $this->getCertificateDisplaySettings();
 
+        $hasSousReserve = $inscriptions->contains(fn($i) => $i->is_sous_reserve);
+
         return view('esbtp.etudiants.certificat-preview', [
             'etudiant' => $etudiant,
             'inscriptions' => $inscriptions,
-            'settings' => $settings
+            'settings' => $settings,
+            'hasSousReserve' => $hasSousReserve,
         ]);
     }
 
@@ -1563,10 +1566,13 @@ class ESBTPEtudiantController extends Controller
             // Récupérer les paramètres de l'école
             $settings = $this->getCertificateDisplaySettings();
 
+            $hasSousReserve = $inscriptions->contains(fn($i) => $i->is_sous_reserve);
+
             $html = view('esbtp.etudiants.certificat', [
                 'etudiant' => $etudiant,
                 'inscriptions' => $inscriptions,
-                'settings' => $settings
+                'settings' => $settings,
+                'hasSousReserve' => $hasSousReserve,
             ])->render();
 
             $pdfService = app(\App\Services\ESBTPPDFService::class);

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -1972,4 +1972,66 @@ class ESBTPInscriptionController extends Controller
             Log::error('Erreur désactivation reminder paiement: ' . $e->getMessage());
         }
     }
+
+    /**
+     * Afficher la page de gestion des inscriptions sous réserve.
+     */
+    public function sousReserveIndex(Request $request)
+    {
+        $anneeEnCours = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+        $annees = ESBTPAnneeUniversitaire::where('is_active', true)
+            ->orderByDesc('start_date')
+            ->get();
+
+        $anneeFilterId = $request->input('annee_id', $anneeEnCours?->id);
+
+        $inscriptions = ESBTPInscription::with([
+                'etudiant', 'classe', 'filiere', 'niveauEtude', 'anneeUniversitaire', 'paiements'
+            ])
+            ->where('is_sous_reserve', true)
+            ->when($anneeFilterId, fn($q) => $q->where('annee_universitaire_id', $anneeFilterId))
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        return view('esbtp.inscriptions.sous-reserve', compact(
+            'inscriptions', 'annees', 'anneeEnCours', 'anneeFilterId'
+        ));
+    }
+
+    /**
+     * Lever la réserve d'une inscription individuelle.
+     */
+    public function leverReserve(ESBTPInscription $inscription)
+    {
+        if (!$inscription->is_sous_reserve) {
+            return redirect()->back()->with('info', 'Cette inscription n\'est pas sous réserve.');
+        }
+
+        $inscription->leverReserve();
+
+        return redirect()->back()->with('success',
+            'La réserve a été levée pour l\'inscription de ' .
+            ($inscription->etudiant->nom ?? '') . ' ' . ($inscription->etudiant->prenoms ?? '') . '.'
+        );
+    }
+
+    /**
+     * Lever les réserves en bulk pour les inscriptions sélectionnées.
+     */
+    public function leverReservesBulk(Request $request)
+    {
+        $ids = $request->input('inscription_ids', []);
+
+        if (empty($ids)) {
+            return redirect()->back()->with('error', 'Aucune inscription sélectionnée.');
+        }
+
+        $count = ESBTPInscription::whereIn('id', $ids)
+            ->where('is_sous_reserve', true)
+            ->update(['is_sous_reserve' => false, 'condition_reserve' => null]);
+
+        return redirect()->back()->with('success',
+            $count . ' inscription(s) ont été confirmée(s). La réserve a été levée.'
+        );
+    }
 }

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -2007,6 +2007,7 @@ class ESBTPInscriptionController extends Controller
             return redirect()->back()->with('info', 'Cette inscription n\'est pas sous réserve.');
         }
 
+        $inscription->load('etudiant');
         $inscription->leverReserve();
 
         return redirect()->back()->with('success',

--- a/app/Http/Requests/Inscription/StoreInscriptionRequest.php
+++ b/app/Http/Requests/Inscription/StoreInscriptionRequest.php
@@ -15,6 +15,9 @@ class StoreInscriptionRequest extends FormRequest
     {
         $rules = [
             'classe_id' => 'required|exists:esbtp_classes,id',
+            'annee_universitaire_id' => 'nullable|exists:esbtp_annee_universitaires,id',
+            'is_sous_reserve' => 'nullable|boolean',
+            'condition_reserve' => 'nullable|string|max:255',
             'nom' => 'required|string|max:100',
             'prenoms' => 'required|string|max:100',
             'sexe' => 'required|in:M,F',
@@ -63,6 +66,7 @@ class StoreInscriptionRequest extends FormRequest
     {
         $messages = [
             'classe_id.required' => 'Veuillez sélectionner une classe',
+            'annee_universitaire_id.exists' => 'L\'année universitaire sélectionnée est invalide',
             'nom.required' => 'Le nom est obligatoire',
             'prenoms.required' => 'Le(s) prénom(s) est/sont obligatoire(s)',
             'sexe.required' => 'Le genre est obligatoire',

--- a/app/Models/ESBTPInscription.php
+++ b/app/Models/ESBTPInscription.php
@@ -33,6 +33,8 @@ class ESBTPInscription extends Model
         'date_inscription',
         'type_inscription', // Première inscription, réinscription, etc.
         'status', // active, annulée, etc.
+        'is_sous_reserve', // Inscription conditionnelle (ex: sous réserve du BAC)
+        'condition_reserve', // Motif de la réserve (ex: BACCALAURÉAT)
         'workflow_step', // Nouveau: étape du workflow
         'montant_scolarite',
         'frais_inscription',
@@ -70,6 +72,7 @@ class ESBTPInscription extends Model
         'montant_scolarite' => 'float',
         'frais_inscription' => 'float',
         'comptabilite_activee' => 'boolean',
+        'is_sous_reserve' => 'boolean',
         'affectation_status' => 'string',
         'est_transfert' => 'boolean',
     ];
@@ -550,5 +553,35 @@ class ESBTPInscription extends Model
         ];
         
         return $labels[$this->workflow_step] ?? $this->workflow_step;
+    }
+
+    /**
+     * Scope pour filtrer les inscriptions sous réserve.
+     */
+    public function scopeSousReserve($query)
+    {
+        return $query->where('is_sous_reserve', true);
+    }
+
+    /**
+     * Vérifie si l'inscription concerne une année future (pas l'année courante).
+     */
+    public function getIsFutureInscriptionAttribute(): bool
+    {
+        $anneeEnCours = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+        if (!$anneeEnCours) {
+            return false;
+        }
+        return $this->annee_universitaire_id !== $anneeEnCours->id;
+    }
+
+    /**
+     * Lever la réserve de cette inscription.
+     */
+    public function leverReserve(): bool
+    {
+        $this->is_sous_reserve = false;
+        $this->condition_reserve = null;
+        return $this->save();
     }
 }

--- a/app/Models/ESBTPInscription.php
+++ b/app/Models/ESBTPInscription.php
@@ -564,18 +564,6 @@ class ESBTPInscription extends Model
     }
 
     /**
-     * Vérifie si l'inscription concerne une année future (pas l'année courante).
-     */
-    public function getIsFutureInscriptionAttribute(): bool
-    {
-        $anneeEnCours = ESBTPAnneeUniversitaire::where('is_current', true)->first();
-        if (!$anneeEnCours) {
-            return false;
-        }
-        return $this->annee_universitaire_id !== $anneeEnCours->id;
-    }
-
-    /**
      * Lever la réserve de cette inscription.
      */
     public function leverReserve(): bool

--- a/app/Services/ESBTPInscriptionService.php
+++ b/app/Services/ESBTPInscriptionService.php
@@ -796,16 +796,28 @@ class ESBTPInscriptionService
      */
     public function prepareInscriptionData(ESBTPClasse $classe, array $requestData): array
     {
-        $anneeCourante = ESBTPAnneeUniversitaire::where('is_current', true)->first();
-        if (!$anneeCourante) {
-            throw new \Exception('Aucune année universitaire courante définie. Veuillez configurer l\'année courante.');
+        // Utiliser l'année fournie par le formulaire, sinon l'année courante
+        if (!empty($requestData['annee_universitaire_id'])) {
+            $annee = ESBTPAnneeUniversitaire::find($requestData['annee_universitaire_id']);
+            if (!$annee) {
+                throw new \Exception('L\'année universitaire sélectionnée est invalide.');
+            }
+        } else {
+            $annee = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+            if (!$annee) {
+                throw new \Exception('Aucune année universitaire courante définie. Veuillez configurer l\'année courante.');
+            }
         }
+
+        $isSousReserve = !empty($requestData['is_sous_reserve']);
 
         return [
             'date_inscription' => $requestData['date_inscription'] ?? now()->format('Y-m-d'),
             'classe_id' => $classe->id,
-            'annee_universitaire_id' => $anneeCourante->id,
+            'annee_universitaire_id' => $annee->id,
             'status' => 'en_attente',
+            'is_sous_reserve' => $isSousReserve,
+            'condition_reserve' => $isSousReserve ? ($requestData['condition_reserve'] ?? null) : null,
             'filiere_id' => $classe->filiere_id,
             'niveau_id' => $classe->niveau_etude_id,
             'type_inscription' => 'première_inscription',

--- a/database/migrations/2026_04_14_114139_add_sous_reserve_fields_to_esbtp_inscriptions_table.php
+++ b/database/migrations/2026_04_14_114139_add_sous_reserve_fields_to_esbtp_inscriptions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('esbtp_inscriptions', function (Blueprint $table) {
+            $table->boolean('is_sous_reserve')->default(false)->after('status');
+            $table->string('condition_reserve')->nullable()->after('is_sous_reserve');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('esbtp_inscriptions', function (Blueprint $table) {
+            $table->dropColumn(['is_sous_reserve', 'condition_reserve']);
+        });
+    }
+};

--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -122,15 +122,15 @@
     /* Footer */
     .doc-footer {
         display:flex; justify-content:space-between; align-items:flex-end;
-        margin-top:40px; gap:20px;
+        margin-top:80px; gap:20px;
     }
     .doc-date { font-style:italic; font-size:.85rem; color:var(--doc-muted); }
     .doc-signature {
         text-align:right; border-top:2px solid var(--doc-accent);
-        padding-top:12px; min-width:200px;
+        padding-top:24px; min-width:200px;
     }
     .doc-sig-title { font-weight:700; color:var(--doc-accent); font-size:.88rem; margin-bottom:8px; }
-    .doc-sig-name  { font-style:italic; color:var(--doc-muted); font-size:.84rem; margin-top:24px; }
+    .doc-sig-name  { font-style:italic; color:var(--doc-muted); font-size:.84rem; margin-top:48px; }
     .doc-sig-note  { text-align:center; font-size:.73rem; font-style:italic; color:var(--doc-muted); margin:16px 0; }
 
     .doc-note {
@@ -225,15 +225,20 @@
             @endif
 
             <p>
-                Est régulièrement inscrit(e) au titre de l'année scolaire
-                <span class="doc-hl">
                 @php
                     $anneeText = $inscription->anneeUniversitaire->name
                         ?? $inscription->anneeUniversitaire->nom
                         ?? $inscription->anneeUniversitaire->libelle ?? '';
-                    echo preg_match('/(\d{4}-\d{4})/', $anneeText, $m) ? $m[1] : $anneeText;
+                    $anneeFormatted = preg_match('/(\d{4}-\d{4})/', $anneeText, $m) ? $m[1] : $anneeText;
                 @endphp
-                </span>
+                @if($inscription->is_sous_reserve)
+                Sera régulièrement inscrit(e) au titre de l'année universitaire
+                <span class="doc-hl">{{ $anneeFormatted }}</span>
+                sous réserve de son <span class="doc-hl">{{ $inscription->condition_reserve ?? 'diplôme' }}</span>
+                @else
+                Est régulièrement inscrit(e) au titre de l'année universitaire
+                <span class="doc-hl">{{ $anneeFormatted }}</span>
+                @endif
             </p>
 
             <div class="doc-student-block">

--- a/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
@@ -173,7 +173,7 @@
 
         /* ── Footer signature — float layout DomPDF-safe ── */
         .doc-footer {
-            margin-top: 36px;
+            margin-top: 72px;
             width: 100%;
             overflow: hidden;
         }
@@ -184,7 +184,7 @@
             font-style: italic;
             color: {{ $pdfMuted }};
             font-size: 11px;
-            margin-top: 32px;
+            margin-top: 64px;
         }
 
         .doc-footer-sign {
@@ -192,8 +192,8 @@
             width: 48%;
             text-align: right;
             border-top: 2px solid {{ $pdfPrimary }};
-            padding-top: 10px;
-            min-height: 60px;
+            padding-top: 20px;
+            min-height: 120px;
         }
 
         .sign-title {
@@ -317,17 +317,22 @@
             @endif
 
             <p>
-                Est régulièrement inscrit(e) au titre de l'année scolaire
-                <span class="hl">
                 @php
                     $anneeText = $inscription->anneeUniversitaire->name
                         ?? $inscription->anneeUniversitaire->nom
                         ?? $inscription->anneeUniversitaire->libelle
                         ?? '';
-                    echo preg_match('/(\d{4}-\d{4})/', $anneeText, $matches)
+                    $anneeFormatted = preg_match('/(\d{4}-\d{4})/', $anneeText, $matches)
                         ? $matches[1] : $anneeText;
                 @endphp
-                </span>
+                @if($inscription->is_sous_reserve)
+                Sera régulièrement inscrit(e) au titre de l'année universitaire
+                <span class="hl">{{ $anneeFormatted }}</span>
+                sous réserve de son <span class="hl">{{ $inscription->condition_reserve ?? 'diplôme' }}</span>
+                @else
+                Est régulièrement inscrit(e) au titre de l'année universitaire
+                <span class="hl">{{ $anneeFormatted }}</span>
+                @endif
             </p>
 
             {{-- Bloc infos étudiant — fond clair + bordure gauche colorée --}}

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -193,10 +193,7 @@
             @endif
 
             <p>Matricule&nbsp;: <span class="doc-hl">{{ $etudiant->matricule }}</span></p>
-            @php
-                $hasSousReserve = $inscriptions->contains(fn($i) => $i->is_sous_reserve);
-            @endphp
-            @if($hasSousReserve)
+            @if($hasSousReserve ?? $inscriptions->contains(fn($i) => $i->is_sous_reserve))
             <p>Sera régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire&nbsp;:</p>
             @else
             <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire&nbsp;:</p>

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -104,15 +104,15 @@
     /* Footer */
     .doc-footer {
         display:flex; justify-content:space-between; align-items:flex-end;
-        margin-top:40px; gap:20px;
+        margin-top:80px; gap:20px;
     }
     .doc-date { font-style:italic; font-size:.85rem; color:var(--doc-muted); }
     .doc-signature {
         text-align:right; border-top:2px solid var(--doc-accent);
-        padding-top:12px; min-width:200px;
+        padding-top:24px; min-width:200px;
     }
     .doc-sig-title { font-weight:700; color:var(--doc-accent); font-size:.88rem; margin-bottom:8px; }
-    .doc-sig-name  { font-style:italic; color:var(--doc-muted); font-size:.84rem; margin-top:24px; }
+    .doc-sig-name  { font-style:italic; color:var(--doc-muted); font-size:.84rem; margin-top:48px; }
 
     .doc-note {
         margin-top:28px; text-align:center; font-size:.73rem;
@@ -193,7 +193,14 @@
             @endif
 
             <p>Matricule&nbsp;: <span class="doc-hl">{{ $etudiant->matricule }}</span></p>
-            <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année académique&nbsp;:</p>
+            @php
+                $hasSousReserve = $inscriptions->contains(fn($i) => $i->is_sous_reserve);
+            @endphp
+            @if($hasSousReserve)
+            <p>Sera régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire&nbsp;:</p>
+            @else
+            <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire&nbsp;:</p>
+            @endif
 
             @php
                 $showClasse  = $settings['show_classe']  ?? true;
@@ -204,7 +211,7 @@
             <table class="doc-table">
                 <thead>
                     <tr>
-                        <th>Année scolaire</th>
+                        <th>Année universitaire</th>
                         @if($showClasse)<th>Classe suivie</th>@endif
                         @if($showNiveau)<th>Niveau d'étude</th>@endif
                         @if($showFiliere)<th>Filière</th>@endif
@@ -220,7 +227,11 @@
                             echo $rawYear
                                 ? (preg_match('/(\d{4}-\d{4})/', $rawYear, $m) ? $m[1] : $rawYear)
                                 : 'Non renseigné';
-                        @endphp</td>
+                        @endphp
+                        @if($inscription->is_sous_reserve)
+                            <br><small style="color:#d97706;font-weight:600;">Sous réserve{{ $inscription->condition_reserve ? ' de son ' . $inscription->condition_reserve : '' }}</small>
+                        @endif
+                        </td>
                         @if($showClasse)<td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>@endif
                         @if($showNiveau)<td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>@endif
                         @if($showFiliere)<td>{{ strtoupper($inscription->filiere->name ?? 'Non renseigné') }}</td>@endif

--- a/resources/views/esbtp/etudiants/certificat.blade.php
+++ b/resources/views/esbtp/etudiants/certificat.blade.php
@@ -299,10 +299,7 @@
 
             <p>Matricule : <span class="hl">{{ $etudiant->matricule }}</span></p>
 
-            @php
-                $hasSousReserve = $inscriptions->contains(fn($i) => $i->is_sous_reserve);
-            @endphp
-            @if($hasSousReserve)
+            @if($hasSousReserve ?? $inscriptions->contains(fn($i) => $i->is_sous_reserve))
             <p>Sera régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
             @else
             <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>

--- a/resources/views/esbtp/etudiants/certificat.blade.php
+++ b/resources/views/esbtp/etudiants/certificat.blade.php
@@ -168,7 +168,7 @@
 
         /* ── Footer signature — float layout DomPDF-safe ── */
         .doc-footer {
-            margin-top: 36px;
+            margin-top: 72px;
             width: 100%;
             overflow: hidden;
         }
@@ -179,7 +179,7 @@
             font-style: italic;
             color: {{ $pdfMuted }};
             font-size: 11px;
-            margin-top: 32px;
+            margin-top: 64px;
         }
 
         .doc-footer-sign {
@@ -187,8 +187,8 @@
             width: 48%;
             text-align: right;
             border-top: 2px solid {{ $pdfPrimary }};
-            padding-top: 10px;
-            min-height: 60px;
+            padding-top: 20px;
+            min-height: 120px;
         }
 
         .sign-title {
@@ -299,12 +299,19 @@
 
             <p>Matricule : <span class="hl">{{ $etudiant->matricule }}</span></p>
 
-            <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année académique :</p>
+            @php
+                $hasSousReserve = $inscriptions->contains(fn($i) => $i->is_sous_reserve);
+            @endphp
+            @if($hasSousReserve)
+            <p>Sera régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
+            @else
+            <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
+            @endif
 
             <table class="doc-table">
                 <thead>
                     <tr>
-                        <th>Année scolaire</th>
+                        <th>Année universitaire</th>
                         @if($showClasse)<th>Classe suivie</th>@endif
                         @if($showNiveau)<th>Niveau d'étude</th>@endif
                         @if($showFiliere)<th>Filière</th>@endif
@@ -318,10 +325,14 @@
                             @php
                                 $rawAY = $inscription->anneeUniversitaire?->libelle
                                     ?? $inscription->anneeUniversitaire?->name ?? null;
-                                echo $rawAY
+                                $yearText = $rawAY
                                     ? (preg_match('/(\d{4}-\d{4})/', $rawAY, $m) ? $m[1] : $rawAY)
                                     : 'Non renseigné';
+                                echo $yearText;
                             @endphp
+                            @if($inscription->is_sous_reserve)
+                                <br><small style="color: #d97706; font-weight: 600;">Sous réserve{{ $inscription->condition_reserve ? ' de son ' . $inscription->condition_reserve : '' }}</small>
+                            @endif
                         </td>
                         @if($showClasse)<td>{{ $inscription->classe->name ?? 'Non renseigné' }}</td>@endif
                         @if($showNiveau)<td>{{ $inscription->niveauEtude->name ?? 'Non renseigné' }}</td>@endif

--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -371,12 +371,71 @@
 
                 <div class="alert-kl alert-kl-info mb-3">
                     <i class="fas fa-info-circle"></i>
-                    <span>Sélectionnez une classe. La filière, le niveau et l'année universitaire seront automatiquement associés.</span>
+                    <span>Sélectionnez une classe et l'année universitaire d'inscription.</span>
                 </div>
 
                 <div class="row">
-                    <div class="col-md-12">
+                    <div class="col-md-8">
                         @include('components.forms.class-selector')
+                    </div>
+                    <div class="col-md-4">
+                        <div class="form-group">
+                            <label for="annee_universitaire_id">
+                                <i class="fas fa-calendar-alt field-icon"></i> Année universitaire <span class="text-danger">*</span>
+                            </label>
+                            <select class="form-select @error('annee_universitaire_id') is-invalid @enderror"
+                                    name="annee_universitaire_id"
+                                    id="annee_universitaire_id"
+                                    required>
+                                @foreach($academicYears->sortByDesc('start_date') as $annee)
+                                    <option value="{{ $annee->id }}"
+                                        {{ (old('annee_universitaire_id', $anneeEnCours->id ?? '') == $annee->id) ? 'selected' : '' }}
+                                        data-is-current="{{ $annee->is_current ? '1' : '0' }}">
+                                        {{ $annee->name }}
+                                        @if($annee->is_current) (Année courante) @endif
+                                    </option>
+                                @endforeach
+                            </select>
+                            @error('annee_universitaire_id')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Bloc inscription sous réserve (visible uniquement si année future) --}}
+                <div class="row mt-3" id="sous-reserve-block" style="display: none;">
+                    <div class="col-md-12">
+                        <div class="alert alert-warning border-left-warning" style="border-left: 4px solid #f59e0b; background: #fffbeb;">
+                            <div class="d-flex align-items-start">
+                                <i class="fas fa-exclamation-triangle me-3 mt-1" style="color: #f59e0b; font-size: 1.2rem;"></i>
+                                <div class="flex-grow-1">
+                                    <strong style="color: #92400e;">Inscription pour une année future</strong>
+                                    <p class="mb-2 mt-1" style="color: #78350f; font-size: 13px;">
+                                        Cette inscription concerne une année universitaire qui n'est pas l'année courante.
+                                        Vous pouvez la marquer comme "sous réserve" (ex: en attente du Baccalauréat).
+                                    </p>
+                                    <div class="form-check mb-2">
+                                        <input class="form-check-input" type="checkbox"
+                                               name="is_sous_reserve" id="is_sous_reserve" value="1"
+                                               {{ old('is_sous_reserve') ? 'checked' : '' }}>
+                                        <label class="form-check-label fw-bold" for="is_sous_reserve" style="color: #92400e;">
+                                            Inscription sous réserve
+                                        </label>
+                                    </div>
+                                    <div id="condition-reserve-field" style="{{ old('is_sous_reserve') ? '' : 'display: none;' }}">
+                                        <label for="condition_reserve" class="form-label" style="color: #78350f; font-size: 13px;">
+                                            Condition / Motif de la réserve :
+                                        </label>
+                                        <input type="text" class="form-control form-control-sm"
+                                               name="condition_reserve" id="condition_reserve"
+                                               value="{{ old('condition_reserve', 'BACCALAURÉAT') }}"
+                                               placeholder="Ex: BACCALAURÉAT, BTS, BEPC..."
+                                               style="max-width: 350px;">
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -797,6 +856,40 @@ document.addEventListener('DOMContentLoaded', function() {
     function resetDuplicateOverride() {
         duplicateState.override = false;
         if (duplicateOverrideInput) duplicateOverrideInput.value = '0';
+    }
+
+    // =============================================
+    // ANNÉE UNIVERSITAIRE + SOUS RÉSERVE
+    // =============================================
+    const anneeSelect = document.getElementById('annee_universitaire_id');
+    const sousReserveBlock = document.getElementById('sous-reserve-block');
+    const isSousReserveCheck = document.getElementById('is_sous_reserve');
+    const conditionField = document.getElementById('condition-reserve-field');
+
+    function updateSousReserveVisibility() {
+        if (!anneeSelect || !sousReserveBlock) return;
+        const selectedOption = anneeSelect.options[anneeSelect.selectedIndex];
+        const isCurrent = selectedOption?.dataset?.isCurrent === '1';
+        sousReserveBlock.style.display = isCurrent ? 'none' : '';
+        // Si on revient sur l'année courante, décocher sous réserve
+        if (isCurrent && isSousReserveCheck) {
+            isSousReserveCheck.checked = false;
+            if (conditionField) conditionField.style.display = 'none';
+        }
+    }
+
+    if (anneeSelect) {
+        anneeSelect.addEventListener('change', updateSousReserveVisibility);
+        // Exécuter au chargement pour gérer old()
+        updateSousReserveVisibility();
+    }
+
+    if (isSousReserveCheck) {
+        isSousReserveCheck.addEventListener('change', function() {
+            if (conditionField) {
+                conditionField.style.display = this.checked ? '' : 'none';
+            }
+        });
     }
 
     // =============================================

--- a/resources/views/esbtp/inscriptions/sous-reserve.blade.php
+++ b/resources/views/esbtp/inscriptions/sous-reserve.blade.php
@@ -1,0 +1,312 @@
+@extends('layouts.app')
+
+@section('title', 'Inscriptions sous réserve')
+
+@section('styles')
+<link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
+<style>
+    .sous-reserve-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+    .filter-bar {
+        display: flex;
+        gap: 1rem;
+        align-items: center;
+        flex-wrap: wrap;
+    }
+    .badge-reserve {
+        display: inline-block;
+        padding: 3px 10px;
+        border-radius: 12px;
+        font-size: 12px;
+        font-weight: 600;
+        background: #fef3c7;
+        color: #92400e;
+        border: 1px solid #f59e0b;
+    }
+    .badge-paye {
+        display: inline-block;
+        padding: 3px 10px;
+        border-radius: 12px;
+        font-size: 12px;
+        font-weight: 600;
+        background: #d1fae5;
+        color: #065f46;
+    }
+    .badge-en-attente {
+        display: inline-block;
+        padding: 3px 10px;
+        border-radius: 12px;
+        font-size: 12px;
+        font-weight: 600;
+        background: #fee2e2;
+        color: #991b1b;
+    }
+    .bulk-actions {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        margin-bottom: 1rem;
+    }
+    .empty-state {
+        text-align: center;
+        padding: 60px 20px;
+        color: var(--text-secondary, #64748b);
+    }
+    .empty-state i {
+        font-size: 3rem;
+        margin-bottom: 1rem;
+        color: #10b981;
+    }
+    .table-modern th { font-size: 13px; }
+    .table-modern td { font-size: 13px; vertical-align: middle; }
+</style>
+@endsection
+
+@section('content')
+<div class="dashboard-acasi">
+    <div class="main-content">
+
+        {{-- Header --}}
+        <div class="dashboard-header">
+            <div class="header-left">
+                <h1><i class="fas fa-clipboard-check me-2"></i>Inscriptions sous réserve</h1>
+                <p class="header-subtitle">Gérer les inscriptions conditionnelles en attente de confirmation</p>
+            </div>
+            <div class="header-actions">
+                <a href="{{ route('esbtp.inscriptions.index') }}" class="btn-acasi secondary">
+                    <i class="fas fa-arrow-left"></i> Retour aux inscriptions
+                </a>
+            </div>
+        </div>
+
+        {{-- Filtre par année --}}
+        <div class="main-card mb-3">
+            <div class="filter-bar">
+                <label class="fw-bold" style="font-size: 14px;">
+                    <i class="fas fa-filter me-1"></i> Filtrer par année :
+                </label>
+                <form method="GET" action="{{ route('esbtp.inscriptions.sous-reserve') }}" class="d-flex gap-2 align-items-center">
+                    <select name="annee_id" class="form-select form-select-sm" style="width: auto; min-width: 200px;" onchange="this.form.submit()">
+                        <option value="">Toutes les années</option>
+                        @foreach($annees as $annee)
+                            <option value="{{ $annee->id }}" {{ $anneeFilterId == $annee->id ? 'selected' : '' }}>
+                                {{ $annee->name }}
+                                @if($annee->is_current) (Courante) @endif
+                            </option>
+                        @endforeach
+                    </select>
+                </form>
+                <span class="text-muted" style="font-size: 13px;">
+                    <strong>{{ $inscriptions->count() }}</strong> inscription(s) sous réserve
+                </span>
+            </div>
+        </div>
+
+        @if(session('success'))
+            <div class="alert alert-success alert-dismissible fade show">
+                <i class="fas fa-check-circle me-2"></i>{{ session('success') }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        @endif
+
+        @if(session('warning'))
+            <div class="alert alert-warning alert-dismissible fade show">
+                <i class="fas fa-exclamation-triangle me-2"></i><strong>Attention :</strong> {{ session('warning') }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        @endif
+
+        @if(session('error'))
+            <div class="alert alert-danger alert-dismissible fade show">
+                <i class="fas fa-exclamation-circle me-2"></i>{{ session('error') }}
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
+        @endif
+
+        @if($inscriptions->isEmpty())
+            <div class="main-card">
+                <div class="empty-state">
+                    <i class="fas fa-check-double"></i>
+                    <h4>Aucune inscription sous réserve</h4>
+                    <p>Toutes les inscriptions pour cette période sont confirmées.</p>
+                </div>
+            </div>
+        @else
+            {{-- Bulk actions --}}
+            <form method="POST" action="{{ route('esbtp.inscriptions.lever-reserves-bulk') }}" id="bulkForm">
+                @csrf
+                <div class="main-card">
+                    <div class="bulk-actions">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" id="selectAll">
+                            <label class="form-check-label fw-bold" for="selectAll" style="font-size: 13px;">
+                                Tout sélectionner
+                            </label>
+                        </div>
+                        <button type="button" class="btn btn-success btn-sm" id="bulkConfirmBtn" disabled
+                                onclick="confirmBulkLever()">
+                            <i class="fas fa-check-double me-1"></i> Lever les réserves sélectionnées
+                        </button>
+                        <span class="text-muted ms-2" style="font-size: 12px;" id="selectedCount">0 sélectionné(s)</span>
+                    </div>
+
+                    <div class="table-responsive">
+                        <table class="table table-modern table-hover mb-0">
+                            <thead>
+                                <tr>
+                                    <th style="width: 40px;"></th>
+                                    <th>Etudiant</th>
+                                    <th>Classe</th>
+                                    <th>Filière</th>
+                                    <th>Année</th>
+                                    <th>Condition</th>
+                                    <th>Paiement</th>
+                                    <th>Statut workflow</th>
+                                    <th style="width: 160px;">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($inscriptions as $inscription)
+                                <tr>
+                                    <td>
+                                        <input class="form-check-input row-checkbox"
+                                               type="checkbox" name="inscription_ids[]"
+                                               value="{{ $inscription->id }}">
+                                    </td>
+                                    <td>
+                                        <strong>{{ $inscription->etudiant->nom ?? '—' }}</strong>
+                                        {{ $inscription->etudiant->prenoms ?? '' }}
+                                    </td>
+                                    <td>{{ $inscription->classe->name ?? '—' }}</td>
+                                    <td>{{ $inscription->filiere->name ?? '—' }}</td>
+                                    <td>
+                                        {{ $inscription->anneeUniversitaire->name ?? '—' }}
+                                        @if($anneeEnCours && $inscription->annee_universitaire_id == $anneeEnCours->id)
+                                            <br><small class="text-success fw-bold">Année courante</small>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <span class="badge-reserve">
+                                            <i class="fas fa-clock me-1"></i>{{ $inscription->condition_reserve ?? 'Non précisé' }}
+                                        </span>
+                                    </td>
+                                    <td>
+                                        @php
+                                            $totalPaye = $inscription->paiements->where('status', 'validé')->sum('montant');
+                                        @endphp
+                                        @if($totalPaye > 0)
+                                            <span class="badge-paye">{{ number_format($totalPaye, 0, ',', ' ') }} F</span>
+                                        @else
+                                            <span class="badge-en-attente">Aucun</span>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <small>{{ $inscription->workflow_step_label }}</small>
+                                    </td>
+                                    <td>
+                                        <div class="d-flex gap-1">
+                                            <form method="POST" action="{{ route('esbtp.inscriptions.lever-reserve', $inscription) }}"
+                                                  onsubmit="return confirm('Confirmer la levée de réserve pour {{ addslashes($inscription->etudiant->nom ?? '') }} {{ addslashes($inscription->etudiant->prenoms ?? '') }} ?')">
+                                                @csrf
+                                                <button type="submit" class="btn btn-success btn-sm" title="Lever la réserve">
+                                                    <i class="fas fa-check"></i> Confirmer
+                                                </button>
+                                            </form>
+                                            <form method="POST" action="{{ route('esbtp.inscriptions.annuler', $inscription) }}"
+                                                  onsubmit="return confirm('Annuler l\'inscription de {{ addslashes($inscription->etudiant->nom ?? '') }} {{ addslashes($inscription->etudiant->prenoms ?? '') }} ? Cette action est irréversible.')">
+                                                @csrf
+                                                @method('PUT')
+                                                <input type="hidden" name="motif_annulation" value="Condition de réserve non remplie">
+                                                <button type="submit" class="btn btn-outline-danger btn-sm" title="Annuler l'inscription">
+                                                    <i class="fas fa-times"></i>
+                                                </button>
+                                            </form>
+                                        </div>
+                                    </td>
+                                </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </form>
+        @endif
+
+    </div>
+</div>
+
+{{-- Modal de confirmation bulk --}}
+<div class="modal fade" id="bulkConfirmModal" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header bg-success text-white">
+                <h5 class="modal-title"><i class="fas fa-check-double me-2"></i>Confirmation</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p>Vous allez lever la réserve pour <strong id="bulkCountText">0</strong> inscription(s).</p>
+                <p class="text-muted">Les documents (certificats, attestations) afficheront désormais
+                   "Est régulièrement inscrit(e)" au lieu de "Sera régulièrement inscrit(e) sous réserve".</p>
+                <p><strong>Confirmer cette action ?</strong></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-success" id="bulkConfirmSubmit">
+                    <i class="fas fa-check-double me-1"></i> Confirmer la levée
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const selectAll = document.getElementById('selectAll');
+    const checkboxes = document.querySelectorAll('.row-checkbox');
+    const bulkBtn = document.getElementById('bulkConfirmBtn');
+    const selectedCount = document.getElementById('selectedCount');
+
+    function updateCount() {
+        const checked = document.querySelectorAll('.row-checkbox:checked').length;
+        selectedCount.textContent = checked + ' sélectionné(s)';
+        bulkBtn.disabled = checked === 0;
+    }
+
+    if (selectAll) {
+        selectAll.addEventListener('change', function() {
+            checkboxes.forEach(cb => cb.checked = this.checked);
+            updateCount();
+        });
+    }
+
+    checkboxes.forEach(cb => {
+        cb.addEventListener('change', function() {
+            if (!this.checked) selectAll.checked = false;
+            if (document.querySelectorAll('.row-checkbox:checked').length === checkboxes.length) {
+                selectAll.checked = true;
+            }
+            updateCount();
+        });
+    });
+});
+
+function confirmBulkLever() {
+    const checked = document.querySelectorAll('.row-checkbox:checked').length;
+    document.getElementById('bulkCountText').textContent = checked;
+    const modal = new bootstrap.Modal(document.getElementById('bulkConfirmModal'));
+    modal.show();
+
+    document.getElementById('bulkConfirmSubmit').onclick = function() {
+        modal.hide();
+        document.getElementById('bulkForm').submit();
+    };
+}
+</script>
+@endpush

--- a/resources/views/pdf/certificat-scolarite.blade.php
+++ b/resources/views/pdf/certificat-scolarite.blade.php
@@ -137,22 +137,22 @@
         }
         
         .footer {
-            margin-top: 50px;
+            margin-top: 100px;
             display: flex;
             justify-content: space-between;
             align-items: flex-end;
         }
-        
+
         .date {
             text-align: left;
         }
-        
+
         .signature {
             text-align: right;
         }
-        
+
         .signature-name {
-            margin-top: 40px;
+            margin-top: 80px;
             font-weight: bold;
         }
         
@@ -213,13 +213,20 @@
         <p>Sous le matricule : <strong>{{ $etudiant->numero_etudiant ?? 'Non attribué' }}</strong></p>
     </div>
     
-    <p style="margin: 25px 0;">Est régulièrement inscrit(e) sur le registre des effectifs de l'année académique :</p>
-    
+    @php
+        $hasSousReserve = $inscriptions->contains(fn($i) => $i->is_sous_reserve);
+    @endphp
+    @if($hasSousReserve)
+    <p style="margin: 25px 0;">Sera régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
+    @else
+    <p style="margin: 25px 0;">Est régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
+    @endif
+
     <!-- Tableau des inscriptions -->
     <table class="inscriptions-table">
         <thead>
             <tr>
-                <th>Année scolaire</th>
+                <th>Année universitaire</th>
                 <th>Classe suivie</th>
                 <th>Filière</th>
                 <th>Moyenne/20</th>
@@ -228,7 +235,12 @@
         <tbody>
             @forelse($inscriptions as $inscription)
             <tr>
-                <td>{{ $inscription->anneeUniversitaire->nom ?? 'Non renseigné' }}</td>
+                <td>
+                    {{ $inscription->anneeUniversitaire->nom ?? 'Non renseigné' }}
+                    @if($inscription->is_sous_reserve)
+                        <br><small style="color: #d97706; font-weight: bold;">Sous réserve{{ $inscription->condition_reserve ? ' de son ' . $inscription->condition_reserve : '' }}</small>
+                    @endif
+                </td>
                 <td>{{ $inscription->classe->nom ?? ($inscription->niveau->nom ?? 'Non renseigné') }}</td>
                 <td>{{ strtoupper($inscription->filiere->nom ?? 'Non renseigné') }}</td>
                 <td>

--- a/routes/web.php
+++ b/routes/web.php
@@ -910,6 +910,11 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             // Routes pour validation groupée des inscriptions
             Route::post('/inscriptions/bulk-valider', [ESBTPInscriptionController::class, 'bulkValider'])->name('inscriptions.bulk-valider');
 
+            // Routes pour gestion des inscriptions sous réserve
+            Route::get('/inscriptions/sous-reserve', [ESBTPInscriptionController::class, 'sousReserveIndex'])->name('inscriptions.sous-reserve');
+            Route::post('/inscriptions/{inscription}/lever-reserve', [ESBTPInscriptionController::class, 'leverReserve'])->name('inscriptions.lever-reserve');
+            Route::post('/inscriptions/lever-reserves-bulk', [ESBTPInscriptionController::class, 'leverReservesBulk'])->name('inscriptions.lever-reserves-bulk');
+
             // Routes pour actions rapides sur inscriptions (modals AJAX)
             Route::get('/inscriptions/{inscription}/data', [ESBTPInscriptionApiController::class, 'getInscriptionData'])->name('inscriptions.data');
             Route::get('/inscriptions/{inscription}/paiement-en-attente', [ESBTPInscriptionApiController::class, 'getPaiementEnAttente'])->name('inscriptions.paiement-en-attente');


### PR DESCRIPTION
- Ajout sélecteur d'année universitaire dans le formulaire d'inscription
  (défaut: année courante, possibilité de choisir une année future)
- Nouveau champ is_sous_reserve + condition_reserve (ex: BACCALAURÉAT)
  pour marquer une inscription comme conditionnelle
- Certificats/attestations: texte adaptatif "Est/Sera régulièrement inscrit(e)"
  + mention "sous réserve de son [CONDITION]" quand applicable
- Remplacement "année scolaire" par "année universitaire" dans les 5 templates
- Doublement de l'espace signature dans tous les documents PDF
- Page de gestion hybride des réserves (/inscriptions/sous-reserve):
  levée individuelle, bulk avec confirmation, annulation
- Redirection automatique vers la page sous-reserve quand l'admin
  définit une année comme courante et qu'il existe des inscriptions
  sous réserve pour cette année

Migration: add_sous_reserve_fields_to_esbtp_inscriptions_table
Fichiers modifiés: 14 (model, service, controller, validation, routes, 5 vues documents, form, nouvelle vue)

https://claude.ai/code/session_01W2SwDrJLxTK7HiymtDBL1q