### PR TITLE
feat(sous-reserve): premium redesign, future-only detection, smart alerts

### DIFF
--- a/app/Http/Controllers/ESBTPEtudiantController.php
+++ b/app/Http/Controllers/ESBTPEtudiantController.php
@@ -2184,11 +2184,22 @@ class ESBTPEtudiantController extends Controller
             return back()->with('error', 'Aucune inscription trouvée pour cet étudiant.');
         }
 
+        // Détecter si l'étudiant a une inscription future sous réserve
+        $anneeCourante = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+        $hasFutureSousReserve = $anneeCourante
+            ? $etudiant->inscriptions->contains(fn($i) =>
+                $i->is_sous_reserve
+                && $i->anneeUniversitaire
+                && optional($i->anneeUniversitaire)->start_date > $anneeCourante->start_date
+            )
+            : false;
+
         return view('esbtp.etudiants.attestation-frequentation-preview', [
             'etudiant' => $etudiant,
             'inscription' => $inscription,
             'settings' => $this->getCertificateDisplaySettings(),
             'alerteWorkflow' => $alerteWorkflow,
+            'hasFutureSousReserve' => $hasFutureSousReserve,
         ]);
     }
 

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -828,6 +828,7 @@ class ESBTPInscriptionController extends Controller
         }
 
         $canViewFinancials = auth()->user()->can('viewFinancials', $inscription);
+        $anneeCourante = ESBTPAnneeUniversitaire::where('is_current', true)->first();
 
         return view(
             "esbtp.inscriptions.show",
@@ -845,6 +846,7 @@ class ESBTPInscriptionController extends Controller
                 "reinscriptionData",
                 "classesDisponibles",
                 "canViewFinancials",
+                "anneeCourante",
             ),
         );
     }
@@ -2001,12 +2003,12 @@ class ESBTPInscriptionController extends Controller
 
         $inscriptions = $query->get();
 
-        // Stats pour les KPI cards
-        $allSousReserve = ESBTPInscription::where('is_sous_reserve', true);
+        // Stats calculées depuis la collection chargée (0 query supplémentaire)
+        $avecPaiement = $inscriptions->filter(fn($i) => $i->paiements->where('status', 'validé')->isNotEmpty())->count();
         $stats = [
-            'total' => (clone $allSousReserve)->count(),
-            'avec_paiement' => (clone $allSousReserve)->whereHas('paiements', fn($q) => $q->where('status', 'validé'))->count(),
-            'sans_paiement' => (clone $allSousReserve)->whereDoesntHave('paiements', fn($q) => $q->where('status', 'validé'))->count(),
+            'total' => $inscriptions->count(),
+            'avec_paiement' => $avecPaiement,
+            'sans_paiement' => $inscriptions->count() - $avecPaiement,
         ];
 
         return view('esbtp.inscriptions.sous-reserve', compact(

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -1983,18 +1983,34 @@ class ESBTPInscriptionController extends Controller
             ->orderByDesc('start_date')
             ->get();
 
-        $anneeFilterId = $request->input('annee_id', $anneeEnCours?->id);
+        // Par défaut : toutes les années (pas filtré sur l'année courante)
+        $anneeFilterId = $request->input('annee_id');
+        $search = $request->input('search');
 
-        $inscriptions = ESBTPInscription::with([
+        $query = ESBTPInscription::with([
                 'etudiant', 'classe', 'filiere', 'niveauEtude', 'anneeUniversitaire', 'paiements'
             ])
             ->where('is_sous_reserve', true)
             ->when($anneeFilterId, fn($q) => $q->where('annee_universitaire_id', $anneeFilterId))
-            ->orderBy('created_at', 'desc')
-            ->get();
+            ->when($search, fn($q) => $q->whereHas('etudiant', fn($eq) =>
+                $eq->where('nom', 'like', "%{$search}%")
+                   ->orWhere('prenoms', 'like', "%{$search}%")
+                   ->orWhere('matricule', 'like', "%{$search}%")
+            ))
+            ->orderBy('created_at', 'desc');
+
+        $inscriptions = $query->get();
+
+        // Stats pour les KPI cards
+        $allSousReserve = ESBTPInscription::where('is_sous_reserve', true);
+        $stats = [
+            'total' => (clone $allSousReserve)->count(),
+            'avec_paiement' => (clone $allSousReserve)->whereHas('paiements', fn($q) => $q->where('status', 'validé'))->count(),
+            'sans_paiement' => (clone $allSousReserve)->whereDoesntHave('paiements', fn($q) => $q->where('status', 'validé'))->count(),
+        ];
 
         return view('esbtp.inscriptions.sous-reserve', compact(
-            'inscriptions', 'annees', 'anneeEnCours', 'anneeFilterId'
+            'inscriptions', 'annees', 'anneeEnCours', 'anneeFilterId', 'search', 'stats'
         ));
     }
 
@@ -2033,6 +2049,24 @@ class ESBTPInscriptionController extends Controller
 
         return redirect()->back()->with('success',
             $count . ' inscription(s) ont été confirmée(s). La réserve a été levée.'
+        );
+    }
+
+    /**
+     * Marquer une inscription comme sous réserve (depuis show pages).
+     */
+    public function marquerSousReserve(Request $request, ESBTPInscription $inscription)
+    {
+        if ($inscription->is_sous_reserve) {
+            return redirect()->back()->with('info', 'Cette inscription est déjà sous réserve.');
+        }
+
+        $inscription->is_sous_reserve = true;
+        $inscription->condition_reserve = $request->input('condition_reserve', 'BACCALAURÉAT');
+        $inscription->save();
+
+        return redirect()->back()->with('success',
+            'L\'inscription a été marquée sous réserve de son ' . $inscription->condition_reserve . '.'
         );
     }
 }

--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -201,9 +201,15 @@
         </div>
 
         {{-- Alerte workflow si inscription non finalisée --}}
-        @if(!empty($alerteWorkflow))
+        @if(!empty($alerteWorkflow) && !empty($hasFutureSousReserve))
+        <div class="doc-alert" style="background:rgba(59,130,246,.08); border-color:#3b82f6; color:#1e40af;">
+            <strong><i class="fas fa-info-circle me-1"></i> Information :</strong>
+            Cet étudiant a une inscription sous réserve pour une année future.
+            L'attestation sera disponible quand l'inscription sera confirmée.
+        </div>
+        @elseif(!empty($alerteWorkflow))
         <div class="doc-alert">
-            <strong>⚠️ Attention :</strong> Aucune inscription active et finalisée trouvée pour cet étudiant.
+            <strong><i class="fas fa-exclamation-triangle me-1"></i> Attention :</strong> Aucune inscription active et finalisée trouvée pour cet étudiant.
             Veuillez <a href="{{ route('esbtp.etudiants.show', $etudiant->id) }}" style="color:var(--doc-accent);">valider et finaliser l'inscription</a>
             (étape "Étudiant créé") avant de générer l'attestation.
         </div>
@@ -231,13 +237,10 @@
                         ?? $inscription->anneeUniversitaire->libelle ?? '';
                     $anneeFormatted = preg_match('/(\d{4}-\d{4})/', $anneeText, $m) ? $m[1] : $anneeText;
                 @endphp
-                @if($inscription->is_sous_reserve)
-                Sera régulièrement inscrit(e) au titre de l'année universitaire
-                <span class="doc-hl">{{ $anneeFormatted }}</span>
-                sous réserve de son <span class="doc-hl">{{ $inscription->condition_reserve ?? 'diplôme' }}</span>
-                @else
                 Est régulièrement inscrit(e) au titre de l'année universitaire
                 <span class="doc-hl">{{ $anneeFormatted }}</span>
+                @if($inscription->is_sous_reserve)
+                sous réserve de son <span class="doc-hl">{{ $inscription->condition_reserve ?? 'diplôme' }}</span>
                 @endif
             </p>
 

--- a/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
@@ -325,13 +325,10 @@
                     $anneeFormatted = preg_match('/(\d{4}-\d{4})/', $anneeText, $matches)
                         ? $matches[1] : $anneeText;
                 @endphp
-                @if($inscription->is_sous_reserve)
-                Sera régulièrement inscrit(e) au titre de l'année universitaire
-                <span class="hl">{{ $anneeFormatted }}</span>
-                sous réserve de son <span class="hl">{{ $inscription->condition_reserve ?? 'diplôme' }}</span>
-                @else
                 Est régulièrement inscrit(e) au titre de l'année universitaire
                 <span class="hl">{{ $anneeFormatted }}</span>
+                @if($inscription->is_sous_reserve)
+                sous réserve de son <span class="hl">{{ $inscription->condition_reserve ?? 'diplôme' }}</span>
                 @endif
             </p>
 

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -193,11 +193,7 @@
             @endif
 
             <p>Matricule&nbsp;: <span class="doc-hl">{{ $etudiant->matricule }}</span></p>
-            @if($hasSousReserve ?? $inscriptions->contains(fn($i) => $i->is_sous_reserve))
-            <p>Sera régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire&nbsp;:</p>
-            @else
             <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire&nbsp;:</p>
-            @endif
 
             @php
                 $showClasse  = $settings['show_classe']  ?? true;

--- a/resources/views/esbtp/etudiants/certificat.blade.php
+++ b/resources/views/esbtp/etudiants/certificat.blade.php
@@ -299,11 +299,7 @@
 
             <p>Matricule : <span class="hl">{{ $etudiant->matricule }}</span></p>
 
-            @if($hasSousReserve ?? $inscriptions->contains(fn($i) => $i->is_sous_reserve))
-            <p>Sera régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
-            @else
             <p>Est régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
-            @endif
 
             <table class="doc-table">
                 <thead>

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -1670,6 +1670,28 @@
         || ($inscCourante->status === 'active' && $inscCourante->workflow_step !== 'etudiant_cree')
     );
 
