### PR TITLE
fix(classes): retour button routes to admin view not student view

### DIFF
--- a/resources/views/esbtp/classes/show.blade.php
+++ b/resources/views/esbtp/classes/show.blade.php
@@ -367,7 +367,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     $queryParams = request()->query();
                     // Retirer le paramètre 'classe' si présent
                     unset($queryParams['classe']);
-                    $returnToIndexUrl = route('esbtp.student.classes.index', $queryParams);
+                    $returnToIndexUrl = route('esbtp.classes.index', $queryParams);
                 @endphp
                 <a href="{{ $returnToIndexUrl }}" class="btn-acasi secondary">
                     <i class="fas fa-arrow-left"></i>Retour à la liste


### PR DESCRIPTION
## Résumé

`show.blade.php` est rendu pour les admins/secrétaires/coordinateurs (les étudiants voient `student_show.blade.php`). Son bouton « Retour à la liste » construisait pourtant une URL vers `esbtp.student.classes.index` (= `/esbtp/student-classes`, réservé aux étudiants).

## Changement

- `resources/views/esbtp/classes/show.blade.php:370` — `route('esbtp.student.classes.index', ...)` → `route('esbtp.classes.index', ...)`

Les filtres dans l'URL (`filiere_id`, `niveau_id`, `statut`, `capacite`, `search`) sont préservés.

## Test

- [ ] En superAdmin/secrétaire, `/esbtp/classes/{id}` → cliquer « Retour à la liste » → atterrir sur `/esbtp/classes` avec les filtres conservés
- [ ] En étudiant, rien ne change (route différente, vue différente)

## Contexte

Identifié pendant la phase de planification du redesign premium des pages classes. Shipé en micro-PR séparée pour isolabilité/rollback, comme recommandé par le critic review.