### PR TITLE
fix: student name display + class average calculation in notes modal

### DIFF
--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -1259,7 +1259,9 @@ class ESBTPClasseController extends Controller
                         "inscription_id" => $inscription->id,
                     ];
                 })
-                ->sortBy([["nom", "asc"], ["prenoms", "asc"]])
+                ->sortBy(function ($student) {
+                    return mb_strtolower($student['nom'] . ' ' . $student['prenoms']);
+                })
                 ->values();
 
             \Log::info("✅ [API] students - Success", [

--- a/public/css/notes-management.css
+++ b/public/css/notes-management.css
@@ -769,8 +769,8 @@
     left: 0;
     z-index: 6;
     background: #fff;
-    width: 185px;
-    min-width: 185px;
+    width: 200px;
+    min-width: 200px;
     border-right: none !important;
 }
 /* Shadow indicator on student col when scrolled (header + footer only) */
@@ -998,7 +998,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 140px;
+    max-width: 160px;
 }
 .nm-student-matricule {
     font-size: 0.65rem;
@@ -1341,7 +1341,7 @@
         max-height: 100vh !important;
     }
     .nm-grid-table .notes-student-col {
-        width: 130px;
-        min-width: 130px;
+        width: 150px;
+        min-width: 150px;
     }
 }

--- a/resources/views/esbtp/notes/index.blade.php
+++ b/resources/views/esbtp/notes/index.blade.php
@@ -787,7 +787,11 @@ function buildNotesGrid() {
                 return;
             }
 
-            cachedStudents = response.students || [];
+            cachedStudents = (response.students || []).sort((a, b) => {
+                const nameA = ((a.nom || '') + ' ' + (a.prenoms || '')).toLowerCase();
+                const nameB = ((b.nom || '') + ' ' + (b.prenoms || '')).toLowerCase();
+                return nameA.localeCompare(nameB, 'fr');
+            });
             cachedStudentsClassId = currentClassId;
             renderNotesGrid(cachedStudents, sortedEvaluations);
         },
@@ -798,13 +802,6 @@ function buildNotesGrid() {
 }
 
 function renderNotesGrid(students, sortedEvaluations) {
-    // Tri alphabétique par nom complet (nom + prénoms)
-    students.sort((a, b) => {
-        const nameA = ((a.nom || '') + ' ' + (a.prenoms || '')).toLowerCase();
-        const nameB = ((b.nom || '') + ' ' + (b.prenoms || '')).toLowerCase();
-        return nameA.localeCompare(nameB, 'fr');
-    });
-
     // Construire l'en-tête
     const thead = $('#notesGrid thead');
     thead.empty();
@@ -1169,7 +1166,7 @@ function calculateClassAverages() {
             const isAbsent = $(`#absent-${studentId}-${evalId}`).is(':checked');
             const rawValue = $(this).val();
 
-            if (!isAbsent && rawValue !== '' && rawValue !== null && rawValue !== undefined) {
+            if (!isAbsent && rawValue !== '') {
                 const noteValue = parseFloat(rawValue);
                 if (!isNaN(noteValue)) {
                     const normalizedNote = (noteValue / params.bareme) * 20;

--- a/resources/views/esbtp/notes/index.blade.php
+++ b/resources/views/esbtp/notes/index.blade.php
@@ -864,7 +864,7 @@ function renderNotesGrid(students, sortedEvaluations) {
                     <div class="nm-student-name">
                         <div class="nm-student-avatar">${initials.toUpperCase()}</div>
                         <div class="nm-student-info">
-                            <div class="nm-student-fullname">${student.nom} ${student.prenoms}</div>
+                            <div class="nm-student-fullname" title="${student.nom} ${student.prenoms}">${student.nom} ${student.prenoms}</div>
                             <div class="nm-student-matricule">${student.matricule || ''}</div>
                         </div>
                     </div>
@@ -1160,12 +1160,15 @@ function calculateClassAverages() {
         noteInputs.each(function() {
             const studentId = $(this).data('student-id');
             const isAbsent = $(`#absent-${studentId}-${evalId}`).is(':checked');
-            const noteValue = parseFloat($(this).val()) || 0;
+            const rawValue = $(this).val();
 
-            if (!isAbsent && !isNaN(noteValue)) {
-                const normalizedNote = (noteValue / params.bareme) * 20;
-                total += normalizedNote;
-                count++;
+            if (!isAbsent && rawValue !== '' && rawValue !== null && rawValue !== undefined) {
+                const noteValue = parseFloat(rawValue);
+                if (!isNaN(noteValue)) {
+                    const normalizedNote = (noteValue / params.bareme) * 20;
+                    total += normalizedNote;
+                    count++;
+                }
             }
         });
 

--- a/resources/views/esbtp/notes/index.blade.php
+++ b/resources/views/esbtp/notes/index.blade.php
@@ -798,6 +798,13 @@ function buildNotesGrid() {
 }
 
 function renderNotesGrid(students, sortedEvaluations) {
+    // Tri alphabétique par nom complet (nom + prénoms)
+    students.sort((a, b) => {
+        const nameA = ((a.nom || '') + ' ' + (a.prenoms || '')).toLowerCase();
+        const nameB = ((b.nom || '') + ' ' + (b.prenoms || '')).toLowerCase();
+        return nameA.localeCompare(nameB, 'fr');
+    });
+
     // Construire l'en-tête
     const thead = $('#notesGrid thead');
     thead.empty();


### PR DESCRIPTION
- Widen student name column (185px→200px, mobile 130→150px) and max-width (140→160px) to show more of the name
- Add title tooltip on student fullname for hover access to complete name
- Fix calculateClassAverages() to skip empty note inputs instead of counting them as 0 — only students with actual grades are included in the per-evaluation class average

https://claude.ai/code/session_014hEhtErPokctiX7oDjRfiX