### PR TITLE
feat(attendances): saisie manuelle heures + redesign premium + AJAX réactif

### DIFF
--- a/app/Http/Controllers/ESBTPAttendanceController.php
+++ b/app/Http/Controllers/ESBTPAttendanceController.php
@@ -3,13 +3,17 @@
 namespace App\Http\Controllers;
 
 use App\Models\ESBTPAttendance;
+use App\Models\ESBTPAttendanceManualHours;
 use App\Models\ESBTPClasse;
+use App\Models\ESBTPPlanificationAcademique;
 use App\Models\ESBTPEtudiant;
 use App\Models\ESBTPSeanceCours;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPMatiere;
 use App\Models\ESBTPAcademicYear;
 use App\Models\ESBTPTeacherAttendance;
+use App\Http\Requests\Attendance\StoreManualAttendanceHoursRequest;
+use App\Services\ESBTP\ManualAttendanceHoursService;
 use App\Models\Notification;
 use App\Notifications\AbsenceNotification;
 use App\Services\MatiereService;
@@ -610,7 +614,28 @@ class ESBTPAttendanceController extends Controller
         // Enregistrer les informations de débogage dans le journal
         \Log::info('Débogage marquage présences', $debug);
 
-        return view('esbtp.attendances.create', compact('classes', 'seances', 'etudiants', 'dateSeance', 'messageErreur', 'classeSelectionnee', 'existingAttendances', 'debug'));
+        // Matières de la classe pour l'onglet "Saisie manuelle"
+        // Source canonique : planifications académiques (filière + niveau), comme ClassPlanningService.
+        // Fallback : pivot esbtp_classe_matiere (BTS pré-attachées) si planifications absentes.
+        $matieresClasse = collect();
+        if ($classeSelectionnee && isset($classe)) {
+            $matieresClasse = $this->getMatieresClasse($classe);
+        }
+
+        $anneeUniversitaireCourante = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+
+        return view('esbtp.attendances.create', compact(
+            'classes',
+            'seances',
+            'etudiants',
+            'dateSeance',
+            'messageErreur',
+            'classeSelectionnee',
+            'existingAttendances',
+            'debug',
+            'matieresClasse',
+            'anneeUniversitaireCourante'
+        ));
     }
 
     /**
@@ -693,7 +718,21 @@ class ESBTPAttendanceController extends Controller
                 );
             }
 
-            return response()->json(['success' => true, 'options' => $options, 'nbSeances' => $seances->count()]);
+            // Matières de la classe pour l'onglet "Saisie manuelle" (via planifications académiques)
+            $classe = ESBTPClasse::find($request->classe_id);
+            $matieres = $classe
+                ? $this->getMatieresClasse($classe)
+                    ->map(fn ($m) => ['id' => $m->id, 'name' => $m->name])
+                    ->values()
+                    ->all()
+                : [];
+
+            return response()->json([
+                'success' => true,
+                'options' => $options,
+                'nbSeances' => $seances->count(),
+                'matieres' => $matieres,
+            ]);
 
         } catch (\Exception $e) {
             \Log::error('❌ [AJAX] Erreur loadSeances: ' . $e->getMessage());
@@ -1742,5 +1781,165 @@ class ESBTPAttendanceController extends Controller
             \Log::error('Erreur calcul classes forte absentéisme: ' . $e->getMessage());
             return 0;
         }
+    }
+
+    /**
+     * Récupère les matières d'une classe via planifications académiques (filière + niveau).
+     * Fallback : pivot esbtp_classe_matiere si aucune planification n'existe (classes BTS legacy).
+     * C'est la source canonique utilisée par ClassPlanningService pour la cohérence
+     * planning / emploi-temps / notes / saisie manuelle.
+     */
+    private function getMatieresClasse(ESBTPClasse $classe): \Illuminate\Support\Collection
+    {
+        if (!$classe->filiere_id || !$classe->niveau_etude_id) {
+            return collect();
+        }
+
+        $matieres = ESBTPPlanificationAcademique::query()
+            ->where('filiere_id', $classe->filiere_id)
+            ->where('niveau_etude_id', $classe->niveau_etude_id)
+            ->whereNotNull('matiere_id')
+            ->with('matiere:id,name')
+            ->get()
+            ->pluck('matiere')
+            ->filter()
+            ->unique('id')
+            ->sortBy('name')
+            ->values();
+
+        if ($matieres->isEmpty()) {
+            // Fallback classes BTS historiques attachées directement via pivot
+            $matieres = $classe->matieres()
+                ->orderBy('name')
+                ->get(['esbtp_matieres.id', 'esbtp_matieres.name']);
+        }
+
+        return $matieres;
+    }
+
+    public function loadManualTab(Request $request, ManualAttendanceHoursService $service)
+    {
+        $request->validate([
+            'classe_id' => 'required|exists:esbtp_classes,id',
+            'matiere_id' => 'required|exists:esbtp_matieres,id',
+            'periode' => 'required|in:semestre1,semestre2,annuel',
+            'annee_universitaire_id' => 'nullable|exists:esbtp_annee_universitaires,id',
+        ]);
+
+        try {
+            $classe = ESBTPClasse::with('filiere', 'niveau')->findOrFail($request->classe_id);
+            $matiere = ESBTPMatiere::findOrFail($request->matiere_id);
+            $periode = $request->periode;
+
+            $anneeUniversitaire = $request->annee_universitaire_id
+                ? ESBTPAnneeUniversitaire::findOrFail($request->annee_universitaire_id)
+                : ESBTPAnneeUniversitaire::where('is_current', true)->firstOrFail();
+
+            $etudiants = $classe->etudiants()
+                ->whereHas('inscriptions', function ($q) use ($anneeUniversitaire, $classe) {
+                    $q->where('annee_universitaire_id', $anneeUniversitaire->id)
+                        ->where('status', 'active')
+                        ->where('classe_id', $classe->id);
+                })
+                ->orderBy('nom')
+                ->orderBy('prenoms')
+                ->get();
+
+            $existing = $service->getForClasseMatiere(
+                $classe->id,
+                $matiere->id,
+                $anneeUniversitaire->id,
+                $periode
+            );
+
+            $existingSessionsCount = ESBTPAttendance::where('classe_id', $classe->id)
+                ->where('matiere_id', $matiere->id)
+                ->where('annee_universitaire_id', $anneeUniversitaire->id)
+                ->where(function ($q) {
+                    $q->where('call_type', 'merged')->orWhereNull('call_type');
+                })
+                ->count();
+
+            $html = view('esbtp.attendances.partials.manual-hours-tab', [
+                'classe' => $classe,
+                'matiere' => $matiere,
+                'periode' => $periode,
+                'anneeUniversitaire' => $anneeUniversitaire,
+                'etudiants' => $etudiants,
+                'existing' => $existing,
+                'existingSessionsCount' => $existingSessionsCount,
+            ])->render();
+
+            return response()->json([
+                'success' => true,
+                'html' => $html,
+                'nbEtudiants' => $etudiants->count(),
+                'nbExisting' => $existing->count(),
+                'existingSessionsCount' => $existingSessionsCount,
+            ]);
+        } catch (\Exception $e) {
+            \Log::error('Erreur loadManualTab: '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);
+            return response()->json([
+                'success' => false,
+                'message' => 'Une erreur est survenue lors du chargement.',
+            ], 500);
+        }
+    }
+
+    public function storeManualHours(StoreManualAttendanceHoursRequest $request, ManualAttendanceHoursService $service)
+    {
+        $classe = ESBTPClasse::findOrFail($request->classe_id);
+        $anneeUniversitaire = ESBTPAnneeUniversitaire::findOrFail($request->annee_universitaire_id);
+
+        $validIds = $classe->etudiants()
+            ->whereHas('inscriptions', function ($q) use ($anneeUniversitaire, $classe) {
+                $q->where('annee_universitaire_id', $anneeUniversitaire->id)
+                    ->where('status', 'active')
+                    ->where('classe_id', $classe->id);
+            })
+            ->pluck('esbtp_etudiants.id')
+            ->all();
+
+        $entries = collect($request->input('entries', []))
+            ->filter(fn ($e) => in_array((int) ($e['etudiant_id'] ?? 0), $validIds, true))
+            ->values()
+            ->all();
+
+        if (empty($entries)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Aucun étudiant valide dans la saisie.',
+            ], 422);
+        }
+
+        $count = $service->upsertBatch(
+            $entries,
+            [
+                'classe_id' => (int) $request->classe_id,
+                'matiere_id' => (int) $request->matiere_id,
+                'annee_universitaire_id' => $anneeUniversitaire->id,
+                'periode' => $request->periode,
+            ],
+            Auth::id()
+        );
+
+        return response()->json([
+            'success' => true,
+            'message' => "{$count} ligne(s) enregistrée(s) avec succès.",
+            'count' => $count,
+        ]);
+    }
+
+    public function deleteManualHours($id, ManualAttendanceHoursService $service)
+    {
+        // Autorisation déjà gérée par le middleware `permission:create_attendance` sur la route.
+        $row = ESBTPAttendanceManualHours::findOrFail((int) $id);
+
+        $service->delete($row->id, Auth::id());
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Entrée supprimée. Le bulletin utilisera à nouveau les séances.',
+        ]);
     }
 }

--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -265,11 +265,14 @@ class ESBTPBulletinController extends Controller
                 }
 
                 // Calculer les absences pour la période du bulletin
+                // (priorité à la saisie manuelle par matière si présente)
                 $donneeAbsences = $this->absenceService->calculerDetailAbsences(
                     $request->etudiant_id,
                     $request->classe_id,
                     $dateDebut,
-                    $dateFin
+                    $dateFin,
+                    $anneeUniversitaire->id,
+                    $request->periode
                 );
 
                 // Intégrer les absences au bulletin
@@ -492,7 +495,9 @@ class ESBTPBulletinController extends Controller
                         $bulletin->etudiant_id,
                         $bulletin->classe_id,
                         $bulletin->anneeUniversitaire->date_debut,
-                        $bulletin->anneeUniversitaire->date_fin
+                        $bulletin->anneeUniversitaire->date_fin,
+                        $bulletin->annee_universitaire_id,
+                        $bulletin->periode
                     );
 
                     $bulletin->absences_justifiees = $absencesAttendance['justifiees'];

--- a/app/Http/Controllers/ESBTPResultatController.php
+++ b/app/Http/Controllers/ESBTPResultatController.php
@@ -461,7 +461,9 @@ class ESBTPResultatController extends Controller
                     $r['etudiant']->id,
                     $classe->id,
                     $anneeObj->date_debut ?? null,
-                    $anneeObj->date_fin ?? null
+                    $anneeObj->date_fin ?? null,
+                    $annee_universitaire_id,
+                    $periode ?: 'annuel'
                 );
                 $noteAssid = $this->bulletinService->calculerNoteAssiduite($absences['justifiees'] ?? 0, $absences['non_justifiees'] ?? 0);
                 $r['note_assiduite'] = $noteAssid;
@@ -795,7 +797,9 @@ class ESBTPResultatController extends Controller
                 $etudiant->id,
                 $classe->id,
                 $anneeUniversitaire->date_debut ?? null,
-                $anneeUniversitaire->date_fin ?? null
+                $anneeUniversitaire->date_fin ?? null,
+                $anneeUniversitaire->id,
+                $periode ?: 'annuel'
             );
             $noteAssiduite = $this->bulletinService->calculerNoteAssiduite($absences['justifiees'] ?? 0, $absences['non_justifiees'] ?? 0);
             $moyenneAvecAssiduite = $moyenneGenerale + $noteAssiduite;
@@ -953,8 +957,16 @@ class ESBTPResultatController extends Controller
                     if ($showAssid && $annee_universitaire_id) {
                         $anneeObj = ESBTPAnneeUniversitaire::find($annee_universitaire_id);
                         if ($anneeObj) {
+                            $periodeForManual = $semestre ? 'semestre'.$semestre : 'annuel';
                             foreach ($moyennes as $etudiantId => &$moy) {
-                                $abs = $this->absenceService->calculerDetailAbsences($etudiantId, $classe_id ?? 0, $anneeObj->date_debut ?? null, $anneeObj->date_fin ?? null);
+                                $abs = $this->absenceService->calculerDetailAbsences(
+                                    $etudiantId,
+                                    $classe_id ?? 0,
+                                    $anneeObj->date_debut ?? null,
+                                    $anneeObj->date_fin ?? null,
+                                    $annee_universitaire_id,
+                                    $periodeForManual
+                                );
                                 $noteAssid = $this->bulletinService->calculerNoteAssiduite($abs['justifiees'] ?? 0, $abs['non_justifiees'] ?? 0);
                                 $moy += $noteAssid;
                             }

--- a/app/Http/Requests/Attendance/StoreManualAttendanceHoursRequest.php
+++ b/app/Http/Requests/Attendance/StoreManualAttendanceHoursRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Requests\Attendance;
+
+use App\Services\ESBTP\ManualAttendanceHoursService;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Validation\Rule;
+
+class StoreManualAttendanceHoursRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create_attendance') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'classe_id' => ['required', 'integer', 'exists:esbtp_classes,id'],
+            'matiere_id' => ['required', 'integer', 'exists:esbtp_matieres,id'],
+            'annee_universitaire_id' => ['required', 'integer', 'exists:esbtp_annee_universitaires,id'],
+            'periode' => ['required', 'string', Rule::in(ManualAttendanceHoursService::PERIODES)],
+            'entries' => ['required', 'array', 'min:1'],
+            'entries.*.etudiant_id' => ['required', 'integer', 'exists:esbtp_etudiants,id'],
+            'entries.*.heures_presence' => ['nullable', 'numeric', 'min:0', 'max:999.99'],
+            'entries.*.heures_absence_justifiees' => ['nullable', 'numeric', 'min:0', 'max:999.99'],
+            'entries.*.heures_absence_non_justifiees' => ['nullable', 'numeric', 'min:0', 'max:999.99'],
+            'entries.*.notes' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'entries.required' => 'Aucune saisie à enregistrer.',
+            'entries.*.etudiant_id.exists' => 'Un étudiant sélectionné n\'existe pas.',
+            'entries.*.heures_presence.numeric' => 'Les heures de présence doivent être un nombre.',
+            'entries.*.heures_presence.min' => 'Les heures de présence ne peuvent pas être négatives.',
+            'entries.*.heures_absence_justifiees.numeric' => 'Les heures d\'absence justifiées doivent être un nombre.',
+            'entries.*.heures_absence_non_justifiees.numeric' => 'Les heures d\'absence non justifiées doivent être un nombre.',
+            'periode.in' => 'La période doit être semestre1, semestre2 ou annuel.',
+        ];
+    }
+
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'success' => false,
+                'message' => 'Validation failed',
+                'errors' => $validator->errors(),
+            ], 422)
+        );
+    }
+}

