### PR TITLE
fix(classes): resolve Route [student.classes.show] not defined on /esbtp/classes

### DIFF
--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -243,7 +243,7 @@ class ESBTPClasseController extends Controller
         }
 
         // Different view rendering based on user role
-        if ($user->can("can_view_student_features")) {
+        if ($user->hasRole('etudiant')) {
             // For students - read-only view
             return view(
                 "esbtp.classes.student_index",
@@ -473,7 +473,7 @@ class ESBTPClasseController extends Controller
             : date("Y") . "-" . (date("Y") + 1);
 
         // Different view rendering based on user role
-        if ($user->can("can_view_student_features")) {
+        if ($user->hasRole('etudiant')) {
             // For students - read-only view
             return view(
                 "esbtp.classes.student_show",

--- a/resources/views/esbtp/classes/student_index.blade.php
+++ b/resources/views/esbtp/classes/student_index.blade.php
@@ -64,7 +64,7 @@
                                         </td>
                                         <td>
                                             <div class="btn-group" role="group">
-                                                <a href="{{ route('student.classes.show', ['classe' => $classe->id]) }}" class="btn btn-sm btn-info" title="Voir les détails">
+                                                <a href="{{ route('esbtp.student.classes.show', ['classe' => $classe->id]) }}" class="btn btn-sm btn-info" title="Voir les détails">
                                                     <i class="fas fa-eye"></i>
                                                 </a>
                                             </div>

--- a/resources/views/esbtp/classes/student_show.blade.php
+++ b/resources/views/esbtp/classes/student_show.blade.php
@@ -10,7 +10,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h5 class="mb-0">Détails de la classe: {{ $classe->name }}</h5>
                     <div>
-                        <a href="{{ route('student.classes.index') }}" class="btn btn-secondary">
+                        <a href="{{ route('esbtp.student.classes.index') }}" class="btn btn-secondary">
                             <i class="fas fa-arrow-left me-1"></i>Retour à la liste
                         </a>
                     </div>


### PR DESCRIPTION
SuperAdmin was seeing student_index view because the controller used
$user->can("can_view_student_features") which returns true for superAdmin.
Changed to $user->hasRole('etudiant') so only actual students get the
student view. Also fixed missing 'esbtp.' prefix on route names in both
student_index and student_show views.

https://claude.ai/code/session_01S6DWueSUDstydoqj9vrqSm