### PR TITLE
feat(emploi-temps): empty-state "Dupliquer la semaine précédente"

### DIFF
--- a/app/Http/Controllers/ESBTPEmploiTempsController.php
+++ b/app/Http/Controllers/ESBTPEmploiTempsController.php
@@ -156,11 +156,13 @@ class ESBTPEmploiTempsController extends Controller
         $anneeUniversitaireCourante = $anneeEnCours;
 
         // Statistiques par semaines — indépendantes des filtres (calculées sur l'année courante)
-        $semainesStats = $this->buildSemainesStats($anneeEnCours);
+        $semainesStats = $this->buildSemainesStats($anneeEnCours, $request->input('semaine'));
         $semaines = $semainesStats['semaines'];
         $totalSemaines = $semainesStats['totalSemaines'];
         $totalClassesPlanifiees = $semainesStats['totalClassesPlanifiees'];
         $semaineCouranteValue = $semainesStats['semaineCouranteValue'];
+        $previousWeekValue = $semainesStats['previousWeekValue'];
+        $previousWeekPlanningCount = $semainesStats['previousWeekPlanningCount'];
 
         $timetableShortcut = app(TimetableShortcutService::class)->getShortcutSummary($anneeEnCours);
 
@@ -168,15 +170,22 @@ class ESBTPEmploiTempsController extends Controller
             'emploisTemps', 'filieres', 'niveaux', 'classes', 'annees', 'anneeUniversitaireCourante',
             'totalEmploisTemps', 'emploisTempsActifsCount', 'totalSeances', 'emploisTempsAnneeEnCours', 'timetableShortcut',
             'emploisTempsActifs', 'totalSemaines', 'totalClassesPlanifiees', 'semaines', 'semaineCouranteValue',
-            'edtExpiresCount', 'totalClassesTenant', 'classesSansEdtCount'
+            'edtExpiresCount', 'totalClassesTenant', 'classesSansEdtCount',
+            'previousWeekValue', 'previousWeekPlanningCount'
         ));
     }
 
     /**
      * Construit les statistiques par semaine pour une année universitaire donnée.
-     * Retourne : totalSemaines, totalClassesPlanifiees, semaines[], semaineCouranteValue.
+     * Retourne : totalSemaines, totalClassesPlanifiees, semaines[], semaineCouranteValue,
+     * previousWeekValue, previousWeekPlanningCount.
+     *
+     * @param  string|null  $requestedWeek  Format "Y-m-d|Y-m-d" — la semaine actuellement
+     *                                      sélectionnée par l'utilisateur (paramètre ?semaine=).
+     *                                      Si elle est vide (aucun planning), on calcule la semaine
+     *                                      précédente pour proposer l'action "Dupliquer".
      */
-    private function buildSemainesStats(?ESBTPAnneeUniversitaire $annee): array
+    private function buildSemainesStats(?ESBTPAnneeUniversitaire $annee, ?string $requestedWeek = null): array
     {
         $query = ESBTPEmploiTemps::query()
             ->whereNotNull('date_debut')
@@ -222,11 +231,39 @@ class ESBTPEmploiTempsController extends Controller
         $semaineCourante = $semaines->firstWhere('status', 'current');
         $semaineCouranteValue = $semaineCourante['value'] ?? null;
 
+        // Détection "semaine précédente" pour l'empty-state "dupliquer".
+        // Si l'utilisateur a sélectionné une semaine avec ?semaine=X|Y, et que cette semaine
+        // n'existe pas dans $byRange (aucun planning), on cherche la plus récente semaine
+        // antérieure à la date de début demandée qui contient au moins un planning.
+        $previousWeekValue = null;
+        $previousWeekPlanningCount = 0;
+
+        if ($requestedWeek && ! isset($byRange[$requestedWeek])) {
+            $dates = explode('|', $requestedWeek);
+            if (count($dates) === 2) {
+                try {
+                    $requestedStart = Carbon::parse($dates[0]);
+                    $candidate = $semaines
+                        ->filter(fn ($s) => $s['start']->lt($requestedStart) && $s['count'] > 0)
+                        ->sortByDesc(fn ($s) => $s['start']->timestamp)
+                        ->first();
+                    if ($candidate) {
+                        $previousWeekValue = $candidate['value'];
+                        $previousWeekPlanningCount = $candidate['count'];
+                    }
+                } catch (\Throwable $e) {
+                    // Format invalide, pas de détection
+                }
+            }
+        }
+
         return [
             'totalSemaines' => $semaines->count(),
             'totalClassesPlanifiees' => count($classesIds),
             'semaines' => $semaines,
             'semaineCouranteValue' => $semaineCouranteValue,
+            'previousWeekValue' => $previousWeekValue,
+            'previousWeekPlanningCount' => $previousWeekPlanningCount,
         ];
     }
 
@@ -2213,6 +2250,155 @@ class ESBTPEmploiTempsController extends Controller
             'conflicts' => $conflictsPayload,
             'total_conflicts' => $totalConflicts,
         ]);
+    }
+
+    /**
+     * Duplique tous les emplois du temps d'une semaine source vers une semaine cible.
+     * Utilisé par l'empty-state "La semaine précédente avait X plannings. Dupliquer →".
+     *
+     * Format des paramètres : "YYYY-MM-DD|YYYY-MM-DD" (date_debut|date_fin).
+     * Les conflits enseignants sont détectés via collectAvailabilityConflicts() ; les
+     * séances en conflit sont simplement ignorées (l'EDT est créé sans ces séances).
+     * Les classes qui ont déjà un EDT pour la semaine cible sont sautées (idempotence).
+     */
+    public function duplicateWeek(Request $request)
+    {
+        $user = auth()->user();
+        if (! $user || ! $user->can('create_timetable')) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            // Format accepté : "YYYY-MM-DD|YYYY-MM-DD" ou "YYYY-MM-DD HH:MM:SS|YYYY-MM-DD HH:MM:SS"
+            // (les pills du rail incluent le time, le format court reste supporté pour les liens).
+            'source_semaine' => ['required', 'string', 'regex:/^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?\|\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?$/'],
+            'target_semaine' => ['required', 'string', 'regex:/^\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?\|\d{4}-\d{2}-\d{2}( \d{2}:\d{2}:\d{2})?$/', 'different:source_semaine'],
+        ]);
+
+        $anneeEnCours = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+        if (! $anneeEnCours) {
+            return redirect()->back()->with('error', "Aucune année universitaire active n'est définie.");
+        }
+
+        [$sourceStart, $sourceEnd] = array_map('trim', explode('|', $validated['source_semaine']));
+        [$targetStart, $targetEnd] = array_map('trim', explode('|', $validated['target_semaine']));
+
+        try {
+            $targetStartCarbon = Carbon::parse($targetStart);
+            $targetEndCarbon = Carbon::parse($targetEnd);
+        } catch (\Throwable $e) {
+            return redirect()->back()->with('error', 'Dates cibles invalides.');
+        }
+
+        $sources = ESBTPEmploiTemps::with(['seances.teacher.availabilities', 'seances.matiere'])
+            ->where('annee_universitaire_id', $anneeEnCours->id)
+            ->whereDate('date_debut', $sourceStart)
+            ->whereDate('date_fin', $sourceEnd)
+            ->get();
+
+        if ($sources->isEmpty()) {
+            return redirect()->back()->with('info', "Aucun emploi du temps trouvé pour la semaine source.");
+        }
+
+        $createdCount = 0;
+        $skippedCount = 0;
+        $availabilitySkipCount = 0;
+        $today = Carbon::today();
+        $isActiveTarget = $targetStartCarbon->lte($today) && $targetEndCarbon->gte($today);
+
+        DB::beginTransaction();
+        try {
+            foreach ($sources as $source) {
+                $alreadyExists = ESBTPEmploiTemps::where('annee_universitaire_id', $anneeEnCours->id)
+                    ->where('classe_id', $source->classe_id)
+                    ->whereDate('date_debut', $targetStartCarbon->toDateString())
+                    ->whereDate('date_fin', $targetEndCarbon->toDateString())
+                    ->exists();
+
+                if ($alreadyExists) {
+                    $skippedCount++;
+                    continue;
+                }
+
+                $availabilityConflicts = $this->collectAvailabilityConflicts($source->seances, $targetStartCarbon);
+                $conflictIds = collect($availabilityConflicts)->pluck('seance_id')->filter()->all();
+
+                $periodeLabel = sprintf(
+                    'Semaine %s-%s',
+                    $targetStartCarbon->format('d/m'),
+                    $targetEndCarbon->format('d/m')
+                );
+
+                $classeName = $source->classe->name ?? 'Classe';
+                $newEmploiTemps = ESBTPEmploiTemps::create([
+                    'titre' => "Emploi du temps - {$classeName} ({$periodeLabel})",
+                    'classe_id' => $source->classe_id,
+                    'annee_universitaire_id' => $anneeEnCours->id,
+                    'semestre' => $source->semestre,
+                    'date_debut' => $targetStartCarbon->toDateString(),
+                    'date_fin' => $targetEndCarbon->toDateString(),
+                    'is_active' => $isActiveTarget,
+                    'is_current' => false,
+                    'created_by' => $user->id,
+                    'updated_by' => $user->id,
+                ]);
+
+                foreach ($source->seances as $seance) {
+                    if (in_array($seance->id, $conflictIds, true)) {
+                        $availabilitySkipCount++;
+                        continue;
+                    }
+                    $newSeance = $seance->replicate();
+                    $newSeance->emploi_temps_id = $newEmploiTemps->id;
+                    $newSeance->classe_id = $source->classe_id;
+                    $newSeance->annee_universitaire_id = $anneeEnCours->id;
+                    $newSeance->homework_evaluation_id = null;
+                    $newSeance->is_active = $isActiveTarget;
+
+                    $dayOffset = is_numeric($seance->jour) ? ((int) $seance->jour - 1) : 0;
+                    $newDateSeance = $targetStartCarbon->copy()->addDays($dayOffset);
+                    $newSeance->date_seance = $newDateSeance->toDateString();
+
+                    if ($seance->homework_due_date && $seance->date_seance) {
+                        $deltaDays = Carbon::parse($seance->date_seance)->diffInDays($newDateSeance, false);
+                        $newSeance->homework_due_date = Carbon::parse($seance->homework_due_date)->addDays($deltaDays)->toDateString();
+                    }
+
+                    $newSeance->save();
+                }
+
+                $createdCount++;
+            }
+
+            DB::commit();
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            \Log::error('Erreur duplication semaine', [
+                'source' => $validated['source_semaine'],
+                'target' => $validated['target_semaine'],
+                'error' => $e->getMessage(),
+            ]);
+
+            return redirect()->back()->with('error', "Erreur lors de la duplication : {$e->getMessage()}");
+        }
+
+        if ($createdCount === 0) {
+            return redirect()
+                ->to(route('esbtp.emploi-temps.index', ['semaine' => $validated['target_semaine']]))
+                ->with('info', "Aucun nouvel emploi du temps créé ({$skippedCount} classe(s) déjà présente(s) sur la semaine cible).");
+        }
+
+        $message = "{$createdCount} emploi(s) du temps dupliqué(s) vers la semaine cible.";
+        if ($skippedCount > 0) {
+            $message .= " {$skippedCount} classe(s) ignorée(s) (EDT déjà présent).";
+        }
+        if ($availabilitySkipCount > 0) {
+            $message .= " {$availabilitySkipCount} séance(s) omise(s) (conflits enseignant).";
+        }
+
+        return redirect()
+            ->to(route('esbtp.emploi-temps.index', ['semaine' => $validated['target_semaine']]))
+            ->with('success', $message);
     }
 
     private function collectAvailabilityConflicts($seances, Carbon $targetStart): array

--- a/resources/views/esbtp/emploi-temps/index.blade.php
+++ b/resources/views/esbtp/emploi-temps/index.blade.php
@@ -1483,6 +1483,85 @@
 
     [x-cloak] { display: none !important; }
 
+    /* ══════════════════════════════════════════════
+       Empty-state intelligent : "Dupliquer la semaine précédente"
+       ══════════════════════════════════════════════ */
+    .et-duplicate-empty {
+        display: flex;
+        align-items: center;
+        gap: 1.25rem;
+        padding: 1.75rem 1.5rem;
+        background: linear-gradient(135deg, #f0f7ff 0%, #fafcff 100%);
+        border: 1px solid #cfe0f5;
+        border-radius: 16px;
+        box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
+    }
+    .et-duplicate-empty__icon {
+        flex-shrink: 0;
+        width: 56px; height: 56px;
+        border-radius: 14px;
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.4rem;
+        color: #fff;
+        box-shadow: 0 6px 18px rgba(4,83,203,.22);
+    }
+    .et-duplicate-empty__body { flex: 1; min-width: 0; }
+    .et-duplicate-empty__title {
+        margin: 0 0 .3rem 0;
+        font-size: 1.05rem;
+        font-weight: 700;
+        color: #0f172a;
+    }
+    .et-duplicate-empty__text {
+        margin: 0 0 .85rem 0;
+        font-size: .88rem;
+        color: #475569;
+        line-height: 1.5;
+    }
+    .et-duplicate-empty__text strong { color: #0f172a; font-weight: 700; }
+    .et-duplicate-empty__form {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin: 0;
+    }
+    .et-duplicate-empty__btn {
+        display: inline-flex;
+        align-items: center;
+        gap: .5rem;
+        padding: .65rem 1.3rem;
+        border-radius: 10px;
+        border: none;
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        color: #fff;
+        font-size: .88rem;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 4px 14px rgba(4,83,203,.24);
+        transition: all .2s ease;
+    }
+    .et-duplicate-empty__btn:hover {
+        background: linear-gradient(135deg, #033a8e, #0453cb);
+        box-shadow: 0 6px 20px rgba(4,83,203,.32);
+        transform: translateY(-1px);
+    }
+    .et-duplicate-empty__link {
+        color: #0453cb;
+        font-size: .82rem;
+        text-decoration: none;
+        font-weight: 500;
+    }
+    .et-duplicate-empty__link:hover { text-decoration: underline; }
+
+    @media (max-width: 576px) {
+        .et-duplicate-empty { flex-direction: column; align-items: flex-start; padding: 1.25rem; }
+        .et-duplicate-empty__btn { width: 100%; justify-content: center; }
+    }
+
     @media (max-width: 576px) {
         .et-card__head { flex-direction: column; }
         .et-card__badges { width: 100%; }
@@ -1722,7 +1801,12 @@
                     <div class="card-body">
                         <!-- Vue en cards (par défaut) -->
                         <div id="cardsContainer" class="emplois-cards-container">
-                            @include('esbtp.emploi-temps.partials.cards', ['emploisTemps' => $emploisTemps, 'timetableShortcut' => $timetableShortcut ?? null])
+                            @include('esbtp.emploi-temps.partials.cards', [
+                                'emploisTemps' => $emploisTemps,
+                                'timetableShortcut' => $timetableShortcut ?? null,
+                                'previousWeekValue' => $previousWeekValue ?? null,
+                                'previousWeekPlanningCount' => $previousWeekPlanningCount ?? 0,
+                            ])
                         </div>
 
                         <!-- Vue tableau (masquée par défaut) -->

--- a/resources/views/esbtp/emploi-temps/partials/cards.blade.php
+++ b/resources/views/esbtp/emploi-temps/partials/cards.blade.php
@@ -199,16 +199,62 @@
         </div>
     </div>
 @empty
-    <div class="empty-state-card">
-        <div class="text-center py-5">
-            <i class="fas fa-calendar-times fa-4x text-muted mb-4"></i>
-            <h5 class="text-muted mb-2">Aucun emploi du temps trouvé</h5>
-            <p class="text-muted mb-4">Créez votre premier emploi du temps pour commencer.</p>
-            <a href="{{ route('esbtp.emploi-temps.create') }}" class="btn btn-primary">
-                <i class="fas fa-plus me-2"></i>Créer un emploi du temps
-            </a>
+    @php
+        // L'utilisateur filtre sur une semaine ?semaine=X|Y qui est vide, et la semaine
+        // précédente contient des plannings → on propose la duplication.
+        $requestedWeek = request('semaine');
+        $canDuplicate = ! empty($previousWeekValue ?? null)
+            && ($previousWeekPlanningCount ?? 0) > 0
+            && ! empty($requestedWeek)
+            && (auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school']) || auth()->user()->can('create_timetable'));
+    @endphp
+    @if($canDuplicate)
+        @php
+            [$prevStart, $prevEnd] = array_map('trim', explode('|', $previousWeekValue));
+            [$targetStart, $targetEnd] = array_map('trim', explode('|', $requestedWeek));
+            $prevLabel = \Carbon\Carbon::parse($prevStart)->isoFormat('D MMM') . ' → ' . \Carbon\Carbon::parse($prevEnd)->isoFormat('D MMM YYYY');
+            $targetLabel = \Carbon\Carbon::parse($targetStart)->isoFormat('D MMM') . ' → ' . \Carbon\Carbon::parse($targetEnd)->isoFormat('D MMM YYYY');
+        @endphp
+        <div class="et-duplicate-empty">
+            <div class="et-duplicate-empty__icon">
+                <i class="fas fa-copy"></i>
+            </div>
+            <div class="et-duplicate-empty__body">
+                <h5 class="et-duplicate-empty__title">Semaine vide</h5>
+                <p class="et-duplicate-empty__text">
+                    Aucun emploi du temps pour la semaine du <strong>{{ $targetLabel }}</strong>.
+                    La semaine précédente du <strong>{{ $prevLabel }}</strong> en contient
+                    <strong>{{ $previousWeekPlanningCount }}</strong>.
+                </p>
+                <form action="{{ route('esbtp.emploi-temps.duplicate-week') }}"
+                      method="POST"
+                      class="et-duplicate-empty__form"
+                      onsubmit="return confirm('Dupliquer {{ $previousWeekPlanningCount }} emploi(s) du temps vers la semaine cible ?\n\nLes séances avec conflits enseignant seront ignorées. Les classes déjà planifiées ne seront pas écrasées.')">
+                    @csrf
+                    <input type="hidden" name="source_semaine" value="{{ $previousWeekValue }}">
+                    <input type="hidden" name="target_semaine" value="{{ $requestedWeek }}">
+                    <button type="submit" class="et-duplicate-empty__btn">
+                        <i class="fas fa-wand-magic-sparkles"></i>
+                        Dupliquer pour cette semaine
+                    </button>
+                    <a href="{{ route('esbtp.emploi-temps.create') }}" class="et-duplicate-empty__link">
+                        Ou créer manuellement →
+                    </a>
+                </form>
+            </div>
         </div>
-    </div>
+    @else
+        <div class="empty-state-card">
+            <div class="text-center py-5">
+                <i class="fas fa-calendar-times fa-4x text-muted mb-4"></i>
+                <h5 class="text-muted mb-2">Aucun emploi du temps trouvé</h5>
+                <p class="text-muted mb-4">Créez votre premier emploi du temps pour commencer.</p>
+                <a href="{{ route('esbtp.emploi-temps.create') }}" class="btn btn-primary">
+                    <i class="fas fa-plus me-2"></i>Créer un emploi du temps
+                </a>
+            </div>
+        </div>
+    @endif
 @endforelse
 
 {{-- Empty-state client-side : visible quand chip + recherche masquent toutes les cards --}}

--- a/routes/web.php
+++ b/routes/web.php
@@ -542,6 +542,10 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
                 ->name('emploi-temps.quick-generate.preview')
                 ->middleware(['permission:create_timetable']);
 
+            Route::post('emploi-temps/duplicate-week', [ESBTPEmploiTempsController::class, 'duplicateWeek'])
+                ->name('emploi-temps.duplicate-week')
+                ->middleware(['permission:create_timetable']);
+
             Route::get('emploi-temps/bulk-edit', [ESBTPEmploiTempsController::class, 'bulkEdit'])
                 ->name('emploi-temps.bulk-edit')
                 ->middleware(['permission:edit_timetables']);


### PR DESCRIPTION
Closes #204

## Summary
Quand un utilisateur navigue vers une semaine sans planning et qu'une semaine antérieure en contient, on propose une duplication en un clic — inspiré des patterns empty-state intelligents (Notion templates, Linear cycles).

### Backend
- \`buildSemainesStats()\` étendu : détecte la semaine précédente avec \`count > 0\` si la semaine requêtée est vide. Expose \`previousWeekValue\` + \`previousWeekPlanningCount\`.
- Nouvelle méthode \`duplicateWeek()\` : transaction DB, idempotent (skip EDT déjà présent), réutilise \`collectAvailabilityConflicts()\` + pattern \`replicate()\` de \`quickGenerate\` (aucune duplication de logique).
- Nouvelle route POST \`/esbtp/emploi-temps/duplicate-week\` (permission:create_timetable).

### UI
- Bloc \`.et-duplicate-empty\` conditionnel dans \`partials/cards.blade.php\` @empty — affiche \"La semaine précédente du X → Y en contient N\" + bouton \"Dupliquer pour cette semaine\".
- Confirmation avant submit (natif \`confirm()\`).
- Fallback empty-state historique \"Créer un EDT\" si aucune semaine précédente.
- CSS premium monochrome bleu (.et-duplicate-empty__*).

## Test plan
- [x] Navigation \`?semaine=2026-04-13+00:00:00|2026-04-19+00:00:00\` (semaine vide) → empty-state visible
- [x] Form correctement formé (action, source, target, CSRF)
- [x] Submit → 4 EDT dupliqués, flash success, redirection vers semaine cible
- [x] Conflits enseignants mentionnés dans le flash message
- [x] Permission \`create_timetable\` requise (middleware route + can() dans méthode)
- [x] Validation regex supporte format avec ou sans time
- [ ] Idempotence : re-cliquer ne duplique pas → skip avec \"déjà présent\"
- [ ] Année universitaire non-active → erreur flash appropriée

## Design
- Gradient bleu KLASSCI uniquement (monochrome)
- Pas d'AI slop (pas de bento grid, pas de glassmorphism)
- Responsive < 576px (flex-direction: column, bouton pleine largeur)