### PR TITLE
fix: guard sous-reserve routes with Route::has() for safe deployment

### DIFF
--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -2126,15 +2126,17 @@
                 sous réserve de son <strong>{{ $inscFutureSousReserve->condition_reserve ?? 'diplôme' }}</strong>.
                 L'inscription sera confirmée quand cette année deviendra l'année courante.
             </div>
+            @if(Route::has('esbtp.inscriptions.sous-reserve'))
             <a href="{{ route('esbtp.inscriptions.sous-reserve') }}" style="display:inline-flex; align-items:center; gap:6px; padding:8px 16px; background:linear-gradient(135deg, #0453cb, #5e91de); color:#fff; border:none; border-radius:8px; font-size:.84rem; font-weight:600; text-decoration:none; cursor:pointer; box-shadow:0 2px 8px rgba(4,83,203,.25);">
                 <i class="fas fa-external-link-alt"></i> Gérer les réserves
             </a>
+            @endif
         </div>
     </div>
     @endif
 
     {{-- Bannière inscription future NON sous réserve (suggestion) --}}
-    @if($inscFutureNonReserve && !$inscFutureSousReserve)
+    @if($inscFutureNonReserve && !$inscFutureSousReserve && Route::has('esbtp.inscriptions.marquer-sous-reserve'))
     <div style="background:linear-gradient(135deg,#fef3c7,#fde68a); border:1.5px solid #f59e0b; border-left:5px solid #d97706; border-radius:10px; padding:16px 20px; margin-bottom:24px; display:flex; align-items:flex-start; gap:14px;">
         <div style="flex-shrink:0; width:36px; height:36px; background:#d97706; border-radius:50%; display:flex; align-items:center; justify-content:center;">
             <i class="fas fa-exclamation-triangle" style="color:#fff; font-size:.9rem;"></i>

--- a/resources/views/esbtp/inscriptions/show.blade.php
+++ b/resources/views/esbtp/inscriptions/show.blade.php
@@ -615,7 +615,7 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
                     && optional($anneeCourante)->start_date
                     && $inscription->anneeUniversitaire->start_date > $anneeCourante->start_date;
             @endphp
-            @if($isFutureNonReserve)
+            @if($isFutureNonReserve && Route::has('esbtp.inscriptions.marquer-sous-reserve'))
             <div style="background:linear-gradient(135deg,#fef3c7,#fde68a); border:1.5px solid #f59e0b; border-left:5px solid #d97706; border-radius:10px; padding:16px 20px; margin-bottom:16px; display:flex; align-items:flex-start; gap:14px;">
                 <div style="flex-shrink:0; width:36px; height:36px; background:#d97706; border-radius:50%; display:flex; align-items:center; justify-content:center;">
                     <i class="fas fa-exclamation-triangle" style="color:#fff; font-size:.9rem;"></i>
@@ -652,7 +652,9 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
                     <div style="color:#1e40af; font-size:.85rem; line-height:1.5; margin-bottom:8px;">
                         Cette inscription pour <strong>{{ $inscription->anneeUniversitaire->name ?? '' }}</strong> est sous réserve
                         de son <strong>{{ $inscription->condition_reserve ?? 'diplôme' }}</strong>.
+                        @if(Route::has('esbtp.inscriptions.sous-reserve'))
                         La réserve sera levée depuis la <a href="{{ route('esbtp.inscriptions.sous-reserve') }}" style="color:#0453cb; font-weight:600;">page de gestion des réserves</a>.
+                        @endif
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Protège les appels route() sous-reserve avec Route::has() pour éviter les crashes lors de déploiements progressifs

## Changes
- `resources/views/esbtp/etudiants/show.blade.php` — Guard Route::has() sur bannière "marquer sous réserve" et lien "gérer les réserves"
- `resources/views/esbtp/inscriptions/show.blade.php` — Guard Route::has() sur bannière "marquer sous réserve" et lien "page de gestion"

## Type of change
- [x] fix — bug fix (RouteNotFoundException sur tenants)

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified