### PR TITLE
fix(preview): use accent_color for document preview text highlighting

### DIFF
--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -7,7 +7,7 @@
 @include('pdf.partials.theme')
 @php
     $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
-    $accentColor  = $pdfSettings['header_bg_color']   ?? '#0453cb';
+    $accentColor  = $pdfSettings['accent_color'] ?? $pdfSettings['primary_color'] ?? '#0453cb';
     $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
     $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
 @endphp

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -7,7 +7,7 @@
 @include('pdf.partials.theme')
 @php
     $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
-    $accentColor  = $pdfSettings['header_bg_color']   ?? '#0453cb';
+    $accentColor  = $pdfSettings['accent_color'] ?? $pdfSettings['primary_color'] ?? '#0453cb';
     $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
     $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
 @endphp


### PR DESCRIPTION
## Summary
- Fix texte invisible sur les previews attestation et certificat : utilise `accent_color` (orange) au lieu de `header_bg_color` (blanc sur ESBTP Abidjan)

## Changes
- `resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php` — `$accentColor` : `header_bg_color` → `accent_color ?? primary_color`
- `resources/views/esbtp/etudiants/certificat-preview.blade.php` — idem

## Root cause
Les previews utilisaient `header_bg_color` comme `--doc-accent` pour la couleur du texte surligné (`.doc-hl`). Sur ESBTP Abidjan, `header_bg_color` = blanc → texte blanc sur fond blanc = invisible. Les PDFs fonctionnaient car ils utilisent `$pdfPrimary` en inline.

## Type of change
- [x] fix — bug fix

## Checklist
- [x] No secrets or sensitive data committed
- [x] PHP syntax verified