### PR TITLE
fix(sous-reserve): hero pré-inscrit, hide non-réinscrit alerts, PDF spacing

### DIFF
--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -204,8 +204,8 @@
         @if(!empty($alerteWorkflow) && !empty($hasFutureSousReserve))
         <div class="doc-alert" style="background:rgba(59,130,246,.08); border-color:#3b82f6; color:#1e40af;">
             <strong><i class="fas fa-info-circle me-1"></i> Information :</strong>
-            Cet étudiant a une inscription sous réserve pour une année future.
-            L'attestation sera disponible quand l'inscription sera confirmée.
+            Cet étudiant a une pré-inscription sous réserve pour une année future.
+            L'attestation ci-dessous est générée à titre indicatif.
         </div>
         @elseif(!empty($alerteWorkflow))
         <div class="doc-alert">

--- a/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation.blade.php
@@ -207,7 +207,7 @@
             color: {{ $pdfMuted }};
             font-style: italic;
             font-size: 10px;
-            margin-top: 18px;
+            margin-top: 40px;
         }
 
         .sign-note {

--- a/resources/views/esbtp/etudiants/certificat.blade.php
+++ b/resources/views/esbtp/etudiants/certificat.blade.php
@@ -202,7 +202,7 @@
             color: {{ $pdfMuted }};
             font-style: italic;
             font-size: 10px;
-            margin-top: 18px;
+            margin-top: 40px;
         }
 
         /* ── Note de bas de page ── */

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -1717,7 +1717,7 @@
             </div>
             {{-- Badge rond : vert seulement si inscrit cette année, sinon gris --}}
             <span class="hero-avatar-status {{ $estInscritCetteAnnee ? 'actif' : 'inactif' }}"
-                  title="{{ $estInscritCetteAnnee ? 'Inscrit ' . ($anneeCourante->name ?? '') : 'Non inscrit pour l\'année en cours' }}"></span>
+                  title="{{ $estInscritCetteAnnee ? 'Inscrit ' . ($anneeCourante->name ?? '') : ($inscFutureSousReserve ? 'Pré-inscrit ' . ($inscFutureSousReserve->anneeUniversitaire->name ?? '') . ' (sous réserve)' : 'Non inscrit pour l\'année en cours') }}"></span>
             {{-- Bouton upload photo (superAdmin / secretaire) --}}
             @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school']))
                 <label class="hero-avatar-upload" id="heroPhotoUploadBtn" title="Modifier la photo">
@@ -1744,6 +1744,10 @@
                         @if($inscCourante->classe->filiere) · {{ $inscCourante->classe->filiere->name }} @endif
                         @if($inscCourante->classe->niveau) · {{ $inscCourante->classe->niveau->name ?? $inscCourante->classe->niveau->nom ?? '' }} @endif
                     @endif
+                @elseif($inscFutureSousReserve)
+                    {{ $inscFutureSousReserve->classe->name ?? '' }}
+                    @if($inscFutureSousReserve->filiere) · {{ $inscFutureSousReserve->filiere->name }} @endif
+                    <span style="color:rgba(255,255,255,0.75); font-style:italic;"> · {{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }} (sous réserve)</span>
                 @elseif($anneeCourante)
                     <span style="color:rgba(255,255,255,0.75); font-style:italic;">Non réinscrit pour {{ $anneeCourante->name }}</span>
                 @else
@@ -1968,8 +1972,8 @@
 {{-- ─── TAB: VUE D'ENSEMBLE ─────────────────────────────────────── --}}
 <div class="tab-panel active" id="tab-overview">
 
-    {{-- Bannière : étudiant non inscrit pour l'année courante --}}
-    @if($anneeCourante && !$inscCourante)
+    {{-- Bannière : étudiant non inscrit pour l'année courante (masquée si pré-inscrit sous réserve) --}}
+    @if($anneeCourante && !$inscCourante && !$inscFutureSousReserve)
     <div style="
         background: linear-gradient(135deg, #fff3cd 0%, #ffeeba 100%);
         border: 1.5px solid #ffc107;
@@ -3927,6 +3931,27 @@
                 &middot; {{ $finInscActive->classe->name }}
             @endif
         </div>
+        @elseif($inscFutureSousReserve ?? null)
+        <div class="fin-hero-year-badge" style="background:rgba(59,130,246,.12); border-color:rgba(59,130,246,.3);">
+            <i class="fas fa-clipboard-check" style="color:#0453cb;"></i>
+            <span style="color:#1e40af;">
+                Pré-inscrit <strong>{{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }}</strong>
+                sous réserve de son {{ $inscFutureSousReserve->condition_reserve ?? 'diplôme' }}
+                @if($inscFutureSousReserve->classe) &middot; {{ $inscFutureSousReserve->classe->name }} @endif
+            </span>
+        </div>
+        @php
+            // Charger les frais de l'inscription future sous réserve pour affichage
+            $finInscFuture = $inscFutureSousReserve;
+            $finPaiementsFuture = collect();
+            foreach($finInscFuture->paiements ?? [] as $pai) {
+                $pai->_annee = $finInscFuture->anneeUniversitaire?->name ?? 'N/A';
+                $finPaiementsFuture->push($pai);
+            }
+            $finTotalPayeFuture = $finPaiementsFuture->filter(fn($p) => str_contains(strtolower($p->status ?? ''), 'valid'))->sum('montant');
+            $finTotalAttenduFuture = 0;
+            try { $finTotalAttenduFuture = $finInscFuture->fraisSubscriptions->sum('amount'); } catch(\Exception $e) {}
+        @endphp
         @else
         <div class="fin-hero-year-badge" style="background:rgba(239,68,68,.15); border-color:rgba(239,68,68,.3);">
             <i class="fas fa-calendar-times" style="color:#ef4444;"></i>


### PR DESCRIPTION
## Summary
- Fix contradictory alerts on etudiants.show: show "Pré-inscrit (sous réserve)" instead of "Non réinscrit" when future sous-reserve exists
- Add sous-reserve inscription info in Finances tab
- Fix attestation preview misleading message
- Increase PDF signature spacing

## Changes
- `resources/views/esbtp/etudiants/show.blade.php` — Hero subtitle shows class+filière+année sous réserve ; avatar badge title adapté ; bannière "pas réinscrit" masquée si inscription future sous réserve ; Finances tab affiche badge bleu pré-inscrit au lieu du rouge "Aucune inscription"
- `resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php` — "sera disponible quand confirmée" → "générée à titre indicatif"
- `resources/views/esbtp/etudiants/certificat.blade.php` — sign-name margin-top 18px → 40px
- `resources/views/esbtp/etudiants/attestation-frequentation.blade.php` — sign-name margin-top 18px → 40px

## Type of change
- [x] fix — bug fix

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified