### PR TITLE
feat(emploi-temps): redesign v2 — chips filtrantes, cards compact, sticky nav, search

### DIFF
--- a/app/Http/Controllers/ESBTPEmploiTempsController.php
+++ b/app/Http/Controllers/ESBTPEmploiTempsController.php
@@ -42,7 +42,12 @@ class ESBTPEmploiTempsController extends Controller
         $anneeEnCours = ESBTPAnneeUniversitaire::where('is_current', true)->first();
 
         // Filtrer les emplois du temps par année courante
-        $emploisTempsQuery = ESBTPEmploiTemps::with(['classe.filiere', 'classe.niveau', 'seances']);
+        $emploisTempsQuery = ESBTPEmploiTemps::with([
+            'classe.filiere',
+            'classe.niveau',
+            'seances:id,emploi_temps_id,heure_debut,heure_fin',
+            'updatedBy:id,name',
+        ])->withCount('seances');
 
         if ($anneeEnCours) {
             $emploisTempsQuery->where('annee_universitaire_id', $anneeEnCours->id);
@@ -128,10 +133,24 @@ class ESBTPEmploiTempsController extends Controller
             return $today->between($startDate, $endDate);
         });
         $emploisTempsActifsCount = $emploisTempsActifs->count();
-        $totalSeances = ESBTPSeanceCours::count();
+
+        // Séances de l'année courante uniquement (bug précédent : count app-wide)
+        $totalSeances = ESBTPSeanceCours::whereHas('emploiTemps', function ($q) use ($anneeEnCours) {
+            if ($anneeEnCours) {
+                $q->where('annee_universitaire_id', $anneeEnCours->id);
+            }
+        })->count();
 
         // Emplois du temps de l'année en cours (déjà filtrés)
         $emploisTempsAnneeEnCours = $emploisTemps->count();
+
+        // Compteurs pour les chips filtrantes (redesign v2)
+        $edtExpiresCount = $emploisTemps->filter(function ($et) use ($today) {
+            return $et->date_fin && Carbon::parse($et->date_fin)->lt($today);
+        })->count();
+        $totalClassesTenant = ESBTPClasse::where('is_active', true)->count();
+        $classesAvecEdtActifIds = $emploisTempsActifs->pluck('classe_id')->unique();
+        $classesSansEdtCount = max(0, $totalClassesTenant - $classesAvecEdtActifIds->count());
 
         // Passer l'année courante avec le bon nom pour la vue
         $anneeUniversitaireCourante = $anneeEnCours;
@@ -148,7 +167,8 @@ class ESBTPEmploiTempsController extends Controller
         return view('esbtp.emploi-temps.index', compact(
             'emploisTemps', 'filieres', 'niveaux', 'classes', 'annees', 'anneeUniversitaireCourante',
             'totalEmploisTemps', 'emploisTempsActifsCount', 'totalSeances', 'emploisTempsAnneeEnCours', 'timetableShortcut',
-            'emploisTempsActifs', 'totalSemaines', 'totalClassesPlanifiees', 'semaines', 'semaineCouranteValue'
+            'emploisTempsActifs', 'totalSemaines', 'totalClassesPlanifiees', 'semaines', 'semaineCouranteValue',
+            'edtExpiresCount', 'totalClassesTenant', 'classesSansEdtCount'
         ));
     }
 

--- a/resources/views/esbtp/emploi-temps/index.blade.php
+++ b/resources/views/esbtp/emploi-temps/index.blade.php
@@ -532,15 +532,20 @@
         -webkit-overflow-scrolling: touch;
     }
     
-    /* Conteneur des cards */
+    /* Conteneur des cards — redesign v2 : stack 1 colonne (cards horizontales), 2 colonnes ≥ 1600px */
     .emplois-cards-container {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        gap: var(--space-md);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-sm);
         margin-bottom: var(--space-lg);
-        align-items: stretch;
-        grid-auto-flow: row dense;
         width: 100%;
+    }
+    @media (min-width: 1600px) {
+        .emplois-cards-container {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: var(--space-md);
+        }
     }
 
     .emploi-card {
@@ -578,16 +583,11 @@
         transition: all 0.3s ease;
     }
 
-    /* Responsive pour les cards */
-    @media (min-width: 1400px) {
-        .emplois-cards-container {
-            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-        }
-    }
-
+    /* Responsive pour les cards (redesign v2 stack — les rules historiques neutralisées) */
     @media (max-width: 991px) {
         .emplois-cards-container {
-            grid-template-columns: 1fr;
+            display: flex;
+            flex-direction: column;
         }
     }
 
@@ -1067,12 +1067,434 @@
         .et-week-nav-right { width: 100%; justify-content: stretch; }
         .et-week-nav-right .et-week-btn { flex: 1; justify-content: center; }
     }
