### PR TITLE
fix(preview): use primary_color for accent text (aligned with PDF)

### DIFF
--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -7,7 +7,7 @@
 @include('pdf.partials.theme')
 @php
     $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
-    $accentColor  = $pdfSettings['accent_color'] ?? $pdfSettings['primary_color'] ?? '#0453cb';
+    $accentColor  = $pdfSettings['primary_color'] ?? $pdfSettings['header_bg_color'] ?? '#0453cb';
     $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
     $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
 @endphp

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -7,7 +7,7 @@
 @include('pdf.partials.theme')
 @php
     $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
-    $accentColor  = $pdfSettings['accent_color'] ?? $pdfSettings['primary_color'] ?? '#0453cb';
+    $accentColor  = $pdfSettings['primary_color'] ?? $pdfSettings['header_bg_color'] ?? '#0453cb';
     $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
     $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
 @endphp


### PR DESCRIPTION
## Summary
- Corrige la couleur accent des previews : `accent_color` → `primary_color` (même source que les PDFs qui fonctionnent)

## Changes
- `attestation-frequentation-preview.blade.php` — `$accentColor = primary_color ?? header_bg_color`
- `certificat-preview.blade.php` — idem

## Contexte
La PR #191 avait mis `accent_color` mais ça prenait vert (header_text_color) au lieu d'orange. Le PDF utilise `primary_color` et affiche orange → on aligne le preview sur la même source.

## Type of change
- [x] fix — bug fix

## Checklist
- [x] No secrets or sensitive data committed