--- a/app/Models/ESBTPAttendanceManualHours.php
+++ b/app/Models/ESBTPAttendanceManualHours.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class ESBTPAttendanceManualHours extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $table = 'esbtp_attendance_manual_hours';
+
+    protected $fillable = [
+        'etudiant_id',
+        'matiere_id',
+        'classe_id',
+        'annee_universitaire_id',
+        'periode',
+        'heures_presence',
+        'heures_absence_justifiees',
+        'heures_absence_non_justifiees',
+        'notes',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'heures_presence' => 'decimal:2',
+        'heures_absence_justifiees' => 'decimal:2',
+        'heures_absence_non_justifiees' => 'decimal:2',
+    ];
+
+    public function etudiant(): BelongsTo
+    {
+        return $this->belongsTo(ESBTPEtudiant::class, 'etudiant_id');
+    }
+
+    public function matiere(): BelongsTo
+    {
+        return $this->belongsTo(ESBTPMatiere::class, 'matiere_id');
+    }
+
+    public function classe(): BelongsTo
+    {
+        return $this->belongsTo(ESBTPClasse::class, 'classe_id');
+    }
+
+    public function anneeUniversitaire(): BelongsTo
+    {
+        return $this->belongsTo(ESBTPAnneeUniversitaire::class, 'annee_universitaire_id');
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\User::class, 'created_by');
+    }
+
+    public function updatedBy(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\User::class, 'updated_by');
+    }
+
+    public function scopeForPeriod($query, int $anneeId, string $periode)
+    {
+        return $query->where('annee_universitaire_id', $anneeId)
+            ->where('periode', $periode);
+    }
+
+    public function scopeForEtudiant($query, int $etudiantId)
+    {
+        return $query->where('etudiant_id', $etudiantId);
+    }
+
+    public function scopeForClasse($query, int $classeId)
+    {
+        return $query->where('classe_id', $classeId);
+    }
+
+    public function getTotalAbsencesAttribute(): float
+    {
+        return (float) $this->heures_absence_justifiees + (float) $this->heures_absence_non_justifiees;
+    }
+
+    public function getTotalHeuresAttribute(): float
+    {
+        return (float) $this->heures_presence + $this->total_absences;
+    }
+}

--- a/app/Services/BulletinService.php
+++ b/app/Services/BulletinService.php
@@ -203,11 +203,14 @@ class BulletinService
         $moyenneGlobale = $this->calculerMoyennePonderee(collect($resultatsParMatiere));
 
         // Calcul des absences et note d'assiduité
+        // (priorité à la saisie manuelle par matière si disponible pour cette année/période)
         $absences = $this->absenceService->calculerDetailAbsences(
             $etudiant->id,
             $classe->id,
             $anneeUniversitaire->date_debut,
-            $anneeUniversitaire->date_fin
+            $anneeUniversitaire->date_fin,
+            $anneeUniversitaire->id,
+            $periode
         );
         // Calculer la note d'assiduité seulement si l'affichage est activé
         $afficherNoteAssiduite = SettingsHelper::get('bulletin_show_attendance_note', '1') === '1';
@@ -331,7 +334,9 @@ class BulletinService
                 $etudiant->id,
                 $classe->id,
                 $anneeUniversitaire->date_debut,
-                $anneeUniversitaire->date_fin
+                $anneeUniversitaire->date_fin,
+                $anneeUniversitaire->id,
+                $periode
             );
             $absencesParMatiere = $absencesParMatiereData['par_matiere'] ?? [];
             $totalHeuresAbsencesParMatiere = $absencesParMatiereData['total_heures'] ?? 0;
@@ -553,7 +558,9 @@ class BulletinService
                         $etudiant->id,
                         $classeId,
                         $anneeUniv->date_debut ?? null,
-                        $anneeUniv->date_fin ?? null
+                        $anneeUniv->date_fin ?? null,
+                        $anneeUniversitaireId,
+                        $periode
                     );
                     $noteAssiduite = $this->calculerNoteAssiduite($absencesEtudiant['justifiees'], $absencesEtudiant['non_justifiees']);
                     $moyenneEtudiant += $noteAssiduite;
@@ -1385,7 +1392,9 @@ class BulletinService
                 $bulletin->etudiant_id,
                 $bulletin->classe_id,
                 $bulletin->anneeUniversitaire->date_debut,
-                $bulletin->anneeUniversitaire->date_fin
+                $bulletin->anneeUniversitaire->date_fin,
+                $bulletin->annee_universitaire_id,
+                $bulletin->periode
             );
 
             \Log::info('Absences détaillées calculées avec succès pour le bulletin #'.$bulletin->id, $absences);

--- a/app/Services/ESBTP/ESBTPAbsenceService.php
+++ b/app/Services/ESBTP/ESBTPAbsenceService.php
@@ -3,23 +3,27 @@
 namespace App\Services\ESBTP;
 
 use App\Models\ESBTPAttendance;
+use App\Models\ESBTPAttendanceManualHours;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
 
 class ESBTPAbsenceService
 {
     /**
-     * Calcule les détails des absences pour un étudiant
+     * Calcule les détails des absences pour un étudiant.
      *
-     * @param int $etudiantId
-     * @param int $classeId
-     * @param string|null $dateDebut
-     * @param string|null $dateFin
-     * @return array
+     * Si $anneeUniversitaireId et $periode sont fournis, la saisie manuelle par matière
+     * (table esbtp_attendance_manual_hours) devient prioritaire sur le calcul session-based
+     * pour les matières concernées.
      */
-    public function calculerDetailAbsences($etudiantId, $classeId, $dateDebut = null, $dateFin = null)
-    {
-        // Si les dates ne sont pas spécifiées, utiliser la période actuelle
+    public function calculerDetailAbsences(
+        $etudiantId,
+        $classeId,
+        $dateDebut = null,
+        $dateFin = null,
+        $anneeUniversitaireId = null,
+        $periode = null
+    ) {
         if (!$dateDebut) {
             $dateDebut = Carbon::now()->startOfMonth()->format('Y-m-d');
         }
@@ -27,24 +31,31 @@ class ESBTPAbsenceService
             $dateFin = Carbon::now()->format('Y-m-d');
         }
 
-        // Récupérer toutes les absences pour la période
-        $query = ESBTPAttendance::where('etudiant_id', $etudiantId);
+        $manualByMatiere = $this->loadManualByMatiere($etudiantId, $anneeUniversitaireId, $periode);
+        $manualMatiereIds = $manualByMatiere->keys()->all();
 
-        if ($dateDebut && $dateFin) {
-            $query->whereBetween('date', [$dateDebut, $dateFin]);
+        $sessionsQuery = ESBTPAttendance::where('etudiant_id', $etudiantId)
+            ->whereBetween('date', [$dateDebut, $dateFin]);
+
+        if (!empty($manualMatiereIds)) {
+            $sessionsQuery->where(function ($q) use ($manualMatiereIds) {
+                $q->whereNull('matiere_id')
+                    ->orWhereNotIn('matiere_id', $manualMatiereIds);
+            });
         }
 
-        $absences = $query->get();
+        $absences = $sessionsQuery->get();
 
-        // Initialiser les compteurs
-        $absencesJustifiees = 0;
-        $absencesNonJustifiees = 0;
+        $absencesJustifiees = 0.0;
+        $absencesNonJustifiees = 0.0;
         $detailJustifiees = [];
         $detailNonJustifiees = [];
 
-        // Calculer les heures d'absence
         foreach ($absences as $absence) {
-            // Calculer la durée de l'absence en heures
+            if (!$absence->heure_debut || !$absence->heure_fin) {
+                continue;
+            }
+
             $heureDebut = Carbon::parse($absence->heure_debut);
             $heureFin = Carbon::parse($absence->heure_fin);
             $duree = $heureDebut->diffInHours($heureFin);
@@ -52,15 +63,40 @@ class ESBTPAbsenceService
             $detail = [
                 'date' => $absence->date,
                 'duree' => $duree,
-                'commentaire' => $absence->commentaire ?? ''
+                'commentaire' => $absence->commentaire ?? '',
+                'source' => 'sessions',
             ];
 
             if ($absence->statut === 'absent_excuse' || $absence->justified_at) {
                 $absencesJustifiees += $duree;
                 $detailJustifiees[] = $detail;
-            } else {
+            } elseif ($absence->statut === 'absent') {
                 $absencesNonJustifiees += $duree;
                 $detailNonJustifiees[] = $detail;
+            }
+        }
+
+        foreach ($manualByMatiere as $row) {
+            $absencesJustifiees += (float) $row->heures_absence_justifiees;
+            $absencesNonJustifiees += (float) $row->heures_absence_non_justifiees;
+
+            if ((float) $row->heures_absence_justifiees > 0) {
+                $detailJustifiees[] = [
+                    'date' => null,
+                    'duree' => (float) $row->heures_absence_justifiees,
+                    'commentaire' => $row->notes ?? 'Saisie manuelle ('.optional($row->matiere)->name.')',
+                    'source' => 'manual',
+                    'matiere_id' => $row->matiere_id,
+                ];
+            }
+            if ((float) $row->heures_absence_non_justifiees > 0) {
+                $detailNonJustifiees[] = [
+                    'date' => null,
+                    'duree' => (float) $row->heures_absence_non_justifiees,
+                    'commentaire' => $row->notes ?? 'Saisie manuelle ('.optional($row->matiere)->name.')',
+                    'source' => 'manual',
+                    'matiere_id' => $row->matiere_id,
+                ];
             }
         }
 
@@ -70,16 +106,26 @@ class ESBTPAbsenceService
             'total' => $absencesJustifiees + $absencesNonJustifiees,
             'detail' => [
                 'justifiees' => $detailJustifiees,
-                'non_justifiees' => $detailNonJustifiees
-            ]
+                'non_justifiees' => $detailNonJustifiees,
+            ],
+            'manual_matieres' => $manualMatiereIds,
         ];
     }
 
     /**
-     * Calcule les absences par matière pour un étudiant (en heures)
+     * Calcule les absences par matière pour un étudiant (en heures).
+     *
+     * Si $anneeUniversitaireId et $periode sont fournis, la saisie manuelle devient prioritaire
+     * par matière. Chaque entrée du tableau retourné contient 'source' = 'manual' | 'sessions'.
      */
-    public function calculerAbsencesParMatiere($etudiantId, $classeId, $dateDebut = null, $dateFin = null)
-    {
+    public function calculerAbsencesParMatiere(
+        $etudiantId,
+        $classeId,
+        $dateDebut = null,
+        $dateFin = null,
+        $anneeUniversitaireId = null,
+        $periode = null
+    ) {
         if (!$dateDebut) {
             $dateDebut = Carbon::now()->startOfYear()->format('Y-m-d');
         }
@@ -87,17 +133,28 @@ class ESBTPAbsenceService
             $dateFin = Carbon::now()->format('Y-m-d');
         }
 
-        $absences = ESBTPAttendance::where('etudiant_id', $etudiantId)
+        $manualByMatiere = $this->loadManualByMatiere($etudiantId, $anneeUniversitaireId, $periode);
+        $manualMatiereIds = $manualByMatiere->keys()->all();
+
+        $sessionsQuery = ESBTPAttendance::where('etudiant_id', $etudiantId)
             ->whereNotNull('matiere_id')
             ->whereIn('statut', ['absent', 'absent_excuse'])
-            ->whereBetween('date', [$dateDebut, $dateFin])
-            ->get();
+            ->whereBetween('date', [$dateDebut, $dateFin]);
+
+        if (!empty($manualMatiereIds)) {
+            $sessionsQuery->whereNotIn('matiere_id', $manualMatiereIds);
+        }
+
+        $absences = $sessionsQuery->get();
 
         $parMatiere = [];
-        $totalHeures = 0;
+        $totalHeures = 0.0;
 
         foreach ($absences as $absence) {
             $matiereId = $absence->matiere_id;
+            if (!$absence->heure_debut || !$absence->heure_fin) {
+                continue;
+            }
             $heureDebut = Carbon::parse($absence->heure_debut);
             $heureFin = Carbon::parse($absence->heure_fin);
             $duree = max(1, $heureDebut->diffInHours($heureFin));
@@ -108,6 +165,7 @@ class ESBTPAbsenceService
                     'total_heures' => 0,
                     'justifiees' => 0,
                     'non_justifiees' => 0,
+                    'source' => 'sessions',
                 ];
             }
 
@@ -121,9 +179,65 @@ class ESBTPAbsenceService
             }
         }
 
+        foreach ($manualByMatiere as $matiereId => $row) {
+            $justif = (float) $row->heures_absence_justifiees;
+            $nonJustif = (float) $row->heures_absence_non_justifiees;
+            $total = $justif + $nonJustif;
+
+            $parMatiere[$matiereId] = [
+                'matiere_id' => $matiereId,
+                'total_heures' => $total,
+                'justifiees' => $justif,
+                'non_justifiees' => $nonJustif,
+                'source' => 'manual',
+                'heures_presence' => (float) $row->heures_presence,
+                'notes' => $row->notes,
+            ];
+            $totalHeures += $total;
+        }
+
         return [
             'par_matiere' => $parMatiere,
             'total_heures' => $totalHeures,
+            'manual_matieres' => $manualMatiereIds,
         ];
+    }
+
+    /**
+     * Charge les saisies manuelles par matière pour un étudiant/période.
+     * Retourne une collection indexée par matiere_id (vide si pas de contexte).
+     */
+    private function loadManualByMatiere($etudiantId, $anneeUniversitaireId, $periode): Collection
+    {
+        if (!$anneeUniversitaireId || !$periode) {
+            return collect();
+        }
+
+        $normalizedPeriode = $this->normalizePeriode((string) $periode);
+
+        return ESBTPAttendanceManualHours::with('matiere:id,name')
+            ->where('etudiant_id', $etudiantId)
+            ->where('annee_universitaire_id', $anneeUniversitaireId)
+            ->where('periode', $normalizedPeriode)
+            ->get()
+            ->keyBy('matiere_id');
+    }
+
+    /**
+     * Normalise les variantes de période ('1', '2', 'S1', 'S2') en clé canonique
+     * compatible avec esbtp_attendance_manual_hours.periode.
+     */
+    private function normalizePeriode(string $periode): string
+    {
+        $periode = trim($periode);
+
+        if ($periode === '1' || strcasecmp($periode, 'S1') === 0) {
+            return 'semestre1';
+        }
+        if ($periode === '2' || strcasecmp($periode, 'S2') === 0) {
+            return 'semestre2';
+        }
+
+        return $periode ?: 'semestre1';
     }
 }

--- a/app/Services/ESBTP/ManualAttendanceHoursService.php
+++ b/app/Services/ESBTP/ManualAttendanceHoursService.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Services\ESBTP;
+
+use App\Models\ESBTPAttendanceManualHours;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class ManualAttendanceHoursService
+{
+    public const PERIODES = ['semestre1', 'semestre2', 'annuel'];
+
+    public function getForEtudiant(int $etudiantId, int $anneeId, string $periode): Collection
+    {
+        return ESBTPAttendanceManualHours::forEtudiant($etudiantId)
+            ->forPeriod($anneeId, $periode)
+            ->get()
+            ->keyBy('matiere_id');
+    }
+
+    public function getForMatiere(int $etudiantId, int $matiereId, int $anneeId, string $periode): ?ESBTPAttendanceManualHours
+    {
+        return ESBTPAttendanceManualHours::forEtudiant($etudiantId)
+            ->where('matiere_id', $matiereId)
+            ->forPeriod($anneeId, $periode)
+            ->first();
+    }
+
+    public function getForClasseMatiere(int $classeId, int $matiereId, int $anneeId, string $periode): Collection
+    {
+        return ESBTPAttendanceManualHours::forClasse($classeId)
+            ->where('matiere_id', $matiereId)
+            ->forPeriod($anneeId, $periode)
+            ->get()
+            ->keyBy('etudiant_id');
+    }
+
+    public function preloadForClasse(int $classeId, int $anneeId, string $periode): Collection
+    {
+        return ESBTPAttendanceManualHours::forClasse($classeId)
+            ->forPeriod($anneeId, $periode)
+            ->get()
+            ->groupBy(fn ($row) => $row->etudiant_id.'_'.$row->matiere_id);
+    }
+
+    public function upsertBatch(array $entries, array $context, int $userId): int
+    {
+        $count = 0;
+
+        DB::transaction(function () use ($entries, $context, $userId, &$count) {
+            foreach ($entries as $entry) {
+                $hasValue = ($entry['heures_presence'] ?? 0) > 0
+                    || ($entry['heures_absence_justifiees'] ?? 0) > 0
+                    || ($entry['heures_absence_non_justifiees'] ?? 0) > 0
+                    || !empty($entry['notes']);
+
+                $existing = ESBTPAttendanceManualHours::where([
+                    'etudiant_id' => $entry['etudiant_id'],
+                    'matiere_id' => $context['matiere_id'],
+                    'annee_universitaire_id' => $context['annee_universitaire_id'],
+                    'periode' => $context['periode'],
+                ])->first();
+
+                if (!$hasValue) {
+                    if ($existing) {
+                        $existing->update(['updated_by' => $userId]);
+                        $existing->delete();
+                        $count++;
+                    }
+                    continue;
+                }
+
+                $payload = [
+                    'etudiant_id' => $entry['etudiant_id'],
+                    'matiere_id' => $context['matiere_id'],
+                    'classe_id' => $context['classe_id'],
+                    'annee_universitaire_id' => $context['annee_universitaire_id'],
+                    'periode' => $context['periode'],
+                    'heures_presence' => $entry['heures_presence'] ?? 0,
+                    'heures_absence_justifiees' => $entry['heures_absence_justifiees'] ?? 0,
+                    'heures_absence_non_justifiees' => $entry['heures_absence_non_justifiees'] ?? 0,
+                    'notes' => $entry['notes'] ?? null,
+                    'updated_by' => $userId,
+                ];
+
+                if ($existing) {
+                    $existing->update($payload);
+                } else {
+                    $payload['created_by'] = $userId;
+                    ESBTPAttendanceManualHours::create($payload);
+                }
+
+                $count++;
+            }
+        });
+
+        return $count;
+    }
+
+    public function delete(int $id, int $userId): bool
+    {
+        $row = ESBTPAttendanceManualHours::find($id);
+        if (!$row) {
+            return false;
+        }
+        $row->update(['updated_by' => $userId]);
+        $row->delete();
+        return true;
+    }
+
+    public static function isValidPeriode(string $periode): bool
+    {
+        return in_array($periode, self::PERIODES, true);
+    }
+}

--- a/database/migrations/2026_04_16_235251_create_esbtp_attendance_manual_hours_table.php
+++ b/database/migrations/2026_04_16_235251_create_esbtp_attendance_manual_hours_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('esbtp_attendance_manual_hours', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('etudiant_id')->constrained('esbtp_etudiants')->cascadeOnDelete();
+            $table->foreignId('matiere_id')->constrained('esbtp_matieres')->cascadeOnDelete();
+            $table->foreignId('classe_id')->constrained('esbtp_classes')->cascadeOnDelete();
+            $table->foreignId('annee_universitaire_id')->constrained('esbtp_annee_universitaires')->cascadeOnDelete();
+            $table->string('periode', 20);
+
+            $table->decimal('heures_presence', 6, 2)->default(0);
+            $table->decimal('heures_absence_justifiees', 6, 2)->default(0);
+            $table->decimal('heures_absence_non_justifiees', 6, 2)->default(0);
+
+            $table->text('notes')->nullable();
+
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('updated_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(
+                ['etudiant_id', 'matiere_id', 'annee_universitaire_id', 'periode'],
+                'manual_hours_unique'
+            );
+            $table->index(
+                ['annee_universitaire_id', 'periode', 'classe_id', 'matiere_id'],
+                'manual_hours_bulletin_idx'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('esbtp_attendance_manual_hours');
+    }
+};

--- a/resources/views/esbtp/attendances/create.blade.php
+++ b/resources/views/esbtp/attendances/create.blade.php
@@ -5,67 +5,83 @@
 @section('content')
 <div class="dashboard-acasi">
     <div class="main-content">
-        <!-- Header Section -->
-        <div class="dashboard-header">
-            <div class="header-left">
-                <h1><i class="fas fa-calendar-check me-2"></i>Marquer les présences</h1>
-                <p class="header-subtitle">Enregistrement des présences étudiantes</p>
-            </div>
-            <div class="header-actions">
-                <a href="{{ route('esbtp.attendances.index') }}" class="btn-acasi secondary">
-                    <i class="fas fa-arrow-left"></i>Retour à la liste
-                </a>
+
+        {{-- ═══════════ Premium Hero ═══════════ --}}
+        <div class="at-hero">
+            <div class="at-hero-top">
+                <div class="at-hero-left">
+                    <div class="at-hero-icon"><i class="fas fa-calendar-check"></i></div>
+                    <div>
+                        <h1>Marquer les présences</h1>
+                        <p>Enregistrement des présences étudiantes par séance ou en saisie manuelle</p>
+                    </div>
+                </div>
+                <div class="at-hero-actions">
+                    <button type="button" class="at-btn at-btn--glass" data-bs-toggle="modal" data-bs-target="#atHelpModal">
+                        <i class="fas fa-circle-question"></i>Aide
+                    </button>
+                    <a href="{{ route('esbtp.attendances.index') }}" class="at-btn at-btn--white">
+                        <i class="fas fa-arrow-left"></i>Retour à la liste
+                    </a>
+                </div>
             </div>
         </div>
 
         @if(session('warning'))
-            <div class="alert alert-warning alert-dismissible fade show mb-4" role="alert">
+            <div class="alert alert-warning alert-dismissible fade show mb-3" role="alert">
                 <i class="fas fa-exclamation-triangle me-2"></i>{{ session('warning') }}
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
         @endif
 
         @if(session('error'))
-            <div class="alert alert-danger alert-dismissible fade show mb-4" role="alert">
+            <div class="alert alert-danger alert-dismissible fade show mb-3" role="alert">
                 <i class="fas fa-exclamation-circle me-2"></i>{{ session('error') }}
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
         @endif
 
         @if(isset($messageErreur))
-            <div class="alert alert-warning alert-dismissible fade show mb-4" role="alert">
+            <div class="alert alert-warning alert-dismissible fade show mb-3" role="alert">
                 <i class="fas fa-exclamation-triangle me-2"></i>{{ $messageErreur }}
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
         @endif
 
-        <div class="main-card">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-calendar-check"></i>
-                    Marquer les présences
-                </div>
-                <div class="main-card-subtitle">Enregistrement des présences étudiantes pour un cours</div>
-            </div>
-            <div class="main-card-body">
+        <div class="at-card">
+            <div class="at-card-body">
 
-                    <!-- Informations de débogage (visible uniquement en développement) -->
-                    @if(config('app.debug') && isset($debug))
-                        <div class="alert alert-secondary mb-4">
-                            <h5><i class="fas fa-bug me-2"></i>Informations de débogage :</h5>
-                            <pre>{{ json_encode($debug, JSON_PRETTY_PRINT) }}</pre>
+                    {{-- Debug visible uniquement en ?debug=1 --}}
+                    @if(config('app.debug') && request()->has('debug') && isset($debug))
+                        <div class="alert alert-secondary mb-3">
+                            <h6 class="mb-2"><i class="fas fa-bug me-2"></i>Debug</h6>
+                            <pre class="mb-0" style="font-size:.75rem">{{ json_encode($debug, JSON_PRETTY_PRINT) }}</pre>
                         </div>
                     @endif
 
-                    <!-- Guide d'utilisation -->
-                    <div class="alert alert-info mb-4">
-                        <h5><i class="fas fa-info-circle me-2"></i>Comment marquer les présences :</h5>
-                        <ol class="mb-0">
-                            <li>Sélectionnez une classe dans la liste déroulante</li>
-                            <li>Choisissez une séance de cours parmi celles disponibles pour cette classe</li>
-                            <li>La date sera automatiquement calculée en fonction de la séance choisie</li>
-                            <li>Marquez les présences pour chaque étudiant et enregistrez</li>
-                        </ol>
+                    {{-- Modal d'aide (opt-in via bouton Aide du hero) --}}
+                    <div class="modal fade" id="atHelpModal" tabindex="-1">
+                        <div class="modal-dialog modal-dialog-centered">
+                            <div class="modal-content">
+                                <div class="modal-header">
+                                    <h5 class="modal-title"><i class="fas fa-info-circle me-2"></i>Comment marquer les présences</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                                </div>
+                                <div class="modal-body">
+                                    <ol class="mb-0" style="padding-left: 1.2rem">
+                                        <li class="mb-2"><strong>Choisissez une classe</strong> dans la liste déroulante.</li>
+                                        <li class="mb-2"><strong>Sélectionnez une séance</strong> parmi celles disponibles pour cette classe.</li>
+                                        <li class="mb-2">La <strong>date</strong> se calcule automatiquement à partir de la séance.</li>
+                                        <li class="mb-2">Marquez chaque étudiant puis <strong>Enregistrez</strong>.</li>
+                                    </ol>
+                                    <hr class="my-3">
+                                    <p class="mb-0 text-muted" style="font-size:.85rem">
+                                        <i class="fas fa-lightbulb me-1 text-warning"></i>
+                                        Vous pouvez aussi basculer sur l'onglet <strong>Saisie manuelle (heures)</strong> pour entrer directement le total d'heures de présence/absence par matière pour un semestre.
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Sélection de la classe et de la séance -->
@@ -128,8 +144,42 @@
                         </form>
                     </div>
 
-                    <!-- Formulaire de saisie des présences - TOUJOURS PRESENT -->
-                    <form action="{{ route('esbtp.attendances.store') }}" method="POST" id="attendanceForm" style="{{ (!request()->filled('seance_id') || !isset($etudiants) || $etudiants->count() == 0) ? 'display:none;' : '' }}">
+                    <div class="att-tabs-wrap"
+                         data-initial-matieres='@json($matieresClasse ?? collect())'
+                         x-data="manualHoursTab({
+                             initialClasseId: {{ (int) request('classe_id', 0) }},
+                             anneeId: {{ (int) (optional($anneeUniversitaireCourante ?? null)->id ?? 0) }},
+                             initialMatieres: JSON.parse($el.dataset.initialMatieres || '[]')
+                         })"
+                         x-show="hasClasse"
+                         x-cloak
+                         @attendance:classe-changed.window="onClasseChanged($event.detail)">
+                        <nav class="att-tabs" role="tablist">
+                            <button type="button"
+                                    class="att-tab"
+                                    :class="{ 'att-tab--active': activeTab === 'seances' }"
+                                    @click="activeTab = 'seances'"
+                                    role="tab">
+                                <i class="fas fa-calendar-check"></i>Saisie par séance
+                            </button>
+                            <button type="button"
+                                    class="att-tab"
+                                    :class="{ 'att-tab--active': activeTab === 'manual' }"
+                                    @click="activeTab = 'manual'"
+                                    role="tab">
+                                <i class="fas fa-list-check"></i>Saisie manuelle (heures)
+                            </button>
+                        </nav>
+
+                        <div x-show="activeTab === 'seances'" role="tabpanel">
+
+                    @php
+                        $hasStudentsRows = request()->filled('seance_id') && isset($etudiants) && $etudiants->count() > 0;
+                        $hideForm = !$hasStudentsRows;
+                    @endphp
+
+                    <!-- Formulaire de saisie des présences (toujours présent pour AJAX) -->
+                    <form action="{{ route('esbtp.attendances.store') }}" method="POST" id="attendanceForm" style="{{ $hideForm ? 'display:none;' : '' }}">
                         @csrf
                         <input type="hidden" name="seance_cours_id" id="hidden_seance_id" value="{{ request('seance_id') }}">
                         <input type="hidden" name="date" id="hidden_date" value="{{ $dateSeance ?? request('date') }}">
@@ -144,106 +194,156 @@
                                     </tr>
                                 </thead>
                                 <tbody id="students-table-body">
-                                    @if(request()->filled('seance_id') && isset($etudiants) && $etudiants->count() > 0)
+                                    @if($hasStudentsRows)
                                         @foreach($etudiants as $etudiant)
                                             @php
-                                                // Récupérer l'attendance existante pour cet étudiant (mode hybride create/update)
                                                 $attendance = $existingAttendances[$etudiant->id] ?? null;
-                                                $statut = $attendance ? $attendance->statut : 'present'; // Défaut: present
-                                                $statutOriginal = $statut; // Pour debug
-                                                // Normaliser 'late' en 'retard' pour compatibilité avec le formulaire
-                                                if ($statut === 'late') {
-                                                    $statut = 'retard';
-                                                }
+                                                $statut = $attendance ? $attendance->statut : 'present';
+                                                $statutOriginal = $statut;
+                                                if ($statut === 'late') { $statut = 'retard'; }
                                                 $commentaire = $attendance ? $attendance->commentaire : '';
                                             @endphp
+                                            @php
+                                                $initials = strtoupper(substr($etudiant->nom ?? '', 0, 1) . substr($etudiant->prenoms ?? '', 0, 1));
+                                                $avatarHue = hexdec(substr(md5($etudiant->nom_complet ?? (string) $etudiant->id), 0, 4)) % 360;
+                                            @endphp
                                             <tr data-etudiant-id="{{ $etudiant->id }}" data-debug-statut="{{ $statut }}" data-debug-statut-original="{{ $statutOriginal }}">
-                                                <td>{{ $etudiant->nom_complet }}</td>
+                                                <td>
+                                                    <div class="at-etu">
+                                                        <span class="at-etu-avatar" @if($etudiant->photo_url) style="background:transparent;padding:0;overflow:hidden;" @else style="background: hsl({{ $avatarHue }}, 55%, 92%); color: hsl({{ $avatarHue }}, 50%, 35%);" @endif>
+                                                            @if($etudiant->photo_url)
+                                                                <img src="{{ $etudiant->photo_url }}" alt="{{ $etudiant->nom_complet }}" style="width:100%;height:100%;object-fit:cover;border-radius:50%;" onerror="this.onerror=null;this.parentElement.style.background='hsl({{ $avatarHue }}, 55%, 92%)';this.parentElement.style.color='hsl({{ $avatarHue }}, 50%, 35%)';this.outerHTML='{{ $initials ?: '?' }}';">
+                                                            @else
+                                                                {{ $initials ?: '?' }}
+                                                            @endif
+                                                        </span>
+                                                        <span class="at-etu-name">{{ $etudiant->nom_complet }}</span>
+                                                    </div>
+                                                </td>
                                                 <td>
                                                     <div class="form-check form-check-inline">
-                                                        <input class="form-check-input"
-                                                               type="radio"
-                                                               name="statuts[{{ $etudiant->id }}]"
-                                                               id="present_{{ $etudiant->id }}"
-                                                               value="present"
-                                                               {{ $statut === 'present' ? 'checked' : '' }}>
+                                                        <input class="form-check-input" type="radio" name="statuts[{{ $etudiant->id }}]" id="present_{{ $etudiant->id }}" value="present" {{ $statut === 'present' ? 'checked' : '' }}>
                                                         <label class="form-check-label text-success" for="present_{{ $etudiant->id }}">Présent</label>
                                                     </div>
                                                     <div class="form-check form-check-inline">
-                                                        <input class="form-check-input"
-                                                               type="radio"
-                                                               name="statuts[{{ $etudiant->id }}]"
-                                                               id="absent_{{ $etudiant->id }}"
-                                                               value="absent"
-                                                               {{ $statut === 'absent' ? 'checked' : '' }}>
+                                                        <input class="form-check-input" type="radio" name="statuts[{{ $etudiant->id }}]" id="absent_{{ $etudiant->id }}" value="absent" {{ $statut === 'absent' ? 'checked' : '' }}>
                                                         <label class="form-check-label text-danger" for="absent_{{ $etudiant->id }}">Absent</label>
                                                     </div>
                                                     <div class="form-check form-check-inline">
-                                                        <input class="form-check-input"
-                                                               type="radio"
-                                                               name="statuts[{{ $etudiant->id }}]"
-                                                               id="retard_{{ $etudiant->id }}"
-                                                               value="retard"
-                                                               {{ $statut === 'retard' ? 'checked' : '' }}>
+                                                        <input class="form-check-input" type="radio" name="statuts[{{ $etudiant->id }}]" id="retard_{{ $etudiant->id }}" value="retard" {{ $statut === 'retard' ? 'checked' : '' }}>
                                                         <label class="form-check-label text-warning" for="retard_{{ $etudiant->id }}">Retard</label>
                                                     </div>
                                                     <div class="form-check form-check-inline">
-                                                        <input class="form-check-input"
-                                                               type="radio"
-                                                               name="statuts[{{ $etudiant->id }}]"
-                                                               id="excuse_{{ $etudiant->id }}"
-                                                               value="excuse"
-                                                               {{ $statut === 'excuse' ? 'checked' : '' }}>
+                                                        <input class="form-check-input" type="radio" name="statuts[{{ $etudiant->id }}]" id="excuse_{{ $etudiant->id }}" value="excuse" {{ $statut === 'excuse' ? 'checked' : '' }}>
                                                         <label class="form-check-label text-info" for="excuse_{{ $etudiant->id }}">Excusé</label>
                                                     </div>
                                                 </td>
                                                 <td>
-                                                    <input type="text"
-                                                           name="commentaires[{{ $etudiant->id }}]"
-                                                           class="form-control"
-                                                           placeholder="Commentaire (optionnel)"
-                                                           value="{{ $commentaire }}">
+                                                    <input type="text" name="commentaires[{{ $etudiant->id }}]" class="form-control" placeholder="Commentaire (optionnel)" value="{{ $commentaire }}">
                                                 </td>
                                             </tr>
                                         @endforeach
-                                    </tbody>
-                                </table>
+                                    @endif
+                                </tbody>
+                            </table>
+                        </div>
+
+                        <div class="mt-4 submit-buttons" style="{{ $hideForm ? 'display:none;' : '' }}">
+                            <button type="submit" class="btn btn-gradient-primary">
+                                <i class="mdi mdi-content-save"></i> Enregistrer les présences
+                            </button>
+                            <a href="{{ route('esbtp.attendances.index') }}" class="btn btn-light">Annuler</a>
+                        </div>
+                    </form>
+
+                    <div class="mt-4 quick-action-buttons" style="{{ $hideForm ? 'display:none;' : '' }}">
+                        <button type="button" class="btn btn-success btn-sm" onclick="marquerTous('present')">
+                            <i class="mdi mdi-check-all"></i> Tous présents
+                        </button>
+                        <button type="button" class="btn btn-danger btn-sm" onclick="marquerTous('absent')">
+                            <i class="mdi mdi-close-all"></i> Tous absents
+                        </button>
+                    </div>
+
+                    {{-- placeholder : les alertes sont rendues en dehors de .att-tabs-wrap ci-dessous --}}
+
                             </div>
 
-                            <div class="mt-4">
-                                <button type="submit" class="btn btn-gradient-primary">
-                                    <i class="mdi mdi-content-save"></i> Enregistrer les présences
-                                </button>
-                                <a href="{{ route('esbtp.attendances.index') }}" class="btn btn-light">Annuler</a>
-                            </div>
-                        </form>
+                            <div x-show="activeTab === 'manual'" role="tabpanel" class="att-manual-wrap">
+                                <template x-if="matieres.length === 0">
+                                    <div class="amh-alert amh-alert--warning">
+                                        <i class="fas fa-triangle-exclamation"></i>
+                                        <div>
+                                            <strong>Aucune matière n'est attachée à cette classe.</strong>
+                                            Vous devez d'abord associer des matières à la classe dans
+                                            <a href="{{ route('esbtp.classes.index') }}" style="color:inherit;text-decoration:underline;">Gestion des classes</a>
+                                            avant de pouvoir saisir les heures manuelles.
+                                        </div>
+                                    </div>
+                                </template>
 
-                        <!-- Boutons pour marquer tous les étudiants avec onclick direct -->
-                        <div class="mt-4">
-                            <button type="button" class="btn btn-success btn-sm" onclick="marquerTous('present')">
-                                <i class="mdi mdi-check-all"></i> Tous présents
-                            </button>
-                            <button type="button" class="btn btn-danger btn-sm" onclick="marquerTous('absent')">
-                                <i class="mdi mdi-close-all"></i> Tous absents
-                            </button>
+                                <template x-if="matieres.length > 0">
+                                    <div class="amh-selector-bar">
+                                        <div class="amh-selector-field">
+                                            <label for="amh-matiere-select">Matière</label>
+                                            <select id="amh-matiere-select" x-model="matiereId" class="form-control" x-ref="matiereSelect">
+                                                <option value="">— Sélectionner une matière —</option>
+                                                @if(isset($matieresClasse))
+                                                    @foreach($matieresClasse as $m)
+                                                        <option value="{{ $m->id }}">{{ $m->name }}</option>
+                                                    @endforeach
+                                                @endif
+                                            </select>
+                                        </div>
+                                        <div class="amh-selector-field">
+                                            <label for="amh-periode-select">Période</label>
+                                            <select id="amh-periode-select" x-model="periode" class="form-control">
+                                                <option value="semestre1">Semestre 1</option>
+                                                <option value="semestre2">Semestre 2</option>
+                                                <option value="annuel">Annuel</option>
+                                            </select>
+                                        </div>
+                                        <button type="button"
+                                                class="amh-btn amh-btn--primary"
+                                                @click="loadGrid()"
+                                                :disabled="!matiereId || loading">
+                                            <i class="fas fa-rotate" :class="{ 'fa-spin': loading }"></i>
+                                            <span x-text="loading ? 'Chargement...' : 'Charger la grille'"></span>
+                                        </button>
+                                    </div>
+                                </template>
+
+                                <div id="amh-container" x-ref="container" x-show="matieres.length > 0">
+                                    <div class="amh-empty" x-show="!html && !loading">
+                                        <i class="fas fa-hand-pointer"></i>
+                                        <div>Sélectionnez une matière et une période, puis cliquez sur <strong>Charger la grille</strong>.</div>
+                                    </div>
+                                    <div class="amh-loading" x-show="loading">
+                                        <i class="fas fa-spinner fa-spin"></i>Chargement...
+                                    </div>
+                                    <div x-html="html" x-show="html && !loading"></div>
+                                </div>
+                            </div>
+                    </div>
+
+                    {{-- Alertes contextuelles (Alpine-réactives) — en dehors des onglets pour être visibles même sans classe --}}
+                    <div x-data="{
+                            hasClasse: {{ (isset($classeSelectionnee) && $classeSelectionnee) ? 'true' : 'false' }},
+                            hasSeance: {{ request()->filled('seance_id') ? 'true' : 'false' }},
+                            hasStudents: {{ (isset($etudiants) && $etudiants->count() > 0) ? 'true' : 'false' }}
+                         }"
+                         @attendance:classe-changed.window="hasClasse = !!$event.detail.classeId; hasSeance = false; hasStudents = false;"
+                         @attendance:seance-loaded.window="hasSeance = true; hasStudents = ($event.detail.nbEtudiants ?? 0) > 0;">
+                        <div class="alert alert-warning" x-show="hasClasse && hasSeance && !hasStudents" x-cloak>
+                            <i class="fas fa-triangle-exclamation me-2"></i>Aucun étudiant n'est inscrit dans cette classe pour l'année en cours.
                         </div>
-                    @elseif(request()->filled('seance_id') && isset($classeSelectionnee) && $classeSelectionnee && isset($etudiants) && $etudiants->count() == 0)
-                        <div class="alert alert-warning">
-                            <i class="mdi mdi-alert-circle"></i> Aucun étudiant n'est inscrit dans cette classe.
+                        <div class="alert alert-info" x-show="hasClasse && !hasSeance" x-cloak>
+                            <i class="fas fa-info-circle me-2"></i>Veuillez sélectionner une séance pour voir les étudiants et marquer les présences.
                         </div>
-                    @elseif(request()->filled('seance_id') && isset($classeSelectionnee) && $classeSelectionnee && !isset($messageErreur))
-                        <div class="alert alert-info">
-                            <i class="mdi mdi-information-outline"></i> Veuillez vérifier que la classe sélectionnée a des étudiants inscrits et que l'emploi du temps est correctement configuré.
+                        <div class="alert alert-info" x-show="!hasClasse" x-cloak>
+                            <i class="fas fa-hand-pointer me-2"></i>Veuillez d'abord sélectionner une classe pour commencer.
                         </div>
-                    @elseif(isset($classeSelectionnee) && $classeSelectionnee && !request()->filled('seance_id') && isset($seances) && $seances->isNotEmpty())
-                        <div class="alert alert-info">
-                            <i class="mdi mdi-information-outline"></i> Veuillez sélectionner une séance pour voir les étudiants et marquer les présences.
-                        </div>
-                    @elseif(!isset($classeSelectionnee) || !$classeSelectionnee)
-                        <div class="alert alert-info">
-                            <i class="mdi mdi-information-outline"></i> Veuillez d'abord sélectionner une classe pour commencer.
-                        </div>
-                    @endif
+                    </div>
                 </div>
             </div>
         </div>
@@ -301,6 +401,659 @@
     @keyframes spin {
         0% { transform: rotate(0deg); }
         100% { transform: rotate(360deg); }
+    }
+
+    /* ═══════════════════════════════════════════════════════════
+       Onglets attendance (seances | manuel)
+       ═══════════════════════════════════════════════════════════ */
+    [x-cloak] { display: none !important; }
+
+    .att-tabs-wrap {
+        margin-top: .25rem;
+    }
+
+    .att-tabs {
+        display: inline-flex;
+        gap: .25rem;
+        padding: .3rem;
+        background: #f1f5f9;
+        border-radius: 12px;
+        margin-bottom: 1.25rem;
+    }
+
+    .att-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: .45rem;
+        background: transparent;
+        border: 0;
+        color: #64748b;
+        font-weight: 600;
+        font-size: .82rem;
+        padding: .55rem 1rem;
+        border-radius: 9px;
+        cursor: pointer;
+        transition: all .2s ease;
+    }
+    .att-tab:hover { color: #0453cb; }
+    .att-tab--active {
+        background: #fff;
+        color: #0453cb;
+        box-shadow: 0 1px 2px rgba(15,23,42,.06);
+    }
+
+    /* ═══════════════════════════════════════════════════════════
+       Panneau Saisie manuelle (namespace amh-*)
+       ═══════════════════════════════════════════════════════════ */
+    .amh-selector-bar {
+        display: flex;
+        gap: 1rem;
+        align-items: flex-end;
+        flex-wrap: wrap;
+        padding: 1rem 1.25rem;
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        margin-bottom: 1.25rem;
+    }
+    .amh-selector-field {
+        flex: 1 1 180px;
+        min-width: 180px;
+    }
+    .amh-selector-field label {
+        display: block;
+        font-size: .72rem;
+        font-weight: 600;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: .04em;
+        margin-bottom: .35rem;
+    }
+
+    .amh-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: .5rem;
+        padding: .6rem 1.1rem;
+        border-radius: 10px;
+        border: 1px solid transparent;
+        font-size: .85rem;
+        font-weight: 600;
+        cursor: pointer;
+        transition: all .2s ease;
+    }
+    .amh-btn--primary {
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        color: #fff;
+    }
+    .amh-btn--primary:hover:not(:disabled) {
+        transform: translateY(-1px);
+        box-shadow: 0 6px 16px rgba(4,83,203,.25);
+    }
+    .amh-btn--primary:disabled {
+        opacity: .55;
+        cursor: not-allowed;
+    }
+    .amh-btn--danger {
+        background: #fee2e2;
+        color: #b91c1c;
+        border-color: #fecaca;
+        padding: .4rem .55rem;
+    }
+    .amh-btn--danger:hover { background: #fca5a5; color: #7f1d1d; }
+
+    .amh-empty, .amh-loading {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: .75rem;
+        padding: 2.5rem 1.5rem;
+        color: #64748b;
+        text-align: center;
+        background: #fff;
+        border: 1px dashed #cbd5e1;
+        border-radius: 12px;
+    }
+    .amh-empty i, .amh-loading i { font-size: 1.8rem; color: #94a3b8; }
+
+    .amh-panel {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        padding: 1.25rem 1.25rem 1.5rem;
+    }
+    .amh-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        flex-wrap: wrap;
+        gap: 1rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid #f1f5f9;
+        margin-bottom: 1rem;
+    }
+    .amh-header__eyebrow {
+        font-size: .72rem;
+        font-weight: 600;
+        color: #0453cb;
+        text-transform: uppercase;
+        letter-spacing: .05em;
+    }
+    .amh-header__title {
+        font-size: 1.15rem;
+        font-weight: 700;
+        color: #0f172a;
+        margin-top: .2rem;
+    }
+    .amh-header__meta {
+        font-size: .82rem;
+        color: #64748b;
+        margin-top: .4rem;
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: .35rem;
+    }
+
+    .amh-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: .3rem;
+        font-size: .7rem;
+        font-weight: 600;
+        padding: .18rem .55rem;
+        border-radius: 999px;
+    }
+    .amh-chip--green { background: #d1fae5; color: #065f46; }
+    .amh-chip--blue  { background: #dbeafe; color: #1e40af; }
+
+    /* État par ligne (badge dynamique piloté par data-state sur tr) */
+    .amh-state-chip {
+        display: none;
+        align-items: center;
+        gap: .3rem;
+        font-size: .65rem;
+        font-weight: 600;
+        padding: .18rem .55rem;
+        border-radius: 999px;
+        margin-left: auto;
+    }
+    .amh-state-chip--saved    { background: #d1fae5; color: #065f46; }
+    .amh-state-chip--modified { background: #fef3c7; color: #92400e; }
+    .amh-state-chip--empty    { background: #f1f5f9; color: #64748b; }
+    .amh-row[data-state="saved"]    .amh-state-chip--saved    { display: inline-flex; }
+    .amh-row[data-state="modified"] .amh-state-chip--modified { display: inline-flex; }
+    .amh-row[data-state="empty"]    .amh-state-chip--empty    { display: inline-flex; }
+
+    /* Bordure gauche colorée selon état */
+    .amh-row { border-left: 3px solid transparent; transition: border-color .15s ease, background .15s ease; }
+    .amh-row[data-state="saved"]    { border-left-color: #10b981; }
+    .amh-row[data-state="modified"] { border-left-color: #f59e0b; background: #fffbeb33; }
+    .amh-row[data-state="empty"]    { border-left-color: transparent; }
+
+    /* Actions par ligne */
+    .amh-row-actions { display: inline-flex; gap: .35rem; }
+    .amh-btn--ghost,
+    .amh-btn--ghost-sm {
+        background: transparent;
+        border: 1px solid #e2e8f0;
+        color: #475569;
+        transition: all .15s ease;
+    }
+    .amh-btn--ghost:hover:not(:disabled),
+    .amh-btn--ghost-sm:hover:not(:disabled) {
+        background: #f1f5f9;
+        color: #0f172a;
+        border-color: #cbd5e1;
+    }
+    .amh-btn--ghost:disabled,
+    .amh-btn--ghost-sm:disabled {
+        opacity: .4;
+        cursor: not-allowed;
+    }
+    .amh-btn--ghost-sm {
+        padding: .35rem .5rem;
+        font-size: .75rem;
+    }
+
+    .amh-header__actions { flex-shrink: 0; }
+
+    .amh-alert {
+        display: flex;
+        gap: .75rem;
+        padding: .85rem 1rem;
+        border-radius: 10px;
+        font-size: .85rem;
+        margin-bottom: 1rem;
+        line-height: 1.5;
+    }
+    .amh-alert i { flex-shrink: 0; margin-top: .15rem; font-size: 1rem; }
+    .amh-alert--warning { background: #fff7ed; color: #9a3412; border: 1px solid #fed7aa; }
+    .amh-alert--muted   { background: #f8fafc; color: #475569; border: 1px solid #e2e8f0; }
+
+    .amh-table-wrap {
+        overflow-x: auto;
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+    }
+    .amh-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: .88rem;
+    }
+    .amh-table thead th {
+        background: #f8fafc;
+        color: #475569;
+        font-size: .72rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: .04em;
+        text-align: left;
+        padding: .7rem .9rem;
+        border-bottom: 1px solid #e2e8f0;
+        white-space: nowrap;
+    }
+    .amh-table tbody td {
+        padding: .55rem .9rem;
+        border-bottom: 1px solid #f1f5f9;
+        vertical-align: middle;
+    }
+    .amh-table tbody tr:last-child td { border-bottom: 0; }
+    .amh-table tbody tr:hover { background: #f8fafc; }
+    .amh-col-name   { min-width: 200px; }
+    .amh-col-hours  { width: 120px; }
+    .amh-col-note   { min-width: 180px; }
+    .amh-col-actions{ width: 60px; text-align: right; }
+
+    .amh-etu { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; }
+    .amh-etu__name { font-weight: 600; color: #0f172a; }
+
+    .amh-input {
+        width: 100%;
+        border: 1px solid #e2e8f0;
+        border-radius: 8px;
+        padding: .45rem .6rem;
+        font-size: .85rem;
+        transition: border .15s;
+    }
+    .amh-input:focus { border-color: #0453cb; outline: none; box-shadow: 0 0 0 3px rgba(4,83,203,.08); }
+
+    .amh-actions {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        margin-top: 1rem;
+        flex-wrap: wrap;
+    }
+    .amh-hint {
+        color: #64748b;
+        font-size: .78rem;
+    }
+
+    @media (max-width: 768px) {
+        .amh-table thead { display: none; }
+        .amh-table tbody tr {
+            display: block;
+            border: 1px solid #e2e8f0;
+            border-radius: 10px;
+            margin-bottom: .5rem;
+            padding: .5rem;
+        }
+        .amh-table tbody td {
+            display: flex;
+            justify-content: space-between;
+            padding: .4rem .5rem;
+            border-bottom: 0;
+        }
+        .amh-table tbody td:before {
+            content: attr(data-label);
+            color: #64748b;
+            font-size: .72rem;
+            font-weight: 600;
+            text-transform: uppercase;
+        }
+    }
+
+    /* ═══════════════════════════════════════════════════════════
+       at-* : Premium redesign page Marquer les présences
+       ═══════════════════════════════════════════════════════════ */
+    .at-hero {
+        background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+        border-radius: 18px;
+        padding: 1.75rem 2rem;
+        color: #fff;
+        margin-bottom: 1.25rem;
+        box-shadow: 0 10px 30px rgba(4, 83, 203, .12);
+    }
+    .at-hero-top {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+    .at-hero-left {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+    }
+    .at-hero-icon {
+        width: 52px; height: 52px;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, .12);
+        backdrop-filter: blur(8px);
+        border: 1px solid rgba(255, 255, 255, .15);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.35rem;
+        flex-shrink: 0;
+        color: #fff;
+    }
+    .at-hero h1 {
+        font-size: 1.45rem;
+        font-weight: 700;
+        color: #fff;
+        margin: 0;
+        letter-spacing: -.01em;
+    }
+    .at-hero p {
+        color: rgba(255, 255, 255, .75);
+        font-size: .88rem;
+        margin: .2rem 0 0;
+    }
+    .at-hero-actions {
+        display: flex;
+        gap: .5rem;
+        flex-wrap: wrap;
+    }
+    .at-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: .5rem;
+        padding: .55rem 1rem;
+        border-radius: 10px;
+        font-size: .82rem;
+        font-weight: 600;
+        border: 1px solid transparent;
+        cursor: pointer;
+        transition: all .18s ease;
+        text-decoration: none;
+    }
+    .at-btn--glass {
+        background: rgba(255, 255, 255, .15);
+        color: #fff;
+        border-color: rgba(255, 255, 255, .2);
+    }
+    .at-btn--glass:hover { background: rgba(255, 255, 255, .25); color: #fff; }
+    .at-btn--white {
+        background: #fff;
+        color: #0453cb;
+    }
+    .at-btn--white:hover { background: #f8fafc; color: #033a8e; transform: translateY(-1px); }
+
+    /* Card principale */
+    .at-card {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        box-shadow: 0 1px 3px rgba(15, 23, 42, .04), 0 1px 2px rgba(15, 23, 42, .06);
+        overflow: hidden;
+    }
+    .at-card-body { padding: 1.5rem; }
+
+    /* Toolbar de sélection classe/séance/date */
+    #selectionForm.row {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 1rem 1.25rem;
+        margin: 0 0 1.25rem 0;
+    }
+    #selectionForm label.form-label {
+        font-size: .72rem;
+        font-weight: 600;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: .04em;
+        margin-bottom: .4rem;
+    }
+    #selectionForm .form-control {
+        border: 1px solid #e2e8f0;
+        border-radius: 10px;
+        background: #fff;
+        padding: .55rem .75rem;
+        font-size: .9rem;
+    }
+    #selectionForm .form-control:focus {
+        border-color: #0453cb;
+        box-shadow: 0 0 0 3px rgba(4, 83, 203, .1);
+    }
+    #selectionForm .form-text {
+        font-size: .72rem;
+        margin-top: .35rem;
+    }
+
+    /* Table étudiants premium */
+    #attendanceForm .table-responsive {
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        overflow: hidden;
+        background: #fff;
+    }
+    #attendanceForm .table {
+        margin: 0;
+        font-size: .88rem;
+    }
+    #attendanceForm .table thead th {
+        background: linear-gradient(180deg, #f8fafc 0%, #f1f5f9 100%);
+        color: #475569;
+        font-size: .72rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: .05em;
+        border: 0;
+        border-bottom: 1px solid #e2e8f0;
+        padding: .85rem 1rem;
+    }
+    #attendanceForm .table tbody tr {
+        transition: background .15s ease;
+    }
+    #attendanceForm .table tbody tr:hover { background: #f8fafc; }
+    #attendanceForm .table tbody td {
+        padding: .75rem 1rem;
+        border-color: #f1f5f9;
+        vertical-align: middle;
+    }
+    #attendanceForm .table tbody td:first-child {
+        font-weight: 600;
+        color: #0f172a;
+        position: relative;
+    }
+    #attendanceForm .table tbody td:first-child::before {
+        content: attr(data-initial);
+        display: none;
+    }
+
+    /* Avatar étudiant avec initiales */
+    .at-etu {
+        display: flex;
+        align-items: center;
+        gap: .65rem;
+        flex-wrap: wrap;
+    }
+    .at-etu-avatar {
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: .72rem;
+        font-weight: 700;
+        letter-spacing: .02em;
+        flex-shrink: 0;
+    }
+    .at-etu-name {
+        color: #0f172a;
+        font-weight: 600;
+    }
+    .at-etu-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: .25rem;
+        font-size: .65rem;
+        font-weight: 600;
+        padding: .15rem .5rem;
+        border-radius: 999px;
+        margin-left: auto;
+    }
+    .at-etu-badge--edit {
+        background: #fef3c7;
+        color: #92400e;
+    }
+
+    /* Radio buttons premium (pill toggles) */
+    #attendanceForm .form-check-inline {
+        margin-right: .35rem;
+        margin-bottom: .15rem;
+    }
+    #attendanceForm .form-check-input[type="radio"] {
+        position: absolute;
+        opacity: 0;
+        pointer-events: none;
+    }
+    #attendanceForm .form-check-label {
+        display: inline-flex;
+        align-items: center;
+        padding: .35rem .7rem;
+        border-radius: 8px;
+        font-size: .78rem;
+        font-weight: 600;
+        background: #f1f5f9;
+        color: #64748b !important;
+        cursor: pointer;
+        transition: all .15s ease;
+        border: 1px solid transparent;
+        user-select: none;
+    }
+    #attendanceForm .form-check-label:hover {
+        background: #e2e8f0;
+    }
+    #attendanceForm .form-check-input[type="radio"]:checked + .form-check-label.text-success {
+        background: #d1fae5;
+        color: #065f46 !important;
+        border-color: #10b981;
+    }
+    #attendanceForm .form-check-input[type="radio"]:checked + .form-check-label.text-danger {
+        background: #fee2e2;
+        color: #991b1b !important;
+        border-color: #ef4444;
+    }
+    #attendanceForm .form-check-input[type="radio"]:checked + .form-check-label.text-warning {
+        background: #fef3c7;
+        color: #92400e !important;
+        border-color: #f59e0b;
+    }
+    #attendanceForm .form-check-input[type="radio"]:checked + .form-check-label.text-info {
+        background: #dbeafe;
+        color: #1e40af !important;
+        border-color: #3b82f6;
+    }
+    /* Focus ring accessibility */
+    #attendanceForm .form-check-input[type="radio"]:focus + .form-check-label {
+        box-shadow: 0 0 0 3px rgba(4, 83, 203, .15);
+    }
+
+    /* Commentaire input */
+    #attendanceForm input[name^="commentaires"] {
+        border: 1px solid transparent;
+        background: #f8fafc;
+        border-radius: 8px;
+        padding: .45rem .7rem;
+        font-size: .85rem;
+        width: 100%;
+        transition: all .15s ease;
+    }
+    #attendanceForm input[name^="commentaires"]:focus {
+        background: #fff;
+        border-color: #cbd5e1;
+        box-shadow: 0 0 0 3px rgba(4, 83, 203, .08);
+    }
+
+    /* Boutons d'action */
+    #attendanceForm .submit-buttons, .quick-action-buttons {
+        display: flex;
+        gap: .5rem;
+        flex-wrap: wrap;
+        align-items: center;
+    }
+    #attendanceForm .btn-gradient-primary {
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        color: #fff;
+        border: 0;
+        padding: .6rem 1.25rem;
+        border-radius: 10px;
+        font-size: .88rem;
+        font-weight: 600;
+        transition: all .2s ease;
+    }
+    #attendanceForm .btn-gradient-primary:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 8px 24px rgba(4, 83, 203, .25);
+        color: #fff;
+    }
+    .quick-action-buttons .btn {
+        border-radius: 9px;
+        padding: .45rem .9rem;
+        font-size: .8rem;
+        font-weight: 600;
+    }
+    .quick-action-buttons .btn-success {
+        background: #10b981;
+        border-color: #10b981;
+    }
+    .quick-action-buttons .btn-success:hover { background: #059669; border-color: #059669; }
+    .quick-action-buttons .btn-danger {
+        background: #ef4444;
+        border-color: #ef4444;
+    }
+    .quick-action-buttons .btn-danger:hover { background: #dc2626; border-color: #dc2626; }
+
+    /* Alertes premium */
+    .at-card .alert {
+        border-radius: 10px;
+        border-width: 1px;
+        padding: .85rem 1rem;
+        font-size: .85rem;
+    }
+    .at-card .alert-info {
+        background: #eff6ff;
+        border-color: #bfdbfe;
+        color: #1e40af;
+    }
+    .at-card .alert-warning {
+        background: #fffbeb;
+        border-color: #fde68a;
+        color: #92400e;
+    }
+
+    /* Masque "Aucun étudiant" avant sélection */
+    #attendanceForm[style*="display:none"] + .quick-action-buttons { display: none !important; }
+
+    /* Mobile */
+    @media (max-width: 768px) {
+        .at-hero { padding: 1.25rem; }
+        .at-hero h1 { font-size: 1.2rem; }
+        .at-hero-top { flex-direction: column; align-items: flex-start; }
+        .at-hero-actions { width: 100%; }
+        #attendanceForm .table tbody td {
+            padding: .55rem .6rem;
+        }
+        #attendanceForm .form-check-label {
+            padding: .3rem .5rem;
+            font-size: .72rem;
+        }
     }
 </style>
 
@@ -417,6 +1170,14 @@
                 const newUrl = '{{ route("esbtp.attendances.create") }}?classe_id=' + classeId;
                 history.pushState({}, '', newUrl);
 
+                // Informer Alpine : la classe a changé, les onglets peuvent apparaître avec les matières
+                window.dispatchEvent(new CustomEvent('attendance:classe-changed', {
+                    detail: {
+                        classeId: parseInt(classeId, 10),
+                        matieres: data.matieres || [],
+                    }
+                }));
+
                 debugLog('✅ Séances chargées, attendez sélection d\'une séance');
             } else {
                 debugError('❌ Erreur:', data.message);
@@ -521,9 +1282,10 @@
                     submitButtonsContainer.insertAdjacentElement('afterend', quickButtons);
                 }
 
-                // Cacher les messages d'info
-                const alerts = document.querySelectorAll('.alert-info');
-                alerts.forEach(alert => alert.style.display = 'none');
+                // Informer Alpine : séance chargée avec N étudiants
+                window.dispatchEvent(new CustomEvent('attendance:seance-loaded', {
+                    detail: { nbEtudiants: data.nbEtudiants || 0 }
+                }));
 
                 // Animer toutes les lignes
                 const rows = tableBody.querySelectorAll('tr');
@@ -535,8 +1297,11 @@
 
                 debugLog('✅ Étudiants chargés:', data.nbEtudiants, 'Mode:', data.mode);
             } else {
+                // Informer Alpine : séance chargée mais 0 étudiant
+                window.dispatchEvent(new CustomEvent('attendance:seance-loaded', {
+                    detail: { nbEtudiants: 0 }
+                }));
                 debugError('❌ Erreur:', data.message);
-                alert('Erreur: ' + data.message);
             }
         })
         .catch(error => {
@@ -551,38 +1316,37 @@
     $(document).ready(function() {
         debugLog('🚀 [ATTENDANCES] Script jQuery chargé');
 
-        // 1. AJAX quand classe change - charger les séances sans reload
+        // 1. AJAX quand classe change — pas de reload, Alpine pilote les onglets
         $('#classe_id').off('change').on('change', function(e) {
             debugLog('🔵 [ATTENDANCES] Classe changée:', $(this).val());
 
-            // BLOQUER la soumission du formulaire
             e.preventDefault();
             e.stopImmediatePropagation();
 
             const classeId = $(this).val();
 
             if (classeId) {
-                debugLog('📡 [ATTENDANCES] Chargement AJAX des séances - PAS DE RELOAD!');
-                // Charger les séances via AJAX
                 loadSeances(classeId);
             } else {
-                // Si aucune classe, cacher les séances et le formulaire
                 const seanceContainer = document.getElementById('seance-select-container');
-                if (seanceContainer) {
-                    seanceContainer.remove();
-                }
-                document.getElementById('attendanceForm').style.display = 'none';
-                document.getElementById('students-table-body').innerHTML = '';
+                if (seanceContainer) seanceContainer.remove();
+                const form = document.getElementById('attendanceForm');
+                if (form) form.style.display = 'none';
+                const tbody = document.getElementById('students-table-body');
+                if (tbody) tbody.innerHTML = '';
+                // Dispatch Alpine event: classe unset
+                window.dispatchEvent(new CustomEvent('attendance:classe-changed', {
+                    detail: { classeId: null, matieres: [] }
+                }));
             }
 
-            return false; // Double sécurité
+            return false;
         });
 
-        // 2. AJAX UNIQUEMENT quand séance change - EVENT DELEGATION car élément dynamique
+        // 2. AJAX quand séance change — pas de reload, injection directe
         $(document).off('change', '#seance_id').on('change', '#seance_id', function(e) {
             debugLog('🔵 [ATTENDANCES] Séance changée:', $(this).val());
 
-            // BLOQUER la soumission du formulaire
             e.preventDefault();
             e.stopImmediatePropagation();
 
@@ -590,19 +1354,12 @@
             const seanceId = $(this).val();
 
             if (classeId && seanceId) {
-                debugLog('📡 [ATTENDANCES] Lancement AJAX - PAS DE RELOAD!');
-
-                // Construire l'URL avec paramètres
                 const newUrl = '{{ route("esbtp.attendances.create") }}?classe_id=' + classeId + '&seance_id=' + seanceId;
-
-                // Mettre à jour l'URL dans le navigateur
                 history.pushState({}, '', newUrl);
-
-                // Charger les étudiants via AJAX (le champ date sera créé dans loadStudents)
                 loadStudents(classeId, seanceId);
             }
 
-            return false; // Double sécurité
+            return false;
         });
 
         // 3. Intercepter la soumission du formulaire pour save AJAX + refresh badge
@@ -631,7 +1388,7 @@
                     debugLog('✅ [ATTENDANCES] Présences enregistrées avec succès');
 
                     // Afficher un message de succès
-                    const alertContainer = document.querySelector('.main-card-body');
+                    const alertContainer = document.querySelector('.at-card-body');
                     const existingSuccess = alertContainer.querySelector('.alert-success');
                     if (existingSuccess) existingSuccess.remove();
 
@@ -702,5 +1459,258 @@
 
         debugLog('✅ [ATTENDANCES] Event delegation configuré - ZERO RELOAD MODE');
     });
+
+    /* ═══════════════════════════════════════════════════════════
+       Onglet Saisie manuelle des heures (Alpine component)
+       ═══════════════════════════════════════════════════════════ */
+    function manualHoursTab(config) {
+        return {
+            activeTab: 'seances',
+            classeId: config.initialClasseId || 0,
+            anneeId: config.anneeId,
+            matieres: Array.isArray(config.initialMatieres) ? config.initialMatieres : [],
+            matiereId: '',
+            periode: 'semestre1',
+            loading: false,
+            html: '',
+
+            get hasClasse() {
+                return !!this.classeId;
+            },
+
+            onClasseChanged(detail) {
+                this.classeId = detail.classeId || 0;
+                this.matieres = Array.isArray(detail.matieres) ? detail.matieres : [];
+                this.matiereId = '';
+                this.html = '';
+                // Reconstruire les <option> du select matière (évite x-for dans <select>)
+                this.$nextTick(() => {
+                    const sel = this.$refs.matiereSelect;
+                    if (!sel) return;
+                    sel.innerHTML = '<option value="">— Sélectionner une matière —</option>'
+                        + this.matieres.map(m => `<option value="${m.id}">${this.escapeHtml(m.name)}</option>`).join('');
+                });
+            },
+
+            escapeHtml(str) {
+                return String(str ?? '').replace(/[&<>"']/g, c => ({
+                    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+                }[c]));
+            },
+
+            async loadGrid() {
+                if (!this.matiereId) return;
+                this.loading = true;
+                this.html = '';
+                try {
+                    const url = new URL('{{ route('esbtp.attendances.manual.load') }}', window.location.origin);
+                    url.searchParams.set('classe_id', this.classeId);
+                    url.searchParams.set('matiere_id', this.matiereId);
+                    url.searchParams.set('periode', this.periode);
+                    if (this.anneeId) url.searchParams.set('annee_universitaire_id', this.anneeId);
+
+                    const res = await fetch(url, {
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest',
+                            'Accept': 'application/json'
+                        }
+                    });
+                    if (!res.ok) {
+                        throw new Error('HTTP '+res.status);
+                    }
+                    const data = await res.json();
+                    if (!data.success) {
+                        throw new Error(data.message || 'Erreur inconnue');
+                    }
+                    this.html = data.html;
+                    this.$nextTick(() => this.bindHandlers());
+                } catch (e) {
+                    this.html = '<div class="amh-alert amh-alert--warning"><i class="fas fa-triangle-exclamation"></i><div>Impossible de charger la grille: '+e.message+'</div></div>';
+                } finally {
+                    this.loading = false;
+                }
+            },
+
+            bindHandlers() {
+                const form = document.getElementById('amh-form');
+                if (form) {
+                    form.addEventListener('submit', (e) => this.handleSubmit(e));
+                }
+                document.querySelectorAll('.amh-delete-btn').forEach(btn => {
+                    btn.addEventListener('click', (e) => this.handleDelete(e));
+                });
+
+                // Inputs : tracker les modifications pour mettre à jour l'état de la ligne
+                document.querySelectorAll('.amh-row .amh-input').forEach(input => {
+                    input.addEventListener('input', (e) => {
+                        const row = e.target.closest('.amh-row');
+                        if (row) this.refreshRowState(row);
+                    });
+                });
+
+                // Reset par ligne
+                document.querySelectorAll('.amh-reset-btn').forEach(btn => {
+                    btn.addEventListener('click', (e) => this.resetRow(e));
+                });
+
+                // Reset global
+                const resetAll = document.getElementById('amh-reset-all');
+                if (resetAll) {
+                    resetAll.addEventListener('click', () => this.resetAll());
+                }
+
+                // Init initial state for each row (pour attraper le rendu initial)
+                document.querySelectorAll('.amh-row').forEach(row => this.refreshRowState(row));
+            },
+
+            refreshRowState(row) {
+                const hasSavedId = !!row.dataset.rowId;
+                const origPres  = row.dataset.origPres  ?? '';
+                const origAbsJ  = row.dataset.origAbsJ  ?? '';
+                const origAbsNj = row.dataset.origAbsNj ?? '';
+                const origNotes = row.dataset.origNotes ?? '';
+
+                const pres  = row.querySelector('.amh-input--pres')?.value  ?? '';
+                const absJ  = row.querySelector('.amh-input--abs-j')?.value ?? '';
+                const absNj = row.querySelector('.amh-input--abs-nj')?.value ?? '';
+                const notes = row.querySelector('.amh-input--note')?.value ?? '';
+
+                const normalized = v => (v === '' || v === null || v === undefined) ? '' : String(parseFloat(v) || 0);
+                const dirty =
+                    normalized(pres) !== normalized(origPres) ||
+                    normalized(absJ) !== normalized(origAbsJ) ||
+                    normalized(absNj) !== normalized(origAbsNj) ||
+                    (notes ?? '') !== (origNotes ?? '');
+
+                const isEmpty =
+                    (pres === '' || parseFloat(pres) === 0) &&
+                    (absJ === '' || parseFloat(absJ) === 0) &&
+                    (absNj === '' || parseFloat(absNj) === 0) &&
+                    !notes;
+
+                let state;
+                if (hasSavedId) {
+                    state = dirty ? 'modified' : 'saved';
+                } else {
+                    state = isEmpty ? 'empty' : 'modified';
+                }
+
+                row.dataset.state = state;
+
+                const resetBtn = row.querySelector('.amh-reset-btn');
+                if (resetBtn) {
+                    resetBtn.disabled = !dirty && !(hasSavedId === false && !isEmpty);
+                }
+            },
+
+            resetRow(e) {
+                const row = e.currentTarget.closest('.amh-row');
+                if (!row) return;
+                const pres  = row.querySelector('.amh-input--pres');
+                const absJ  = row.querySelector('.amh-input--abs-j');
+                const absNj = row.querySelector('.amh-input--abs-nj');
+                const notes = row.querySelector('.amh-input--note');
+                if (pres)  pres.value  = row.dataset.origPres  ?? '';
+                if (absJ)  absJ.value  = row.dataset.origAbsJ  ?? '';
+                if (absNj) absNj.value = row.dataset.origAbsNj ?? '';
+                if (notes) notes.value = row.dataset.origNotes ?? '';
+                this.refreshRowState(row);
+            },
+
+            resetAll() {
+                const dirtyRows = document.querySelectorAll('.amh-row[data-state="modified"]');
+                if (dirtyRows.length === 0) {
+                    this.showToast('Aucune modification à annuler', 'success');
+                    return;
+                }
+                if (!confirm(`Annuler les modifications non enregistrées pour ${dirtyRows.length} ligne${dirtyRows.length > 1 ? 's' : ''} ?`)) return;
+                document.querySelectorAll('.amh-row').forEach(row => {
+                    const pres  = row.querySelector('.amh-input--pres');
+                    const absJ  = row.querySelector('.amh-input--abs-j');
+                    const absNj = row.querySelector('.amh-input--abs-nj');
+                    const notes = row.querySelector('.amh-input--note');
+                    if (pres)  pres.value  = row.dataset.origPres  ?? '';
+                    if (absJ)  absJ.value  = row.dataset.origAbsJ  ?? '';
+                    if (absNj) absNj.value = row.dataset.origAbsNj ?? '';
+                    if (notes) notes.value = row.dataset.origNotes ?? '';
+                    this.refreshRowState(row);
+                });
+                this.showToast('Modifications annulées', 'success');
+            },
+
+            async handleSubmit(e) {
+                e.preventDefault();
+                const form = e.target;
+                const submitBtn = form.querySelector('#amh-submit');
+                const originalHtml = submitBtn.innerHTML;
+                submitBtn.disabled = true;
+                submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin"></i>Enregistrement...';
+
+                const formData = new FormData(form);
+
+                try {
+                    const res = await fetch('{{ route('esbtp.attendances.manual.store') }}', {
+                        method: 'POST',
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest',
+                            'Accept': 'application/json',
+                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content
+                                || form.querySelector('input[name="_token"]')?.value
+                        },
+                        body: formData
+                    });
+                    const data = await res.json();
+                    if (!res.ok || !data.success) {
+                        const err = data.errors
+                            ? Object.values(data.errors).flat().join('\n')
+                            : (data.message || 'Erreur inconnue');
+                        throw new Error(err);
+                    }
+                    this.showToast(data.message || 'Enregistré avec succès', 'success');
+                    await this.loadGrid();
+                } catch (err) {
+                    this.showToast('Erreur: '+err.message, 'error');
+                } finally {
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = originalHtml;
+                }
+            },
+
+            async handleDelete(e) {
+                const btn = e.currentTarget;
+                const rowId = btn.dataset.rowId;
+                if (!rowId) return;
+                if (!confirm('Supprimer cette saisie manuelle ? Le bulletin utilisera à nouveau les séances pour cette matière.')) return;
+
+                try {
+                    const res = await fetch(`/esbtp/attendances/manual/${rowId}`, {
+                        method: 'DELETE',
+                        headers: {
+                            'X-Requested-With': 'XMLHttpRequest',
+                            'Accept': 'application/json',
+                            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content
+                        }
+                    });
+                    const data = await res.json();
+                    if (!res.ok || !data.success) {
+                        throw new Error(data.message || 'Erreur');
+                    }
+                    this.showToast(data.message || 'Supprimé', 'success');
+                    await this.loadGrid();
+                } catch (err) {
+                    this.showToast('Erreur: '+err.message, 'error');
+                }
+            },
+
+            showToast(msg, type) {
+                const t = document.createElement('div');
+                t.style.cssText = 'position:fixed;top:1rem;right:1rem;padding:.8rem 1.2rem;border-radius:10px;color:#fff;font-weight:600;font-size:.85rem;z-index:9999;box-shadow:0 8px 24px rgba(0,0,0,.15);'
+                    + (type === 'error' ? 'background:#dc2626;' : 'background:#10b981;');
+                t.textContent = msg;
+                document.body.appendChild(t);
+                setTimeout(() => t.remove(), 3500);
+            }
+        };
+    }
 </script>
 @endpush

--- a/resources/views/esbtp/attendances/index.blade.php
+++ b/resources/views/esbtp/attendances/index.blade.php
@@ -449,6 +449,10 @@
         width: 36px; height: 36px; border-radius: 10px;
         display: flex; align-items: center; justify-content: center;
         font-size: 0.75rem; font-weight: 700; color: #fff; flex-shrink: 0;
+        overflow: hidden;
+    }
+    .att-avatar img {
+        width: 100%; height: 100%; object-fit: cover;
     }
 
     .att-student-name { font-weight: 600; font-size: 0.875rem; color: var(--text-primary); }
@@ -1029,8 +1033,12 @@
                             </td>
                             <td>
                                 <div style="display:flex;align-items:center;gap:.6rem;">
-                                    <div class="att-avatar" style="background:{{ $avatarBg }};">
-                                        {{ strtoupper(substr($attendance->etudiant->nom_complet, 0, 2)) }}
+                                    <div class="att-avatar" style="background:{{ $attendance->etudiant->photo_url ? 'transparent' : $avatarBg }};">
+                                        @if($attendance->etudiant->photo_url)
+                                            <img src="{{ $attendance->etudiant->photo_url }}" alt="{{ $attendance->etudiant->nom_complet }}" onerror="this.parentElement.style.background='{{ $avatarBg }}';this.outerHTML='{{ strtoupper(substr($attendance->etudiant->nom_complet, 0, 2)) }}';">
+                                        @else
+                                            {{ strtoupper(substr($attendance->etudiant->nom_complet, 0, 2)) }}
+                                        @endif
                                     </div>
                                     <div>
                                         <div class="att-student-name">{{ $attendance->etudiant->nom_complet }}</div>

--- a/resources/views/esbtp/attendances/partials/manual-hours-tab.blade.php
+++ b/resources/views/esbtp/attendances/partials/manual-hours-tab.blade.php
@@ -1,0 +1,156 @@
+<div class="amh-panel" data-classe-id="{{ $classe->id }}" data-matiere-id="{{ $matiere->id }}" data-periode="{{ $periode }}" data-annee-id="{{ $anneeUniversitaire->id }}">
+    <div class="amh-header">
+        <div class="amh-header__titles">
+            <div class="amh-header__eyebrow">{{ $classe->name }} · {{ $matiere->name }}</div>
+            <div class="amh-header__title">Saisie manuelle — {{ ucfirst(str_replace('semestre', 'Semestre ', $periode)) }}</div>
+            <div class="amh-header__meta">
+                Année {{ $anneeUniversitaire->name ?? $anneeUniversitaire->libelle ?? '—' }}
+                · {{ $etudiants->count() }} étudiant{{ $etudiants->count() > 1 ? 's' : '' }}
+                @if($existing->count() > 0)
+                    · <span class="amh-chip amh-chip--blue"><i class="fas fa-database"></i>{{ $existing->count() }} ligne{{ $existing->count() > 1 ? 's' : '' }} sauvegardée{{ $existing->count() > 1 ? 's' : '' }}</span>
+                @endif
+            </div>
+        </div>
+        @if(!$etudiants->isEmpty())
+            <div class="amh-header__actions">
+                <button type="button" class="amh-btn amh-btn--ghost" id="amh-reset-all"
+                        title="Annule toutes les modifications non enregistrées et restaure les valeurs sauvegardées">
+                    <i class="fas fa-rotate-left"></i>Tout réinitialiser
+                </button>
+            </div>
+        @endif
+    </div>
+
+    @if($existingSessionsCount > 0)
+        <div class="amh-alert amh-alert--warning">
+            <i class="fas fa-triangle-exclamation"></i>
+            <div>
+                <strong>{{ $existingSessionsCount }} séance{{ $existingSessionsCount > 1 ? 's' : '' }} déjà enregistrée{{ $existingSessionsCount > 1 ? 's' : '' }}</strong>
+                pour cette matière et cette année.
+                Si vous saisissez des totaux manuels ci-dessous, ils deviendront <strong>la source prioritaire</strong> sur le bulletin pour cette matière et cette période.
+                Les séances restent conservées et seront réutilisées automatiquement si vous supprimez la ligne manuelle.
+            </div>
+        </div>
+    @endif
+
+    @if($etudiants->isEmpty())
+        <div class="amh-alert amh-alert--muted">
+            <i class="fas fa-user-slash"></i>
+            <div>Aucun étudiant inscrit dans cette classe pour l'année universitaire en cours.</div>
+        </div>
+    @else
+        <form id="amh-form" class="amh-form" autocomplete="off">
+            @csrf
+            <input type="hidden" name="classe_id" value="{{ $classe->id }}">
+            <input type="hidden" name="matiere_id" value="{{ $matiere->id }}">
+            <input type="hidden" name="annee_universitaire_id" value="{{ $anneeUniversitaire->id }}">
+            <input type="hidden" name="periode" value="{{ $periode }}">
+
+            <div class="amh-table-wrap">
+                <table class="amh-table">
+                    <thead>
+                        <tr>
+                            <th class="amh-col-name">Étudiant</th>
+                            <th class="amh-col-hours">Présence (h)</th>
+                            <th class="amh-col-hours">Abs. justifiées (h)</th>
+                            <th class="amh-col-hours">Abs. non justifiées (h)</th>
+                            <th class="amh-col-note">Note</th>
+                            <th class="amh-col-actions">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($etudiants as $i => $etu)
+                            @php
+                                $row = $existing->get($etu->id);
+                                $origPres  = $row ? rtrim(rtrim(number_format((float) $row->heures_presence, 2, '.', ''), '0'), '.') : '';
+                                $origAbsJ  = $row ? rtrim(rtrim(number_format((float) $row->heures_absence_justifiees, 2, '.', ''), '0'), '.') : '';
+                                $origAbsNj = $row ? rtrim(rtrim(number_format((float) $row->heures_absence_non_justifiees, 2, '.', ''), '0'), '.') : '';
+                                $origNotes = $row?->notes ?? '';
+                                $initialState = $row ? 'saved' : 'empty';
+                            @endphp
+                            <tr class="amh-row"
+                                data-etudiant-id="{{ $etu->id }}"
+                                data-row-id="{{ $row?->id }}"
+                                data-state="{{ $initialState }}"
+                                data-orig-pres="{{ $origPres }}"
+                                data-orig-abs-j="{{ $origAbsJ }}"
+                                data-orig-abs-nj="{{ $origAbsNj }}"
+                                data-orig-notes="{{ $origNotes }}">
+                                <td class="amh-col-name">
+                                    <div class="amh-etu">
+                                        <span class="amh-etu__name">{{ $etu->nom_complet ?? trim(($etu->nom ?? '').' '.($etu->prenoms ?? '')) }}</span>
+                                        <span class="amh-state-chip amh-state-chip--saved" data-state-for="saved"
+                                              title="Valeurs sauvegardées sur le bulletin">
+                                            <i class="fas fa-check"></i>Enregistré
+                                        </span>
+                                        <span class="amh-state-chip amh-state-chip--modified" data-state-for="modified"
+                                              title="Modifications non sauvegardées">
+                                            <i class="fas fa-pen"></i>Modifié
+                                        </span>
+                                        <span class="amh-state-chip amh-state-chip--empty" data-state-for="empty"
+                                              title="Aucune donnée — le bulletin utilisera les séances">
+                                            <i class="far fa-circle"></i>Vierge
+                                        </span>
+                                    </div>
+                                </td>
+                                <td class="amh-col-hours">
+                                    <input type="number" step="0.25" min="0" max="999.99"
+                                           name="entries[{{ $i }}][heures_presence]"
+                                           value="{{ $origPres }}"
+                                           class="amh-input amh-input--pres"
+                                           placeholder="0">
+                                </td>
+                                <td class="amh-col-hours">
+                                    <input type="number" step="0.25" min="0" max="999.99"
+                                           name="entries[{{ $i }}][heures_absence_justifiees]"
+                                           value="{{ $origAbsJ }}"
+                                           class="amh-input amh-input--abs-j"
+                                           placeholder="0">
+                                </td>
+                                <td class="amh-col-hours">
+                                    <input type="number" step="0.25" min="0" max="999.99"
+                                           name="entries[{{ $i }}][heures_absence_non_justifiees]"
+                                           value="{{ $origAbsNj }}"
+                                           class="amh-input amh-input--abs-nj"
+                                           placeholder="0">
+                                </td>
+                                <td class="amh-col-note">
+                                    <input type="text" maxlength="500"
+                                           name="entries[{{ $i }}][notes]"
+                                           value="{{ $origNotes }}"
+                                           class="amh-input amh-input--note"
+                                           placeholder="Note optionnelle">
+                                </td>
+                                <td class="amh-col-actions">
+                                    <input type="hidden" name="entries[{{ $i }}][etudiant_id]" value="{{ $etu->id }}">
+                                    <div class="amh-row-actions">
+                                        <button type="button" class="amh-btn amh-btn--ghost-sm amh-reset-btn"
+                                                title="Réinitialiser cette ligne">
+                                            <i class="fas fa-rotate-left"></i>
+                                        </button>
+                                        @if($row)
+                                            <button type="button" class="amh-btn amh-btn--danger amh-delete-btn"
+                                                    data-row-id="{{ $row->id }}"
+                                                    title="Supprimer la saisie manuelle (le bulletin retombera sur les séances)">
+                                                <i class="fas fa-trash"></i>
+                                            </button>
+                                        @endif
+                                    </div>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+
+            <div class="amh-actions">
+                <button type="submit" class="amh-btn amh-btn--primary" id="amh-submit">
+                    <i class="fas fa-save"></i>Enregistrer les heures
+                </button>
+                <span class="amh-hint">
+                    Laisser vide = aucune saisie manuelle pour cet étudiant (le bulletin utilise les séances).
+                </span>
+            </div>
+        </form>
+    @endif
+</div>

--- a/resources/views/esbtp/attendances/partials/student-list.blade.php
+++ b/resources/views/esbtp/attendances/partials/student-list.blade.php
@@ -1,68 +1,51 @@
 @foreach($etudiants as $etudiant)
     @php
-        // Récupérer l'attendance existante pour cet étudiant (si elle existe)
         $attendance = $existingAttendances[$etudiant->id] ?? null;
-        $statut = $attendance ? $attendance->statut : 'present'; // Défaut: present
-        // Normaliser 'late' en 'retard' pour compatibilité avec le formulaire
-        if ($statut === 'late') {
-            $statut = 'retard';
-        }
+        $statut = $attendance ? $attendance->statut : 'present';
+        if ($statut === 'late') { $statut = 'retard'; }
         $commentaire = $attendance ? $attendance->commentaire : '';
         $mode = $attendance ? 'modification' : 'nouveau';
-        $modeLabel = $attendance ? '<i class="fas fa-edit"></i> Modification' : '<i class="fas fa-plus-circle"></i> Nouveau marquage';
-        $modeBadgeClass = $attendance ? 'badge bg-warning text-dark' : 'badge bg-success';
+        $initials = strtoupper(substr($etudiant->nom ?? '', 0, 1) . substr($etudiant->prenoms ?? '', 0, 1));
+        $avatarHue = hexdec(substr(md5($etudiant->nom_complet ?? (string) $etudiant->id), 0, 4)) % 360;
     @endphp
     <tr data-etudiant-id="{{ $etudiant->id }}" data-mode="{{ $mode }}">
         <td>
-            <div class="d-flex align-items-center justify-content-between">
-                <span>{{ $etudiant->nom_complet }}</span>
-                <span class="{{ $modeBadgeClass }} ms-2" style="font-size: 0.75rem;">{!! $modeLabel !!}</span>
+            <div class="at-etu">
+                <span class="at-etu-avatar" @if($etudiant->photo_url) style="background:transparent;padding:0;overflow:hidden;" @else style="background: hsl({{ $avatarHue }}, 55%, 92%); color: hsl({{ $avatarHue }}, 50%, 35%);" @endif>
+                    @if($etudiant->photo_url)
+                        <img src="{{ $etudiant->photo_url }}" alt="{{ $etudiant->nom_complet }}" style="width:100%;height:100%;object-fit:cover;border-radius:50%;" onerror="this.onerror=null;this.parentElement.style.background='hsl({{ $avatarHue }}, 55%, 92%)';this.parentElement.style.color='hsl({{ $avatarHue }}, 50%, 35%)';this.outerHTML='{{ $initials ?: '?' }}';">
+                    @else
+                        {{ $initials ?: '?' }}
+                    @endif
+                </span>
+                <span class="at-etu-name">{{ $etudiant->nom_complet }}</span>
+                @if($attendance)
+                    <span class="at-etu-badge at-etu-badge--edit" title="Modification d'une présence existante">
+                        <i class="fas fa-edit"></i>Modifié
+                    </span>
+                @endif
             </div>
         </td>
         <td>
             <div class="form-check form-check-inline">
-                <input class="form-check-input"
-                       type="radio"
-                       name="statuts[{{ $etudiant->id }}]"
-                       id="present_{{ $etudiant->id }}"
-                       value="present"
-                       {{ $statut === 'present' ? 'checked' : '' }}>
+                <input class="form-check-input" type="radio" name="statuts[{{ $etudiant->id }}]" id="present_{{ $etudiant->id }}" value="present" {{ $statut === 'present' ? 'checked' : '' }}>
                 <label class="form-check-label text-success" for="present_{{ $etudiant->id }}">Présent</label>
             </div>
             <div class="form-check form-check-inline">
-                <input class="form-check-input"
-                       type="radio"
-                       name="statuts[{{ $etudiant->id }}]"
-                       id="absent_{{ $etudiant->id }}"
-                       value="absent"
-                       {{ $statut === 'absent' ? 'checked' : '' }}>
+                <input class="form-check-input" type="radio" name="statuts[{{ $etudiant->id }}]" id="absent_{{ $etudiant->id }}" value="absent" {{ $statut === 'absent' ? 'checked' : '' }}>
                 <label class="form-check-label text-danger" for="absent_{{ $etudiant->id }}">Absent</label>
             </div>
             <div class="form-check form-check-inline">
-                <input class="form-check-input"
-                       type="radio"
-                       name="statuts[{{ $etudiant->id }}]"
-                       id="retard_{{ $etudiant->id }}"
-                       value="retard"
-                       {{ $statut === 'retard' ? 'checked' : '' }}>
+                <input class="form-check-input" type="radio" name="statuts[{{ $etudiant->id }}]" id="retard_{{ $etudiant->id }}" value="retard" {{ $statut === 'retard' ? 'checked' : '' }}>
                 <label class="form-check-label text-warning" for="retard_{{ $etudiant->id }}">Retard</label>
             </div>
             <div class="form-check form-check-inline">
-                <input class="form-check-input"
-                       type="radio"
-                       name="statuts[{{ $etudiant->id }}]"
-                       id="excuse_{{ $etudiant->id }}"
-                       value="excuse"
-                       {{ $statut === 'excuse' ? 'checked' : '' }}>
+                <input class="form-check-input" type="radio" name="statuts[{{ $etudiant->id }}]" id="excuse_{{ $etudiant->id }}" value="excuse" {{ $statut === 'excuse' ? 'checked' : '' }}>
                 <label class="form-check-label text-info" for="excuse_{{ $etudiant->id }}">Excusé</label>
             </div>
         </td>
         <td>
-            <input type="text"
-                   name="commentaires[{{ $etudiant->id }}]"
-                   class="form-control"
-                   placeholder="Commentaire (optionnel)"
-                   value="{{ $commentaire }}">
+            <input type="text" name="commentaires[{{ $etudiant->id }}]" class="form-control" placeholder="Commentaire (optionnel)" value="{{ $commentaire }}">
         </td>
     </tr>
 @endforeach

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -3751,6 +3751,56 @@
                 <span>{{ $presConstatTextCur }}</span>
             </div>
         @endif
+
+        @if($presInscCourante)
+            @php
+                $manualHoursCur = \App\Models\ESBTPAttendanceManualHours::with('matiere:id,name')
+                    ->where('etudiant_id', $etudiant->id)
+                    ->where('annee_universitaire_id', $presAnneeCourante->id)
+                    ->orderBy('matiere_id')
+                    ->orderBy('periode')
+                    ->get();
+            @endphp
+            @if($manualHoursCur->isNotEmpty())
+                <div class="et-manual-hours" style="margin-top:18px; padding-top:16px; border-top:1px solid rgba(255,255,255,.08);">
+                    <div style="display:flex; align-items:center; gap:8px; margin-bottom:10px;">
+                        <i class="fas fa-list-check" style="color:#0453cb;"></i>
+                        <span style="font-size:.82rem; font-weight:600; color:var(--k-text);">Saisie manuelle (heures par matière)</span>
+                        <span class="amh-chip amh-chip--blue" style="margin-left:auto; display:inline-flex; align-items:center; gap:.3rem; font-size:.65rem; font-weight:600; padding:.18rem .55rem; border-radius:999px; background:#dbeafe; color:#1e40af;">
+                            <i class="fas fa-star"></i>Source prioritaire sur bulletin
+                        </span>
+                    </div>
+                    <div style="overflow-x:auto; border:1px solid var(--k-border); border-radius:10px;">
+                        <table style="width:100%; border-collapse:collapse; font-size:.8rem;">
+                            <thead>
+                                <tr style="background:rgba(4,83,203,.04);">
+                                    <th style="text-align:left; padding:.55rem .75rem; color:var(--k-muted); font-size:.7rem; text-transform:uppercase; letter-spacing:.04em;">Matière</th>
+                                    <th style="text-align:left; padding:.55rem .75rem; color:var(--k-muted); font-size:.7rem; text-transform:uppercase; letter-spacing:.04em;">Période</th>
+                                    <th style="text-align:right; padding:.55rem .75rem; color:var(--k-muted); font-size:.7rem; text-transform:uppercase; letter-spacing:.04em;">Présence</th>
+                                    <th style="text-align:right; padding:.55rem .75rem; color:var(--k-muted); font-size:.7rem; text-transform:uppercase; letter-spacing:.04em;">Abs. just.</th>
+                                    <th style="text-align:right; padding:.55rem .75rem; color:var(--k-muted); font-size:.7rem; text-transform:uppercase; letter-spacing:.04em;">Abs. non just.</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($manualHoursCur as $mh)
+                                    <tr style="border-top:1px solid var(--k-border);">
+                                        <td style="padding:.5rem .75rem; color:var(--k-text); font-weight:500;">{{ optional($mh->matiere)->name ?? '—' }}</td>
+                                        <td style="padding:.5rem .75rem; color:var(--k-muted);">{{ ucfirst(str_replace('semestre', 'Semestre ', $mh->periode)) }}</td>
+                                        <td style="padding:.5rem .75rem; text-align:right; color:#10b981; font-weight:600;">{{ rtrim(rtrim(number_format((float) $mh->heures_presence, 2, '.', ''), '0'), '.') }}h</td>
+                                        <td style="padding:.5rem .75rem; text-align:right; color:#3b82f6; font-weight:600;">{{ rtrim(rtrim(number_format((float) $mh->heures_absence_justifiees, 2, '.', ''), '0'), '.') }}h</td>
+                                        <td style="padding:.5rem .75rem; text-align:right; color:#ef4444; font-weight:600;">{{ rtrim(rtrim(number_format((float) $mh->heures_absence_non_justifiees, 2, '.', ''), '0'), '.') }}h</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                    <p style="font-size:.72rem; color:var(--k-muted); margin:.6rem 0 0 0; font-style:italic;">
+                        <i class="fas fa-info-circle"></i>
+                        Pour ces matières et périodes, le bulletin utilise ces heures manuelles au lieu des séances.
+                    </p>
+                </div>
+            @endif
+        @endif
     </div>
     @endif
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -709,6 +709,20 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
                     ->name('load-students')
                     ->middleware('permission:create_attendance');
 
+                // Saisie manuelle des heures par matière
+                Route::get('/attendances/manual/load', [ESBTPAttendanceController::class, 'loadManualTab'])
+                    ->name('manual.load')
+                    ->middleware('permission:create_attendance');
+
+                Route::post('/attendances/manual', [ESBTPAttendanceController::class, 'storeManualHours'])
+                    ->name('manual.store')
+                    ->middleware('permission:create_attendance');
+
+                Route::delete('/attendances/manual/{id}', [ESBTPAttendanceController::class, 'deleteManualHours'])
+                    ->whereNumber('id')
+                    ->name('manual.destroy')
+                    ->middleware('permission:create_attendance');
+
                 // Then parameter routes
                 Route::get('/attendances/{attendance}', [ESBTPAttendanceController::class, 'show'])
                     ->name('show')


### PR DESCRIPTION
## Résumé

Ajout d'un onglet **Saisie manuelle (heures)** dans `/esbtp/attendances/create` : la secrétaire peut entrer directement le total d'heures de présence, d'absences justifiées et non justifiées par étudiant × matière × semestre, sans passer par la saisie session-par-session. Ces heures deviennent la **source prioritaire** sur le bulletin (assiduité + note de conduite), les séances restent conservées et réutilisables en supprimant la ligne manuelle.

Redesign premium complet de la page (namespace `at-*`), restauration du flow AJAX sans reload, photos étudiants, et correction de la source canonique des matières d'une classe.

## Changements

### Feature — Saisie manuelle des heures
- Nouvelle table `esbtp_attendance_manual_hours` (unique sur etudiant + matière + année + période)
- Service dédié `ManualAttendanceHoursService` (upsertBatch transactionnel)
- Intégration bulletin via `ESBTPAbsenceService` (params optionnels `\$anneeUniversitaireId` + `\$periode`, normalisation `'1'/'S1' → 'semestre1'`), backward-compat
- Onglet AJAX lazy-loaded, warning si séances existent, fallback automatique sur séances si la ligne manuelle est supprimée
- Tableau \"Saisie manuelle par matière\" dans `etudiants.show` onglet Présences avec badge \"Source prioritaire sur bulletin\"

### UX — État + reset par ligne
- Badges par ligne : **Vierge** (gris) / **Enregistré** (vert) / **Modifié** (jaune)
- Bordure gauche colorée selon état
- Bouton ⟲ reset par ligne (disabled si rien à annuler)
- Bouton **Tout réinitialiser** dans le header

### Redesign premium (namespace `at-*`)
- Hero gradient bleu avec icône + boutons Aide/Retour
- Modal d'aide opt-in (remplace le bloc \"Comment marquer les présences\" toujours visible)
- Toolbar sélection classe/séance/date, pill-toggle radios colorés (vert/rouge/jaune/bleu)
- Avatars HSL dérivés du nom + photos étudiants (`photo_url`) avec fallback initiales
- Debug masqué par défaut (`?debug=1` pour afficher)

### Fix — AJAX anti-reload
- Restauration du flow full AJAX : `history.pushState` + `CustomEvent` (`attendance:classe-changed`, `attendance:seance-loaded`) pilotent Alpine
- Alertes contextuelles Alpine-réactives (plus de stale state après sélection)
- `loadSeances()` retourne désormais `seances` + `matieres` en une seule requête (agrégation)
- Form et tbody toujours présents dans le DOM, masqués via `style=\"display:none\"` (fix du `getElementById` qui retournait null)

### Fix — Source canonique matières d'une classe
- Helper `getMatieresClasse(\$classe)` : requête sur `esbtp_planifications_academiques` (filière + niveau) au lieu de `\$classe->matieres()` pivot (vide pour LMD et la plupart des classes)
- Fallback sur pivot `esbtp_classe_matiere` pour compat BTS legacy

### Photos étudiants sur `/esbtp/attendances/index`
- Remplacement du cercle coloré par `<img src=photo_url>` avec fallback initiales onerror

## Test plan

### Prérequis
Se connecter en tant que `superadmin` sur `https://presentation.klassci.com`.

### Golden paths
- [ ] `/esbtp/attendances/create` → sélectionner une classe → la page ne reload PAS, les séances se chargent, les onglets apparaissent
- [ ] Sélectionner une séance → les étudiants apparaissent, pas de reload
- [ ] Onglet **Saisie manuelle (heures)** → sélectionner matière + semestre → charger la grille
- [ ] Remplir une ligne → badge passe à **Modifié** + bordure jaune
- [ ] Cliquer ⟲ reset → valeurs restaurées, badge **Vierge**
- [ ] Enregistrer → badge **Enregistré** (vert)
- [ ] Supprimer la ligne manuelle (trash) → bulletin retombe sur les séances
- [ ] Générer un bulletin avec une saisie manuelle existante → la note d'assiduité utilise les heures manuelles (et non les séances)
- [ ] `/esbtp/etudiants/{id}` onglet Présences → tableau \"Saisie manuelle par matière\" visible si entrées existent
- [ ] `/esbtp/attendances/index` → photos étudiants affichées si présentes

### Edge cases
- [ ] Classe sans matière attachée (planif vide) → alerte \"Aucune matière n'est attachée à cette classe\" dans l'onglet manuel
- [ ] Classe avec 0 étudiants → alerte \"Aucun étudiant inscrit\"
- [ ] Période stockée en `'1'` ou `'2'` dans le bulletin → matching correct avec les entrées `'semestre1'` / `'semestre2'`
- [ ] Supprimer une classe → cascade sur `esbtp_attendance_manual_hours`
- [ ] Photo étudiant cassée (404) → fallback sur initiales via `onerror`

### Migration
\`\`\`bash
php artisan migrate
\`\`\`
Crée la table `esbtp_attendance_manual_hours` avec unique + index bulletin (annee + periode + classe + matiere).

Closes #211