### PR TITLE
fix(permissions): return JSON for AJAX errors + scope coordinateur notes permissions

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -5,6 +5,7 @@ namespace App\Exceptions;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Session\TokenMismatchException;
 use RuntimeException;
+use Spatie\Permission\Exceptions\UnauthorizedException;
 use Throwable;
 
 class Handler extends ExceptionHandler
@@ -44,9 +45,25 @@ class Handler extends ExceptionHandler
     public function render($request, Throwable $e)
     {
         if ($e instanceof TokenMismatchException) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Votre session a expiré. Veuillez rafraîchir la page et réessayer.',
+                ], 419);
+            }
+
             return redirect()->back()
                 ->withInput($request->except('password', 'password_confirmation'))
                 ->with('warning', 'Votre session a expiré. Veuillez réessayer.');
+        }
+
+        if ($e instanceof UnauthorizedException) {
+            if ($request->expectsJson()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Vous n\'avez pas la permission d\'effectuer cette action.',
+                ], 403);
+            }
         }
 
         if ($e instanceof CoefficientMissingException) {

--- a/bin/deploy/fix_permissions.php
+++ b/bin/deploy/fix_permissions.php
@@ -393,9 +393,9 @@ try {
         'view_niveaux_etudes',
         // Matières
         'view_matieres', 'edit_matieres', 'create_matieres',
-        // Notes — full CRUD
-        'view_notes', 'create_notes', 'edit_notes', 'edit_existing_notes',
-        'view_grades', 'create_grade', 'edit_grades', 'delete_grades',
+        // Notes — création et consultation uniquement (pas de modification)
+        'view_notes', 'create_notes',
+        'view_grades', 'create_grade',
         // Évaluations
         'view_evaluations', 'create_evaluations', 'edit_evaluations', 'view_exams',
         // Bulletins


### PR DESCRIPTION
- Handler.php: return JSON 419 for TokenMismatchException on AJAX requests
  instead of redirecting to HTML (caused parsererror in jQuery)
- Handler.php: return JSON 403 for Spatie UnauthorizedException on AJAX
  requests instead of rendering the 403.blade.php HTML page
- fix_permissions.php: remove edit_notes, edit_existing_notes, edit_grades,
  delete_grades from coordinateur role (view + create only, no modify)

Refs: coordinateur notes save error returning HTML instead of JSON

https://claude.ai/code/session_019h2Cquo1DAzV8JVxHz7vwc