+    // Inscription future sous réserve (ex: inscrit pour 2026-2027 sous réserve du BAC)
+    $inscFutureSousReserve = $anneeCourante
+        ? $etudiant->inscriptions->first(fn($i) =>
+            $i->is_sous_reserve
+            && $i->anneeUniversitaire
+            && $i->anneeUniversitaire->start_date
+            && $anneeCourante->start_date
+            && $i->anneeUniversitaire->start_date > $anneeCourante->start_date
+        )
+        : null;
+
+    // Inscription future NON sous réserve (pour suggérer de marquer)
+    $inscFutureNonReserve = $anneeCourante
+        ? $etudiant->inscriptions->first(fn($i) =>
+            !$i->is_sous_reserve
+            && $i->anneeUniversitaire
+            && $i->anneeUniversitaire->start_date
+            && $anneeCourante->start_date
+            && $i->anneeUniversitaire->start_date > $anneeCourante->start_date
+        )
+        : null;
+
     // Pré-inscription caissier : matricule PRE-* = infos à compléter
     $isPreInscription = $etudiant->matricule && str_starts_with($etudiant->matricule, 'PRE-') && $inscCourante;
     $preInscriptionMissing = [];
@@ -1752,6 +1774,10 @@
                 <span class="hero-pill"><i class="fas fa-id-card"></i> {{ $etudiant->matricule ?? 'Non attribué' }}</span>
                 @if($estInscritCetteAnnee)
                     <span class="hero-pill green"><i class="fas fa-circle" style="font-size:.45rem"></i> Inscrit {{ $anneeCourante->name ?? '' }}</span>
+                @elseif($inscFutureSousReserve)
+                    <span class="hero-pill" style="background:rgba(245,158,11,.3); color:#fcd34d; border-color:rgba(245,158,11,.5);">
+                        <i class="fas fa-clipboard-check" style="font-size:.6rem"></i> Pré-inscrit {{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }} (sous réserve)
+                    </span>
                 @else
                     <span class="hero-pill" style="background:rgba(255,255,255,0.15); color:#fff; border-color:rgba(255,255,255,0.4);">
                         <i class="fas fa-exclamation-circle" style="font-size:.7rem; color:#fbbf24;"></i> Non réinscrit {{ $anneeCourante ? $anneeCourante->name : '' }}
@@ -2086,6 +2112,53 @@
                 <input type="hidden" name="redirect_to" value="etudiant">
             </form>
             @endcan
+        </div>
+    </div>
+    @endif
+
+    {{-- Bannière inscription future sous réserve (info) --}}
+    @if($inscFutureSousReserve)
+    <div style="background:linear-gradient(135deg,#dbeafe,#bfdbfe); border:1.5px solid #3b82f6; border-left:5px solid #0453cb; border-radius:10px; padding:16px 20px; margin-bottom:24px; display:flex; align-items:flex-start; gap:14px;">
+        <div style="flex-shrink:0; width:36px; height:36px; background:#0453cb; border-radius:50%; display:flex; align-items:center; justify-content:center;">
+            <i class="fas fa-clipboard-check" style="color:#fff; font-size:.9rem;"></i>
+        </div>
+        <div style="flex:1;">
+            <div style="font-weight:700; color:#1e3a5f; font-size:.95rem; margin-bottom:4px;">
+                Pré-inscrit pour {{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }}
+            </div>
+            <div style="color:#1e40af; font-size:.85rem; line-height:1.5; margin-bottom:8px;">
+                Cet étudiant est inscrit pour l'année <strong>{{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }}</strong>
+                sous réserve de son <strong>{{ $inscFutureSousReserve->condition_reserve ?? 'diplôme' }}</strong>.
+                L'inscription sera confirmée quand cette année deviendra l'année courante.
+            </div>
+            <a href="{{ route('esbtp.inscriptions.sous-reserve') }}" style="display:inline-flex; align-items:center; gap:6px; padding:8px 16px; background:linear-gradient(135deg, #0453cb, #5e91de); color:#fff; border:none; border-radius:8px; font-size:.84rem; font-weight:600; text-decoration:none; cursor:pointer; box-shadow:0 2px 8px rgba(4,83,203,.25);">
+                <i class="fas fa-external-link-alt"></i> Gérer les réserves
+            </a>
+        </div>
+    </div>
+    @endif
+
+    {{-- Bannière inscription future NON sous réserve (suggestion) --}}
+    @if($inscFutureNonReserve && !$inscFutureSousReserve)
+    <div style="background:linear-gradient(135deg,#fef3c7,#fde68a); border:1.5px solid #f59e0b; border-left:5px solid #d97706; border-radius:10px; padding:16px 20px; margin-bottom:24px; display:flex; align-items:flex-start; gap:14px;">
+        <div style="flex-shrink:0; width:36px; height:36px; background:#d97706; border-radius:50%; display:flex; align-items:center; justify-content:center;">
+            <i class="fas fa-exclamation-triangle" style="color:#fff; font-size:.9rem;"></i>
+        </div>
+        <div style="flex:1;">
+            <div style="font-weight:700; color:#92400e; font-size:.95rem; margin-bottom:4px;">
+                Inscription année future non marquée sous réserve
+            </div>
+            <div style="color:#78350f; font-size:.85rem; line-height:1.5; margin-bottom:8px;">
+                Cet étudiant a une inscription pour <strong>{{ $inscFutureNonReserve->anneeUniversitaire->name ?? '' }}</strong>
+                qui n'est pas marquée sous réserve. Souhaitez-vous la marquer ?
+            </div>
+            <form method="POST" action="{{ route('esbtp.inscriptions.marquer-sous-reserve', $inscFutureNonReserve) }}" style="display:inline-flex; gap:8px; align-items:center;">
+                @csrf
+                <input type="text" name="condition_reserve" value="BACCALAURÉAT" class="form-control form-control-sm" style="width:180px; font-size:.82rem;" placeholder="Condition...">
+                <button type="submit" style="display:inline-flex; align-items:center; gap:6px; padding:8px 16px; background:linear-gradient(135deg, #d97706, #f59e0b); color:#fff; border:none; border-radius:8px; font-size:.84rem; font-weight:600; cursor:pointer; box-shadow:0 2px 8px rgba(217,119,6,.3);">
+                    <i class="fas fa-clipboard-check"></i> Marquer sous réserve
+                </button>
+            </form>
         </div>
     </div>
     @endif

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -1670,26 +1670,17 @@
         || ($inscCourante->status === 'active' && $inscCourante->workflow_step !== 'etudiant_cree')
     );
 
-    // Inscription future sous réserve (ex: inscrit pour 2026-2027 sous réserve du BAC)
+    // Inscriptions futures : filtrage commun (année start_date > courante)
+    $isFutureYear = fn($i) => optional($i->anneeUniversitaire)->start_date
+        && optional($anneeCourante)->start_date
+        && $i->anneeUniversitaire->start_date > $anneeCourante->start_date;
+
     $inscFutureSousReserve = $anneeCourante
-        ? $etudiant->inscriptions->first(fn($i) =>
-            $i->is_sous_reserve
-            && $i->anneeUniversitaire
-            && $i->anneeUniversitaire->start_date
-            && $anneeCourante->start_date
-            && $i->anneeUniversitaire->start_date > $anneeCourante->start_date
-        )
+        ? $etudiant->inscriptions->first(fn($i) => $i->is_sous_reserve && $isFutureYear($i))
         : null;
 
-    // Inscription future NON sous réserve (pour suggérer de marquer)
     $inscFutureNonReserve = $anneeCourante
-        ? $etudiant->inscriptions->first(fn($i) =>
-            !$i->is_sous_reserve
-            && $i->anneeUniversitaire
-            && $i->anneeUniversitaire->start_date
-            && $anneeCourante->start_date
-            && $i->anneeUniversitaire->start_date > $anneeCourante->start_date
-        )
+        ? $etudiant->inscriptions->first(fn($i) => !$i->is_sous_reserve && $isFutureYear($i))
         : null;
 
     // Pré-inscription caissier : matricule PRE-* = infos à compléter

--- a/resources/views/esbtp/inscriptions/create.blade.php
+++ b/resources/views/esbtp/inscriptions/create.blade.php
@@ -393,7 +393,8 @@
                                 @foreach($academicYears->sortByDesc('start_date') as $annee)
                                     <option value="{{ $annee->id }}"
                                         {{ (old('annee_universitaire_id', $anneeEnCours->id ?? '') == $annee->id) ? 'selected' : '' }}
-                                        data-is-current="{{ $annee->is_current ? '1' : '0' }}">
+                                        data-is-current="{{ $annee->is_current ? '1' : '0' }}"
+                                        data-start-date="{{ $annee->start_date?->format('Y-m-d') ?? '' }}">
                                         {{ $annee->name }}
                                         @if($annee->is_current) (Année courante) @endif
                                     </option>
@@ -869,13 +870,20 @@ document.addEventListener('DOMContentLoaded', function() {
     const isSousReserveCheck = document.getElementById('is_sous_reserve');
     const conditionField = document.getElementById('condition-reserve-field');
 
+    // Trouver la start_date de l'année courante pour comparer
+    const currentYearOption = anneeSelect ? [...anneeSelect.options].find(o => o.dataset.isCurrent === '1') : null;
+    const currentYearStartDate = currentYearOption?.dataset?.startDate || '';
+
     function updateSousReserveVisibility() {
         if (!anneeSelect || !sousReserveBlock) return;
         const selectedOption = anneeSelect.options[anneeSelect.selectedIndex];
         const isCurrent = selectedOption?.dataset?.isCurrent === '1';
-        sousReserveBlock.style.display = isCurrent ? 'none' : '';
-        // Si on revient sur l'année courante, décocher sous réserve
-        if (isCurrent && isSousReserveCheck) {
+        const startDate = selectedOption?.dataset?.startDate || '';
+        // Afficher sous réserve uniquement si année FUTURE (pas courante, pas passée)
+        const isFuture = !isCurrent && startDate && currentYearStartDate && startDate > currentYearStartDate;
+        sousReserveBlock.style.display = isFuture ? '' : 'none';
+        // Si pas future, décocher sous réserve
+        if (!isFuture && isSousReserveCheck) {
             isSousReserveCheck.checked = false;
             if (conditionField) conditionField.style.display = 'none';
         }

--- a/resources/views/esbtp/inscriptions/show.blade.php
+++ b/resources/views/esbtp/inscriptions/show.blade.php
@@ -609,13 +609,11 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
 
             {{-- Bannière inscription année future non marquée sous réserve --}}
             @php
-                $showAnneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
-                $isFutureNonReserve = $showAnneeCourante
+                $isFutureNonReserve = ($anneeCourante ?? null)
                     && !$inscription->is_sous_reserve
-                    && $inscription->anneeUniversitaire
-                    && $inscription->anneeUniversitaire->start_date
-                    && $showAnneeCourante->start_date
-                    && $inscription->anneeUniversitaire->start_date > $showAnneeCourante->start_date;
+                    && optional($inscription->anneeUniversitaire)->start_date
+                    && optional($anneeCourante)->start_date
+                    && $inscription->anneeUniversitaire->start_date > $anneeCourante->start_date;
             @endphp
             @if($isFutureNonReserve)
             <div style="background:linear-gradient(135deg,#fef3c7,#fde68a); border:1.5px solid #f59e0b; border-left:5px solid #d97706; border-radius:10px; padding:16px 20px; margin-bottom:16px; display:flex; align-items:flex-start; gap:14px;">

--- a/resources/views/esbtp/inscriptions/show.blade.php
+++ b/resources/views/esbtp/inscriptions/show.blade.php
@@ -607,6 +607,59 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
                 </div>
             @endif
 
+            {{-- Bannière inscription année future non marquée sous réserve --}}
+            @php
+                $showAnneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
+                $isFutureNonReserve = $showAnneeCourante
+                    && !$inscription->is_sous_reserve
+                    && $inscription->anneeUniversitaire
+                    && $inscription->anneeUniversitaire->start_date
+                    && $showAnneeCourante->start_date
+                    && $inscription->anneeUniversitaire->start_date > $showAnneeCourante->start_date;
+            @endphp
+            @if($isFutureNonReserve)
+            <div style="background:linear-gradient(135deg,#fef3c7,#fde68a); border:1.5px solid #f59e0b; border-left:5px solid #d97706; border-radius:10px; padding:16px 20px; margin-bottom:16px; display:flex; align-items:flex-start; gap:14px;">
+                <div style="flex-shrink:0; width:36px; height:36px; background:#d97706; border-radius:50%; display:flex; align-items:center; justify-content:center;">
+                    <i class="fas fa-exclamation-triangle" style="color:#fff; font-size:.9rem;"></i>
+                </div>
+                <div style="flex:1;">
+                    <div style="font-weight:700; color:#92400e; font-size:.95rem; margin-bottom:4px;">
+                        Inscription pour une année future
+                    </div>
+                    <div style="color:#78350f; font-size:.85rem; line-height:1.5; margin-bottom:8px;">
+                        Cette inscription concerne l'année <strong>{{ $inscription->anneeUniversitaire->name }}</strong> qui n'est pas encore l'année courante.
+                        Souhaitez-vous la marquer sous réserve (ex: en attente du Baccalauréat) ?
+                    </div>
+                    <form method="POST" action="{{ route('esbtp.inscriptions.marquer-sous-reserve', $inscription) }}" style="display:inline-flex; gap:8px; align-items:center;">
+                        @csrf
+                        <input type="text" name="condition_reserve" value="BACCALAURÉAT" class="form-control form-control-sm" style="width:180px; font-size:.82rem;" placeholder="Condition...">
+                        <button type="submit" style="display:inline-flex; align-items:center; gap:6px; padding:8px 16px; background:linear-gradient(135deg, #d97706, #f59e0b); color:#fff; border:none; border-radius:8px; font-size:.84rem; font-weight:600; cursor:pointer; box-shadow:0 2px 8px rgba(217,119,6,.3);">
+                            <i class="fas fa-clipboard-check"></i> Marquer sous réserve
+                        </button>
+                    </form>
+                </div>
+            </div>
+            @endif
+
+            {{-- Bannière inscription sous réserve (info) --}}
+            @if($inscription->is_sous_reserve)
+            <div style="background:linear-gradient(135deg,#dbeafe,#bfdbfe); border:1.5px solid #3b82f6; border-left:5px solid #0453cb; border-radius:10px; padding:16px 20px; margin-bottom:16px; display:flex; align-items:flex-start; gap:14px;">
+                <div style="flex-shrink:0; width:36px; height:36px; background:#0453cb; border-radius:50%; display:flex; align-items:center; justify-content:center;">
+                    <i class="fas fa-info-circle" style="color:#fff; font-size:.9rem;"></i>
+                </div>
+                <div style="flex:1;">
+                    <div style="font-weight:700; color:#1e3a5f; font-size:.95rem; margin-bottom:4px;">
+                        Inscription sous réserve
+                    </div>
+                    <div style="color:#1e40af; font-size:.85rem; line-height:1.5; margin-bottom:8px;">
+                        Cette inscription pour <strong>{{ $inscription->anneeUniversitaire->name ?? '' }}</strong> est sous réserve
+                        de son <strong>{{ $inscription->condition_reserve ?? 'diplôme' }}</strong>.
+                        La réserve sera levée depuis la <a href="{{ route('esbtp.inscriptions.sous-reserve') }}" style="color:#0453cb; font-weight:600;">page de gestion des réserves</a>.
+                    </div>
+                </div>
+            </div>
+            @endif
+
             {{-- Bannière pré-inscription caissier --}}
             @if($inscription->etudiant && $inscription->etudiant->matricule && str_starts_with($inscription->etudiant->matricule, 'PRE-'))
             @php

--- a/resources/views/esbtp/inscriptions/sous-reserve.blade.php
+++ b/resources/views/esbtp/inscriptions/sous-reserve.blade.php
@@ -5,65 +5,84 @@
 @section('styles')
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 <style>
-    .sous-reserve-header {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        flex-wrap: wrap;
-        gap: 1rem;
+    .sr-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+    .sr-stat-card {
+        background: #fff; border-radius: 12px; padding: 20px 24px;
+        box-shadow: 0 1px 3px rgba(0,0,0,.08); position: relative; overflow: hidden;
+        transition: transform .2s, box-shadow .2s;
     }
-    .filter-bar {
-        display: flex;
-        gap: 1rem;
-        align-items: center;
-        flex-wrap: wrap;
+    .sr-stat-card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,.12); }
+    .sr-stat-card::before { content:''; position:absolute; top:0; left:0; right:0; height:4px; }
+    .sr-stat-card.primary::before { background: linear-gradient(90deg, #0453cb, #5e91de); }
+    .sr-stat-card.success::before { background: linear-gradient(90deg, #059669, #10b981); }
+    .sr-stat-card.danger::before { background: linear-gradient(90deg, #dc2626, #ef4444); }
+    .sr-stat-top { display: flex; justify-content: space-between; align-items: flex-start; }
+    .sr-stat-icon {
+        width: 44px; height: 44px; border-radius: 10px; display: flex;
+        align-items: center; justify-content: center; font-size: 1.1rem; color: #fff;
     }
-    .badge-reserve {
-        display: inline-block;
-        padding: 3px 10px;
-        border-radius: 12px;
-        font-size: 12px;
-        font-weight: 600;
-        background: #fef3c7;
-        color: #92400e;
-        border: 1px solid #f59e0b;
+    .sr-stat-value { font-size: 1.8rem; font-weight: 700; color: #1e293b; line-height: 1; margin-top: 12px; }
+    .sr-stat-label { font-size: .78rem; color: #64748b; text-transform: uppercase; letter-spacing: .5px; margin-top: 4px; }
+
+    .sr-filter-card {
+        background: #fff; border-radius: 12px; padding: 20px 24px;
+        box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem;
     }
-    .badge-paye {
-        display: inline-block;
-        padding: 3px 10px;
-        border-radius: 12px;
-        font-size: 12px;
-        font-weight: 600;
-        background: #d1fae5;
-        color: #065f46;
+    .sr-filter-title { font-size: .9rem; font-weight: 700; color: #1e293b; margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
+    .sr-filter-title i { color: #0453cb; }
+
+    .sr-table-card {
+        background: #fff; border-radius: 12px; overflow: hidden;
+        box-shadow: 0 1px 3px rgba(0,0,0,.08);
     }
-    .badge-en-attente {
-        display: inline-block;
-        padding: 3px 10px;
-        border-radius: 12px;
-        font-size: 12px;
-        font-weight: 600;
-        background: #fee2e2;
-        color: #991b1b;
+    .sr-table-header {
+        padding: 16px 24px; display: flex; justify-content: space-between;
+        align-items: center; border-bottom: 1px solid #e2e8f0; flex-wrap: wrap; gap: 10px;
     }
-    .bulk-actions {
-        display: flex;
-        gap: 0.5rem;
-        align-items: center;
-        margin-bottom: 1rem;
+    .sr-table thead th {
+        background: linear-gradient(135deg, #0453cb, #1b64d4); color: #fff;
+        font-size: .78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .4px;
+        padding: 12px 16px; white-space: nowrap; border: none;
     }
-    .empty-state {
-        text-align: center;
-        padding: 60px 20px;
-        color: var(--text-secondary, #64748b);
+    .sr-table tbody td { padding: 12px 16px; font-size: .85rem; color: #334155; vertical-align: middle; border-bottom: 1px solid #f1f5f9; }
+    .sr-table tbody tr:hover { background: rgba(4,83,203,.03); }
+    .sr-table tbody tr:last-child td { border-bottom: none; }
+
+    .sr-badge {
+        display: inline-flex; align-items: center; gap: 5px;
+        padding: 4px 10px; border-radius: 6px; font-size: .75rem; font-weight: 600;
     }
-    .empty-state i {
-        font-size: 3rem;
-        margin-bottom: 1rem;
-        color: #10b981;
+    .sr-badge.reserve { background: rgba(245,158,11,.1); color: #92400e; border: 1px solid rgba(245,158,11,.3); }
+    .sr-badge.paye { background: rgba(16,185,129,.1); color: #065f46; }
+    .sr-badge.non-paye { background: rgba(239,68,68,.1); color: #991b1b; }
+    .sr-badge.workflow { background: rgba(59,130,246,.1); color: #1e40af; }
+
+    .sr-btn { display: inline-flex; align-items: center; gap: 5px; padding: 6px 12px; border-radius: 6px; font-size: .8rem; font-weight: 600; border: none; cursor: pointer; transition: all .2s; }
+    .sr-btn.confirm { background: linear-gradient(135deg, #059669, #10b981); color: #fff; }
+    .sr-btn.confirm:hover { transform: translateY(-1px); box-shadow: 0 3px 8px rgba(16,185,129,.35); }
+    .sr-btn.cancel { background: transparent; color: #dc2626; border: 1px solid #fecaca; }
+    .sr-btn.cancel:hover { background: #fef2f2; }
+
+    .sr-bulk-bar {
+        padding: 12px 24px; display: flex; align-items: center; gap: 12px;
+        background: linear-gradient(135deg, #f0f9ff, #e0f2fe); border-bottom: 1px solid #bae6fd;
     }
-    .table-modern th { font-size: 13px; }
-    .table-modern td { font-size: 13px; vertical-align: middle; }
+    .sr-bulk-count { font-size: .82rem; color: #0369a1; font-weight: 600; }
+
+    .sr-empty {
+        text-align: center; padding: 60px 20px;
+    }
+    .sr-empty-icon {
+        width: 80px; height: 80px; border-radius: 50%; margin: 0 auto 16px;
+        background: linear-gradient(135deg, #d1fae5, #a7f3d0);
+        display: flex; align-items: center; justify-content: center;
+    }
+    .sr-empty-icon i { font-size: 2rem; color: #059669; }
+    .sr-empty h4 { color: #1e293b; font-size: 1.1rem; margin-bottom: 6px; }
+    .sr-empty p { color: #64748b; font-size: .88rem; }
+
+    .sr-student-name { font-weight: 600; color: #1e293b; }
+    .sr-student-name small { font-weight: 400; color: #64748b; display: block; margin-top: 2px; }
 </style>
 @endsection
 
@@ -79,150 +98,200 @@
             </div>
             <div class="header-actions">
                 <a href="{{ route('esbtp.inscriptions.index') }}" class="btn-acasi secondary">
-                    <i class="fas fa-arrow-left"></i> Retour aux inscriptions
+                    <i class="fas fa-arrow-left me-1"></i> Retour aux inscriptions
                 </a>
             </div>
         </div>
 
-        {{-- Filtre par année --}}
-        <div class="main-card mb-3">
-            <div class="filter-bar">
-                <label class="fw-bold" style="font-size: 14px;">
-                    <i class="fas fa-filter me-1"></i> Filtrer par année :
-                </label>
-                <form method="GET" action="{{ route('esbtp.inscriptions.sous-reserve') }}" class="d-flex gap-2 align-items-center">
-                    <select name="annee_id" class="form-select form-select-sm" style="width: auto; min-width: 200px;" onchange="this.form.submit()">
-                        <option value="">Toutes les années</option>
-                        @foreach($annees as $annee)
-                            <option value="{{ $annee->id }}" {{ $anneeFilterId == $annee->id ? 'selected' : '' }}>
-                                {{ $annee->name }}
-                                @if($annee->is_current) (Courante) @endif
-                            </option>
-                        @endforeach
-                    </select>
-                </form>
-                <span class="text-muted" style="font-size: 13px;">
-                    <strong>{{ $inscriptions->count() }}</strong> inscription(s) sous réserve
-                </span>
+        {{-- Stat cards --}}
+        <div class="sr-stats">
+            <div class="sr-stat-card primary">
+                <div class="sr-stat-top">
+                    <div>
+                        <div class="sr-stat-value">{{ $stats['total'] }}</div>
+                        <div class="sr-stat-label">Total sous réserve</div>
+                    </div>
+                    <div class="sr-stat-icon" style="background: linear-gradient(135deg, #0453cb, #5e91de);">
+                        <i class="fas fa-clipboard-check"></i>
+                    </div>
+                </div>
+            </div>
+            <div class="sr-stat-card success">
+                <div class="sr-stat-top">
+                    <div>
+                        <div class="sr-stat-value">{{ $stats['avec_paiement'] }}</div>
+                        <div class="sr-stat-label">Avec paiement</div>
+                    </div>
+                    <div class="sr-stat-icon" style="background: linear-gradient(135deg, #059669, #10b981);">
+                        <i class="fas fa-money-bill-wave"></i>
+                    </div>
+                </div>
+            </div>
+            <div class="sr-stat-card danger">
+                <div class="sr-stat-top">
+                    <div>
+                        <div class="sr-stat-value">{{ $stats['sans_paiement'] }}</div>
+                        <div class="sr-stat-label">Sans paiement</div>
+                    </div>
+                    <div class="sr-stat-icon" style="background: linear-gradient(135deg, #dc2626, #ef4444);">
+                        <i class="fas fa-exclamation-circle"></i>
+                    </div>
+                </div>
             </div>
         </div>
 
+        {{-- Alerts --}}
         @if(session('success'))
-            <div class="alert alert-success alert-dismissible fade show">
-                <i class="fas fa-check-circle me-2"></i>{{ session('success') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
+            <div class="alert alert-success alert-dismissible fade show"><i class="fas fa-check-circle me-2"></i>{{ session('success') }}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>
         @endif
-
         @if(session('warning'))
-            <div class="alert alert-warning alert-dismissible fade show">
-                <i class="fas fa-exclamation-triangle me-2"></i><strong>Attention :</strong> {{ session('warning') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
+            <div class="alert alert-warning alert-dismissible fade show"><i class="fas fa-exclamation-triangle me-2"></i><strong>Attention :</strong> {{ session('warning') }}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>
+        @endif
+        @if(session('error'))
+            <div class="alert alert-danger alert-dismissible fade show"><i class="fas fa-exclamation-circle me-2"></i>{{ session('error') }}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>
         @endif
 
-        @if(session('error'))
-            <div class="alert alert-danger alert-dismissible fade show">
-                <i class="fas fa-exclamation-circle me-2"></i>{{ session('error') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
-            </div>
-        @endif
+        {{-- Filtres --}}
+        <div class="sr-filter-card">
+            <div class="sr-filter-title"><i class="fas fa-filter"></i> Filtrer les inscriptions</div>
+            <form method="GET" action="{{ route('esbtp.inscriptions.sous-reserve') }}">
+                <div class="row g-3 align-items-end">
+                    <div class="col-md-4">
+                        <label class="form-label" style="font-size:.82rem; font-weight:600; color:#334155;">
+                            <i class="fas fa-search me-1"></i> Recherche
+                        </label>
+                        <input type="text" class="form-control" name="search" value="{{ $search ?? '' }}" placeholder="Nom, prénom ou matricule...">
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label" style="font-size:.82rem; font-weight:600; color:#334155;">
+                            <i class="fas fa-calendar-alt me-1"></i> Année universitaire
+                        </label>
+                        <select name="annee_id" class="form-select">
+                            <option value="">Toutes les années</option>
+                            @foreach($annees as $annee)
+                                <option value="{{ $annee->id }}" {{ ($anneeFilterId ?? '') == $annee->id ? 'selected' : '' }}>
+                                    {{ $annee->name }}@if($annee->is_current) (Courante)@endif
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-md-3">
+                        <label class="form-label" style="font-size:.82rem; font-weight:600; color:#334155;">
+                            <i class="fas fa-graduation-cap me-1"></i> Condition
+                        </label>
+                        <select name="condition" class="form-select">
+                            <option value="">Toutes</option>
+                            <option value="BACCALAURÉAT" {{ request('condition') === 'BACCALAURÉAT' ? 'selected' : '' }}>BACCALAURÉAT</option>
+                            <option value="BTS" {{ request('condition') === 'BTS' ? 'selected' : '' }}>BTS</option>
+                        </select>
+                    </div>
+                    <div class="col-md-2">
+                        <button type="submit" class="btn-acasi primary w-100">
+                            <i class="fas fa-search me-1"></i> Filtrer
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
 
         @if($inscriptions->isEmpty())
-            <div class="main-card">
-                <div class="empty-state">
-                    <i class="fas fa-check-double"></i>
+            <div class="sr-table-card">
+                <div class="sr-empty">
+                    <div class="sr-empty-icon"><i class="fas fa-check-double"></i></div>
                     <h4>Aucune inscription sous réserve</h4>
                     <p>Toutes les inscriptions pour cette période sont confirmées.</p>
                 </div>
             </div>
         @else
-            {{-- Bulk actions --}}
             <form method="POST" action="{{ route('esbtp.inscriptions.lever-reserves-bulk') }}" id="bulkForm">
                 @csrf
-                <div class="main-card">
-                    <div class="bulk-actions">
-                        <div class="form-check">
+                <div class="sr-table-card">
+                    {{-- Bulk bar --}}
+                    <div class="sr-bulk-bar">
+                        <div class="form-check mb-0">
                             <input class="form-check-input" type="checkbox" id="selectAll">
-                            <label class="form-check-label fw-bold" for="selectAll" style="font-size: 13px;">
+                            <label class="form-check-label fw-bold" for="selectAll" style="font-size:.82rem; color:#0369a1;">
                                 Tout sélectionner
                             </label>
                         </div>
-                        <button type="button" class="btn btn-success btn-sm" id="bulkConfirmBtn" disabled
-                                onclick="confirmBulkLever()">
-                            <i class="fas fa-check-double me-1"></i> Lever les réserves sélectionnées
+                        <button type="button" class="sr-btn confirm" id="bulkConfirmBtn" disabled onclick="confirmBulkLever()">
+                            <i class="fas fa-check-double"></i> Lever les réserves
                         </button>
-                        <span class="text-muted ms-2" style="font-size: 12px;" id="selectedCount">0 sélectionné(s)</span>
+                        <span class="sr-bulk-count" id="selectedCount">0 sélectionné(s)</span>
+                        <span style="margin-left:auto; font-size:.82rem; color:#64748b;">
+                            <strong>{{ $inscriptions->count() }}</strong> résultat(s)
+                        </span>
                     </div>
 
+                    {{-- Table --}}
                     <div class="table-responsive">
-                        <table class="table table-modern table-hover mb-0">
+                        <table class="table sr-table mb-0">
                             <thead>
                                 <tr>
-                                    <th style="width: 40px;"></th>
-                                    <th>Etudiant</th>
+                                    <th style="width:40px;"></th>
+                                    <th>Étudiant</th>
                                     <th>Classe</th>
-                                    <th>Filière</th>
                                     <th>Année</th>
                                     <th>Condition</th>
                                     <th>Paiement</th>
-                                    <th>Statut workflow</th>
-                                    <th style="width: 160px;">Actions</th>
+                                    <th>Workflow</th>
+                                    <th style="width:150px;">Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 @foreach($inscriptions as $inscription)
                                 <tr>
                                     <td>
-                                        <input class="form-check-input row-checkbox"
-                                               type="checkbox" name="inscription_ids[]"
-                                               value="{{ $inscription->id }}">
+                                        <input class="form-check-input row-checkbox" type="checkbox" name="inscription_ids[]" value="{{ $inscription->id }}">
                                     </td>
                                     <td>
-                                        <strong>{{ $inscription->etudiant->nom ?? '—' }}</strong>
-                                        {{ $inscription->etudiant->prenoms ?? '' }}
+                                        <div class="sr-student-name">
+                                            {{ $inscription->etudiant->nom ?? '—' }} {{ $inscription->etudiant->prenoms ?? '' }}
+                                            <small>{{ $inscription->etudiant->matricule ?? '' }}</small>
+                                        </div>
                                     </td>
-                                    <td>{{ $inscription->classe->name ?? '—' }}</td>
-                                    <td>{{ $inscription->filiere->name ?? '—' }}</td>
                                     <td>
-                                        {{ $inscription->anneeUniversitaire->name ?? '—' }}
-                                        @if($anneeEnCours && $inscription->annee_universitaire_id == $anneeEnCours->id)
-                                            <br><small class="text-success fw-bold">Année courante</small>
+                                        {{ $inscription->classe->name ?? '—' }}
+                                        @if($inscription->filiere)
+                                            <br><small style="color:#64748b;">{{ $inscription->filiere->name }}</small>
                                         @endif
                                     </td>
                                     <td>
-                                        <span class="badge-reserve">
-                                            <i class="fas fa-clock me-1"></i>{{ $inscription->condition_reserve ?? 'Non précisé' }}
+                                        <strong>{{ $inscription->anneeUniversitaire->name ?? '—' }}</strong>
+                                        @if($anneeEnCours && $inscription->annee_universitaire_id == $anneeEnCours->id)
+                                            <br><small style="color:#059669; font-weight:600;">Année courante</small>
+                                        @endif
+                                    </td>
+                                    <td>
+                                        <span class="sr-badge reserve">
+                                            <i class="fas fa-clock"></i> {{ $inscription->condition_reserve ?? 'Non précisé' }}
                                         </span>
                                     </td>
                                     <td>
-                                        @php
-                                            $totalPaye = $inscription->paiements->where('status', 'validé')->sum('montant');
-                                        @endphp
+                                        @php $totalPaye = $inscription->paiements->where('status', 'validé')->sum('montant'); @endphp
                                         @if($totalPaye > 0)
-                                            <span class="badge-paye">{{ number_format($totalPaye, 0, ',', ' ') }} F</span>
+                                            <span class="sr-badge paye"><i class="fas fa-check-circle"></i> {{ number_format($totalPaye, 0, ',', ' ') }} F</span>
                                         @else
-                                            <span class="badge-en-attente">Aucun</span>
+                                            <span class="sr-badge non-paye"><i class="fas fa-times-circle"></i> Aucun</span>
                                         @endif
                                     </td>
                                     <td>
-                                        <small>{{ $inscription->workflow_step_label }}</small>
+                                        <span class="sr-badge workflow"><i class="fas fa-tasks"></i> {{ $inscription->workflow_step_label }}</span>
                                     </td>
                                     <td>
                                         <div class="d-flex gap-1">
                                             <form method="POST" action="{{ route('esbtp.inscriptions.lever-reserve', $inscription) }}"
-                                                  onsubmit="return confirm('Confirmer la levée de réserve pour {{ addslashes($inscription->etudiant->nom ?? '') }} {{ addslashes($inscription->etudiant->prenoms ?? '') }} ?')">
+                                                  onsubmit="return confirm('Confirmer la levée de réserve pour {{ addslashes(($inscription->etudiant->nom ?? '') . ' ' . ($inscription->etudiant->prenoms ?? '')) }} ?')">
                                                 @csrf
-                                                <button type="submit" class="btn btn-success btn-sm" title="Lever la réserve">
+                                                <button type="submit" class="sr-btn confirm" title="Lever la réserve">
                                                     <i class="fas fa-check"></i> Confirmer
                                                 </button>
                                             </form>
                                             <form method="POST" action="{{ route('esbtp.inscriptions.annuler', $inscription) }}"
-                                                  onsubmit="return confirm('Annuler l\'inscription de {{ addslashes($inscription->etudiant->nom ?? '') }} {{ addslashes($inscription->etudiant->prenoms ?? '') }} ? Cette action est irréversible.')">
-                                                @csrf
-                                                @method('PUT')
+                                                  onsubmit="return confirm('Annuler cette inscription ? Cette action est irréversible.')">
+                                                @csrf @method('PUT')
                                                 <input type="hidden" name="motif_annulation" value="Condition de réserve non remplie">
-                                                <button type="submit" class="btn btn-outline-danger btn-sm" title="Annuler l'inscription">
+                                                <button type="submit" class="sr-btn cancel" title="Annuler l'inscription">
                                                     <i class="fas fa-times"></i>
                                                 </button>
                                             </form>
@@ -240,24 +309,22 @@
     </div>
 </div>
 
-{{-- Modal de confirmation bulk --}}
+{{-- Modal confirmation bulk --}}
 <div class="modal fade" id="bulkConfirmModal" tabindex="-1">
     <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header bg-success text-white">
-                <h5 class="modal-title"><i class="fas fa-check-double me-2"></i>Confirmation</h5>
+        <div class="modal-content" style="border:none; border-radius:14px; overflow:hidden;">
+            <div class="modal-header" style="background:linear-gradient(135deg, #059669, #10b981); color:#fff; border:none; padding:20px 24px;">
+                <h5 class="modal-title"><i class="fas fa-check-double me-2"></i> Confirmation</h5>
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
             </div>
-            <div class="modal-body">
+            <div class="modal-body" style="padding:24px;">
                 <p>Vous allez lever la réserve pour <strong id="bulkCountText">0</strong> inscription(s).</p>
-                <p class="text-muted">Les documents (certificats, attestations) afficheront désormais
-                   "Est régulièrement inscrit(e)" au lieu de "Sera régulièrement inscrit(e) sous réserve".</p>
-                <p><strong>Confirmer cette action ?</strong></p>
+                <p style="color:#64748b; font-size:.88rem;">Les documents afficheront désormais "Est régulièrement inscrit(e)" sans la mention sous réserve.</p>
             </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                <button type="button" class="btn btn-success" id="bulkConfirmSubmit">
-                    <i class="fas fa-check-double me-1"></i> Confirmer la levée
+            <div class="modal-footer" style="border:none; padding:16px 24px;">
+                <button type="button" class="btn btn-light" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="sr-btn confirm" id="bulkConfirmSubmit" style="padding:8px 20px;">
+                    <i class="fas fa-check-double"></i> Confirmer la levée
                 </button>
             </div>
         </div>
@@ -289,9 +356,7 @@ document.addEventListener('DOMContentLoaded', function() {
     checkboxes.forEach(cb => {
         cb.addEventListener('change', function() {
             if (!this.checked) selectAll.checked = false;
-            if (document.querySelectorAll('.row-checkbox:checked').length === checkboxes.length) {
-                selectAll.checked = true;
-            }
+            if (document.querySelectorAll('.row-checkbox:checked').length === checkboxes.length) selectAll.checked = true;
             updateCount();
         });
     });
@@ -302,7 +367,6 @@ function confirmBulkLever() {
     document.getElementById('bulkCountText').textContent = checked;
     const modal = new bootstrap.Modal(document.getElementById('bulkConfirmModal'));
     modal.show();
-
     document.getElementById('bulkConfirmSubmit').onclick = function() {
         modal.hide();
         document.getElementById('bulkForm').submit();

--- a/resources/views/pdf/certificat-scolarite.blade.php
+++ b/resources/views/pdf/certificat-scolarite.blade.php
@@ -213,14 +213,7 @@
         <p>Sous le matricule : <strong>{{ $etudiant->numero_etudiant ?? 'Non attribué' }}</strong></p>
     </div>
     
-    @php
-        $hasSousReserve = $inscriptions->contains(fn($i) => $i->is_sous_reserve);
-    @endphp
-    @if($hasSousReserve)
-    <p style="margin: 25px 0;">Sera régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
-    @else
     <p style="margin: 25px 0;">Est régulièrement inscrit(e) sur le registre des effectifs de l'année universitaire :</p>
-    @endif
 
     <!-- Tableau des inscriptions -->
     <table class="inscriptions-table">

--- a/routes/web.php
+++ b/routes/web.php
@@ -915,6 +915,7 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             Route::post('/inscriptions/bulk-valider', [ESBTPInscriptionController::class, 'bulkValider'])->name('inscriptions.bulk-valider');
 
             Route::post('/inscriptions/{inscription}/lever-reserve', [ESBTPInscriptionController::class, 'leverReserve'])->name('inscriptions.lever-reserve');
+            Route::post('/inscriptions/{inscription}/marquer-sous-reserve', [ESBTPInscriptionController::class, 'marquerSousReserve'])->name('inscriptions.marquer-sous-reserve');
 
             // Routes pour actions rapides sur inscriptions (modals AJAX)
             Route::get('/inscriptions/{inscription}/data', [ESBTPInscriptionApiController::class, 'getInscriptionData'])->name('inscriptions.data');


### PR DESCRIPTION
## Summary
- Redesign premium de la page sous-reserve avec stat-cards, filtres avancés, table moderne
- Le bloc sous-reserve n'apparait plus que pour les années **futures** (pas passées)
- Alertes intelligentes sur inscriptions.show et etudiants.show pour les inscriptions futures
- Fix wording documents : toujours "Est régulièrement inscrit(e)" + append "sous réserve"

## Changes
- `app/Http/Controllers/ESBTPInscriptionController.php` — Stats KPI, recherche nom/matricule, filtre par défaut = toutes années, nouvelle méthode `marquerSousReserve()`
- `app/Http/Controllers/ESBTPEtudiantController.php` — Passe `$hasFutureSousReserve` à l'attestation preview
- `resources/views/esbtp/inscriptions/sous-reserve.blade.php` — Redesign complet : stat-cards gradient, filtre card premium, table avec headers gradient bleu, badges modernes, bulk bar, modal gradient
- `resources/views/esbtp/inscriptions/create.blade.php` — `data-start-date` sur les options + JS compare dates pour n'afficher sous-reserve que si année future
- `resources/views/esbtp/inscriptions/show.blade.php` — Bannière amber "marquer sous réserve" si inscription future non marquée + bannière bleue info si déjà sous réserve
- `resources/views/esbtp/etudiants/show.blade.php` — Hero pill "Pré-inscrit (sous réserve)" au lieu de "Non réinscrit" + bannières info/suggestion
- `resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php` — Message adapté si inscription future sous réserve
- 5 vues certificats/attestations — "Est" (pas "Sera") + append "sous réserve de son [CONDITION]"
- `routes/web.php` — Route `marquer-sous-reserve`

## Type of change
- [x] feat — new feature
- [x] fix — bug fix (future-only detection, wording)

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified