### PR TITLE
fix(preview): separate header-bg from accent color in document previews

### DIFF
--- a/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
+++ b/resources/views/esbtp/etudiants/attestation-frequentation-preview.blade.php
@@ -7,12 +7,14 @@
 @include('pdf.partials.theme')
 @php
     $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
-    $accentColor  = $pdfSettings['primary_color'] ?? $pdfSettings['header_bg_color'] ?? '#0453cb';
+    $headerBg     = $pdfSettings['header_bg_color']   ?? '#0453cb';
+    $accentColor  = $pdfSettings['primary_color']     ?? $headerBg;
     $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
     $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
 @endphp
 <style>
     :root {
+        --doc-header-bg: {{ $headerBg }};
         --doc-accent: {{ $accentColor }};
         --doc-atext:  {{ $accentText }};
         --doc-body:   {{ $bodyText }};
@@ -47,7 +49,7 @@
 
     /* Header établissement */
     .doc-header {
-        background:var(--doc-accent); color:var(--doc-atext);
+        background:var(--doc-header-bg); color:var(--doc-atext);
         border-radius:10px; padding:20px 24px;
         display:flex; align-items:center; gap:18px;
         position:relative; overflow:hidden;

--- a/resources/views/esbtp/etudiants/certificat-preview.blade.php
+++ b/resources/views/esbtp/etudiants/certificat-preview.blade.php
@@ -7,12 +7,14 @@
 @include('pdf.partials.theme')
 @php
     $pdfSettings  = \App\Helpers\SettingsHelper::getPdfSettings();
-    $accentColor  = $pdfSettings['primary_color'] ?? $pdfSettings['header_bg_color'] ?? '#0453cb';
+    $headerBg     = $pdfSettings['header_bg_color']   ?? '#0453cb';
+    $accentColor  = $pdfSettings['primary_color']     ?? $headerBg;
     $accentText   = $pdfSettings['header_text_color'] ?? '#ffffff';
     $bodyText     = $pdfSettings['text_color']        ?? '#1f2937';
 @endphp
 <style>
     :root {
+        --doc-header-bg: {{ $headerBg }};
         --doc-accent: {{ $accentColor }};
         --doc-atext:  {{ $accentText }};
         --doc-body:   {{ $bodyText }};
@@ -47,7 +49,7 @@
 
     /* Header établissement */
     .doc-header {
-        background:var(--doc-accent); color:var(--doc-atext);
+        background:var(--doc-header-bg); color:var(--doc-atext);
         border-radius:10px; padding:20px 24px;
         display:flex; align-items:center; gap:18px;
         position:relative; overflow:hidden;
@@ -91,7 +93,7 @@
     /* Table */
     .doc-table { width:100%; border-collapse:collapse; font-size:.84rem; margin:18px 0 6px; }
     .doc-table thead th {
-        background:var(--doc-accent); color:var(--doc-atext);
+        background:var(--doc-header-bg); color:var(--doc-atext);
         padding:9px 12px; font-weight:700; font-size:.73rem;
         letter-spacing:.07em; text-transform:uppercase; border:none; text-align:center;
     }


### PR DESCRIPTION
## Summary
- Sépare `--doc-header-bg` (fond en-tête = blanc) de `--doc-accent` (texte surligné = orange/primary) dans les previews certificat et attestation

## Changes
- `attestation-frequentation-preview.blade.php` — Ajout variable `$headerBg` + `--doc-header-bg`, `.doc-header` utilise `--doc-header-bg`
- `certificat-preview.blade.php` — Idem + `.doc-table thead th` utilise `--doc-header-bg`

## Root cause
Une seule variable `--doc-accent` servait à la fois pour le fond d'en-tête ET le texte surligné. Sur ESBTP Abidjan (fond blanc, accent orange), le fond devenait orange au lieu de blanc.

## Type of change
- [x] fix — bug fix

## Checklist
- [x] No secrets or sensitive data committed