### PR TITLE
fix(inscriptions): align permission check in update with edit form

### DIFF
--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -973,7 +973,7 @@ class ESBTPInscriptionController extends Controller
 
             if (
                 $inscription->status === "active" &&
-                !Auth::user()->can("inscriptions.manage")
+                !Auth::user()->can("access_admin")
             ) {
                 // Empêcher la modification de la filière, niveau et classe pour les inscriptions actives (sauf utilisateurs autorisés)
                 unset($data["filiere_id"]);


### PR DESCRIPTION
The edit form uses `access_admin` to show editable class/filiere/niveau
fields, but the controller checked `inscriptions.manage` before
persisting those changes. Coordinateurs (who have `access_admin` but
not `inscriptions.manage`) could see and change the fields, get a
success message, yet the class was silently reverted to its old value.

https://claude.ai/code/session_01137EL2rgRasgGyKSnPwbtk