### PR TITLE
feat(etudiants): sous-reserve fallback across all tabs + fix payment modal

### DIFF
--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -3630,23 +3630,32 @@
         }
     @endphp
     <div class="fin-hero" style="margin-bottom:16px;">
+        @if($presInscCourante)
         <div class="fin-hero-year-badge">
             <i class="fas fa-calendar-check"></i>
             Année en cours :
             <strong>{{ $presAnneeCourante->name }}</strong>
-            @if($presInscCourante?->classe)
+            @if($presInscCourante->classe)
                 &middot; {{ $presInscCourante->classe->name }}
             @endif
         </div>
+        @elseif($inscFutureSousReserve ?? null)
+        <div class="fin-hero-year-badge" style="background:rgba(59,130,246,.12); border-color:rgba(59,130,246,.3);">
+            <i class="fas fa-clipboard-check" style="color:#0453cb;"></i>
+            <span style="color:#1e40af;">
+                Pré-inscrit <strong>{{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }}</strong>
+                sous réserve de son {{ $inscFutureSousReserve->condition_reserve ?? 'diplôme' }}
+                @if($inscFutureSousReserve->classe) &middot; {{ $inscFutureSousReserve->classe->name }} @endif
+            </span>
+        </div>
+        @else
+        <div class="fin-hero-year-badge" style="background:rgba(239,68,68,.15); border-color:rgba(239,68,68,.3);">
+            <i class="fas fa-calendar-times" style="color:#ef4444;"></i>
+            <span style="color:#ef4444;">Aucune inscription pour {{ $presAnneeCourante->name }}</span>
+        </div>
+        @endif
 
-        @if(!$presInscCourante && ($inscFutureSousReserve ?? null))
-            <div style="display:flex; align-items:center; gap:10px; padding:14px 16px; background:rgba(59,130,246,.06); border-radius:10px; border-left:3px solid #3b82f6;">
-                <i class="fas fa-clipboard-check" style="color:#0453cb; font-size:1.1rem; flex-shrink:0;"></i>
-                <span style="font-size:.84rem; color:#1e40af; font-weight:500;">
-                    Pré-inscrit <strong>{{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }}</strong> sous réserve — données de présence non encore disponibles.
-                </span>
-            </div>
-        @elseif(!$presInscCourante)
+        @if(!$presInscCourante && !($inscFutureSousReserve ?? null))
             <div style="display:flex; align-items:center; gap:10px; padding:14px 16px; background:rgba(239,68,68,.06); border-radius:10px; border-left:3px solid #ef4444;">
                 <i class="fas fa-exclamation-circle" style="color:#ef4444; font-size:1.1rem; flex-shrink:0;"></i>
                 <span style="font-size:.84rem; color:#991b1b; font-weight:500;">Aucune inscription pour {{ $presAnneeCourante->name }} — données de présence indisponibles.</span>

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -2982,7 +2982,22 @@
     @else
 
     {{-- ══ BLOC ANNÉE EN COURS (toujours plat, jamais collapsible) ══ --}}
-    @if($acadIsNotCurrentYear)
+    @if($acadIsNotCurrentYear && ($inscFutureSousReserve ?? null))
+        {{-- Pré-inscrit sous réserve pour une année future --}}
+        <div class="fin-hero" style="margin-bottom:16px;">
+            <div class="fin-hero-year-badge" style="background:rgba(59,130,246,.12); border-color:rgba(59,130,246,.3);">
+                <i class="fas fa-clipboard-check" style="color:#0453cb;"></i>
+                <span style="color:#1e40af;">
+                    Pré-inscrit <strong>{{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }}</strong>
+                    sous réserve de son {{ $inscFutureSousReserve->condition_reserve ?? 'diplôme' }}
+                    @if($inscFutureSousReserve->classe) &middot; {{ $inscFutureSousReserve->classe->name }} @endif
+                </span>
+            </div>
+            <p style="margin:12px 0 0; font-size:.82rem; color:var(--k-muted); text-align:center;">
+                <i class="fas fa-info-circle" style="margin-right:5px;"></i>Résultats académiques non encore disponibles pour cette année. Consultez les années précédentes ci-dessous.
+            </p>
+        </div>
+    @elseif($acadIsNotCurrentYear)
         {{-- Pas de données pour l'année courante --}}
         <div class="fin-hero" style="margin-bottom:16px;">
             <div class="fin-hero-year-badge" style="background:rgba(239,68,68,.15); border-color:rgba(239,68,68,.3);">
@@ -3333,9 +3348,13 @@
     {{-- ══ AUTRES ANNÉES ══════════════════════════════════════ --}}
     @php
         /* Si l'année courante n'a pas de données, toutes les inscriptions vont ici
-           mais on exclut quand même l'inscription de l'année courante (sans données) */
+           mais on exclut l'inscription courante (sans données) et la future sous réserve (affichée dans le hero) */
+        $acadExcludeIds = collect([$anneeCourante?->id])->filter();
+        if ($inscFutureSousReserve ?? null) {
+            $acadExcludeIds->push($inscFutureSousReserve->annee_universitaire_id);
+        }
         $acadInscsPrec = $acadIsNotCurrentYear
-            ? $acadInscs->filter(fn($i) => $anneeCourante ? $i->annee_universitaire_id !== $anneeCourante->id : true)
+            ? $acadInscs->filter(fn($i) => !$acadExcludeIds->contains($i->annee_universitaire_id))
             : $acadAutres;
     @endphp
     @if($acadInscsPrec->count())

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -2167,8 +2167,8 @@
         // Absences : uniquement année courante
         $kpiAbsTotal       = $totalAbsences; // null si pas inscrit cette année
 
-        // Inscription de référence : année courante uniquement
-        $kpiInscActive = $inscCourante ?? null;
+        // Inscription de référence : année courante, sinon future sous réserve
+        $kpiInscActive = $inscCourante ?? ($inscFutureSousReserve ?? null);
 
         $kpiPaiTotal = $kpiInscActive
             ? $kpiInscActive->paiements->where('status', 'validé')->sum('montant')
@@ -2539,7 +2539,7 @@
         <div style="padding:24px;color:var(--k-gray);font-size:.9rem;">Aucune inscription enregistrée.</div>
         @endforelse
         {{-- CTA Réinscription si pas encore inscrit pour l'année courante --}}
-        @if($anneeCourante && !$inscCourante)
+        @if($anneeCourante && !$inscCourante && !$inscFutureSousReserve)
         <a href="{{ route('esbtp.reinscription.show', $etudiant) }}" class="insc-card insc-cta-card">
             <div class="insc-card-accent inactif"></div>
             <div class="insc-card-inner" style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:100%;gap:12px;text-align:center;">
@@ -3620,7 +3620,14 @@
             @endif
         </div>
 
-        @if(!$presInscCourante)
+        @if(!$presInscCourante && ($inscFutureSousReserve ?? null))
+            <div style="display:flex; align-items:center; gap:10px; padding:14px 16px; background:rgba(59,130,246,.06); border-radius:10px; border-left:3px solid #3b82f6;">
+                <i class="fas fa-clipboard-check" style="color:#0453cb; font-size:1.1rem; flex-shrink:0;"></i>
+                <span style="font-size:.84rem; color:#1e40af; font-weight:500;">
+                    Pré-inscrit <strong>{{ $inscFutureSousReserve->anneeUniversitaire->name ?? '' }}</strong> sous réserve — données de présence non encore disponibles.
+                </span>
+            </div>
+        @elseif(!$presInscCourante)
             <div style="display:flex; align-items:center; gap:10px; padding:14px 16px; background:rgba(239,68,68,.06); border-radius:10px; border-left:3px solid #ef4444;">
                 <i class="fas fa-exclamation-circle" style="color:#ef4444; font-size:1.1rem; flex-shrink:0;"></i>
                 <span style="font-size:.84rem; color:#991b1b; font-weight:500;">Aucune inscription pour {{ $presAnneeCourante->name }} — données de présence indisponibles.</span>

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -5528,7 +5528,7 @@ document.addEventListener('DOMContentLoaded', function() {
 .etd-skeleton-input { height: 38px; width: 100%; }
 .etd-skeleton-msg { height: 52px; width: 100%; margin-bottom: 1rem; }
 </style>
-@if(isset($finInscActive) && $finInscActive)
+@if(isset($finInscRef) && $finInscRef)
 <div class="modal fade" id="etudiantPaymentModal" tabindex="-1" aria-labelledby="etudiantPaymentModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content" style="border-radius:15px; border:none; box-shadow:0 10px 40px rgba(0,0,0,.2);">
@@ -5551,7 +5551,7 @@ document.addEventListener('DOMContentLoaded', function() {
                                 <div style="color:#084298;font-weight:500;margin-bottom:.25rem;">{{ $etudiant->nom_complet }}</div>
                                 <div style="color:#052c65;font-size:.9rem;">
                                     Matricule : <strong>{{ $etudiant->matricule ?? 'N/A' }}</strong>
-                                    <span id="etd-modal-classe-info">@if($finInscActive?->classe) · {{ $finInscActive->classe->name }} @endif</span>
+                                    <span id="etd-modal-classe-info">@if($finInscRef?->classe) · {{ $finInscRef->classe->name }} @endif</span>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- Extend le pattern sous-reserve fallback à TOUS les tabs de etudiants.show
- Fix le modal de paiement qui ne s'affichait pas (conditionné à $finInscActive au lieu de $finInscRef)

## Changes (etudiants/show.blade.php uniquement)

### Finances tab
- Modal de paiement : `@if($finInscActive)` → `@if($finInscRef)` pour rendre le HTML quand seule l'inscription future existe

### Vue d'ensemble tab
- KPIs paiements : `$kpiInscActive` fallback vers `$inscFutureSousReserve`
- CTA "Réinscrire" masqué quand pré-inscrit sous réserve

### Académique tab
- Badge bleu "Pré-inscrit [ANNÉE] sous réserve" au lieu du rouge "Aucune inscription"
- Inscription future exclue de "Autres années" (pas de doublon)

### Présences tab
- Hero badge conditionnel : bleu "Pré-inscrit sous réserve" / rouge "Aucune inscription" / vert "Année en cours"
- Suppression du doublon bannière info

## Type of change
- [x] fix — bug fix (modal paiement, doublons)
- [x] feat — new feature (fallback tous tabs)

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified