### PR TITLE
feat(sidebar): add sous-reserve link in navigation

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1570,6 +1570,10 @@
                                     <div class="menu-text">Réinscriptions</div>
                                 </a>
                                 @endcan
+                                <a href="{{ route('esbtp.inscriptions.sous-reserve') }}" class="menu-sublink {{ Request::routeIs('esbtp.inscriptions.sous-reserve') ? 'active' : '' }}">
+                                    <div class="menu-icon"><i class="fas fa-clipboard-check"></i></div>
+                                    <div class="menu-text">Sous réserve</div>
+                                </a>
                             </div>
                         </div>
                     @endcan
@@ -1860,6 +1864,12 @@
                             <a href="{{ route('esbtp.reinscription.index') }}" class="menu-link {{ Request::routeIs('esbtp.reinscription.*') ? 'active' : '' }}">
                                 <div class="menu-icon"><i class="fas fa-redo"></i></div>
                                 <div class="menu-text">Reinscriptions</div>
+                            </a>
+                        </div>
+                        <div class="menu-item">
+                            <a href="{{ route('esbtp.inscriptions.sous-reserve') }}" class="menu-link {{ Request::routeIs('esbtp.inscriptions.sous-reserve') ? 'active' : '' }}">
+                                <div class="menu-icon"><i class="fas fa-clipboard-check"></i></div>
+                                <div class="menu-text">Sous réserve</div>
                             </a>
                         </div>
                         @endcan


### PR DESCRIPTION
## Summary
- Ajout du lien "Sous réserve" dans la sidebar pour accéder à la page de gestion des inscriptions conditionnelles

## Changes
- `resources/views/layouts/app.blade.php` — Ajout du menu item "Sous réserve" (icône `fas fa-clipboard-check`) dans les deux sections sidebar :
  - Menu accordion superAdmin (après Réinscriptions)
  - Menu flat secrétaire/coordinateur (après Reinscriptions)

## Type of change
- [x] feat — new feature

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified