### PR TITLE
fix: AJAX notes save returns JSON instead of HTML for coordinateur

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -44,8 +44,13 @@ class Handler extends ExceptionHandler
 
     public function render($request, Throwable $e)
     {
+        $isAjax = $request->expectsJson()
+            || $request->ajax()
+            || str_contains($request->path(), 'ajax')
+            || str_contains($request->path(), 'api/');
+
         if ($e instanceof TokenMismatchException) {
-            if ($request->expectsJson()) {
+            if ($isAjax) {
                 return response()->json([
                     'success' => false,
                     'message' => 'Votre session a expiré. Veuillez rafraîchir la page et réessayer.',
@@ -58,7 +63,7 @@ class Handler extends ExceptionHandler
         }
 
         if ($e instanceof UnauthorizedException) {
-            if ($request->expectsJson()) {
+            if ($isAjax) {
                 return response()->json([
                     'success' => false,
                     'message' => 'Vous n\'avez pas la permission d\'effectuer cette action.',

--- a/app/Http/Controllers/ESBTPNoteController.php
+++ b/app/Http/Controllers/ESBTPNoteController.php
@@ -543,14 +543,22 @@ class ESBTPNoteController extends Controller
      */
     public function saveNoteAjax(Request $request)
     {
-        $request->validate([
-            'etudiant_id'   => 'required|exists:esbtp_etudiants,id',
-            'evaluation_id' => 'required|exists:esbtp_evaluations,id',
-            'note'          => 'nullable|numeric|min:0',
-            'is_absent'     => 'nullable|string',
-        ]);
-
         try {
+            $validator = \Validator::make($request->all(), [
+                'etudiant_id'   => 'required|exists:esbtp_etudiants,id',
+                'evaluation_id' => 'required|exists:esbtp_evaluations,id',
+                'note'          => 'nullable|numeric|min:0',
+                'is_absent'     => 'nullable|string',
+            ]);
+
+            if ($validator->fails()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => $validator->errors()->first(),
+                    'errors'  => $validator->errors()->toArray(),
+                ], 422);
+            }
+
             $evaluation = ESBTPEvaluation::findOrFail($request->evaluation_id);
 
             if (! $evaluation->is_published) {
@@ -605,13 +613,21 @@ class ESBTPNoteController extends Controller
      */
     public function saveNotesAjaxBulk(Request $request)
     {
-        $request->validate([
+        $validator = \Validator::make($request->all(), [
             'notes'                 => 'required|array|min:1',
             'notes.*.etudiant_id'   => 'required|integer',
             'notes.*.evaluation_id' => 'required|integer',
             'notes.*.note'          => 'nullable|numeric|min:0',
             'notes.*.is_absent'     => 'nullable|string',
         ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'message' => $validator->errors()->first(),
+                'errors'  => $validator->errors()->toArray(),
+            ], 422);
+        }
 
         $errors = 0;
         $saved  = 0;

--- a/app/Http/Middleware/PaywallMiddleware.php
+++ b/app/Http/Middleware/PaywallMiddleware.php
@@ -88,7 +88,7 @@ class PaywallMiddleware
 
         if ($status['is_blocked']) {
             // Si c'est une requête AJAX, retourner du JSON
-            if ($request->expectsJson()) {
+            if ($request->expectsJson() || $request->ajax() || str_contains($request->path(), 'ajax')) {
                 return response()->json([
                     'success' => false,
                     'message' => 'Accès bloqué par le paywall',

--- a/resources/views/esbtp/notes/index.blade.php
+++ b/resources/views/esbtp/notes/index.blade.php
@@ -995,6 +995,10 @@ function saveNote(studentId, evaluationId, noteValue) {
         url: '{{ route("esbtp.notes.save-ajax") }}',
         method: 'POST',
         dataType: 'json',
+        headers: {
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        },
         data: {
             _token: '{{ csrf_token() }}',
             etudiant_id: studentId,
@@ -1041,6 +1045,10 @@ function toggleAbsence(studentId, evaluationId, isAbsent) {
             url: '{{ route("esbtp.notes.save-ajax") }}',
             method: 'POST',
             dataType: 'json',
+            headers: {
+                'Accept': 'application/json',
+                'X-Requested-With': 'XMLHttpRequest'
+            },
             data: {
                 _token: '{{ csrf_token() }}',
                 etudiant_id: studentId,
@@ -1233,6 +1241,10 @@ $('#saveAllNotesBtn').on('click', function() {
         url: '{{ route("esbtp.notes.save-ajax-bulk") }}',
         method: 'POST',
         dataType: 'json',
+        headers: {
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+        },
         data: {
             _token: '{{ csrf_token() }}',
             notes: notesPayload


### PR DESCRIPTION
## Summary

- **Handler.php** : retourne du JSON (419/403) au lieu de rediriger vers du HTML quand une exception `TokenMismatchException` ou `UnauthorizedException` (Spatie) est levée sur une requête AJAX. Détection élargie avec `$request->ajax()` + URL path contenant `ajax` ou `api/`
- **ESBTPNoteController** : remplace `$request->validate()` par `Validator::make()` dans `saveNoteAjax` et `saveNotesAjaxBulk` pour que les erreurs de validation retournent toujours du JSON au lieu de rediriger
- **Blade notes/index** : ajout des headers explicites `Accept: application/json` et `X-Requested-With: XMLHttpRequest` sur les 3 appels AJAX (saveNote, toggleAbsence, bulk save)
- **PaywallMiddleware** : alignement de la détection AJAX avec le même pattern que le Handler
- **fix_permissions.php** : retrait de `edit_notes`, `edit_existing_notes`, `edit_grades`, `delete_grades` du coordinateur (consultation + création uniquement)

## Contexte

Le coordinateur obtenait un `parsererror` jQuery (status 200, responseText = HTML) au lieu d'une réponse JSON lors de la sauvegarde des notes. Cause racine : bug connu Spatie ([#563](https://github.com/spatie/laravel-permission/issues/563)) + middlewares qui redirigent vers du HTML sans vérifier si la requête est AJAX.

## Après déploiement

```bash
php bin/deploy/fix_permissions.php
php artisan permission:cache-reset
php artisan view:clear
php artisan cache:clear
```

## Test plan

- [ ] Connecté en coordinateur, sauvegarder une note → doit recevoir une réponse JSON (succès ou erreur lisible)
- [ ] Connecté en superAdmin, sauvegarder une note → toujours fonctionnel
- [ ] Vérifier que le coordinateur ne peut PAS modifier une note existante (message d'erreur JSON)

https://claude.ai/code/session_019h2Cquo1DAzV8JVxHz7vwc