### PR TITLE
fix(emploi-temps): vue Compact ignore la sélection de semaine

### DIFF
--- a/app/Http/Controllers/ESBTPEmploiTempsController.php
+++ b/app/Http/Controllers/ESBTPEmploiTempsController.php
@@ -2022,6 +2022,7 @@ class ESBTPEmploiTempsController extends Controller
         return response()->json([
             'success' => true,
             'html_cards' => view('esbtp.emploi-temps.partials.cards', compact('emploisTemps', 'timetableShortcut'))->render(),
+            'html_compact' => view('esbtp.emploi-temps.partials.cards-compact', compact('emploisTemps'))->render(),
             'html_table' => view('esbtp.emploi-temps.partials.table-rows', compact('emploisTemps', 'timetableShortcut'))->render(),
             'count' => $emploisTemps->count(),
         ]);

--- a/resources/views/esbtp/emploi-temps/index.blade.php
+++ b/resources/views/esbtp/emploi-temps/index.blade.php
@@ -2833,6 +2833,11 @@ document.addEventListener('DOMContentLoaded', function () {
                     // Update cards container
                     document.getElementById('cardsContainer').innerHTML = data.html_cards;
 
+                    // Update compact container (3e vue row-dense)
+                    if (data.html_compact !== undefined) {
+                        document.getElementById('compactContainer').innerHTML = data.html_compact;
+                    }
+
                     // Update table body
                     document.getElementById('tableBody').innerHTML = data.html_table;
 


### PR DESCRIPTION
Non-bug d'intention : la vue Compact affichait TOUTES les semaines même quand on cliquait sur une pill spécifique, car le endpoint refresh() AJAX ne renvoyait que html_cards + html_table. Fix : ajouter html_compact au payload + l'injecter côté JS. Testé : 3 rows affichés pour la semaine 26 janv → 1 févr, cohérent avec la vue Cards.