### PR TITLE
feat(inscriptions): inscription sous réserve pour année future + documents adaptatifs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a20fde9067918fc1ccbc44717f386b1a",
+    "content-hash": "31eb578b2d0967889933129cc9cf12b9",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -5284,6 +5284,52 @@
                 "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.6.0"
             },
             "time": "2024-07-01T07:33:21+00:00"
+        },
+        {
+            "name": "setasign/fpdf",
+            "version": "1.8.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDF.git",
+                "reference": "0838e0ee4925716fcbbc50ad9e1799b5edfae0a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/0838e0ee4925716fcbbc50ad9e1799b5edfae0a0",
+                "reference": "0838e0ee4925716fcbbc50ad9e1799b5edfae0a0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-gd": "*",
+                "ext-zlib": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "fpdf.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Plathey",
+                    "email": "oliver@fpdf.org",
+                    "homepage": "http://fpdf.org/"
+                }
+            ],
+            "description": "FPDF is a PHP class which allows to generate PDF files with pure PHP. F from FPDF stands for Free: you may use it for any kind of usage and modify it to suit your needs.",
+            "homepage": "http://www.fpdf.org",
+            "keywords": [
+                "fpdf",
+                "pdf"
+            ],
+            "support": {
+                "source": "https://github.com/Setasign/FPDF/tree/1.8.6"
+            },
+            "time": "2023-06-26T14:44:25+00:00"
         },
         {
             "name": "setasign/fpdi",
@@ -10599,5 +10645,5 @@
         "php": "^7.4|^8.0|^8.1|^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -370,18 +370,21 @@
                 </div>
 
                 <div class="alert-kl alert-kl-info mb-3">
-                    <i class="fas fa-info-circle"></i>
+                    <i class="fas fa-info-circle me-1"></i>
                     <span>Sélectionnez une classe et l'année universitaire d'inscription.</span>
                 </div>
 
-                <div class="row">
-                    <div class="col-md-8">
+                <div class="row mb-3">
+                    <div class="col-md-12">
                         @include('components.forms.class-selector')
                     </div>
-                    <div class="col-md-4">
+                </div>
+
+                <div class="row">
+                    <div class="col-md-6">
                         <div class="form-group">
                             <label for="annee_universitaire_id">
-                                <i class="fas fa-calendar-alt field-icon"></i> Année universitaire <span class="text-danger">*</span>
+                                <i class="fas fa-calendar-alt me-1"></i> Année universitaire <span class="text-danger">*</span>
                             </label>
                             <select class="form-select @error('annee_universitaire_id') is-invalid @enderror"
                                     name="annee_universitaire_id"
@@ -410,7 +413,7 @@
                             <div class="d-flex align-items-start">
                                 <i class="fas fa-exclamation-triangle me-3 mt-1" style="color: #f59e0b; font-size: 1.2rem;"></i>
                                 <div class="flex-grow-1">
-                                    <strong style="color: #92400e;">Inscription pour une année future</strong>
+                                    <strong style="color: #92400e;"><i class="fas fa-clock me-1"></i> Inscription pour une année future</strong>
                                     <p class="mb-2 mt-1" style="color: #78350f; font-size: 13px;">
                                         Cette inscription concerne une année universitaire qui n'est pas l'année courante.
                                         Vous pouvez la marquer comme "sous réserve" (ex: en attente du Baccalauréat).
@@ -420,12 +423,12 @@
                                                name="is_sous_reserve" id="is_sous_reserve" value="1"
                                                {{ old('is_sous_reserve') ? 'checked' : '' }}>
                                         <label class="form-check-label fw-bold" for="is_sous_reserve" style="color: #92400e;">
-                                            Inscription sous réserve
+                                            <i class="fas fa-file-signature me-1"></i> Inscription sous réserve
                                         </label>
                                     </div>
                                     <div id="condition-reserve-field" style="{{ old('is_sous_reserve') ? '' : 'display: none;' }}">
                                         <label for="condition_reserve" class="form-label" style="color: #78350f; font-size: 13px;">
-                                            Condition / Motif de la réserve :
+                                            <i class="fas fa-graduation-cap me-1"></i> Condition / Motif de la réserve :
                                         </label>
                                         <input type="text" class="form-control form-control-sm"
                                                name="condition_reserve" id="condition_reserve"

--- a/routes/web.php
+++ b/routes/web.php
@@ -897,6 +897,10 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             Route::get('/inscriptions/check-transfert/{classe}', [ESBTPInscriptionApiController::class, 'checkTransfert'])->name('inscriptions.check-transfert');
             Route::get('/inscriptions/duplicates', [ESBTPInscriptionApiController::class, 'duplicates'])->name('inscriptions.duplicates');
             Route::post('/inscriptions/check-duplicates', [ESBTPInscriptionApiController::class, 'checkDuplicates'])->name('inscriptions.check-duplicates');
+            // Routes pour gestion des inscriptions sous réserve (AVANT les routes {inscription})
+            Route::get('/inscriptions/sous-reserve', [ESBTPInscriptionController::class, 'sousReserveIndex'])->name('inscriptions.sous-reserve');
+            Route::post('/inscriptions/lever-reserves-bulk', [ESBTPInscriptionController::class, 'leverReservesBulk'])->name('inscriptions.lever-reserves-bulk');
+
             Route::post('/inscriptions', [ESBTPInscriptionController::class, 'store'])->name('inscriptions.store');
             Route::get('/inscriptions/{inscription}', [ESBTPInscriptionController::class, 'show'])->name('inscriptions.show');
             Route::get('/inscriptions/{inscription}/situation-financiere/preview', [ESBTPInscriptionPaiementController::class, 'previewSituationFinanciere'])->name('inscriptions.situation-financiere.preview');
@@ -910,10 +914,7 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             // Routes pour validation groupée des inscriptions
             Route::post('/inscriptions/bulk-valider', [ESBTPInscriptionController::class, 'bulkValider'])->name('inscriptions.bulk-valider');
 
-            // Routes pour gestion des inscriptions sous réserve
-            Route::get('/inscriptions/sous-reserve', [ESBTPInscriptionController::class, 'sousReserveIndex'])->name('inscriptions.sous-reserve');
             Route::post('/inscriptions/{inscription}/lever-reserve', [ESBTPInscriptionController::class, 'leverReserve'])->name('inscriptions.lever-reserve');
-            Route::post('/inscriptions/lever-reserves-bulk', [ESBTPInscriptionController::class, 'leverReservesBulk'])->name('inscriptions.lever-reserves-bulk');
 
             // Routes pour actions rapides sur inscriptions (modals AJAX)
             Route::get('/inscriptions/{inscription}/data', [ESBTPInscriptionApiController::class, 'getInscriptionData'])->name('inscriptions.data');


### PR DESCRIPTION
## Summary
- Permet d'inscrire un étudiant pour une année universitaire future sans changer l'année courante, avec statut "sous réserve" (ex: en attente du Baccalauréat)
- Les certificats/attestations adaptent automatiquement leur formulation ("Est" → "Sera régulièrement inscrit(e) sous réserve de son BACCALAURÉAT")
- Page de gestion hybride pour lever les réserves (individuel + bulk) quand l'année devient courante

## Changes
- `database/migrations/..._add_sous_reserve_fields_to_esbtp_inscriptions_table.php` — Ajoute `is_sous_reserve` (boolean) et `condition_reserve` (string nullable)
- `app/Models/ESBTPInscription.php` — Nouveaux champs fillable/casts, scope `sousReserve()`, méthode `leverReserve()`
- `app/Services/ESBTPInscriptionService.php` — `prepareInscriptionData()` accepte `annee_universitaire_id` optionnel (fallback: année courante)
- `app/Http/Requests/Inscription/StoreInscriptionRequest.php` — Règles validation pour année, sous_reserve, condition
- `app/Http/Controllers/ESBTPInscriptionController.php` — 3 nouvelles méthodes: `sousReserveIndex()`, `leverReserve()`, `leverReservesBulk()`
- `app/Http/Controllers/ESBTPAnneeUniversitaireController.php` — Redirection automatique vers page sous-reserve quand on active une année avec inscriptions conditionnelles (méthode privée `redirectIfSousReservesExist()`)
- `app/Http/Controllers/ESBTPEtudiantController.php` — Passe `$hasSousReserve` aux vues certificat
- `resources/views/esbtp/inscriptions/create.blade.php` — Sélecteur d'année universitaire + bloc conditionnel sous réserve avec checkbox et champ condition
- `resources/views/esbtp/inscriptions/sous-reserve.blade.php` — Nouvelle page de gestion: tableau filtrable, levée individuelle/bulk, modal de confirmation
- `resources/views/esbtp/etudiants/certificat.blade.php` + `certificat-preview.blade.php` — Texte conditionnel "Est/Sera", "année universitaire" (au lieu de "année scolaire"), espace signature doublé
- `resources/views/esbtp/etudiants/attestation-frequentation.blade.php` + `attestation-frequentation-preview.blade.php` — Idem + mention "sous réserve de son [CONDITION]"
- `resources/views/pdf/certificat-scolarite.blade.php` — Idem (template legacy)
- `routes/web.php` — 3 nouvelles routes (sous-reserve index, lever individuel, lever bulk) positionnées avant le wildcard `{inscription}`

## Type of change
- [x] feat — new feature
- [x] fix — bug fix (route ordering)
- [x] refactor — extract helper method, remove N+1 accessor

## Migration requise
```bash
php artisan migrate
```

## Testing
- [ ] Tested on esbtp-abidjan.klassci.com after deploy
- [ ] No regressions

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified on all modified PHP files