### PR TITLE
fix: ForcePasswordChange bloque les AJAX + formulaire mot de passe

### DIFF
--- a/app/Http/Controllers/Auth/PasswordChangeController.php
+++ b/app/Http/Controllers/Auth/PasswordChangeController.php
@@ -32,37 +32,34 @@ class PasswordChangeController extends Controller
      */
     public function updatePassword(Request $request)
     {
+        $user = auth()->user();
+
+        // Vérifier le mot de passe actuel EN PREMIER (avant la validation du nouveau)
+        if (!Hash::check($request->current_password, $user->password)) {
+            return back()->withErrors([
+                'current_password' => 'Le mot de passe actuel est incorrect. Vérifiez que vous avez bien saisi votre mot de passe actuel (celui utilisé pour vous connecter).'
+            ])->withInput($request->only('current_password'));
+        }
+
+        // Valider le nouveau mot de passe seulement après confirmation du mot de passe actuel
         $request->validate([
             'current_password' => ['required'],
             'password' => ['required', 'confirmed', Password::min(8)
                 ->letters()
-                ->mixedCase()
                 ->numbers()
-                ->symbols()
             ],
         ], [
             'current_password.required' => 'Le mot de passe actuel est requis.',
             'password.required' => 'Le nouveau mot de passe est requis.',
-            'password.confirmed' => 'La confirmation du mot de passe ne correspond pas.',
-            'password.min' => 'Le mot de passe doit contenir au moins 8 caractères.',
-            'password.letters' => 'Le mot de passe doit contenir au moins une lettre.',
-            'password.mixed_case' => 'Le mot de passe doit contenir au moins une majuscule et une minuscule.',
-            'password.numbers' => 'Le mot de passe doit contenir au moins un chiffre.',
-            'password.symbols' => 'Le mot de passe doit contenir au moins un symbole.',
+            'password.confirmed' => 'La confirmation du mot de passe ne correspond pas. Vérifiez que les deux champs "Nouveau mot de passe" sont identiques.',
+            'password.min' => 'Le nouveau mot de passe doit contenir au moins 8 caractères.',
+            'password.letters' => 'Le nouveau mot de passe doit contenir au moins une lettre.',
+            'password.numbers' => 'Le nouveau mot de passe doit contenir au moins un chiffre.',
         ]);
 
-        $user = auth()->user();
-
-        // Vérifier le mot de passe actuel
-        if (!Hash::check($request->current_password, $user->password)) {
-            return back()->withErrors([
-                'current_password' => 'Le mot de passe actuel est incorrect.'
-            ]);
-        }
-
-        // Mettre à jour le mot de passe
+        // Mettre à jour le mot de passe (le mutateur setPasswordAttribute hashe automatiquement)
         $user->update([
-            'password' => Hash::make($request->password)
+            'password' => $request->password,
         ]);
 
         // Marquer que l'utilisateur a changé son mot de passe
@@ -71,7 +68,9 @@ class PasswordChangeController extends Controller
         // Marquer la première connexion si nécessaire
         $this->userService->markFirstLogin($user);
 
-        return redirect()->route('dashboard')->with('success', 
+        \Log::info('Mot de passe changé avec succès', ['user_id' => $user->id, 'email' => $user->email]);
+
+        return redirect()->route('dashboard')->with('success',
             'Votre mot de passe a été changé avec succès. Bienvenue dans le système ESBTP!');
     }
 }

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -42,6 +42,7 @@ class Kernel extends HttpKernel
             \Illuminate\Session\Middleware\StartSession::class,
             // \Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\ForceJsonOnAjax::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,
             \App\Http\Middleware\UpdateLastLogin::class,

--- a/app/Http/Middleware/ForceJsonOnAjax.php
+++ b/app/Http/Middleware/ForceJsonOnAjax.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+/**
+ * Force l'en-tête Accept: application/json sur les requêtes AJAX.
+ *
+ * Ce middleware tourne AVANT VerifyCsrfToken et auth pour que tous les
+ * middlewares en aval détectent correctement $request->expectsJson()
+ * et retournent du JSON au lieu de rediriger vers du HTML.
+ */
+class ForceJsonOnAjax
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $isAjaxRoute = str_contains($request->path(), 'ajax')
+            || str_contains($request->path(), 'api/');
+
+        if ($isAjaxRoute || $request->ajax()) {
+            $request->headers->set('Accept', 'application/json');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ForcePasswordChange.php
+++ b/app/Http/Middleware/ForcePasswordChange.php
@@ -41,6 +41,14 @@ class ForcePasswordChange
 
         // Vérifier si l'utilisateur doit changer son mot de passe (premier login)
         if ($user->must_change_password) {
+            if ($request->expectsJson() || $request->ajax() || str_contains($request->path(), 'ajax')) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Veuillez d\'abord changer votre mot de passe.',
+                    'redirect' => route('password.change.form'),
+                ], 403);
+            }
+
             return redirect()->route('password.change.form')
                 ->with('password_change_reason', 'first_login')
                 ->with('warning', 'Bienvenue ! Pour sécuriser votre compte, veuillez créer un mot de passe personnalisé.');
@@ -48,6 +56,14 @@ class ForcePasswordChange
 
         // Vérifier si le mot de passe est expiré (> X mois)
         if (\App\Services\UserService::isPasswordExpired($user)) {
+            if ($request->expectsJson() || $request->ajax() || str_contains($request->path(), 'ajax')) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Votre mot de passe a expiré. Veuillez le changer.',
+                    'redirect' => route('password.change.form'),
+                ], 403);
+            }
+
             return redirect()->route('password.change.form')
                 ->with('password_change_reason', 'expired')
                 ->with('warning', 'Votre mot de passe a expiré. Pour la sécurité de votre compte, veuillez en créer un nouveau.');

--- a/resources/views/auth/change-password.blade.php
+++ b/resources/views/auth/change-password.blade.php
@@ -83,9 +83,8 @@
                     </p>
                     <ul style="font-size: var(--text-small); color: var(--text-secondary); margin: 0; padding-left: var(--space-md);">
                         <li>Au moins 8 caractères</li>
-                        <li>Au moins une lettre majuscule et une minuscule</li>
+                        <li>Au moins une lettre</li>
                         <li>Au moins un chiffre</li>
-                        <li>Au moins un symbole spécial (!@#$%^&*)</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
## Summary

- **ROOT CAUSE trouvée** : le middleware `ForcePasswordChange` redirige les requêtes AJAX vers `/password/change` (HTML) au lieu de retourner du JSON → `parsererror` jQuery. Confirmé via l'onglet Network : `save-ajax` → 302 → `password/change` (200 HTML)
- **ForceJsonOnAjax middleware** : nouveau middleware global qui force `Accept: application/json` sur toute requête dont l'URL contient `ajax` ou `api/`, placé AVANT `VerifyCsrfToken` dans le Kernel
- **Formulaire changement mot de passe** : simplifié les règles (retrait majuscule/minuscule obligatoire + symbole obligatoire), vérification du mot de passe actuel EN PREMIER, suppression du double `Hash::make()`

## Fichiers modifiés

| Fichier | Changement |
|---------|-----------|
| `app/Http/Middleware/ForcePasswordChange.php` | Retourne JSON 403 pour les AJAX au lieu de rediriger |
| `app/Http/Middleware/ForceJsonOnAjax.php` | **NOUVEAU** — force Accept header pour les routes AJAX |
| `app/Http/Kernel.php` | Ajout de ForceJsonOnAjax avant VerifyCsrfToken |
| `app/Http/Controllers/Auth/PasswordChangeController.php` | Règles simplifiées, vérification mot de passe actuel en premier |
| `resources/views/auth/change-password.blade.php` | Mise à jour des exigences affichées |

## Test plan

- [ ] Coordinateur avec mot de passe expiré : la page notes affiche un message JSON au lieu de parsererror
- [ ] Formulaire changement mot de passe : mot de passe `Esbtp2024` (sans symbole) est accepté
- [ ] Après changement de mot de passe, la page redirige vers le dashboard

https://claude.ai/code/session_019h2Cquo1DAzV8JVxHz7vwc