+
+    /* ══════════════════════════════════════════════
+       Redesign v2 — alert strip, chips, search, sticky
+       ══════════════════════════════════════════════ */
+
+    /* Alert strip (conditionnelle, visible uniquement si expirés > 0) */
+    .et-alert-strip {
+        display: flex;
+        align-items: center;
+        gap: .85rem;
+        padding: .7rem 1rem;
+        margin-bottom: .85rem;
+        background: #fef2f2;
+        border: 1px solid #fecaca;
+        border-radius: 12px;
+        color: #991b1b;
+        max-height: 48px;
+        font-size: .86rem;
+    }
+    .et-alert-strip__icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px; height: 28px;
+        border-radius: 8px;
+        background: rgba(220, 38, 38, .12);
+        color: #dc2626;
+        flex-shrink: 0;
+    }
+    .et-alert-strip__body { flex: 1; min-width: 0; }
+    .et-alert-strip__body strong { color: #b91c1c; font-weight: 700; }
+    .et-alert-strip__hint { color: #7f1d1d; opacity: .75; }
+    .et-alert-strip__action {
+        display: inline-flex;
+        align-items: center;
+        gap: .4rem;
+        padding: .4rem .85rem;
+        border-radius: 8px;
+        border: 1px solid #dc2626;
+        background: #fff;
+        color: #b91c1c;
+        font-size: .8rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all .18s ease;
+        flex-shrink: 0;
+    }
+    .et-alert-strip__action:hover { background: #dc2626; color: #fff; }
+
+    /* Chips filtrantes */
+    .et-chips-bar {
+        display: flex;
+        align-items: center;
+        gap: .5rem;
+        flex-wrap: wrap;
+        margin-bottom: 1rem;
+    }
+    .et-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: .45rem;
+        padding: .45rem .85rem;
+        border-radius: 999px;
+        border: 1px solid #e2e8f0;
+        background: #fff;
+        color: #475569;
+        font-size: .82rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all .18s ease;
+        text-decoration: none;
+        line-height: 1.2;
+    }
+    .et-chip:hover { border-color: #0453cb; color: #0453cb; background: rgba(4,83,203,.03); }
+    .et-chip.is-active {
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        border-color: transparent;
+        color: #fff;
+        box-shadow: 0 4px 12px rgba(4,83,203,.22);
+    }
+    .et-chip__count {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 22px;
+        padding: 1px 6px;
+        border-radius: 999px;
+        background: rgba(15,23,42,.06);
+        color: #475569;
+        font-size: .72rem;
+        font-weight: 700;
+    }
+    .et-chip.is-active .et-chip__count { background: rgba(255,255,255,.22); color: #fff; }
+    .et-chip__dot {
+        display: inline-block;
+        width: 8px; height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+    .et-chip__dot--success { background: #10b981; box-shadow: 0 0 0 3px rgba(16,185,129,.18); }
+    .et-chip__dot--danger  { background: #dc2626; box-shadow: 0 0 0 3px rgba(220,38,38,.18); }
+    .et-chip__dot--muted   { background: #94a3b8; box-shadow: 0 0 0 3px rgba(148,163,184,.18); }
+    .et-chips-separator {
+        width: 1px;
+        height: 24px;
+        background: #e2e8f0;
+        margin: 0 .25rem;
+    }
+    .et-chip--link {
+        color: #0453cb;
+        border-style: dashed;
+        border-color: #cbd5e1;
+    }
+    .et-chip--link:hover { border-style: solid; }
+    .et-chip--link i { font-size: .7rem; opacity: .7; }
+
+    /* Recherche inline dans le header de la liste */
+    .et-list-card__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: .75rem;
+    }
+    .et-list-card__tools {
+        display: flex;
+        align-items: center;
+        gap: .6rem;
+        flex-wrap: wrap;
+    }
+    .et-search-inline {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+    }
+    .et-search-inline > i.fa-search {
+        position: absolute;
+        left: .75rem;
+        color: #94a3b8;
+        font-size: .8rem;
+        pointer-events: none;
+    }
+    .et-search-inline__input {
+        padding: .4rem .75rem .4rem 2rem;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        font-size: .82rem;
+        width: 220px;
+        background: #fff;
+        transition: all .18s ease;
+    }
+    .et-search-inline__input:focus {
+        outline: none;
+        border-color: #0453cb;
+        box-shadow: 0 0 0 3px rgba(4,83,203,.08);
+        width: 260px;
+    }
+    .et-search-inline__clear {
+        position: absolute;
+        right: .3rem;
+        padding: .2rem .4rem;
+        background: transparent;
+        border: none;
+        color: #94a3b8;
+        cursor: pointer;
+        font-size: .9rem;
+    }
+    .et-search-inline__clear:hover { color: #dc2626; }
+
+    /* Sticky week-navigator au scroll */
+    .et-week-nav {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        backdrop-filter: blur(6px);
+        background: rgba(255,255,255,.96);
+    }
+
+    /* Current week pill : bordure dorée discrète */
+    .et-week-pill--current:not(.is-active) {
+        border-color: #facc15 !important;
+        box-shadow: 0 0 0 2px rgba(250,204,21,.12);
+    }
+    .et-week-pill--current:not(.is-active) .et-week-pill-range::after {
+        content: '•';
+        color: #facc15;
+        margin-left: 4px;
+    }
+
+    /* Empty-state quand le filtre masque toutes les cards */
+    .et-empty-filter {
+        padding: 2.5rem 1rem;
+        text-align: center;
+        color: #64748b;
+        background: #f8fafc;
+        border: 1px dashed #cbd5e1;
+        border-radius: 12px;
+        font-size: .88rem;
+    }
+    .et-empty-filter i { font-size: 1.6rem; color: #94a3b8; margin-bottom: .5rem; display: block; }
+
+    @media (max-width: 768px) {
+        .et-alert-strip { max-height: none; flex-wrap: wrap; }
+        .et-alert-strip__action { margin-left: auto; }
+        .et-search-inline__input,
+        .et-search-inline__input:focus { width: 100%; }
+        .et-search-inline { flex: 1 1 100%; }
+        .et-list-card__tools { width: 100%; }
+    }
+
+    /* ══════════════════════════════════════════════
+       Card EDT v1 — redesign compact premium
+       ══════════════════════════════════════════════ */
+    .et-card {
+        position: relative;
+        display: flex;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        margin-bottom: .85rem;
+        overflow: hidden;
+        box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
+        transition: box-shadow .2s ease, transform .2s ease, border-color .2s ease;
+    }
+    .et-card:hover {
+        box-shadow: 0 8px 30px rgba(4,83,203,.08), 0 2px 8px rgba(15,23,42,.04);
+        transform: translateY(-1px);
+        border-color: #cbd5e1;
+    }
+    .et-card__stripe {
+        width: 4px;
+        flex-shrink: 0;
+        display: block;
+    }
+    .et-card__inner {
+        flex: 1;
+        padding: 1rem 1.1rem;
+        display: flex;
+        flex-direction: column;
+        gap: .7rem;
+        min-width: 0;
+    }
+
+    /* Head : titre + badges */
+    .et-card__head {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: .75rem;
+        flex-wrap: wrap;
+    }
+    .et-card__titles { flex: 1; min-width: 0; }
+    .et-card__title {
+        margin: 0 0 .15rem 0;
+        font-size: .98rem;
+        font-weight: 700;
+        color: #0f172a;
+        line-height: 1.3;
+    }
+    .et-card__subtitle {
+        display: flex;
+        align-items: center;
+        gap: .35rem;
+        font-size: .78rem;
+        color: #64748b;
+        font-weight: 500;
+        flex-wrap: wrap;
+    }
+    .et-card__sep { color: #cbd5e1; font-weight: 400; }
+    .et-card__badges { display: flex; gap: .35rem; flex-wrap: wrap; flex-shrink: 0; }
+    .et-card__badge {
+        display: inline-flex;
+        align-items: center;
+        gap: .3rem;
+        padding: .2rem .55rem;
+        border-radius: 999px;
+        font-size: .7rem;
+        font-weight: 700;
+        line-height: 1.4;
+    }
+    .et-card__badge i { font-size: .65rem; }
+    .et-card__badge--danger  { background: #fee2e2; color: #b91c1c; }
+    .et-card__badge--success { background: rgba(16,185,129,.14); color: #047857; }
+    .et-card__badge--warning { background: rgba(245,158,11,.15); color: #b45309; }
+    .et-card__badge--info    { background: rgba(4,83,203,.1); color: #0453cb; }
+
+    /* Meta row */
+    .et-card__meta {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+        font-size: .82rem;
+        color: #475569;
+    }
+    .et-card__meta-item {
+        display: inline-flex;
+        align-items: center;
+        gap: .35rem;
+        font-weight: 500;
+    }
+    .et-card__meta-item i { color: #94a3b8; font-size: .78rem; }
+    .et-card__meta-item--muted {
+        padding: .1rem .5rem;
+        border-radius: 6px;
+        background: #f1f5f9;
+        font-size: .72rem;
+        font-weight: 700;
+        color: #475569;
+    }
+
+    /* Footer fraîcheur */
+    .et-card__footer {
+        display: flex;
+        align-items: center;
+        gap: .4rem;
+        font-size: .72rem;
+        color: #94a3b8;
+        padding-top: .5rem;
+        border-top: 1px dashed #e2e8f0;
+    }
+    .et-card__footer i { font-size: .7rem; }
+
+    /* Actions */
+    .et-card__actions {
+        display: flex;
+        align-items: center;
+        gap: .45rem;
+        margin-top: .25rem;
+    }
+    .et-card-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: .35rem;
+        padding: .5rem .85rem;
+        border-radius: 10px;
+        font-size: .8rem;
+        font-weight: 600;
+        text-decoration: none;
+        border: 1px solid #e2e8f0;
+        background: #fff;
+        color: #475569;
+        cursor: pointer;
+        transition: all .18s ease;
+        white-space: nowrap;
+    }
+    .et-card-btn:hover { border-color: #0453cb; color: #0453cb; background: rgba(4,83,203,.04); }
+    .et-card-btn--ghost { color: #b91c1c; }
+    .et-card-btn--ghost:hover { border-color: #dc2626; color: #b91c1c; background: #fee2e2; }
+    .et-card-btn--primary {
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        border-color: transparent;
+        color: #fff;
+        margin-left: auto;
+        box-shadow: 0 4px 12px rgba(4,83,203,.22);
+    }
+    .et-card-btn--primary:hover {
+        background: linear-gradient(135deg, #033a8e, #0453cb);
+        color: #fff;
+        box-shadow: 0 6px 18px rgba(4,83,203,.3);
+    }
+    .et-card-btn--icon {
+        width: 36px;
+        height: 36px;
+        padding: 0;
+        justify-content: center;
+        color: #64748b;
+    }
+
+    /* Menu popover (edit / delete) */
+    .et-card__menu { position: relative; }
+    .et-card__menu-pop {
+        position: absolute;
+        top: calc(100% + 4px);
+        right: 0;
+        min-width: 160px;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        box-shadow: 0 10px 30px rgba(15,23,42,.12), 0 4px 12px rgba(15,23,42,.06);
+        padding: .3rem;
+        z-index: 50;
+    }
+    .et-card__menu-pop a,
+    .et-card__menu-pop button,
+    .et-card__menu-item {
+        display: flex;
+        align-items: center;
+        gap: .55rem;
+        width: 100%;
+        padding: .5rem .75rem;
+        border-radius: 7px;
+        font-size: .82rem;
+        color: #1e293b;
+        text-decoration: none;
+        background: transparent;
+        border: none;
+        text-align: left;
+        cursor: pointer;
+        transition: background .15s ease;
+    }
+    .et-card__menu-pop a:hover,
+    .et-card__menu-item:hover { background: rgba(4,83,203,.08); color: #0453cb; }
+    .et-card__menu-item--danger { color: #b91c1c; }
+    .et-card__menu-item--danger:hover { background: #fee2e2; color: #b91c1c; }
+    .et-card__menu-pop form { margin: 0; }
+    .et-card__menu-pop i { width: 14px; text-align: center; color: #94a3b8; }
+    .et-card__menu-pop a:hover i,
+    .et-card__menu-item:hover i { color: inherit; }
+
+    /* Décoration subtile selon statut (bordure gauche existante via stripe suffit, on garde) */
+    .et-card--expired { background: #fffcfc; }
+    .et-card--active { background: #fafffe; }
+
+    [x-cloak] { display: none !important; }
+
+    @media (max-width: 576px) {
+        .et-card__head { flex-direction: column; }
+        .et-card__badges { width: 100%; }
+        .et-card-btn--primary { margin-left: 0; flex: 1; justify-content: center; }
+        .et-card__actions { flex-wrap: wrap; }
+    }
 </style>
 @endsection
 
 @section('content')
 <div class="dashboard-acasi">
-    <div class="main-content">
+    <div class="main-content" x-data="{ statusFilter: '{{ request('status_chip', 'all') }}', searchQuery: '' }">
         <!-- Header premium -->
         <div class="emploi-temps-header">
             <div class="et-header-inner">
@@ -1082,7 +1504,7 @@
                     </div>
                     <div>
                         <h1>Gestion des emplois du temps</h1>
-                        <p class="et-subtitle">Administration avancee des plannings scolaires</p>
+                        <p class="et-subtitle">{{ $anneeUniversitaireCourante->name ?? 'Aucune année active' }} · {{ $totalClassesTenant ?? 0 }} classes au total</p>
                     </div>
                 </div>
                 <div class="et-header-actions">
@@ -1117,28 +1539,45 @@
             </div>
         @endif
 
-        <!-- KPI Grid premium -->
-        <div class="et-kpi-grid">
-            <div class="et-kpi et-kpi--primary">
-                <div class="et-kpi-icon"><i class="fas fa-calendar-week"></i></div>
-                <div class="et-kpi-value">{{ $totalSemaines ?? 0 }}</div>
-                <div class="et-kpi-label">Semaines planifiées</div>
+        {{-- Alert strip conditionnelle : visible uniquement si des EDT sont expirés --}}
+        @if(($edtExpiresCount ?? 0) > 0)
+            <div class="et-alert-strip" role="alert">
+                <div class="et-alert-strip__icon"><i class="fas fa-circle-exclamation"></i></div>
+                <div class="et-alert-strip__body">
+                    <strong>{{ $edtExpiresCount }}</strong> emploi{{ $edtExpiresCount > 1 ? 's' : '' }} du temps expiré{{ $edtExpiresCount > 1 ? 's' : '' }}
+                    <span class="et-alert-strip__hint">— à renouveler pour éviter toute rupture de planning</span>
+                </div>
+                <button type="button" class="et-alert-strip__action" @click="statusFilter = 'expired'; document.getElementById('emploisListAnchor')?.scrollIntoView({behavior:'smooth', block:'start'})">
+                    Voir les expirés
+                    <i class="fas fa-arrow-right"></i>
+                </button>
             </div>
-            <div class="et-kpi et-kpi--success">
-                <div class="et-kpi-icon"><i class="fas fa-check-circle"></i></div>
-                <div class="et-kpi-value">{{ $emploisTempsActifsCount }}</div>
-                <div class="et-kpi-label">Plannings actifs cette semaine</div>
-            </div>
-            <div class="et-kpi et-kpi--accent">
-                <div class="et-kpi-icon"><i class="fas fa-users"></i></div>
-                <div class="et-kpi-value">{{ $totalClassesPlanifiees ?? 0 }}</div>
-                <div class="et-kpi-label">Classes planifiées</div>
-            </div>
-            <div class="et-kpi et-kpi--soft">
-                <div class="et-kpi-icon"><i class="fas fa-graduation-cap"></i></div>
-                <div class="et-kpi-value et-kpi-value--sm">{{ $anneeUniversitaireCourante->name ?? 'N/A' }}</div>
-                <div class="et-kpi-label">Année universitaire</div>
-            </div>
+        @endif
+
+        {{-- Chips filtrantes (Alpine) : filtrage client-side des cards par statut --}}
+        <div class="et-chips-bar">
+            <button type="button" class="et-chip" :class="{ 'is-active': statusFilter === 'all' }" @click="statusFilter = 'all'">
+                <span class="et-chip__label">Tout</span>
+                <span class="et-chip__count">{{ $emploisTemps->count() }}</span>
+            </button>
+            <button type="button" class="et-chip" :class="{ 'is-active': statusFilter === 'active' }" @click="statusFilter = 'active'">
+                <span class="et-chip__dot et-chip__dot--success"></span>
+                <span class="et-chip__label">Actif</span>
+                <span class="et-chip__count">{{ $emploisTempsActifsCount }}</span>
+            </button>
+            <button type="button" class="et-chip" :class="{ 'is-active': statusFilter === 'expired' }" @click="statusFilter = 'expired'">
+                <span class="et-chip__dot et-chip__dot--danger"></span>
+                <span class="et-chip__label">Expiré</span>
+                <span class="et-chip__count">{{ $edtExpiresCount ?? 0 }}</span>
+            </button>
+            <div class="et-chips-separator"></div>
+            @if(($classesSansEdtCount ?? 0) > 0)
+                <a href="#raccourciEmploisTemps" class="et-chip et-chip--link">
+                    <span class="et-chip__dot et-chip__dot--muted"></span>
+                    <span class="et-chip__label">{{ $classesSansEdtCount }} classe{{ $classesSansEdtCount > 1 ? 's' : '' }} sans emploi du temps</span>
+                    <i class="fas fa-arrow-right"></i>
+                </a>
+            @endif
         </div>
 
         <!-- Navigateur de semaine -->
@@ -1225,23 +1664,40 @@
 
         <div class="row">
             <!-- Main content -->
-            <div class="col-lg-8">
+            <div class="col-lg-8" id="emploisListAnchor">
                 <div class="et-list-card">
-                    <div class="card-header">
+                    <div class="card-header et-list-card__header">
                         <h5 class="mb-0">
                             <i class="fas fa-calendar-alt me-2"></i>Liste des emplois du temps
                         </h5>
-                        <div class="emploi-view-toggle">
-                            <div class="btn-group btn-group-sm" role="group">
-                                <input type="radio" class="btn-check" name="viewMode" id="cardView" checked>
-                                <label class="btn btn-outline-secondary" for="cardView">
-                                    <i class="fas fa-th-large"></i> Cards
-                                </label>
-                                
-                                <input type="radio" class="btn-check" name="viewMode" id="tableView">
-                                <label class="btn btn-outline-secondary" for="tableView">
-                                    <i class="fas fa-table"></i> Tableau
-                                </label>
+                        <div class="et-list-card__tools">
+                            <div class="et-search-inline">
+                                <i class="fas fa-search"></i>
+                                <input type="search"
+                                       class="et-search-inline__input"
+                                       placeholder="Filtrer par classe ou filière..."
+                                       x-model.debounce.300ms="searchQuery"
+                                       aria-label="Filtrer les emplois du temps">
+                                <button type="button"
+                                        class="et-search-inline__clear"
+                                        x-show="searchQuery.length > 0"
+                                        @click="searchQuery = ''"
+                                        aria-label="Effacer la recherche">
+                                    <i class="fas fa-times-circle"></i>
+                                </button>
+                            </div>
+                            <div class="emploi-view-toggle">
+                                <div class="btn-group btn-group-sm" role="group">
+                                    <input type="radio" class="btn-check" name="viewMode" id="cardView" checked>
+                                    <label class="btn btn-outline-secondary" for="cardView">
+                                        <i class="fas fa-th-large"></i> Cards
+                                    </label>
+
+                                    <input type="radio" class="btn-check" name="viewMode" id="tableView">
+                                    <label class="btn btn-outline-secondary" for="tableView">
+                                        <i class="fas fa-table"></i> Tableau
+                                    </label>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/resources/views/esbtp/emploi-temps/index.blade.php
+++ b/resources/views/esbtp/emploi-temps/index.blade.php
@@ -1494,7 +1494,25 @@
 
 @section('content')
 <div class="dashboard-acasi">
-    <div class="main-content" x-data="{ statusFilter: '{{ request('status_chip', 'all') }}', searchQuery: '' }">
+    <div class="main-content" x-data="{
+        statusFilter: '{{ request('status_chip', 'all') }}',
+        searchQuery: '',
+        matchesCard(status, haystack) {
+            if (this.statusFilter !== 'all' && this.statusFilter !== status) return false;
+            const q = this.searchQuery.trim().toLowerCase();
+            return q === '' || (haystack || '').includes(q);
+        },
+        get visibleCardsCount() {
+            let n = 0;
+            document.querySelectorAll('.et-card[data-status]').forEach(el => {
+                if (this.matchesCard(el.dataset.status, el.dataset.search)) n++;
+            });
+            return n;
+        },
+        get hasActiveFilter() {
+            return this.statusFilter !== 'all' || this.searchQuery.trim() !== '';
+        }
+    }">
         <!-- Header premium -->
         <div class="emploi-temps-header">
             <div class="et-header-inner">

--- a/resources/views/esbtp/emploi-temps/partials/cards.blade.php
+++ b/resources/views/esbtp/emploi-temps/partials/cards.blade.php
@@ -79,7 +79,7 @@
          data-status="{{ $cardStatus }}"
          data-search="{{ $searchHaystack }}"
          x-show="(statusFilter === 'all' || statusFilter === '{{ $cardStatus }}')
-                 && (searchQuery.trim() === '' || '{{ addslashes($searchHaystack) }}'.includes(searchQuery.toLowerCase()))"
+                 && (searchQuery.trim() === '' || $el.dataset.search.includes(searchQuery.toLowerCase()))"
          x-transition.opacity>
 
         <span class="et-card__stripe" style="background: {{ $stripeColor }};" aria-hidden="true"></span>
@@ -210,4 +210,20 @@
         </div>
     </div>
 @endforelse
+
+{{-- Empty-state client-side : visible quand chip + recherche masquent toutes les cards --}}
+@if($emploisTemps->isNotEmpty())
+    <div class="et-empty-filter"
+         x-show="hasActiveFilter && visibleCardsCount === 0"
+         x-cloak
+         style="display: none;">
+        <i class="fas fa-filter"></i>
+        <div>Aucun emploi du temps ne correspond au filtre actuel.</div>
+        <button type="button"
+                class="et-card-btn et-card-btn--ghost mt-3"
+                @click="statusFilter = 'all'; searchQuery = ''">
+            <i class="fas fa-times"></i>Réinitialiser les filtres
+        </button>
+    </div>
+@endif
 

--- a/resources/views/esbtp/emploi-temps/partials/cards.blade.php
+++ b/resources/views/esbtp/emploi-temps/partials/cards.blade.php
@@ -1,5 +1,10 @@
+@php
+    // Palette monochrome bleue KLASSCI — stripe gauche stable par filière
+    $etStripePalette = ['#0a3d8f', '#0453cb', '#1e5fc4', '#2d6dc8', '#3b7ddb', '#4a8bd9', '#5e91de', '#7aa8e4'];
+@endphp
+
 @if(!empty($timetableShortcut) && ($timetableShortcut['show'] ?? false))
-    <div class="emploi-card emploi-shortcut-card">
+    <div class="emploi-card emploi-shortcut-card" id="raccourciEmploisTemps">
         <div class="emploi-card-body">
             <div class="emploi-shortcut-title">
                 <i class="fas fa-calendar-exclamation me-2"></i>Raccourci emplois du temps
@@ -41,101 +46,154 @@
         $isUpcoming = $startDate && $startDate->gt($today);
         $isCurrentPeriod = $startDate && $endDate && $today->between($startDate, $endDate);
         $isExpiringSoon = $endDate && $endDate->gte($today) && $endDate->diffInDays($today) <= 3;
+
+        // Statut pour les chips (aligne sur statusFilter côté Alpine)
+        $cardStatus = $isExpired ? 'expired' : ($isCurrentPeriod ? 'active' : 'upcoming');
+
+        // Couleur stripe stable par filière (hash monochrome bleu)
+        $filiereName = $emploiTemps->classe->filiere->name ?? '—';
+        $stripeIdx = hexdec(substr(md5($filiereName), 0, 4)) % count($etStripePalette);
+        $stripeColor = $etStripePalette[$stripeIdx];
+
+        // Meta : séances + heures (eager loaded, pas de N+1)
+        $seancesCount = $emploiTemps->seances_count ?? ($emploiTemps->seances?->count() ?? 0);
+        $totalMinutes = ($emploiTemps->seances ?? collect())->sum(function ($s) {
+            if (!$s->heure_debut || !$s->heure_fin) return 0;
+            return \Carbon\Carbon::parse($s->heure_debut)->diffInMinutes(\Carbon\Carbon::parse($s->heure_fin));
+        });
+        $totalHours = intdiv((int) $totalMinutes, 60);
+        $totalRemMinutes = (int) $totalMinutes % 60;
+
+        // Haystack pour la recherche inline (classe + filière + niveau)
+        $searchHaystack = strtolower(trim(
+            ($emploiTemps->classe->name ?? '') . ' ' .
+            ($emploiTemps->classe->filiere->name ?? '') . ' ' .
+            ($emploiTemps->classe->niveau->name ?? '')
+        ));
+
+        $canEdit = auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school']) || auth()->user()->can('edit_timetables');
+        $canDelete = auth()->user()->can('access_admin') && auth()->user()->can('delete_timetables');
     @endphp
-    <div class="emploi-card {{ $isCurrentPeriod ? 'active' : '' }} {{ $isExpired ? 'expired' : '' }} {{ $isUpcoming ? 'upcoming' : '' }}">
-        <div class="emploi-card-header">
-            <h6 class="emploi-card-title">
-                <i class="fas fa-calendar-alt me-2"></i>
-                {{ $emploiTemps->titre ?? 'Emploi du temps' }}
-            </h6>
-            <div class="emploi-status-badges">
-                @if($isExpired)
-                    <span class="badge-moderne danger">Expiré</span>
-                @elseif($isCurrentPeriod)
-                    <span class="badge-moderne success">Actif</span>
-                @elseif($isUpcoming)
-                    <span class="badge-moderne secondary">Inactif</span>
-                @else
-                    <span class="badge-moderne secondary">Inactif</span>
-                @endif
-                @if($isExpiringSoon && !$isExpired)
-                    <span class="badge-moderne warning">Expire bientôt</span>
-                @endif
-            </div>
-        </div>
 
-        <div class="emploi-card-body">
-            <div class="emploi-info-list">
-                <div class="emploi-info-row">
-                    <i class="fas fa-users"></i>
-                    <span class="emploi-info-key">Classe</span>
-                    <span class="emploi-info-val">{{ $emploiTemps->classe->name ?? 'Non définie' }}</span>
-                </div>
-                <div class="emploi-info-row">
-                    <i class="fas fa-sitemap"></i>
-                    <span class="emploi-info-key">Filière</span>
-                    <span class="emploi-info-val">{{ $emploiTemps->classe->filiere->name ?? 'Non définie' }}</span>
-                </div>
-                <div class="emploi-info-row">
-                    <i class="fas fa-layer-group"></i>
-                    <span class="emploi-info-key">Niveau</span>
-                    <span class="emploi-info-val">{{ $emploiTemps->classe->niveau->name ?? 'Non défini' }}</span>
-                </div>
-                <div class="emploi-info-row">
-                    <i class="fas fa-calendar"></i>
-                    <span class="emploi-info-key">Année</span>
-                    <span class="emploi-info-val">{{ Str::limit($emploiTemps->annee->name ?? 'Non définie', 15) }}</span>
-                </div>
-            </div>
+    <div class="et-card et-card--{{ $cardStatus }}"
+         data-status="{{ $cardStatus }}"
+         data-search="{{ $searchHaystack }}"
+         x-show="(statusFilter === 'all' || statusFilter === '{{ $cardStatus }}')
+                 && (searchQuery.trim() === '' || '{{ addslashes($searchHaystack) }}'.includes(searchQuery.toLowerCase()))"
+         x-transition.opacity>
 
-            <div class="emploi-info-pills">
-                <span class="emploi-info-pill primary">
-                    <i class="fas fa-clock"></i>
-                    Période:
-                    @if($emploiTemps->semestre == 'Semestre 1')
-                        S1
-                    @elseif($emploiTemps->semestre == 'Semestre 2')
-                        S2
-                    @else
-                        Année
+        <span class="et-card__stripe" style="background: {{ $stripeColor }};" aria-hidden="true"></span>
+
+        <div class="et-card__inner">
+            <div class="et-card__head">
+                <div class="et-card__titles">
+                    <h6 class="et-card__title">{{ $emploiTemps->classe->name ?? 'Classe inconnue' }}</h6>
+                    <div class="et-card__subtitle">
+                        <span>{{ $filiereName }}</span>
+                        <span class="et-card__sep">·</span>
+                        <span>{{ $emploiTemps->classe->niveau->name ?? 'Niveau inconnu' }}</span>
+                    </div>
+                </div>
+                <div class="et-card__badges">
+                    @if($isExpired)
+                        <span class="et-card__badge et-card__badge--danger">
+                            <i class="fas fa-circle-exclamation"></i>Expiré
+                        </span>
+                    @elseif($isCurrentPeriod)
+                        <span class="et-card__badge et-card__badge--success">
+                            <i class="fas fa-circle-check"></i>Actif
+                        </span>
+                    @elseif($isUpcoming)
+                        <span class="et-card__badge et-card__badge--info">
+                            <i class="fas fa-calendar"></i>À venir
+                        </span>
                     @endif
-                </span>
-                @if($emploiTemps->date_debut && $emploiTemps->date_fin)
-                    <span class="emploi-info-pill info">
+                    @if($isExpiringSoon && !$isExpired)
+                        <span class="et-card__badge et-card__badge--warning">
+                            <i class="fas fa-clock"></i>Expire bientôt
+                        </span>
+                    @endif
+                </div>
+            </div>
+
+            <div class="et-card__meta">
+                @if($startDate && $endDate)
+                    <span class="et-card__meta-item">
                         <i class="fas fa-calendar-day"></i>
-                        Dates:
-                        {{ \Carbon\Carbon::parse($emploiTemps->date_debut)->format('d/m/Y') }}
-                        <i class="fas fa-arrow-right mx-1"></i>
-                        {{ \Carbon\Carbon::parse($emploiTemps->date_fin)->format('d/m/Y') }}
+                        {{ $startDate->isoFormat('D MMM') }} → {{ $endDate->isoFormat('D MMM YYYY') }}
+                    </span>
+                @endif
+                <span class="et-card__meta-item">
+                    <i class="fas fa-layer-group"></i>
+                    {{ $seancesCount }} séance{{ $seancesCount > 1 ? 's' : '' }}
+                </span>
+                @if($totalMinutes > 0)
+                    <span class="et-card__meta-item">
+                        <i class="fas fa-clock"></i>
+                        {{ $totalHours }}h{{ $totalRemMinutes > 0 ? str_pad((string) $totalRemMinutes, 2, '0', STR_PAD_LEFT) : '' }}
+                    </span>
+                @endif
+                @if($emploiTemps->semestre && $emploiTemps->semestre !== 'Année')
+                    <span class="et-card__meta-item et-card__meta-item--muted">
+                        {{ $emploiTemps->semestre === 'Semestre 1' ? 'S1' : ($emploiTemps->semestre === 'Semestre 2' ? 'S2' : $emploiTemps->semestre) }}
                     </span>
                 @endif
             </div>
 
-            <div class="emploi-actions">
+            @if($emploiTemps->updatedBy || $emploiTemps->updated_at)
+                <div class="et-card__footer">
+                    <i class="fas fa-user-pen"></i>
+                    Modifié {{ $emploiTemps->updated_at?->diffForHumans() }}
+                    @if($emploiTemps->updatedBy)
+                        par {{ $emploiTemps->updatedBy->name }}
+                    @endif
+                </div>
+            @endif
+
+            <div class="et-card__actions">
                 <a href="{{ route('esbtp.emploi-temps.export-pdf', $emploiTemps->id) }}"
-                   class="btn-pdf" title="Exporter en PDF">
-                    <i class="fas fa-file-pdf"></i>PDF
+                   class="et-card-btn et-card-btn--ghost"
+                   title="Exporter en PDF">
+                    <i class="fas fa-file-pdf"></i>
+                    <span>PDF</span>
                 </a>
                 <a href="{{ route('esbtp.emploi-temps.show', $emploiTemps->id) }}"
-                   class="btn btn-sm btn-outline-primary" title="Voir">
-                    <i class="fas fa-eye"></i>
+                   class="et-card-btn et-card-btn--primary"
+                   title="Ouvrir l'emploi du temps">
+                    <span>Ouvrir</span>
+                    <i class="fas fa-arrow-right"></i>
                 </a>
-                @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school']) || auth()->user()->can('edit_timetables'))
-                <a href="{{ route('esbtp.emploi-temps.edit', $emploiTemps->id) }}"
-                   class="btn btn-sm btn-outline-warning" title="Modifier">
-                    <i class="fas fa-edit"></i>
-                </a>
-                @endif
-                @if(auth()->user()->can('access_admin') && auth()->user()->can('delete_timetables'))
-                <form action="{{ route('esbtp.emploi-temps.destroy', $emploiTemps->id) }}"
-                      method="POST" style="display: inline;"
-                      onsubmit="return confirm('Êtes-vous sûr de vouloir supprimer cet emploi du temps ?')">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-sm btn-outline-danger" title="Supprimer">
-                        <i class="fas fa-trash"></i>
-                    </button>
-                </form>
+                @if($canEdit || $canDelete)
+                    <div class="et-card__menu" x-data="{ open: false }" @click.outside="open = false">
+                        <button type="button"
+                                class="et-card-btn et-card-btn--icon"
+                                @click="open = !open"
+                                :aria-expanded="open.toString()"
+                                aria-label="Plus d'actions">
+                            <i class="fas fa-ellipsis-vertical"></i>
+                        </button>
+                        <div class="et-card__menu-pop"
+                             x-show="open"
+                             x-transition.opacity.duration.150ms
+                             style="display: none;">
+                            @if($canEdit)
+                                <a href="{{ route('esbtp.emploi-temps.edit', $emploiTemps->id) }}" class="et-card__menu-item">
+                                    <i class="fas fa-edit"></i>Modifier
+                                </a>
+                            @endif
+                            @if($canDelete)
+                                <form action="{{ route('esbtp.emploi-temps.destroy', $emploiTemps->id) }}"
+                                      method="POST"
+                                      onsubmit="return confirm('Êtes-vous sûr de vouloir supprimer cet emploi du temps ?')">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="et-card__menu-item et-card__menu-item--danger">
+                                        <i class="fas fa-trash"></i>Supprimer
+                                    </button>
+                                </form>
+                            @endif
+                        </div>
+                    </div>
                 @endif
             </div>
         </div>
@@ -152,3 +210,4 @@
         </div>
     </div>
 @endforelse
+


### PR DESCRIPTION
## Summary
Refonte UX resserrée de la page `/esbtp/emploi-temps` après audit critic (scope initial trop large, 3 redondances identifiées et éliminées).

### Principaux changements
- **Remplace** le grid KPI 4 tuiles non-actionnable par des **chips filtrantes** (Tout / Actif / Expiré) + lien `X classes sans EDT`
- **Alert strip** rouge conditionnelle au-dessus des chips (visible uniquement si expirés > 0)
- **Cards redesignées** : stripe gauche 4px colorée par filière (hash djb2, palette 8 bleus monochromes), meta row `dates · séances · heures`, badge Expiré affirmé, footer fraîcheur (`Modifié il y a X par Y`), actions `[PDF] [Ouvrir →] [⋯]`
- **Recherche inline** 300ms debounce dans le header de la liste
- **Sticky week-nav** au scroll (CSS pur)
- Current-week pill avec bordure dorée

### Backend (zéro N+1)
- Fix bug `totalSeances` : scope par année courante (avant : count app-wide)
- `withCount('seances')` + eager `updatedBy:id,name` + séances allégées (`id, emploi_temps_id, heure_debut, heure_fin`)
- 24 queries totales / < 4 sur le path critique

### Scope coupé (audit critic)
- Vue Compact row-dense → issue séparée
- Group by filière toggle → over-eng pour 4-22 classes
- Empty-state "dupliquer semaine précédente" → feature complète, issue séparée
- Week-rail bordures statut → kitsch sur 52 semaines
- Card entière cliquable → dette a11y avec menu ⋯ + bouton Ouvrir

### Tests locaux
- Chips filtrent correctement (live Alpine, aucun rechargement)
- Search "rostan" → 1 card visible sur 26
- Zéro erreur console
- SQL profiling : 3 queries sur 26 cards (EDT + seances batch + users batch)
- Sticky nav actif au scroll
- Responsive < 576px OK

### Screenshots avant/après
**Avant** : grid KPI 4 tuiles (13 semaines / 0 plannings actifs / 4 classes / 2025-2026), cards avec 6 lignes de métadonnées redondantes.

**Après** : alert strip + chips filtrantes + search inline + cards compact avec stripe filière.

## Test plan
- [ ] Navigation `/esbtp/emploi-temps` affiche chips avec bons counts
- [ ] Clic `Actif` / `Expiré` filtre les cards en temps réel
- [ ] Recherche `rostan` filtre à ~300ms
- [ ] Alert strip visible uniquement si expirés > 0
- [ ] Stripe filière stable entre rechargements (hash déterministe)
- [ ] Menu ⋯ ouvre edit/delete, fermé sur click extérieur
- [ ] Sticky week-nav fonctionne au scroll
- [ ] Vue tableau non impactée
- [ ] Mobile < 576px utilisable

Closes #202