### PR TITLE
fix(emploi-temps): chip 'X classes sans EDT' ouvre la modal au lieu de scroller vers un élément masqué

### DIFF
--- a/resources/views/esbtp/emploi-temps/index.blade.php
+++ b/resources/views/esbtp/emploi-temps/index.blade.php
@@ -1819,12 +1819,15 @@
                 <span class="et-chip__count">{{ $edtExpiresCount ?? 0 }}</span>
             </button>
             <div class="et-chips-separator"></div>
-            @if(($classesSansEdtCount ?? 0) > 0)
-                <a href="#raccourciEmploisTemps" class="et-chip et-chip--link">
+            @if(($classesSansEdtCount ?? 0) > 0 && (auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school']) || auth()->user()->can('create_timetable')))
+                <button type="button"
+                        class="et-chip et-chip--link"
+                        data-bs-toggle="modal"
+                        data-bs-target="#quickGenerateModal">
                     <span class="et-chip__dot et-chip__dot--muted"></span>
                     <span class="et-chip__label">{{ $classesSansEdtCount }} classe{{ $classesSansEdtCount > 1 ? 's' : '' }} sans emploi du temps</span>
                     <i class="fas fa-arrow-right"></i>
-                </a>
+                </button>
             @endif
         </div>
 


### PR DESCRIPTION
Le chip pointait vers #raccourciEmploisTemps (dans #cardsContainer). En vue Compact ou Tableau, le parent est display:none → scroll vers rien. Fix : bouton qui ouvre directement #quickGenerateModal, fonctionne dans toutes les vues.