### PR TITLE
feat(classes): redesign premium index + show (P0+P1)

### DIFF
--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -2032,7 +2032,7 @@ class ESBTPClasseController extends Controller
         try {
             $result = $this->studentService->searchAvailableStudents(
                 $classe,
-                $request->input('q', ''),
+                (string) $request->input('q', ''),
             );
 
             return response()->json([

--- a/resources/views/esbtp/classes/index.blade.php
+++ b/resources/views/esbtp/classes/index.blade.php
@@ -1,281 +1,1035 @@
 @extends('layouts.app')
 
-@section('title', 'Liste des classes - KLASSCI')
+@section('title', 'Gestion des classes - KLASSCI')
 
 @push('styles')
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
+<style>
+/* =====================================================================
+   CLASSES INDEX — namespace ci-*
+   Design premium monochrome bleu KLASSCI
+   ===================================================================== */
+
+/* -------- Variables locales -------- */
+.dashboard-acasi {
+    --ci-primary: #0453cb;
+    --ci-primary-dark: #033a8e;
+    --ci-accent: #3b7ddb;
+    --ci-text: #1e293b;
+    --ci-muted: #64748b;
+    --ci-surface: #f8fafc;
+    --ci-border: #e2e8f0;
+    --ci-success: #10b981;
+    --ci-warn: #f59e0b;
+    --ci-danger: #ef4444;
+}
+
+/* =========================================
+   HERO
+   ========================================= */
+.ci-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 2rem 2.5rem 1.5rem;
+    color: #fff;
+    margin-bottom: 1.25rem;
+    position: relative;
+    overflow: hidden;
+}
+.ci-hero::before {
+    content: '';
+    position: absolute;
+    top: -40px; right: -40px;
+    width: 220px; height: 220px;
+    border-radius: 50%;
+    background: rgba(255,255,255,.06);
+    pointer-events: none;
+}
+
+.ci-hero-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    position: relative;
+    z-index: 1;
+}
+
+.ci-hero-left {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.ci-hero-icon {
+    width: 52px; height: 52px;
+    border-radius: 14px;
+    background: rgba(255,255,255,.12);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.35rem;
+    flex-shrink: 0;
+    color: #fff;
+}
+
+.ci-hero h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #fff;
+    margin: 0 0 .2rem;
+}
+.ci-hero p {
+    color: rgba(255,255,255,.75);
+    font-size: .88rem;
+    margin: 0 0 .5rem;
+}
+
+.ci-hero-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    padding: .3rem .7rem;
+    background: rgba(255,255,255,.12);
+    border: 1px solid rgba(255,255,255,.18);
+    border-radius: 99px;
+    color: #fff;
+    font-size: .78rem;
+    font-weight: 500;
+}
+.ci-hero-chip-btn {
+    background: transparent;
+    border: none;
+    color: rgba(255,255,255,.7);
+    padding: 0 .1rem;
+    cursor: pointer;
+    transition: color .15s;
+    font-size: .82rem;
+}
+.ci-hero-chip-btn:hover { color: #fff; }
+
+.ci-hero-actions {
+    display: flex;
+    gap: .5rem;
+    flex-wrap: wrap;
+}
+
+/* Boutons hero */
+.ci-btn--glass,
+.ci-btn--white {
+    display: inline-flex;
+    align-items: center;
+    gap: .4rem;
+    padding: .55rem 1.1rem;
+    border-radius: 10px;
+    font-size: .83rem;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all .2s ease;
+    border: 1px solid transparent;
+}
+.ci-btn--glass {
+    background: rgba(255,255,255,.12);
+    color: #fff;
+    border-color: rgba(255,255,255,.18);
+}
+.ci-btn--glass:hover {
+    background: rgba(255,255,255,.2);
+    color: #fff;
+    transform: translateY(-1px);
+}
+.ci-btn--white {
+    background: #fff;
+    color: var(--ci-primary);
+}
+.ci-btn--white:hover {
+    background: #f1f5f9;
+    color: var(--ci-primary-dark);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 14px rgba(0,0,0,.12);
+}
+
+/* KPIs hero */
+.ci-kpis {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: .75rem;
+    margin-top: 1.5rem;
+    position: relative;
+    z-index: 1;
+}
+.ci-kpi {
+    background: rgba(255,255,255,.1);
+    border: 1px solid rgba(255,255,255,.15);
+    border-radius: 12px;
+    padding: .9rem 1rem;
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    transition: background .2s;
+}
+.ci-kpi:hover { background: rgba(255,255,255,.15); }
+.ci-kpi-icon {
+    width: 40px; height: 40px;
+    border-radius: 10px;
+    background: rgba(255,255,255,.14);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1rem;
+    color: #fff;
+    flex-shrink: 0;
+}
+.ci-kpi-body { flex: 1; min-width: 0; }
+.ci-kpi-value {
+    font-size: 1.45rem;
+    font-weight: 700;
+    color: #fff;
+    line-height: 1;
+}
+.ci-kpi-label {
+    font-size: .72rem;
+    color: rgba(255,255,255,.7);
+    margin-top: .25rem;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    font-weight: 500;
+}
+.ci-kpi-bar {
+    height: 4px;
+    background: rgba(255,255,255,.2);
+    border-radius: 99px;
+    margin-top: .5rem;
+    overflow: hidden;
+}
+.ci-kpi-bar-fill {
+    height: 100%;
+    background: #fff;
+    border-radius: 99px;
+    transition: width .6s ease;
+}
+
+/* =========================================
+   ALERTS (flash messages)
+   ========================================= */
+.ci-alert {
+    display: flex;
+    align-items: center;
+    gap: .6rem;
+    padding: .85rem 1.1rem;
+    border-radius: 12px;
+    margin-bottom: 1rem;
+    font-weight: 500;
+    font-size: .9rem;
+}
+.ci-alert--success {
+    background: #ecfdf5;
+    border: 1px solid #a7f3d0;
+    color: #065f46;
+}
+.ci-alert--danger {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    color: #991b1b;
+}
+
+/* =========================================
+   OVERCAPACITY BANNER (monochrome)
+   ========================================= */
+.ci-banner {
+    background: #fffbeb;
+    border: 1px solid #fde68a;
+    border-left: 4px solid var(--ci-warn);
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1rem;
+    display: flex;
+    align-items: flex-start;
+    gap: .9rem;
+}
+.ci-banner-icon {
+    width: 36px; height: 36px;
+    border-radius: 10px;
+    background: #fef3c7;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--ci-warn);
+    flex-shrink: 0;
+    font-size: 1rem;
+}
+.ci-banner-body { flex: 1; min-width: 0; }
+.ci-banner-title {
+    font-weight: 700;
+    color: #92400e;
+    margin-bottom: .2rem;
+    font-size: .92rem;
+}
+.ci-banner-text {
+    color: #78350f;
+    font-size: .82rem;
+    line-height: 1.45;
+}
+.ci-banner-actions {
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+    flex-shrink: 0;
+}
+.ci-btn--outline {
+    display: inline-flex;
+    align-items: center;
+    gap: .3rem;
+    padding: .4rem .8rem;
+    border-radius: 8px;
+    border: 1px solid #92400e;
+    background: transparent;
+    color: #92400e;
+    font-size: .78rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all .2s;
+}
+.ci-btn--outline:hover {
+    background: #92400e;
+    color: #fff;
+}
+.ci-banner-close {
+    width: 32px; height: 32px;
+    border-radius: 8px;
+    border: none;
+    background: transparent;
+    color: #92400e;
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    transition: background .15s;
+}
+.ci-banner-close:hover { background: rgba(146,64,14,.1); }
+
+/* =========================================
+   TOOLBAR FILTRES
+   ========================================= */
+.ci-toolbar {
+    background: #fff;
+    border: 1px solid var(--ci-border);
+    border-radius: 14px;
+    padding: 1rem 1.25rem;
+    margin-bottom: 1.25rem;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04);
+}
+.ci-toolbar-row {
+    display: flex;
+    gap: .6rem;
+    flex-wrap: wrap;
+    align-items: center;
+}
+.ci-search {
+    position: relative;
+    flex: 1 1 280px;
+    min-width: 240px;
+}
+.ci-search i {
+    position: absolute;
+    left: .9rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--ci-muted);
+    font-size: .88rem;
+    pointer-events: none;
+}
+.ci-search input {
+    width: 100%;
+    padding: .6rem .9rem .6rem 2.3rem;
+    border: 1px solid var(--ci-border);
+    border-radius: 10px;
+    font-size: .88rem;
+    background: var(--ci-surface);
+    transition: all .2s;
+}
+.ci-search input:focus {
+    outline: none;
+    background: #fff;
+    border-color: var(--ci-primary);
+    box-shadow: 0 0 0 3px rgba(4,83,203,.1);
+}
+.ci-filter-select {
+    padding: .6rem .9rem;
+    border: 1px solid var(--ci-border);
+    border-radius: 10px;
+    font-size: .85rem;
+    background: var(--ci-surface) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%2364748b' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E") no-repeat right .75rem center;
+    padding-right: 2rem;
+    cursor: pointer;
+    appearance: none;
+    color: var(--ci-text);
+    transition: all .2s;
+    min-width: 150px;
+}
+.ci-filter-select:focus {
+    outline: none;
+    border-color: var(--ci-primary);
+    box-shadow: 0 0 0 3px rgba(4,83,203,.1);
+}
+.ci-btn--ghost {
+    display: inline-flex;
+    align-items: center;
+    gap: .35rem;
+    padding: .55rem .85rem;
+    border: 1px solid var(--ci-border);
+    border-radius: 10px;
+    background: #fff;
+    color: var(--ci-text);
+    font-size: .83rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all .2s;
+    text-decoration: none;
+}
+.ci-btn--ghost:hover {
+    border-color: var(--ci-primary);
+    color: var(--ci-primary);
+    background: rgba(4,83,203,.04);
+}
+
+.ci-toolbar-meta {
+    margin-top: .75rem;
+    padding-top: .75rem;
+    border-top: 1px dashed var(--ci-border);
+    font-size: .78rem;
+    color: var(--ci-muted);
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+.ci-count i {
+    margin-right: .35rem;
+    color: var(--ci-primary);
+}
+
+/* Dropdown menu premium */
+.ci-dropdown {
+    border-radius: 12px;
+    border: 1px solid var(--ci-border);
+    box-shadow: 0 10px 30px rgba(15,23,42,.1);
+    padding: .4rem;
+    min-width: 200px;
+}
+.ci-dropdown .dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: .55rem;
+    padding: .55rem .75rem;
+    border-radius: 8px;
+    font-size: .85rem;
+    color: var(--ci-text);
+    cursor: pointer;
+}
+.ci-dropdown .dropdown-item i {
+    width: 18px;
+    text-align: center;
+    color: var(--ci-muted);
+    font-size: .88rem;
+}
+.ci-dropdown .dropdown-item:hover {
+    background: rgba(4,83,203,.08);
+    color: var(--ci-primary);
+}
+.ci-dropdown .dropdown-item:hover i { color: var(--ci-primary); }
+.ci-dropdown-item--danger:hover,
+.ci-dropdown-item--danger:hover i {
+    color: #991b1b !important;
+    background: rgba(239,68,68,.08) !important;
+}
+
+/* =========================================
+   GRID RESULTATS
+   ========================================= */
+.ci-results {
+    margin-bottom: 1.5rem;
+}
+.ci-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.1rem;
+}
+
+/* =========================================
+   CARD CLASSE (classe-card.blade.php)
+   ========================================= */
+.ci-card {
+    background: #fff;
+    border: 1px solid var(--ci-border);
+    border-radius: 14px;
+    padding: 1.1rem 1.25rem;
+    position: relative;
+    transition: all .2s ease;
+    display: flex;
+    flex-direction: column;
+    gap: .85rem;
+}
+.ci-card:hover {
+    border-color: #c7d4e5;
+    box-shadow: 0 8px 26px rgba(4,83,203,.08), 0 2px 6px rgba(15,23,42,.04);
+    transform: translateY(-2px);
+}
+.ci-card--inactive {
+    background: #f8fafc;
+    opacity: .72;
+}
+.ci-card-ribbon {
+    position: absolute;
+    top: 0; left: 0;
+    width: 3px;
+    height: 100%;
+    border-radius: 14px 0 0 14px;
+}
+.ci-card-ribbon--active { background: linear-gradient(180deg, var(--ci-primary), var(--ci-accent)); }
+.ci-card-ribbon--inactive { background: #cbd5e1; }
+
+.ci-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: .75rem;
+}
+.ci-card-identity {
+    display: flex;
+    align-items: center;
+    gap: .75rem;
+    flex: 1;
+    min-width: 0;
+}
+.ci-card-icon {
+    width: 42px; height: 42px;
+    border-radius: 11px;
+    background: linear-gradient(135deg, rgba(4,83,203,.1), rgba(59,125,219,.1));
+    color: var(--ci-primary);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1rem;
+    flex-shrink: 0;
+}
+.ci-card-titles { min-width: 0; }
+.ci-card-title {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0 0 .15rem;
+    color: var(--ci-text);
+    line-height: 1.25;
+}
+.ci-card-link {
+    color: inherit;
+    text-decoration: none;
+}
+.ci-card-link:hover { color: var(--ci-primary); }
+.ci-card-code {
+    display: inline-block;
+    background: var(--ci-surface);
+    color: var(--ci-muted);
+    font-family: 'Courier New', monospace;
+    font-size: .72rem;
+    font-weight: 600;
+    padding: .15rem .5rem;
+    border-radius: 6px;
+    letter-spacing: .03em;
+}
+
+.ci-card-header-right {
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+    position: relative;
+    z-index: 2;
+}
+
+.ci-card-status {
+    font-size: .68rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    padding: .25rem .55rem;
+    border-radius: 99px;
+}
+.ci-card-status--active {
+    background: rgba(16,185,129,.12);
+    color: #065f46;
+}
+.ci-card-status--inactive {
+    background: rgba(148,163,184,.2);
+    color: #475569;
+}
+
+.ci-card-menu { position: relative; }
+.ci-card-kebab {
+    width: 32px; height: 32px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--ci-muted);
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center;
+    font-size: .85rem;
+    transition: all .15s;
+}
+.ci-card-kebab:hover,
+.ci-card-kebab[aria-expanded="true"] {
+    background: var(--ci-surface);
+    color: var(--ci-primary);
+    border-color: var(--ci-border);
+}
+
+.ci-card-meta {
+    display: flex;
+    flex-direction: column;
+    gap: .3rem;
+}
+.ci-card-meta-line {
+    font-size: .82rem;
+    color: var(--ci-text);
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+}
+.ci-card-meta-line i {
+    color: var(--ci-muted);
+    width: 14px;
+    text-align: center;
+    font-size: .78rem;
+}
+.ci-card-meta-parent {
+    color: var(--ci-muted);
+    font-size: .76rem;
+    font-weight: 400;
+}
+
+.ci-card-stats {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    padding: .6rem 0;
+    background: var(--ci-surface);
+    border-radius: 10px;
+    gap: .5rem;
+}
+.ci-card-stat {
+    flex: 1;
+    text-align: center;
+}
+.ci-card-stat-value {
+    display: block;
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: var(--ci-primary);
+    line-height: 1;
+}
+.ci-card-stat-value--warn { color: var(--ci-warn); }
+.ci-card-stat-value--ok { color: var(--ci-success); }
+.ci-card-stat-label {
+    font-size: .68rem;
+    color: var(--ci-muted);
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    font-weight: 500;
+    margin-top: .15rem;
+    display: block;
+}
+.ci-card-stat--separator {
+    flex: 0 0 1px;
+    background: var(--ci-border);
+    align-self: stretch;
+    margin: .2rem 0;
+}
+
+.ci-card-bar {
+    position: relative;
+    height: 8px;
+    background: var(--ci-surface);
+    border-radius: 99px;
+    overflow: hidden;
+}
+.ci-card-bar-fill {
+    height: 100%;
+    border-radius: 99px;
+    transition: width .6s ease;
+}
+.ci-card-bar-fill--low { background: linear-gradient(90deg, #a7d4ff, #5e91de); }
+.ci-card-bar-fill--mid { background: linear-gradient(90deg, #5e91de, var(--ci-primary)); }
+.ci-card-bar-fill--high { background: linear-gradient(90deg, var(--ci-primary), var(--ci-primary-dark)); }
+.ci-card-bar-fill--full { background: linear-gradient(90deg, #fcd34d, var(--ci-warn)); }
+.ci-card-bar-pct {
+    position: absolute;
+    right: .3rem;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: .62rem;
+    font-weight: 700;
+    color: var(--ci-text);
+    background: #fff;
+    padding: 0 .3rem;
+    border-radius: 4px;
+}
+
+.ci-card-footer {
+    font-size: .75rem;
+    color: var(--ci-muted);
+    display: flex;
+    align-items: center;
+    gap: .35rem;
+    padding-top: .5rem;
+    border-top: 1px solid var(--ci-surface);
+}
+.ci-card-footer i { font-size: .72rem; }
+
+/* =========================================
+   LOAD MORE (restylé)
+   ========================================= */
+.ci-load-more-container {
+    text-align: center;
+    margin-top: 1.75rem;
+}
+.ci-load-more-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .75rem 1.75rem;
+    background: #fff;
+    border: 1px solid var(--ci-border);
+    border-radius: 99px;
+    color: var(--ci-primary);
+    font-size: .88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all .2s;
+    box-shadow: 0 1px 3px rgba(15,23,42,.05);
+}
+.ci-load-more-btn:hover {
+    background: var(--ci-primary);
+    color: #fff;
+    border-color: var(--ci-primary);
+    box-shadow: 0 6px 18px rgba(4,83,203,.25);
+    transform: translateY(-1px);
+}
+.ci-load-more-spinner {
+    padding: 1rem;
+}
+
+/* Empty state */
+.ci-empty {
+    text-align: center;
+    padding: 3rem 1.5rem;
+    background: #fff;
+    border: 2px dashed var(--ci-border);
+    border-radius: 14px;
+}
+.ci-empty-icon {
+    width: 72px; height: 72px;
+    border-radius: 50%;
+    background: var(--ci-surface);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ci-muted);
+    font-size: 1.75rem;
+    margin-bottom: 1rem;
+}
+.ci-empty-title {
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--ci-text);
+    margin-bottom: .35rem;
+}
+.ci-empty-text {
+    font-size: .88rem;
+    color: var(--ci-muted);
+    margin-bottom: 1rem;
+}
+
+/* =========================================
+   MODALS monochrome
+   ========================================= */
+.ci-modal-header {
+    background: linear-gradient(135deg, #0a3d8f 0%, var(--ci-primary) 100%);
+    color: #fff;
+    border-bottom: none;
+    padding: 1rem 1.5rem;
+    border-top-left-radius: calc(0.5rem - 1px);
+    border-top-right-radius: calc(0.5rem - 1px);
+}
+.ci-modal-header .modal-title {
+    color: #fff;
+    font-weight: 700;
+    font-size: 1rem;
+}
+.ci-modal-header .btn-close-white { filter: brightness(2); }
+
+.ci-info-box {
+    display: flex;
+    gap: .6rem;
+    padding: .8rem 1rem;
+    background: rgba(4,83,203,.06);
+    border-left: 3px solid var(--ci-primary);
+    border-radius: 8px;
+    color: var(--ci-text);
+    font-size: .85rem;
+    line-height: 1.5;
+    margin-top: .75rem;
+}
+.ci-info-box i {
+    color: var(--ci-primary);
+    font-size: 1rem;
+    flex-shrink: 0;
+    margin-top: .15rem;
+}
+
+.ci-steps {
+    padding-left: 1.2rem;
+    line-height: 1.8;
+    color: var(--ci-text);
+    font-size: .88rem;
+}
+
+/* Overcapacity modal table (monochrome) */
+.ci-overcapacity-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    font-size: .85rem;
+}
+.ci-overcapacity-table th {
+    background: var(--ci-surface);
+    color: var(--ci-muted);
+    font-size: .72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    padding: .6rem .8rem;
+    border-bottom: 1px solid var(--ci-border);
+    text-align: left;
+}
+.ci-overcapacity-table td {
+    padding: .7rem .8rem;
+    border-bottom: 1px solid var(--ci-surface);
+    vertical-align: middle;
+}
+.ci-badge {
+    display: inline-block;
+    padding: .2rem .55rem;
+    border-radius: 6px;
+    font-size: .75rem;
+    font-weight: 600;
+}
+.ci-badge--muted { background: var(--ci-surface); color: var(--ci-muted); }
+.ci-badge--primary { background: rgba(4,83,203,.12); color: var(--ci-primary); }
+.ci-badge--warn { background: #fef3c7; color: #92400e; }
+.ci-badge--danger { background: #fee2e2; color: #991b1b; }
+.ci-badge--success { background: rgba(16,185,129,.12); color: #065f46; }
+
+/* =========================================
+   RESPONSIVE
+   ========================================= */
+@media (max-width: 992px) {
+    .ci-hero { padding: 1.5rem 1.5rem 1.25rem; }
+    .ci-hero h1 { font-size: 1.3rem; }
+}
+@media (max-width: 768px) {
+    .ci-hero-top { flex-direction: column; align-items: stretch; }
+    .ci-hero-actions { justify-content: flex-start; }
+    .ci-kpis { grid-template-columns: repeat(2, 1fr); }
+    .ci-grid { grid-template-columns: 1fr; }
+    .ci-search { flex: 1 1 100%; }
+    .ci-filter-select { flex: 1 1 calc(50% - .3rem); min-width: 0; }
+}
+@media (max-width: 480px) {
+    .ci-hero { padding: 1.25rem; }
+    .ci-hero h1 { font-size: 1.15rem; }
+    .ci-kpis { grid-template-columns: 1fr; }
+    .ci-hero-icon { width: 44px; height: 44px; font-size: 1.1rem; }
+}
+</style>
 @endpush
 
 @section('content')
 <div class="dashboard-acasi">
     <div class="main-content">
-        <!-- Header moderne -->
-        <div class="dashboard-header">
-            <div class="header-left">
-                <h1>Gestion des Classes</h1>
-                <p class="header-subtitle">Organisation et suivi des classes par filière et niveau</p>
-            </div>
-            <div class="header-actions">
-                @if(auth()->user()->can('access_admin'))
-                <form action="{{ route('esbtp.classes.sync-systeme-academique') }}" method="POST" style="display:inline;">
-                    @csrf
-                    <button type="submit" class="btn-acasi secondary" title="Synchroniser BTS/LMD depuis les niveaux d'études">
-                        <i class="fas fa-sync-alt"></i>Sync BTS/LMD
-                    </button>
-                </form>
-                <button type="button" class="btn-acasi primary" id="btn-open-create-modal">
-                    <i class="fas fa-plus-circle"></i>Nouvelle Classe
-                </button>
-                @endif
-            </div>
-        </div>
-        <!-- Messages d'état -->
-        @if(session('success'))
-            <div class="card-moderne" style="background: rgba(16, 185, 129, 0.1); border-left: 4px solid var(--success); margin-bottom: var(--space-lg);">
-                <div style="padding: var(--space-md);">
-                    <div class="color-success font-semibold">
-                        <i class="fas fa-check-circle me-2"></i>{{ session('success') }}
+
+        {{-- =========================
+             HERO + KPIs
+             ========================= --}}
+        <div class="ci-hero">
+            <div class="ci-hero-top">
+                <div class="ci-hero-left">
+                    <div class="ci-hero-icon">
+                        <i class="fas fa-chalkboard-teacher"></i>
+                    </div>
+                    <div>
+                        <h1>Gestion des classes</h1>
+                        <p>Organisation et suivi par filière et niveau</p>
+                        <span class="ci-hero-chip">
+                            <i class="fas fa-calendar-alt"></i>
+                            Année {{ $anneeAcademique }}
+                            <button type="button" class="ci-hero-chip-btn" data-bs-toggle="modal" data-bs-target="#yearChangeModal" title="Comment changer d'année ?">
+                                <i class="fas fa-info-circle"></i>
+                            </button>
+                        </span>
                     </div>
                 </div>
+                <div class="ci-hero-actions">
+                    @if(auth()->user()->can('access_admin'))
+                        <form action="{{ route('esbtp.classes.sync-systeme-academique') }}" method="POST" style="display:inline;">
+                            @csrf
+                            <button type="submit" class="ci-btn--glass" title="Synchroniser BTS/LMD depuis les niveaux d'études">
+                                <i class="fas fa-sync-alt"></i>Sync BTS/LMD
+                            </button>
+                        </form>
+                        <button type="button" class="ci-btn--white" id="btn-open-create-modal">
+                            <i class="fas fa-plus-circle"></i>Nouvelle classe
+                        </button>
+                    @endif
+                </div>
+            </div>
+
+            <div class="ci-kpis">
+                <div class="ci-kpi">
+                    <div class="ci-kpi-icon"><i class="fas fa-graduation-cap"></i></div>
+                    <div class="ci-kpi-body">
+                        <div class="ci-kpi-value">{{ $kpiStats['totalClasses'] }}</div>
+                        <div class="ci-kpi-label">{{ $kpiStats['classesActives'] }} actives</div>
+                    </div>
+                </div>
+                <div class="ci-kpi">
+                    <div class="ci-kpi-icon"><i class="fas fa-users"></i></div>
+                    <div class="ci-kpi-body">
+                        <div class="ci-kpi-value">{{ $kpiStats['totalEtudiants'] }}</div>
+                        <div class="ci-kpi-label">Étudiants inscrits</div>
+                    </div>
+                </div>
+                <div class="ci-kpi">
+                    <div class="ci-kpi-icon"><i class="fas fa-chair"></i></div>
+                    <div class="ci-kpi-body">
+                        <div class="ci-kpi-value">{{ $kpiStats['placesDisponibles'] }}</div>
+                        <div class="ci-kpi-label">sur {{ $kpiStats['totalPlaces'] }} places</div>
+                        <div class="ci-kpi-bar"><div class="ci-kpi-bar-fill" style="width: {{ $kpiStats['tauxOccupation'] }}%"></div></div>
+                    </div>
+                </div>
+                <div class="ci-kpi">
+                    <div class="ci-kpi-icon"><i class="fas fa-chart-pie"></i></div>
+                    <div class="ci-kpi-body">
+                        <div class="ci-kpi-value">{{ $kpiStats['tauxOccupation'] }}%</div>
+                        <div class="ci-kpi-label">Taux d'occupation</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        {{-- Messages flash --}}
+        @if(session('success'))
+            <div class="ci-alert ci-alert--success">
+                <i class="fas fa-check-circle"></i>{{ session('success') }}
+            </div>
+        @endif
+        @if(session('error'))
+            <div class="ci-alert ci-alert--danger">
+                <i class="fas fa-exclamation-triangle"></i>{{ session('error') }}
             </div>
         @endif
 
-        @if(session('error'))
-            <div class="card-moderne" style="background: rgba(239, 68, 68, 0.1); border-left: 4px solid var(--danger); margin-bottom: var(--space-lg);">
-                <div style="padding: var(--space-md);">
-                    <div class="color-danger font-semibold">
-                        <i class="fas fa-exclamation-triangle me-2"></i>{{ session('error') }}
-                    </div>
-                </div>
+        {{-- Bannière overcapacité (chargée en JS, masquée par défaut) --}}
+        <div id="overcapacity-warning" class="ci-banner" style="display: none;">
+            <div class="ci-banner-icon"><i class="fas fa-triangle-exclamation"></i></div>
+            <div class="ci-banner-body">
+                <div class="ci-banner-title" id="overcapacity-title">Classes en surcapacité détectées</div>
+                <div class="ci-banner-text" id="overcapacity-message">Certaines classes ont dépassé leur capacité maximale autorisée.</div>
             </div>
-@endif
+            <div class="ci-banner-actions">
+                <button type="button" class="ci-btn--outline" onclick="showOvercapacityModal()">
+                    <i class="fas fa-list"></i>Voir les détails
+                </button>
+                <button type="button" class="ci-banner-close" onclick="dismissOvercapacityWarning()" title="Ignorer">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+        </div>
 
-        <!-- Avertissement Classes en Surcapacité -->
-        <div id="overcapacity-warning" class="card-moderne" style="background: rgba(251, 146, 60, 0.1); border-left: 4px solid var(--warning); margin-bottom: var(--space-lg); display: none;">
-            <div style="padding: var(--space-md);">
-                <div class="d-flex align-items-start justify-content-between">
-                    <div class="flex-grow-1">
-                        <div class="color-warning font-semibold mb-2">
-                            <i class="fas fa-exclamation-triangle me-2"></i>
-                            <span id="overcapacity-title">Classes en surcapacité détectées</span>
-                        </div>
-                        <div id="overcapacity-message" class="text-muted small mb-3">
-                            Certaines classes ont dépassé leur capacité maximale autorisée.
-                        </div>
-                        <button type="button" class="btn btn-sm btn-outline-warning" onclick="showOvercapacityModal()">
-                            <i class="fas fa-list me-1"></i>Voir les détails
-                        </button>
-                    </div>
-                    <button type="button" class="btn btn-sm btn-outline-secondary ms-3" onclick="dismissOvercapacityWarning()">
-                        <i class="fas fa-times"></i>
+        {{-- =========================
+             TOOLBAR (filtres + export)
+             ========================= --}}
+        <form method="GET" action="{{ route('esbtp.classes.index') }}" id="filtersForm" class="ci-toolbar">
+            <div class="ci-toolbar-row">
+                <div class="ci-search">
+                    <i class="fas fa-search"></i>
+                    <input type="text" name="search" id="search" value="{{ request('search') }}" placeholder="Rechercher une classe (nom ou code)..." autocomplete="off">
+                </div>
+
+                <select name="filiere_id" id="filiere_id" class="ci-filter-select">
+                    <option value="">Toutes les filières</option>
+                    @foreach($filieres as $filiere)
+                        <option value="{{ $filiere->id }}" @selected(request('filiere_id') == $filiere->id)>{{ $filiere->name }}</option>
+                    @endforeach
+                </select>
+
+                <select name="niveau_id" id="niveau_id" class="ci-filter-select">
+                    <option value="">Tous les niveaux</option>
+                    @foreach($niveaux as $niveau)
+                        <option value="{{ $niveau->id }}" @selected(request('niveau_id') == $niveau->id)>{{ $niveau->name }}</option>
+                    @endforeach
+                </select>
+
+                <select name="statut" id="statut" class="ci-filter-select">
+                    <option value="">Tous les statuts</option>
+                    <option value="active" @selected(request('statut') == 'active')>Actives</option>
+                    <option value="inactive" @selected(request('statut') == 'inactive')>Inactives</option>
+                </select>
+
+                <select name="capacite" id="capacite" class="ci-filter-select">
+                    <option value="">Toutes capacités</option>
+                    <option value="disponible" @selected(request('capacite') == 'disponible')>Places disponibles</option>
+                    <option value="pleine" @selected(request('capacite') == 'pleine')>Classes pleines</option>
+                </select>
+
+                <button type="button" id="reset-filters-btn" class="ci-btn--ghost" title="Réinitialiser les filtres">
+                    <i class="fas fa-rotate-left"></i>
+                </button>
+
+                <div class="dropdown">
+                    <button type="button" class="ci-btn--ghost" data-bs-toggle="dropdown" aria-expanded="false">
+                        <i class="fas fa-download"></i>Exporter
                     </button>
+                    <ul class="dropdown-menu dropdown-menu-end ci-dropdown">
+                        <li><button type="button" class="dropdown-item" onclick="exportClasses('excel')"><i class="fas fa-file-excel"></i>Excel (.xlsx)</button></li>
+                        <li><button type="button" class="dropdown-item" onclick="exportClasses('csv')"><i class="fas fa-file-csv"></i>CSV</button></li>
+                        <li><button type="button" class="dropdown-item" onclick="exportClasses('pdf')"><i class="fas fa-file-pdf"></i>PDF</button></li>
+                    </ul>
                 </div>
-            </div>
-        </div>
 
-        <!-- Information année académique courante -->
-        <div class="card-moderne mb-lg">
-            <div class="p-lg">
-                <div class="section-title mb-md">
-                    <i class="fas fa-calendar me-2"></i>Contexte d'affichage
-                </div>
-                <div style="display: flex; gap: var(--space-md); align-items: end;">
-                    <div style="flex: 1; max-width: 300px;">
-                        <label for="annee_academique" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Année Académique Courante</label>
-                        <select name="annee_academique" id="annee_academique" class="year-selector" style="width: 100%; background-color: #f8f9fa; cursor: not-allowed;" disabled>
-                            <option value="{{ $anneeAcademique }}" selected>
-                                {{ $anneeAcademique }} (Année en cours)
-                            </option>
-                        </select>
-                    </div>
-                    <button type="button" class="btn-acasi secondary" onclick="showYearChangeInfo()" title="Comment changer d'année ?">
-                        <i class="fas fa-info-circle"></i>Changer d'année
-                    </button>
-                </div>
-                <div class="mt-3">
-                    <small class="text-muted">
-                        <i class="fas fa-info-circle me-1"></i>
-                        Les classes sont visibles pour toutes les années, mais les étudiants affichés correspondent à l'année courante.
-                    </small>
-                </div>
-            </div>
-        </div>
-
-        <!-- Filtres avancés -->
-        <div class="card-moderne mb-lg">
-            <div class="p-lg">
-                <div class="section-title mb-md">
-                    <i class="fas fa-filter me-2"></i>Filtres de recherche
-                </div>
-                <form method="GET" action="{{ route('esbtp.classes.index') }}" id="filtersForm">
-                    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: var(--space-md); margin-bottom: var(--space-md);">
-                        <!-- Recherche générale -->
-                        <div>
-                            <label for="search" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Recherche</label>
-                            <input type="text" name="search" id="search" value="{{ request('search') }}" placeholder="Nom ou code de classe..." class="form-control" style="width: 100%;">
-                        </div>
-                        
-                        <!-- Filière -->
-                        <div>
-                            <label for="filiere_id" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Filière</label>
-                            <select name="filiere_id" id="filiere_id" class="form-control" style="width: 100%;">
-                                <option value="">Toutes les filières</option>
-                                @foreach($filieres as $filiere)
-                                    <option value="{{ $filiere->id }}" {{ request('filiere_id') == $filiere->id ? 'selected' : '' }}>
-                                        {{ $filiere->name }}
-                                    </option>
-                                @endforeach
-                            </select>
-                        </div>
-                        
-                        <!-- Niveau -->
-                        <div>
-                            <label for="niveau_id" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Niveau</label>
-                            <select name="niveau_id" id="niveau_id" class="form-control" style="width: 100%;">
-                                <option value="">Tous les niveaux</option>
-                                @foreach($niveaux as $niveau)
-                                    <option value="{{ $niveau->id }}" {{ request('niveau_id') == $niveau->id ? 'selected' : '' }}>
-                                        {{ $niveau->name }}
-                                    </option>
-                                @endforeach
-                            </select>
-                        </div>
-                        
-                        
-                        <!-- Statut -->
-                        <div>
-                            <label for="statut" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Statut</label>
-                            <select name="statut" id="statut" class="form-control" style="width: 100%;">
-                                <option value="">Tous les statuts</option>
-                                <option value="active" {{ request('statut') == 'active' ? 'selected' : '' }}>Actives</option>
-                                <option value="inactive" {{ request('statut') == 'inactive' ? 'selected' : '' }}>Inactives</option>
-                            </select>
-                        </div>
-                        
-                        <!-- Capacité -->
-                        <div>
-                            <label for="capacite" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Capacité</label>
-                            <select name="capacite" id="capacite" class="form-control" style="width: 100%;">
-                                <option value="">Toutes</option>
-                                <option value="disponible" {{ request('capacite') == 'disponible' ? 'selected' : '' }}>Disponibles</option>
-                                <option value="pleine" {{ request('capacite') == 'pleine' ? 'selected' : '' }}>Pleines</option>
-                            </select>
-                        </div>
-                    </div>
-                    
-                    <div style="display: flex; gap: var(--space-md); align-items: center; flex-wrap: wrap;">
-                        <button type="submit" class="btn-acasi primary">
-                            <i class="fas fa-search me-1"></i>Filtrer
-                        </button>
-                        <button type="button" id="reset-filters-btn" class="btn-acasi secondary">
-                            <i class="fas fa-times me-1"></i>Réinitialiser
-                        </button>
-
-                        <!-- Boutons d'export -->
-                        <div class="dropup" style="display: inline-block;">
-                            <button type="button" class="btn-acasi secondary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-                                <i class="fas fa-download"></i>Exporter
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li>
-                                    <a class="dropdown-item" href="#" onclick="exportClasses('excel'); return false;">
-                                        <i class="fas fa-file-excel text-success me-2"></i>Excel (.xlsx)
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item" href="#" onclick="exportClasses('csv'); return false;">
-                                        <i class="fas fa-file-csv text-info me-2"></i>CSV
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item" href="#" onclick="exportClasses('pdf'); return false;">
-                                        <i class="fas fa-file-pdf text-danger me-2"></i>PDF
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-
-                        <div style="margin-left: auto; font-size: var(--text-small); color: var(--text-muted);">
-                            <i class="fas fa-list me-1"></i><span id="classes-count">{{ $classes->count() }}</span> classe(s) trouvée(s)
-                        </div>
-                    </div>
-                </form>
-            </div>
-        </div>
-
-        <!-- Statistiques KPI -->
-        <div class="kpi-grid">
-            <div class="card-moderne kpi-card animate-slide-up">
-                <div class="kpi-title">
-                    <i class="fas fa-graduation-cap me-1"></i>Total Classes Actives
-                </div>
-                <div class="kpi-value color-primary">{{ $kpiStats['totalClasses'] }}</div>
-                <div class="kpi-trend {{ $kpiStats['classesActives'] == $kpiStats['totalClasses'] ? 'positive' : 'negative' }}">
-                    <i class="fas fa-{{ $kpiStats['classesActives'] == $kpiStats['totalClasses'] ? 'check' : 'exclamation' }}-circle"></i>
-                    {{ $kpiStats['classesActives'] }} actives
-                </div>
+                {{-- Bouton submit caché pour maintenir compatibilité form AJAX --}}
+                <button type="submit" style="display:none;" aria-hidden="true">Filtrer</button>
             </div>
 
-            <div class="card-moderne kpi-card animate-slide-up">
-                <div class="kpi-title">
-                    <i class="fas fa-users me-1"></i>Étudiants Inscrits
-                </div>
-                <div class="kpi-value color-accent">{{ $kpiStats['totalEtudiants'] }}</div>
-                <div class="kpi-trend positive">
-                    <i class="fas fa-chart-line"></i>
-                    Année {{ $anneeAcademique }}
-                </div>
+            <div class="ci-toolbar-meta">
+                <span class="ci-count"><i class="fas fa-list"></i><span id="classes-count">{{ $classes->count() }}</span> classe(s) trouvée(s)</span>
             </div>
+        </form>
 
-            <div class="card-moderne kpi-card animate-slide-up">
-                <div class="kpi-title">
-                    <i class="fas fa-chair me-1"></i>Places Disponibles
-                </div>
-                <div class="kpi-value color-{{ $kpiStats['placesDisponibles'] > 0 ? 'success' : 'danger' }}">{{ $kpiStats['placesDisponibles'] }}</div>
-                <div class="kpi-trend {{ $kpiStats['placesDisponibles'] > 0 ? 'positive' : 'negative' }}">
-                    <i class="fas fa-{{ $kpiStats['placesDisponibles'] > 0 ? 'arrow-up' : 'arrow-down' }}"></i>
-                    sur {{ $kpiStats['totalPlaces'] }} places
-                </div>
-            </div>
-
-            <div class="card-moderne kpi-card animate-slide-up">
-                <div class="kpi-title">
-                    <i class="fas fa-percentage me-1"></i>Taux Occupation
-                </div>
-                <div class="kpi-value color-{{ $kpiStats['tauxOccupation'] > 90 ? 'danger' : ($kpiStats['tauxOccupation'] > 70 ? 'warning' : 'success') }}">{{ $kpiStats['tauxOccupation'] }}%</div>
-                <div class="kpi-trend {{ $kpiStats['tauxOccupation'] < 100 ? 'positive' : 'negative' }}">
-                    <i class="fas fa-chart-pie"></i>
-                    Occupation globale
-                </div>
-            </div>
-        </div>
-
-        <!-- Liste des classes en grid moderne -->
-        <div class="card-moderne" style="padding: var(--space-lg);">
-            <div class="section-title">
-                <i class="fas fa-list me-2"></i>Classes par Filière et Niveau
-            </div>
-
-            <div id="classes-results">
-                @include('esbtp.classes.partials.results', ['classes' => $classes])
-            </div>
+        {{-- =========================
+             GRID RÉSULTATS
+             ========================= --}}
+        <div id="classes-results" class="ci-results">
+            @include('esbtp.classes.partials.results', ['classes' => $classes])
         </div>
 
     </div>
 </div>
 
-{{-- Modal Création Classe AJAX --}}
+{{-- ========================================
+     MODAL CRÉATION CLASSE (AJAX)
+     ======================================== --}}
 <div class="modal fade" id="createClasseModal" tabindex="-1" aria-labelledby="createClasseModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content">
-            <div class="modal-header">
+            <div class="modal-header ci-modal-header">
                 <h5 class="modal-title" id="createClasseModalLabel">
-                    <i class="fas fa-plus-circle me-2"></i>Nouvelle Classe
+                    <i class="fas fa-plus-circle me-2"></i>Nouvelle classe
                 </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
             </div>
             <div class="modal-body" id="modal-create-body">
-                {{-- Chargé via AJAX --}}
                 <div class="text-center py-5">
                     <div class="spinner-border text-primary" role="status">
                         <span class="visually-hidden">Chargement...</span>
@@ -284,28 +1038,29 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                    <i class="fas fa-times"></i> Annuler
+                    <i class="fas fa-times me-1"></i>Annuler
                 </button>
                 <button type="button" class="btn btn-primary" id="modal-create-submit-btn" disabled>
-                    <i class="fas fa-save"></i> Enregistrer la classe
+                    <i class="fas fa-save me-1"></i>Enregistrer la classe
                 </button>
             </div>
         </div>
     </div>
 </div>
 
-{{-- Modal Édition Classe AJAX --}}
+{{-- ========================================
+     MODAL ÉDITION CLASSE (AJAX)
+     ======================================== --}}
 <div class="modal fade" id="editClasseModal" tabindex="-1" aria-labelledby="editClasseModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content">
-            <div class="modal-header">
+            <div class="modal-header ci-modal-header">
                 <h5 class="modal-title" id="editClasseModalLabel">
-                    <i class="fas fa-edit me-2"></i>Modifier la Classe
+                    <i class="fas fa-edit me-2"></i>Modifier la classe
                 </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
             </div>
             <div class="modal-body" id="modal-edit-body">
-                {{-- Chargé via AJAX --}}
                 <div class="text-center py-5">
                     <div class="spinner-border text-primary" role="status">
                         <span class="visually-hidden">Chargement...</span>
@@ -314,36 +1069,36 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                    <i class="fas fa-times"></i> Annuler
+                    <i class="fas fa-times me-1"></i>Annuler
                 </button>
                 <button type="button" class="btn btn-primary" id="modal-edit-submit-btn" disabled>
-                    <i class="fas fa-save"></i> Mettre à jour la classe
+                    <i class="fas fa-save me-1"></i>Mettre à jour la classe
                 </button>
             </div>
-</div>
+        </div>
     </div>
 </div>
 
-{{-- Modal Classes en Surcapacité --}}
+{{-- ========================================
+     MODAL OVERCAPACITY (détails surcapacité)
+     ======================================== --}}
 <div class="modal fade" id="overcapacityModal" tabindex="-1" aria-labelledby="overcapacityModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content">
-            <div class="modal-header bg-warning bg-opacity-10">
+            <div class="modal-header ci-modal-header">
                 <h5 class="modal-title" id="overcapacityModalLabel">
-                    <i class="fas fa-exclamation-triangle text-warning me-2"></i>
-                    Classes en Surcapacité
+                    <i class="fas fa-triangle-exclamation me-2"></i>Classes en surcapacité
                 </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
             </div>
             <div class="modal-body">
-                <div class="alert alert-warning mb-3">
-                    <i class="fas fa-info-circle me-2"></i>
-                    <strong>Attention :</strong> Les classes ci-dessous ont dépassé leur capacité maximale autorisée.
+                <div class="ci-info-box mb-3" style="margin-top:0;">
+                    <i class="fas fa-info-circle"></i>
+                    <div><strong>Attention :</strong> les classes ci-dessous ont dépassé leur capacité maximale autorisée.</div>
                 </div>
-                
                 <div id="overcapacity-content">
                     <div class="text-center py-4">
-                        <div class="spinner-border text-warning" role="status">
+                        <div class="spinner-border text-primary" role="status">
                             <span class="visually-hidden">Chargement...</span>
                         </div>
                         <div class="mt-2 text-muted">Chargement des classes en surcapacité...</div>
@@ -352,530 +1107,385 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
-                    <i class="fas fa-times"></i> Fermer
+                    <i class="fas fa-times me-1"></i>Fermer
                 </button>
             </div>
         </div>
     </div>
 </div>
 
-@section('scripts')
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    loadOvercapacityClasses();
-});
-
-// Charger les classes en surcapacité
-function loadOvercapacityClasses() {
-    fetch('{{ route("esbtp.classes.overcapacity") }}')
-        .then(response => response.json())
-        .then(data => {
-            if (data.success && data.classes.length > 0) {
-                // Afficher l'avertissement dans la page
-                const warning = document.getElementById('overcapacity-warning');
-                warning.style.display = 'block';
-                
-                // Mettre à jour le titre et message
-                document.getElementById('overcapacity-title').textContent = 
-                    `${data.classes.length} classe(s) en surcapacité (${data.annee_universitaire})`;
-                document.getElementById('overcapacity-message').textContent = 
-                    data.message;
-                
-                // Charger les détails dans le modal
-                loadOvercapacityModalContent(data.classes);
-            }
-        })
-        .catch(error => {
-            console.error('Erreur lors du chargement des classes en surcapacité:', error);
-        });
-}
-
-// Charger le contenu du modal
-function loadOvercapacityModalContent(classes) {
-    const content = document.getElementById('overcapacity-content');
-    
-    if (classes.length === 0) {
-        content.innerHTML = `
-            <div class="text-center py-4">
-                <i class="fas fa-check-circle text-success fa-3x mb-3"></i>
-                <h5 class="text-success">Aucune classe en surcapacité</h5>
-                <p class="text-muted">Toutes les classes respectent leur capacité maximale.</p>
-            </div>
-        `;
-        return;
-    }
-    
-    let html = `
-        <div class="table-responsive">
-            <table class="table table-hover">
-                <thead class="table-warning">
-                    <tr>
-                        <th>Classe</th>
-                        <th>Filière</th>
-                        <th>Niveau</th>
-                        <th>Capacité</th>
-                        <th>Inscrits</th>
-                        <th>Taux Occupation</th>
-                        <th>Dépassement</th>
-                        <th>Statut</th>
-                    </tr>
-                </thead>
-                <tbody>
-    `;
-    
-    classes.forEach(classe => {
-        const tauxClass = classe.taux_occupation >= 150 ? 'danger' : 
-                           classe.taux_occupation >= 120 ? 'warning' : 'warning';
-        
-        html += `
-            <tr>
-                <td>
-                    <strong>${classe.nom}</strong>
-                    <br><small class="text-muted">ID: ${classe.id}</small>
-                </td>
-                <td>${classe.filiere}</td>
-                <td>${classe.niveau}</td>
-                <td>
-                    <span class="badge bg-secondary">${classe.places_totales}</span>
-                </td>
-                <td>
-                    <span class="badge bg-info">${classe.inscriptions_actives}</span>
-                </td>
-                <td>
-                    <span class="badge bg-${tauxClass}">${classe.taux_occupation}%</span>
-                </td>
-                <td>
-                    <span class="badge bg-danger">+${classe.depassement}</span>
-                </td>
-                <td>
-                    <span class="badge bg-${classe.statut === 'Actif' ? 'success' : 'secondary'}">
-                        ${classe.statut}
-                    </span>
-                </td>
-            </tr>
-        `;
-    });
-    
-    html += `
-                </tbody>
-            </table>
-        </div>
-        
-        <div class="alert alert-info mt-3">
-            <i class="fas fa-lightbulb me-2"></i>
-            <strong>Recommandation :</strong> 
-            <ul class="mb-0 mt-2">
-                <li>Envisagez d'augmenter la capacité des classes concernées</li>
-                <li>Créez des classes supplémentaires si nécessaire</li>
-                <li>Les superadmins et secrétaires peuvent contourner cette limite en cas de nécessité</li>
-            </ul>
-        </div>
-    `;
-    
-    content.innerHTML = html;
-}
-
-// Afficher le modal des classes en surcapacité
-function showOvercapacityModal() {
-    const modal = new bootstrap.Modal(document.getElementById('overcapacityModal'));
-    modal.show();
-}
-
-// Masquer l'avertissement
-function dismissOvercapacityWarning() {
-    const warning = document.getElementById('overcapacity-warning');
-    warning.style.display = 'none';
-}
-</script>
-@endsection
+{{-- Modal "Changer d'année" (partial partagé) --}}
+@include('esbtp.classes.partials.year-change-modal')
 
 @endsection
-
-@push('styles')
-<style>
-/* Styles spécifiques pour améliorer l'intégration avec dashboard-moderne.css */
-.me-1 {
-    margin-right: 0.25rem;
-}
-
-.me-2 {
-    margin-right: 0.5rem;
-}
-
-/* Amélioration responsive pour les grilles */
-@media (max-width: 768px) {
-    .resultats-grid {
-        grid-template-columns: 1fr !important;
-    }
-    
-    .kpi-grid {
-        grid-template-columns: repeat(2, 1fr) !important;
-    }
-}
-
-@media (max-width: 480px) {
-    .kpi-grid {
-        grid-template-columns: 1fr !important;
-    }
-}
-
-/* Effets hover pour les cards de classe */
-.resultat-card:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-hover);
-}
-</style>
-@endpush
-
-<!-- Modal pour les instructions de changement d'année -->
-<div class="modal fade" id="yearChangeModal" tabindex="-1" role="dialog" aria-labelledby="yearChangeModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="yearChangeModalLabel">Comment changer l'année académique ?</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close" style="background: none; border: none; font-size: 1.5rem; font-weight: bold; color: #999; cursor: pointer;">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <p><strong>Pour consulter les données d'une autre année :</strong></p>
-                <ol style="padding-left: 20px; line-height: 1.6; margin: 15px 0;">
-                    <li><strong>Aller dans</strong> : Menu → Années Universitaires</li>
-                    <li><strong>Trouver l'année souhaitée</strong> (ex: 2023-2024)</li>
-                    <li><strong>Cliquer sur "Activer"</strong> pour la définir comme année courante</li>
-                    <li><strong>Revenir ici</strong> : Les étudiants affichés dans chaque classe se mettront à jour automatiquement</li>
-                </ol>
-                <hr style="margin: 15px 0;">
-                <p style="color: #6b7280; font-size: 14px;">
-                    <i class="fas fa-info-circle"></i> 
-                    <strong>Note :</strong> Seule une année peut être "courante" à la fois. 
-                    Changer l'année courante affecte l'affichage des étudiants dans toute l'application.
-                </p>
-                <div style="background: #f3f4f6; padding: 12px; border-radius: 6px; margin-top: 15px;">
-                    <strong>Exemple :</strong><br>
-                    • Année courante = 2024-2025 → Voir les étudiants inscrits en 2024-2025<br>
-                    • Année courante = 2023-2024 → Voir les étudiants inscrits en 2023-2024
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal" onclick="$('#yearChangeModal').modal('hide');">Fermer</button>
-                <a href="{{ route('esbtp.annees-universitaires.index') }}" target="_blank" class="btn btn-primary">
-                    <i class="fas fa-external-link-alt"></i> Aller aux Années
-                </a>
-            </div>
-        </div>
-    </div>
-</div>
-
-<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
-
-<script>
-function showYearChangeInfo() {
-    $('#yearChangeModal').modal('show');
-}
-
-// Gérer la fermeture de la modal d'info année
-$(document).ready(function() {
-    // Gérer la fermeture avec le bouton X
-    $('#yearChangeModal .close[data-dismiss="modal"]').on('click', function() {
-        $('#yearChangeModal').modal('hide');
-    });
-
-    // Gérer la fermeture avec le bouton Fermer
-    $('#yearChangeModal button[data-dismiss="modal"]').on('click', function() {
-        $('#yearChangeModal').modal('hide');
-    });
-});
-</script>
 
 @push('scripts')
 <script>
-    document.addEventListener('DOMContentLoaded', function () {
-        const form = document.getElementById('filtersForm');
-        const resultsContainer = document.getElementById('classes-results');
-        const classesGrid = document.getElementById('classes-grid');
-        const submitButton = form.querySelector('button[type="submit"]');
-        const filterInputs = form.querySelectorAll('select, input[name="search"]');
-        const resetBtn = document.getElementById('reset-filters-btn');
-        const classesCountSpan = document.getElementById('classes-count');
+document.addEventListener('DOMContentLoaded', function() {
+    // =============================================
+    // Chargement initial des classes en surcapacité
+    // =============================================
+    loadOvercapacityClasses();
 
-        let currentPage = 1;
-        let hasMorePages = false;
-        let isLoading = false;
-        let currentFilters = {};
-
-        // Fonctions helper pour récupérer les éléments dynamiques
-        function getLoadMoreBtn() {
-            return document.getElementById('load-more-btn');
-        }
-
-        function getLoadMoreSpinner() {
-            return document.getElementById('load-more-spinner');
-        }
-
-        // Initialiser Select2 si disponible
-        if (typeof $ !== 'undefined' && typeof $.fn.select2 !== 'undefined') {
-            $('#filiere_id, #niveau_id, #statut, #capacite').select2({
-                theme: 'bootstrap4',
-                placeholder: 'Sélectionner une option',
-                allowClear: true
-            });
-        }
-
-        function setLoading(loading) {
-            isLoading = loading;
-            if (submitButton) {
-                submitButton.disabled = loading;
-            }
-        }
-
-        function updateLoadMoreButton(hasMore) {
-            hasMorePages = hasMore;
-            const btn = getLoadMoreBtn();
-            const spinner = getLoadMoreSpinner();
-
-            if (btn && spinner) {
-                if (hasMore) {
-                    btn.style.display = 'inline-flex';
-                    spinner.classList.add('d-none');
-                } else {
-                    btn.style.display = 'none';
-                    spinner.classList.add('d-none');
-                }
-            }
-        }
-
-        function fetchResults(reset = true) {
-            if (isLoading) return;
-
-            setLoading(true);
-
-            if (reset) {
-                currentPage = 1;
-                if (classesGrid) {
-                    classesGrid.innerHTML = '';
-                }
-            }
-
-            const formData = new FormData(form);
-            formData.set('page', currentPage);
-            const params = new URLSearchParams(formData);
-            const targetUrl = `${form.action}?${params.toString()}`;
-
-            // Sauvegarder les filtres courants
-            currentFilters = Object.fromEntries(formData);
-
-            fetch(targetUrl, {
-                headers: {
-                    'X-Requested-With': 'XMLHttpRequest',
-                    'Accept': 'application/json'
-                },
-                credentials: 'same-origin'
-            })
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error('Erreur lors du chargement des classes.');
-                }
-                return response.json();
-            })
+    function loadOvercapacityClasses() {
+        fetch('{{ route("esbtp.classes.overcapacity") }}')
+            .then(response => response.json())
             .then(data => {
-                if (reset) {
-                    // Remplacer tout le contenu
-                    resultsContainer.innerHTML = `
-                        <div class="resultats-grid" id="classes-grid" style="margin-top: var(--space-lg);">
-                            ${data.html}
-                        </div>
-                        <div id="load-more-container" class="text-center" style="margin-top: var(--space-lg);">
-                            <button type="button" id="load-more-btn" class="btn-acasi primary" style="display: none;">
-                                <i class="fas fa-angle-down me-2"></i>Charger plus de classes
-                            </button>
-                            <div id="load-more-spinner" class="d-none" style="padding: var(--space-md);">
-                                <div class="spinner-border text-primary" role="status">
-                                    <span class="visually-hidden">Chargement...</span>
-                                </div>
-                            </div>
-                        </div>
-                    `;
-                } else {
-                    // Ajouter à la fin
-                    const grid = document.getElementById('classes-grid');
-                    if (grid) {
-                        grid.insertAdjacentHTML('beforeend', data.html);
-                    }
+                if (data.success && data.classes.length > 0) {
+                    const warning = document.getElementById('overcapacity-warning');
+                    warning.style.display = 'flex';
+
+                    document.getElementById('overcapacity-title').textContent =
+                        `${data.classes.length} classe(s) en surcapacité (${data.annee_universitaire})`;
+                    document.getElementById('overcapacity-message').textContent = data.message;
+
+                    loadOvercapacityModalContent(data.classes);
                 }
-
-                // Toujours rebinder et mettre à jour après chargement
-                bindLoadMore();
-                updateLoadMoreButton(data.hasMore);
-
-                // Mettre à jour le compteur si disponible
-                if (data.total && classesCountSpan) {
-                    classesCountSpan.textContent = data.total;
-                }
-
-                setLoading(false);
             })
             .catch(error => {
-                debugError(error);
-                alert('Impossible de charger les classes. Veuillez réessayer.');
-                setLoading(false);
+                console.error('Erreur chargement classes surcapacité:', error);
             });
+    }
+
+    function loadOvercapacityModalContent(classes) {
+        const content = document.getElementById('overcapacity-content');
+
+        if (classes.length === 0) {
+            content.innerHTML = `
+                <div class="text-center py-4">
+                    <i class="fas fa-check-circle" style="font-size:2.5rem;color:#10b981;margin-bottom:.75rem;"></i>
+                    <h5 style="color:#065f46;">Aucune classe en surcapacité</h5>
+                    <p class="text-muted">Toutes les classes respectent leur capacité maximale.</p>
+                </div>
+            `;
+            return;
         }
 
-        function bindLoadMore() {
-            const btn = getLoadMoreBtn();
-            const spinner = getLoadMoreSpinner();
+        let html = `
+            <div class="table-responsive">
+                <table class="ci-overcapacity-table">
+                    <thead>
+                        <tr>
+                            <th>Classe</th>
+                            <th>Filière</th>
+                            <th>Niveau</th>
+                            <th class="text-center">Capacité</th>
+                            <th class="text-center">Inscrits</th>
+                            <th class="text-center">Taux</th>
+                            <th class="text-center">Dépassement</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+        `;
 
-            if (btn && spinner) {
-                // Supprimer ancien listener si existe
-                const newBtn = btn.cloneNode(true);
-                btn.parentNode.replaceChild(newBtn, btn);
+        classes.forEach(classe => {
+            const tauxClass = classe.taux_occupation >= 150 ? 'danger' : 'warn';
+            html += `
+                <tr>
+                    <td><strong>${classe.nom}</strong></td>
+                    <td>${classe.filiere}</td>
+                    <td>${classe.niveau}</td>
+                    <td class="text-center"><span class="ci-badge ci-badge--muted">${classe.places_totales}</span></td>
+                    <td class="text-center"><span class="ci-badge ci-badge--primary">${classe.inscriptions_actives}</span></td>
+                    <td class="text-center"><span class="ci-badge ci-badge--${tauxClass}">${classe.taux_occupation}%</span></td>
+                    <td class="text-center"><span class="ci-badge ci-badge--danger">+${classe.depassement}</span></td>
+                </tr>
+            `;
+        });
 
-                newBtn.addEventListener('click', function() {
-                    if (isLoading || !hasMorePages) return;
+        html += `
+                    </tbody>
+                </table>
+            </div>
+            <div class="ci-info-box">
+                <i class="fas fa-lightbulb"></i>
+                <div>
+                    <strong>Recommandation :</strong>
+                    <ul class="mb-0 mt-2" style="padding-left:1.1rem;line-height:1.6;">
+                        <li>Envisager d'augmenter la capacité des classes concernées</li>
+                        <li>Créer des classes supplémentaires si nécessaire</li>
+                        <li>Les superAdmins et secrétaires peuvent contourner cette limite</li>
+                    </ul>
+                </div>
+            </div>
+        `;
 
-                    newBtn.style.display = 'none';
-                    spinner.classList.remove('d-none');
+        content.innerHTML = html;
+    }
 
-                    currentPage++;
-                    fetchResults(false); // false = ne pas reset, juste ajouter
-                });
+    // Expose pour appels inline
+    window.showOvercapacityModal = function() {
+        const modal = bootstrap.Modal.getOrCreateInstance(document.getElementById('overcapacityModal'));
+        modal.show();
+    };
+    window.dismissOvercapacityWarning = function() {
+        document.getElementById('overcapacity-warning').style.display = 'none';
+    };
+});
+</script>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const form = document.getElementById('filtersForm');
+    const resultsContainer = document.getElementById('classes-results');
+    const submitButton = form.querySelector('button[type="submit"]');
+    const filterInputs = form.querySelectorAll('select, input[name="search"]');
+    const resetBtn = document.getElementById('reset-filters-btn');
+    const classesCountSpan = document.getElementById('classes-count');
+
+    let currentPage = 1;
+    let hasMorePages = false;
+    let isLoading = false;
+
+    // Debounce recherche
+    let searchDebounce = null;
+
+    function getLoadMoreBtn() { return document.getElementById('load-more-btn'); }
+    function getLoadMoreSpinner() { return document.getElementById('load-more-spinner'); }
+
+    // Select2 si disponible (guardé — fonctionne sans)
+    if (typeof $ !== 'undefined' && typeof $.fn.select2 !== 'undefined') {
+        $('#filiere_id, #niveau_id, #statut, #capacite').select2({
+            theme: 'bootstrap4',
+            placeholder: 'Sélectionner une option',
+            allowClear: true,
+            minimumResultsForSearch: Infinity
+        });
+    }
+
+    function setLoading(loading) {
+        isLoading = loading;
+    }
+
+    function updateLoadMoreButton(hasMore) {
+        hasMorePages = hasMore;
+        const btn = getLoadMoreBtn();
+        const spinner = getLoadMoreSpinner();
+        if (btn && spinner) {
+            btn.style.display = hasMore ? 'inline-flex' : 'none';
+            spinner.classList.add('d-none');
+        }
+    }
+
+    function fetchResults(reset = true) {
+        if (isLoading) return;
+        setLoading(true);
+
+        if (reset) {
+            currentPage = 1;
+            const grid = document.getElementById('classes-grid');
+            if (grid) grid.innerHTML = '';
+        }
+
+        const formData = new FormData(form);
+        formData.set('page', currentPage);
+        const params = new URLSearchParams(formData);
+        const targetUrl = `${form.action}?${params.toString()}`;
+
+        fetch(targetUrl, {
+            headers: {
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json'
+            },
+            credentials: 'same-origin'
+        })
+        .then(response => {
+            if (!response.ok) throw new Error('Erreur chargement classes.');
+            return response.json();
+        })
+        .then(data => {
+            if (reset) {
+                resultsContainer.innerHTML = `
+                    <div class="ci-grid" id="classes-grid">
+                        ${data.html}
+                    </div>
+                    <div id="load-more-container" class="ci-load-more-container">
+                        <button type="button" id="load-more-btn" class="ci-load-more-btn" style="display: none;">
+                            <i class="fas fa-angle-down"></i>Charger plus de classes
+                        </button>
+                        <div id="load-more-spinner" class="ci-load-more-spinner d-none">
+                            <div class="spinner-border text-primary" role="status">
+                                <span class="visually-hidden">Chargement...</span>
+                            </div>
+                        </div>
+                    </div>
+                `;
+            } else {
+                const grid = document.getElementById('classes-grid');
+                if (grid) grid.insertAdjacentHTML('beforeend', data.html);
             }
-        }
 
-        // Event listeners
-        form.addEventListener('submit', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
-            fetchResults(true); // true = reset
-            return false;
+            bindLoadMore();
+            updateLoadMoreButton(data.hasMore);
+
+            if (typeof data.total !== 'undefined' && classesCountSpan) {
+                classesCountSpan.textContent = data.total;
+            }
+
+            setLoading(false);
+        })
+        .catch(error => {
+            console.error('Erreur chargement classes:', error);
+            setLoading(false);
         });
+    }
 
-        filterInputs.forEach((input) => {
-            input.addEventListener('change', () => {
-                fetchResults(true); // true = reset
-            });
+    function bindLoadMore() {
+        const btn = getLoadMoreBtn();
+        const spinner = getLoadMoreSpinner();
+        if (!btn || !spinner) return;
+
+        const newBtn = btn.cloneNode(true);
+        btn.parentNode.replaceChild(newBtn, btn);
+
+        newBtn.addEventListener('click', function() {
+            if (isLoading || !hasMorePages) return;
+            newBtn.style.display = 'none';
+            spinner.classList.remove('d-none');
+            currentPage++;
+            fetchResults(false);
         });
+    }
 
-        // Bouton Réinitialiser
-        if (resetBtn) {
-            resetBtn.addEventListener('click', function(e) {
-                e.preventDefault();
+    // Submit form intercepté
+    form.addEventListener('submit', function (event) {
+        event.preventDefault();
+        fetchResults(true);
+        return false;
+    });
 
-                // Réinitialiser le formulaire
-                form.reset();
-
-                // Réinitialiser les Select2 si présents
-                if (typeof $ !== 'undefined' && typeof $.fn.select2 !== 'undefined') {
-                    $('#filiere_id, #niveau_id, #statut, #capacite').val(null).trigger('change');
-                }
-
-                // Recharger les résultats
-                fetchResults(true);
+    // Change sur filtres → fetch immédiat
+    // Input recherche → debounce 400ms
+    filterInputs.forEach((input) => {
+        if (input.tagName === 'INPUT' && input.name === 'search') {
+            input.addEventListener('input', () => {
+                clearTimeout(searchDebounce);
+                searchDebounce = setTimeout(() => fetchResults(true), 400);
             });
-        }
-
-        // Bind initial load more button
-        bindLoadMore();
-
-        // Initialiser hasMorePages depuis l'attribut data du bouton
-        const initialBtn = getLoadMoreBtn();
-        if (initialBtn) {
-            const initialHasMore = initialBtn.getAttribute('data-has-more') === 'true';
-            updateLoadMoreButton(initialHasMore);
+        } else {
+            input.addEventListener('change', () => fetchResults(true));
         }
     });
 
-    /**
-     * Fonction pour exporter les classes selon le format choisi
-     * @param {string} format - 'excel', 'csv' ou 'pdf'
-     */
-    function exportClasses(format) {
-        // Récupérer les paramètres de filtrage actuels depuis l'URL
-        const urlParams = new URLSearchParams(window.location.search);
-
-        // Construction de l'URL d'export selon le format
-        let exportUrl = '';
-        switch(format) {
-            case 'excel':
-                exportUrl = '{{ route("esbtp.classes.export.excel") }}';
-                break;
-            case 'csv':
-                exportUrl = '{{ route("esbtp.classes.export.csv") }}';
-                break;
-            case 'pdf':
-                exportUrl = '{{ route("esbtp.classes.export.pdf") }}';
-                break;
-            default:
-                debugError('Format d\'export non reconnu:', format);
-                return;
-        }
-
-        // Ajouter les paramètres de filtrage à l'URL d'export
-        const exportParams = new URLSearchParams();
-        if (urlParams.has('filiere_id')) exportParams.set('filiere_id', urlParams.get('filiere_id'));
-        if (urlParams.has('niveau_id')) exportParams.set('niveau_id', urlParams.get('niveau_id'));
-        if (urlParams.has('statut')) exportParams.set('statut', urlParams.get('statut'));
-        if (urlParams.has('capacite')) exportParams.set('capacite', urlParams.get('capacite'));
-        if (urlParams.has('search')) exportParams.set('search', urlParams.get('search'));
-
-        // Construire l'URL finale avec les paramètres
-        const finalUrl = exportParams.toString() ? `${exportUrl}?${exportParams.toString()}` : exportUrl;
-
-        // Rediriger vers l'URL d'export (déclenche le téléchargement)
-        window.location.href = finalUrl;
-    }
-
-    // ========================================
-    // GESTION DES MODALS AJAX (Création + Édition)
-    // ========================================
-
-    /**
-     * Initialise Select2 sur les selects du formulaire chargé en AJAX
-     * @param {string} formId - ID du formulaire
-     */
-    function initClasseFormScripts(formId) {
-        // Initialiser Select2 si disponible
-        if (typeof $.fn.select2 !== 'undefined') {
-            $(`#${formId}_filiere_id, #${formId}_niveau_etude_id, #${formId}_annee_universitaire_id`).select2({
-                theme: 'bootstrap4',
-                placeholder: 'Sélectionner une option',
-                allowClear: true,
-                dropdownParent: formId.includes('modal') ? $(`#${formId}`).closest('.modal') : undefined
-            });
-        }
-
-        // Auto-génération du code de classe basé sur le nom (seulement si vide)
-        $(`#${formId}_name`).on('blur', function() {
-            const codeInput = $(`#${formId}_code`);
-            if (codeInput.val() === '') {
-                const name = $(this).val();
-                if (name) {
-                    // Extraire les premières lettres de chaque mot et les convertir en majuscules
-                    const code = name.split(' ')
-                        .map(word => word.charAt(0).toUpperCase())
-                        .join('');
-                    codeInput.val(code);
-                }
+    if (resetBtn) {
+        resetBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            form.reset();
+            if (typeof $ !== 'undefined' && typeof $.fn.select2 !== 'undefined') {
+                $('#filiere_id, #niveau_id, #statut, #capacite').val(null).trigger('change');
             }
+            fetchResults(true);
         });
     }
 
-    // ========================================
-    // MODAL CRÉATION - Ouverture et chargement
-    // ========================================
+    bindLoadMore();
+    const initialBtn = getLoadMoreBtn();
+    if (initialBtn) {
+        const initialHasMore = initialBtn.getAttribute('data-has-more') === 'true';
+        updateLoadMoreButton(initialHasMore);
+    }
+});
 
+// =============================================
+// Export (déclaré globalement pour onclick inline)
+// =============================================
+function exportClasses(format) {
+    const urlParams = new URLSearchParams(window.location.search);
+    const urls = {
+        excel: '{{ route("esbtp.classes.export.excel") }}',
+        csv: '{{ route("esbtp.classes.export.csv") }}',
+        pdf: '{{ route("esbtp.classes.export.pdf") }}'
+    };
+    const exportUrl = urls[format];
+    if (!exportUrl) {
+        console.error('Format export inconnu:', format);
+        return;
+    }
+
+    const exportParams = new URLSearchParams();
+    ['filiere_id', 'niveau_id', 'statut', 'capacite', 'search'].forEach(key => {
+        if (urlParams.has(key)) exportParams.set(key, urlParams.get(key));
+    });
+
+    const finalUrl = exportParams.toString() ? `${exportUrl}?${exportParams.toString()}` : exportUrl;
+    window.location.href = finalUrl;
+}
+</script>
+
+<script>
+// ============================================================
+// GESTION DES MODALS AJAX (Création + Édition) — BS5 natif
+// ============================================================
+
+function initClasseFormScripts(formId) {
+    if (typeof $ !== 'undefined' && typeof $.fn.select2 !== 'undefined') {
+        $(`#${formId}_filiere_id, #${formId}_niveau_etude_id, #${formId}_annee_universitaire_id`).select2({
+            theme: 'bootstrap4',
+            placeholder: 'Sélectionner une option',
+            allowClear: true,
+            dropdownParent: formId.includes('modal') ? $(`#${formId}`).closest('.modal') : undefined
+        });
+    }
+
+    $(`#${formId}_name`).on('blur', function() {
+        const codeInput = $(`#${formId}_code`);
+        if (codeInput.val() === '') {
+            const name = $(this).val();
+            if (name) {
+                const code = name.split(' ').map(w => w.charAt(0).toUpperCase()).join('');
+                codeInput.val(code);
+            }
+        }
+    });
+}
+
+function displayValidationErrors(errors, formId) {
+    $(`#${formId} .is-invalid`).removeClass('is-invalid');
+    $(`#${formId} .invalid-feedback`).remove();
+    for (const [field, messages] of Object.entries(errors)) {
+        const input = document.getElementById(`${formId}_${field}`);
+        if (input) {
+            input.classList.add('is-invalid');
+            const errorDiv = document.createElement('div');
+            errorDiv.className = 'invalid-feedback';
+            errorDiv.textContent = messages[0];
+            input.parentNode.appendChild(errorDiv);
+        }
+    }
+}
+
+function showSuccessMessage(message) {
+    const alertHtml = `
+        <div class="ci-alert ci-alert--success" role="alert">
+            <i class="fas fa-check-circle"></i>${message}
+        </div>
+    `;
+    const mainContent = document.querySelector('.main-content');
+    if (mainContent) {
+        mainContent.insertAdjacentHTML('afterbegin', alertHtml);
+        setTimeout(() => {
+            const alert = mainContent.querySelector('.ci-alert');
+            if (alert) alert.remove();
+        }, 5000);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
     const btnOpenCreateModal = document.getElementById('btn-open-create-modal');
-    const createClasseModal = new bootstrap.Modal(document.getElementById('createClasseModal'));
+    const createModalEl = document.getElementById('createClasseModal');
+    if (!createModalEl) return;
+
+    const createClasseModal = new bootstrap.Modal(createModalEl);
     const modalCreateBody = document.getElementById('modal-create-body');
     const modalCreateSubmitBtn = document.getElementById('modal-create-submit-btn');
 
+    const editModalEl = document.getElementById('editClasseModal');
+    const editClasseModal = new bootstrap.Modal(editModalEl);
+    const modalEditBody = document.getElementById('modal-edit-body');
+    const modalEditSubmitBtn = document.getElementById('modal-edit-submit-btn');
+
     if (btnOpenCreateModal) {
         btnOpenCreateModal.addEventListener('click', function() {
-            console.log('🟢 Ouverture modal création classe');
-
-            // Afficher le spinner
             modalCreateBody.innerHTML = `
                 <div class="text-center py-5">
                     <div class="spinner-border text-primary" role="status">
@@ -883,98 +1493,50 @@ $(document).ready(function() {
                     </div>
                 </div>
             `;
-
-            // Désactiver le bouton submit pendant le chargement
             modalCreateSubmitBtn.disabled = true;
 
-            // Charger le formulaire via AJAX
             fetch('{{ route("esbtp.classes.create") }}?ajax=1', {
                 method: 'GET',
-                headers: {
-                    'X-Requested-With': 'XMLHttpRequest',
-                    'Accept': 'text/html'
-                }
+                headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'text/html' }
             })
             .then(response => {
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
                 return response.text();
             })
             .then(html => {
-                console.log('✅ Formulaire création chargé');
-
-                // Charger le formulaire partial dans le modal
                 modalCreateBody.innerHTML = html;
-
-                // Initialiser Select2 et scripts du formulaire
                 initClasseFormScripts('modal-create-classe-form');
-
-                // Activer le bouton submit
                 modalCreateSubmitBtn.disabled = false;
-
-                // Ouvrir le modal
                 createClasseModal.show();
             })
             .catch(error => {
-                console.error('❌ Erreur chargement formulaire création:', error);
+                console.error('Erreur chargement formulaire création:', error);
                 modalCreateBody.innerHTML = `
-                    <div class="alert alert-danger">
-                        <i class="fas fa-exclamation-triangle me-2"></i>
-                        Erreur lors du chargement du formulaire. Veuillez réessayer.
+                    <div class="ci-alert ci-alert--danger">
+                        <i class="fas fa-exclamation-triangle"></i>Erreur lors du chargement du formulaire. Veuillez réessayer.
                     </div>
                 `;
             });
         });
     }
 
-    // ========================================
-    // MODAL CRÉATION - Soumission AJAX
-    // ========================================
-
-    // Click sur le bouton submit du modal → déclenche le submit du formulaire
     if (modalCreateSubmitBtn) {
         modalCreateSubmitBtn.addEventListener('click', function() {
-            console.log('🔵 Click sur bouton submit création');
             const form = document.getElementById('modal-create-classe-form');
-            if (form) {
-                console.log('🔵 Déclenchement submit manuel du formulaire');
-                form.requestSubmit(); // Déclenche l'événement submit du formulaire
-            } else {
-                console.error('❌ Formulaire création introuvable');
-            }
+            if (form) form.requestSubmit();
         });
     }
 
-    // Délégation d'événements pour intercepter le submit du formulaire création
-    // IMPORTANT: Phase de CAPTURE (true en 3ème paramètre) pour intercepter AVANT tous les autres handlers
+    // Intercept submit create form (capture phase)
     document.addEventListener('submit', function(e) {
-        // Vérifier si c'est le formulaire de création qui est soumis
         if (e.target && e.target.id === 'modal-create-classe-form') {
-            // BLOQUER IMMÉDIATEMENT la soumission normale
             e.preventDefault();
             e.stopPropagation();
-            e.stopImmediatePropagation(); // Empêche même les autres listeners sur le même élément
-
-            console.log('📤 Submit formulaire création intercepté');
-            console.log('🛑 preventDefault() appelé - la page NE DEVRAIT PAS se recharger');
+            e.stopImmediatePropagation();
 
             const form = e.target;
-
-            // Désactiver le bouton pour éviter les doubles clics
             modalCreateSubmitBtn.disabled = true;
-            modalCreateSubmitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Enregistrement...';
-
-            // Collecter les données du formulaire
-            const formData = new FormData(form);
-
-            // Soumettre via AJAX
-            console.log('🌐 Envoi requête AJAX vers:', form.action);
-            console.log('📋 Headers:', {
-                'X-Requested-With': 'XMLHttpRequest',
-                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-                'Accept': 'application/json'
-            });
+            modalCreateSubmitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Enregistrement...';
 
             fetch(form.action, {
                 method: 'POST',
@@ -983,87 +1545,47 @@ $(document).ready(function() {
                     'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
                     'Accept': 'application/json'
                 },
-                body: formData
+                body: new FormData(form)
             })
             .then(response => {
-                console.log('📥 Réponse création reçue');
-                console.log('  Status:', response.status);
-                console.log('  Content-Type:', response.headers.get('content-type'));
-                console.log('  Redirected:', response.redirected);
-                console.log('  URL:', response.url);
-
-                // Vérifier si c'est vraiment du JSON
-                const contentType = response.headers.get('content-type');
-                if (!contentType || !contentType.includes('application/json')) {
-                    console.error('❌ La réponse n\'est pas du JSON! Content-Type:', contentType);
-                    throw new Error('La réponse n\'est pas du JSON');
+                const contentType = response.headers.get('content-type') || '';
+                if (!contentType.includes('application/json')) {
+                    throw new Error('Réponse non-JSON');
                 }
-
                 return response.json();
             })
             .then(data => {
-                console.log('📊 Données création reçues:', data);
-
                 if (data.success) {
-                    console.log('✅ Classe créée avec succès:', data.classe);
-
-                    // Réactiver le bouton
                     modalCreateSubmitBtn.disabled = false;
-                    modalCreateSubmitBtn.innerHTML = '<i class="fas fa-save"></i> Enregistrer la classe';
-
-                    // Fermer le modal
+                    modalCreateSubmitBtn.innerHTML = '<i class="fas fa-save me-1"></i>Enregistrer la classe';
                     createClasseModal.hide();
-
-                    // Ajouter la nouvelle carte directement sans recharger la page
                     addNewClasseCard(data.classe, data.message || 'La classe a été créée avec succès.');
                 } else {
-                    // Afficher les erreurs de validation
-                    console.warn('⚠️ Erreurs de validation:', data.errors);
                     displayValidationErrors(data.errors, 'modal-create-classe-form');
-
-                    // Réactiver le bouton
                     modalCreateSubmitBtn.disabled = false;
-                    modalCreateSubmitBtn.innerHTML = '<i class="fas fa-save"></i> Enregistrer la classe';
+                    modalCreateSubmitBtn.innerHTML = '<i class="fas fa-save me-1"></i>Enregistrer la classe';
                 }
             })
             .catch(error => {
-                console.error('❌ Erreur soumission formulaire:', error);
-                alert('Une erreur est survenue lors de l\'enregistrement. Veuillez réessayer.');
-
-                // Réactiver le bouton
+                console.error('Erreur soumission formulaire:', error);
+                alert('Une erreur est survenue lors de l\'enregistrement.');
                 modalCreateSubmitBtn.disabled = false;
-                modalCreateSubmitBtn.innerHTML = '<i class="fas fa-save"></i> Enregistrer la classe';
+                modalCreateSubmitBtn.innerHTML = '<i class="fas fa-save me-1"></i>Enregistrer la classe';
             });
 
-            // IMPORTANT: Retourner false pour garantir qu'aucun submit ne se produise
             return false;
         }
-    }, true); // ← Phase de CAPTURE (3ème paramètre = true) pour intercepter AVANT bubbling
+    }, true);
 
-    // ========================================
-    // MODAL ÉDITION - Ouverture et chargement
-    // ========================================
-
-    const editClasseModal = new bootstrap.Modal(document.getElementById('editClasseModal'));
-    const modalEditBody = document.getElementById('modal-edit-body');
-    const modalEditSubmitBtn = document.getElementById('modal-edit-submit-btn');
-
-    // Délégation d'événement pour les boutons "Modifier" (car générés dynamiquement)
+    // Click handler délégation pour .btn-open-edit-modal
     document.addEventListener('click', function(e) {
         const btnEdit = e.target.closest('.btn-open-edit-modal');
         if (!btnEdit) return;
 
         e.preventDefault();
-
         const classeId = btnEdit.getAttribute('data-classe-id');
-        if (!classeId) {
-            console.error('❌ ID classe manquant sur le bouton');
-            return;
-        }
+        if (!classeId) return;
 
-        console.log('🟠 Ouverture modal édition classe:', classeId);
-
-        // Afficher le spinner
         modalEditBody.innerHTML = `
             <div class="text-center py-5">
                 <div class="spinner-border text-primary" role="status">
@@ -1071,96 +1593,50 @@ $(document).ready(function() {
                 </div>
             </div>
         `;
-
-        // Désactiver le bouton submit pendant le chargement
         modalEditSubmitBtn.disabled = true;
-
-        // Stocker l'ID de la classe en cours d'édition
         modalEditSubmitBtn.setAttribute('data-classe-id', classeId);
 
-        // Charger le formulaire d'édition via AJAX
         fetch(`/esbtp/classes/${classeId}/edit?ajax=1`, {
             method: 'GET',
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'Accept': 'text/html'
-            }
+            headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'text/html' }
         })
         .then(response => {
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
             return response.text();
         })
         .then(html => {
-            console.log('✅ Formulaire édition chargé pour classe:', classeId);
-
-            // Charger le formulaire partial dans le modal
             modalEditBody.innerHTML = html;
-
-            // Initialiser Select2 et scripts du formulaire
             initClasseFormScripts('modal-edit-classe-form');
-
-            // Activer le bouton submit
             modalEditSubmitBtn.disabled = false;
-
-            // Ouvrir le modal
             editClasseModal.show();
         })
         .catch(error => {
-            console.error('❌ Erreur chargement formulaire édition:', error);
+            console.error('Erreur chargement formulaire édition:', error);
             modalEditBody.innerHTML = `
-                <div class="alert alert-danger">
-                    <i class="fas fa-exclamation-triangle me-2"></i>
-                    Erreur lors du chargement du formulaire. Veuillez réessayer.
+                <div class="ci-alert ci-alert--danger">
+                    <i class="fas fa-exclamation-triangle"></i>Erreur lors du chargement du formulaire.
                 </div>
             `;
         });
     });
 
-    // ========================================
-    // MODAL ÉDITION - Soumission AJAX
-    // ========================================
-
-    // Click sur le bouton submit du modal édition → déclenche le submit du formulaire
     if (modalEditSubmitBtn) {
         modalEditSubmitBtn.addEventListener('click', function() {
-            console.log('🔵 Click sur bouton submit édition');
             const form = document.getElementById('modal-edit-classe-form');
-            if (form) {
-                console.log('🔵 Déclenchement submit manuel du formulaire édition');
-                form.requestSubmit(); // Déclenche l'événement submit du formulaire
-            } else {
-                console.error('❌ Formulaire édition introuvable');
-            }
+            if (form) form.requestSubmit();
         });
     }
 
-    // Délégation d'événements pour intercepter le submit du formulaire édition
-    // IMPORTANT: Phase de CAPTURE (true en 3ème paramètre) pour intercepter AVANT tous les autres handlers
     document.addEventListener('submit', function(e) {
-        // Vérifier si c'est le formulaire d'édition qui est soumis
         if (e.target && e.target.id === 'modal-edit-classe-form') {
-            // BLOQUER IMMÉDIATEMENT la soumission normale
             e.preventDefault();
             e.stopPropagation();
-            e.stopImmediatePropagation(); // Empêche même les autres listeners sur le même élément
-
-            console.log('📤 Submit formulaire édition intercepté');
-            console.log('🛑 preventDefault() appelé - la page NE DEVRAIT PAS se recharger');
+            e.stopImmediatePropagation();
 
             const form = e.target;
-            const classeId = modalEditSubmitBtn.getAttribute('data-classe-id');
-            console.log('📤 Soumission formulaire édition pour classe:', classeId);
-
-            // Désactiver le bouton pour éviter les doubles clics
             modalEditSubmitBtn.disabled = true;
-            modalEditSubmitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Mise à jour...';
+            modalEditSubmitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Mise à jour...';
 
-            // Collecter les données du formulaire
-            const formData = new FormData(form);
-
-            // Soumettre via AJAX
             fetch(form.action, {
                 method: 'POST',
                 headers: {
@@ -1168,308 +1644,135 @@ $(document).ready(function() {
                     'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
                     'Accept': 'application/json'
                 },
-                body: formData
+                body: new FormData(form)
             })
-            .then(response => {
-                console.log('📥 Réponse reçue, status:', response.status);
-                return response.json();
-            })
+            .then(response => response.json())
             .then(data => {
-                console.log('📊 Données reçues:', data);
-
                 if (data.success) {
-                    console.log('✅ Classe mise à jour avec succès:', data.classe);
-
-                    // Réactiver le bouton IMMÉDIATEMENT
                     modalEditSubmitBtn.disabled = false;
-                    modalEditSubmitBtn.innerHTML = '<i class="fas fa-save"></i> Mettre à jour la classe';
-
-                    // Fermer le modal
+                    modalEditSubmitBtn.innerHTML = '<i class="fas fa-save me-1"></i>Mettre à jour la classe';
                     editClasseModal.hide();
-
-                    // Mettre à jour uniquement la carte de la classe modifiée
-                    // Le message de succès sera affiché APRÈS le refresh de la carte
-                    updateClasseCard(data.classe, data.message || 'La classe a été mise à jour avec succès.');
+                    updateClasseCard(data.classe, data.message || 'La classe a été mise à jour.');
                 } else {
-                    console.warn('⚠️ Erreurs de validation:', data.errors);
-
-                    // Afficher les erreurs de validation
                     displayValidationErrors(data.errors, 'modal-edit-classe-form');
-
-                    // Réactiver le bouton
                     modalEditSubmitBtn.disabled = false;
-                    modalEditSubmitBtn.innerHTML = '<i class="fas fa-save"></i> Mettre à jour la classe';
+                    modalEditSubmitBtn.innerHTML = '<i class="fas fa-save me-1"></i>Mettre à jour la classe';
                 }
             })
             .catch(error => {
-                console.error('❌ Erreur soumission formulaire:', error);
-                alert('Une erreur est survenue lors de la mise à jour. Veuillez réessayer.');
-
-                // Réactiver le bouton
+                console.error('Erreur soumission formulaire:', error);
+                alert('Une erreur est survenue lors de la mise à jour.');
                 modalEditSubmitBtn.disabled = false;
-                modalEditSubmitBtn.innerHTML = '<i class="fas fa-save"></i> Mettre à jour la classe';
+                modalEditSubmitBtn.innerHTML = '<i class="fas fa-save me-1"></i>Mettre à jour la classe';
             });
 
-            // IMPORTANT: Retourner false pour garantir qu'aucun submit ne se produise
             return false;
         }
-    }, true); // ← Phase de CAPTURE (3ème paramètre = true) pour intercepter AVANT bubbling
+    }, true);
+});
 
-    // ========================================
-    // FONCTIONS UTILITAIRES
-    // ========================================
+// ============================================================
+// Fonctions refresh card (création + édition)
+// ============================================================
 
-    /**
-     * Affiche les erreurs de validation dans le formulaire
-     * @param {Object} errors - Objet des erreurs retourné par Laravel
-     * @param {string} formId - ID du formulaire
-     */
-    function displayValidationErrors(errors, formId) {
-        // Réinitialiser les erreurs précédentes
-        $(`#${formId} .is-invalid`).removeClass('is-invalid');
-        $(`#${formId} .invalid-feedback`).remove();
+function addNewClasseCard(classe, successMessage = null) {
+    const classeId = classe.id;
+    const refreshUrl = `/esbtp/classes/${classeId}/refresh-ligne`;
+    const resultsContainer = document.querySelector('#classes-grid');
 
-        // Afficher les nouvelles erreurs
-        for (const [field, messages] of Object.entries(errors)) {
-            const input = document.getElementById(`${formId}_${field}`);
-            if (input) {
-                input.classList.add('is-invalid');
-                const errorDiv = document.createElement('div');
-                errorDiv.className = 'invalid-feedback';
-                errorDiv.textContent = messages[0]; // Première erreur seulement
-                input.parentNode.appendChild(errorDiv);
-            }
-        }
+    if (!resultsContainer) {
+        window.location.reload();
+        return;
     }
 
-    /**
-     * Affiche un message de succès en haut de la page
-     * @param {string} message - Message à afficher
-     */
-    function showSuccessMessage(message) {
-        const alertHtml = `
-            <div class="alert alert-success alert-dismissible fade show" role="alert" style="margin-bottom: 1rem;">
-                <i class="fas fa-check-circle me-2"></i>${message}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            </div>
-        `;
+    fetch(refreshUrl, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' }
+    })
+    .then(response => response.ok ? response.json() : Promise.reject(new Error(`HTTP ${response.status}`)))
+    .then(data => {
+        if (!data.success || !data.html) throw new Error(data.message || 'Réponse invalide');
 
-        // Insérer au début de .main-content
-        const mainContent = document.querySelector('.main-content');
-        if (mainContent) {
-            mainContent.insertAdjacentHTML('afterbegin', alertHtml);
+        const template = document.createElement('template');
+        template.innerHTML = data.html.trim();
 
-            // Auto-dismiss après 5 secondes
-            setTimeout(() => {
-                const alert = mainContent.querySelector('.alert');
-                if (alert) {
-                    alert.remove();
-                }
-            }, 5000);
-        }
-    }
+        let newCardFragment = template.content.querySelector(`[data-classe-id="${classeId}"]`);
+        if (!newCardFragment) newCardFragment = template.content.querySelector('.ci-card');
+        if (!newCardFragment) throw new Error('HTML sans carte valide');
 
-    /**
-     * Ajoute une nouvelle carte de classe après création
-     * Pattern identique à updateClasseCard mais pour insertion au début de la liste
-     * @param {Object} classe - Données de la nouvelle classe
-     * @param {String} successMessage - Message de succès à afficher après l'ajout
-     */
-    function addNewClasseCard(classe, successMessage = null) {
-        console.log('➕ Ajout nouvelle carte classe:', classe.id);
+        const newCard = newCardFragment.cloneNode(true);
 
-        const classeId = classe.id;
-        const refreshUrl = `/esbtp/classes/${classeId}/refresh-ligne`;
-
-        // Trouver le conteneur de la liste des classes
-        const resultsContainer = document.querySelector('#classes-grid');
-        console.log('📦 Conteneur trouvé:', resultsContainer ? 'OUI ✅' : 'NON ❌');
-
-        if (!resultsContainer) {
-            console.error('❌ Conteneur #classes-grid non trouvé - rechargement complet');
-            window.location.reload();
-            return;
+        const modalFragment = template.content.querySelector(`#deleteModal${classeId}`);
+        if (modalFragment) {
+            document.body.appendChild(modalFragment.cloneNode(true));
         }
 
-        // Fetch la nouvelle carte HTML depuis le serveur
-        fetch(refreshUrl, {
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'Accept': 'application/json'
-            }
-        })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            return response.json();
-        })
-        .then(data => {
-            if (!data.success || !data.html) {
-                throw new Error(data.message || 'Réponse serveur invalide');
-            }
+        resultsContainer.insertBefore(newCard, resultsContainer.firstChild);
 
-            console.log('✅ HTML reçu du serveur pour nouvelle classe:', classeId);
+        // Animation insertion
+        newCard.style.opacity = '0';
+        newCard.style.transform = 'translateY(-20px)';
+        newCard.style.transition = 'opacity 0.3s ease, transform 0.3s ease, background-color 0.3s ease';
+        newCard.offsetHeight;
+        newCard.style.opacity = '1';
+        newCard.style.transform = 'translateY(0)';
+        newCard.style.backgroundColor = 'rgba(16, 185, 129, 0.08)';
+        setTimeout(() => { newCard.style.backgroundColor = ''; }, 1000);
 
-            // Créer un élément temporaire pour parser le HTML
-            const template = document.createElement('template');
-            template.innerHTML = data.html.trim();
+        if (successMessage) showSuccessMessage(successMessage);
+        newCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    })
+    .catch(error => {
+        console.error('Erreur ajout carte:', error);
+        window.location.reload();
+    });
+}
 
-            // Récupérer la nouvelle carte depuis le template
-            let newCardFragment = template.content.querySelector(`[data-classe-id="${classeId}"]`);
+function updateClasseCard(classe, successMessage = null) {
+    const classeId = classe.id;
+    const refreshUrl = `/esbtp/classes/${classeId}/refresh-ligne`;
+    const existingCard = document.querySelector(`[data-classe-id="${classeId}"]`);
 
-            if (!newCardFragment) {
-                // Si pas de data-classe-id, prendre le premier élément
-                newCardFragment = template.content.querySelector('.card-moderne');
-            }
-
-            if (!newCardFragment) {
-                console.error('❌ HTML retourné sans carte valide:', data.html);
-                throw new Error('HTML retourné sans carte de classe valide');
-            }
-
-            // Cloner la nouvelle carte
-            const newCard = newCardFragment.cloneNode(true);
-
-            // Récupérer le modal de suppression si présent
-            const modalFragment = template.content.querySelector(`#deleteModal${classeId}`);
-            if (modalFragment) {
-                const newModal = modalFragment.cloneNode(true);
-                document.body.appendChild(newModal);
-            }
-
-            // Insérer la nouvelle carte AU DÉBUT de la liste (prepend)
-            resultsContainer.insertBefore(newCard, resultsContainer.firstChild);
-
-            console.log('✅ Nouvelle carte classe ajoutée avec succès:', classeId);
-
-            // Animation visuelle (flash vert + slide down)
-            newCard.style.opacity = '0';
-            newCard.style.transform = 'translateY(-20px)';
-            newCard.style.transition = 'opacity 0.3s ease, transform 0.3s ease, background-color 0.3s ease';
-
-            // Forcer le reflow pour que la transition fonctionne
-            newCard.offsetHeight;
-
-            newCard.style.opacity = '1';
-            newCard.style.transform = 'translateY(0)';
-            newCard.style.backgroundColor = 'rgba(16, 185, 129, 0.1)'; // Vert léger
-
-            setTimeout(() => {
-                newCard.style.backgroundColor = '';
-            }, 1000);
-
-            // Afficher le message de succès APRÈS l'ajout de la carte
-            if (successMessage) {
-                showSuccessMessage(successMessage);
-            }
-
-            // Scroll vers la nouvelle carte
-            newCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-
-        })
-        .catch(error => {
-            console.error('❌ Erreur ajout nouvelle carte classe:', error);
-            // En cas d'erreur, on reload la page
-            console.log('🔄 Rechargement de la page suite à l\'erreur...');
-            window.location.reload();
-        });
+    if (!existingCard) {
+        window.location.reload();
+        return;
     }
 
-    /**
-     * Met à jour la carte d'une classe après édition
-     * @param {Object} classe - Données de la classe mise à jour
-     * @param {String} successMessage - Message de succès à afficher après le refresh
-     */
-    function updateClasseCard(classe, successMessage = null) {
-        console.log('🔄 Refresh carte classe:', classe.id);
+    fetch(refreshUrl, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' }
+    })
+    .then(response => response.ok ? response.json() : Promise.reject(new Error(`HTTP ${response.status}`)))
+    .then(data => {
+        if (!data.success || !data.html) throw new Error(data.message || 'Réponse invalide');
 
-        const classeId = classe.id;
-        const refreshUrl = `/esbtp/classes/${classeId}/refresh-ligne`;
-        const existingCard = document.querySelector(`[data-classe-id="${classeId}"]`);
+        const template = document.createElement('template');
+        template.innerHTML = data.html.trim();
 
-        if (!existingCard) {
-            console.warn('⚠️ Carte non trouvée pour ID:', classeId, '- rechargement complet');
-            window.location.reload();
-            return;
+        let newCardFragment = template.content.querySelector(`[data-classe-id="${classeId}"]`);
+        if (!newCardFragment) newCardFragment = template.content.querySelector('.ci-card');
+        if (!newCardFragment) throw new Error('HTML sans carte valide');
+
+        const newCard = newCardFragment.cloneNode(true);
+
+        const modalFragment = template.content.querySelector(`#deleteModal${classeId}`);
+        if (modalFragment) {
+            const newModal = modalFragment.cloneNode(true);
+            const existingModal = document.getElementById(`deleteModal${classeId}`);
+            if (existingModal) existingModal.replaceWith(newModal);
+            else document.body.appendChild(newModal);
         }
 
-        // Fetch la nouvelle carte HTML depuis le serveur
-        fetch(refreshUrl, {
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'Accept': 'application/json'
-            }
-        })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            return response.json();
-        })
-        .then(data => {
-            if (!data.success || !data.html) {
-                throw new Error(data.message || 'Réponse serveur invalide');
-            }
+        existingCard.replaceWith(newCard);
 
-            console.log('✅ HTML reçu du serveur pour classe:', classeId);
+        newCard.style.transition = 'background-color 0.3s ease';
+        newCard.style.backgroundColor = 'rgba(16, 185, 129, 0.08)';
+        setTimeout(() => { newCard.style.backgroundColor = ''; }, 500);
 
-            // Créer un élément temporaire pour parser le HTML
-            const template = document.createElement('template');
-            template.innerHTML = data.html.trim();
-
-            // Récupérer la nouvelle carte depuis le template
-            let newCardFragment = template.content.querySelector(`[data-classe-id="${classeId}"]`);
-
-            if (!newCardFragment) {
-                // Si pas de data-classe-id, prendre le premier élément
-                newCardFragment = template.content.querySelector('.card-moderne');
-            }
-
-            if (!newCardFragment) {
-                console.error('❌ HTML retourné sans carte valide:', data.html);
-                throw new Error('HTML retourné sans carte de classe valide');
-            }
-
-            // Cloner la nouvelle carte
-            const newCard = newCardFragment.cloneNode(true);
-
-            // Récupérer le modal de suppression si présent
-            const modalFragment = template.content.querySelector(`#deleteModal${classeId}`);
-            if (modalFragment) {
-                const newModal = modalFragment.cloneNode(true);
-                const existingModal = document.getElementById(`deleteModal${classeId}`);
-                if (existingModal) {
-                    existingModal.replaceWith(newModal);
-                } else {
-                    document.body.appendChild(newModal);
-                }
-            }
-
-            // Remplacer l'ancienne carte par la nouvelle
-            existingCard.replaceWith(newCard);
-
-            console.log('✅ Carte classe rafraîchie avec succès:', classeId);
-
-            // Animation visuelle rapide (flash vert)
-            newCard.style.transition = 'background-color 0.3s ease';
-            newCard.style.backgroundColor = 'rgba(16, 185, 129, 0.1)'; // Vert léger
-            setTimeout(() => {
-                newCard.style.backgroundColor = '';
-            }, 500);
-
-            // Afficher le message de succès APRÈS le refresh de la carte
-            if (successMessage) {
-                showSuccessMessage(successMessage);
-            }
-
-        })
-        .catch(error => {
-            console.error('❌ Erreur refresh carte classe:', error);
-            // En cas d'erreur, on reload la page
-            console.log('🔄 Rechargement de la page suite à l\'erreur...');
-            window.location.reload();
-        });
-    }
+        if (successMessage) showSuccessMessage(successMessage);
+    })
+    .catch(error => {
+        console.error('Erreur refresh carte:', error);
+        window.location.reload();
+    });
+}
 </script>
 @endpush

--- a/resources/views/esbtp/classes/partials/classe-card.blade.php
+++ b/resources/views/esbtp/classes/partials/classe-card.blade.php
@@ -1,145 +1,184 @@
 {{--
-    Partial pour afficher UNE SEULE carte de classe
-    Utilisé par items.blade.php (liste) et par refreshLigne (AJAX update)
+    Carte d'UNE classe — design premium namespace ci-*
+    - Card cliquable via Bootstrap 5 .stretched-link (pas de JS stopPropagation)
+    - Menu kebab BS5 dropdown pour actions secondaires
+    - 1 seul CTA visible (btn edit) si access_admin, sinon la card entière = CTA view
 
-    Paramètres requis:
-    - $classe : instance de ESBTPClasse avec relations chargées (filiere, niveau, annee)
+    Paramètres requis :
+    - $classe : ESBTPClasse avec relations (filiere, niveau, annee)
 --}}
+@php
+    $occupation = $classe->places_totales > 0
+        ? min(100, round(($classe->nombre_etudiants / $classe->places_totales) * 100))
+        : 0;
+    $occLevel = $occupation >= 95 ? 'full' : ($occupation >= 75 ? 'high' : ($occupation >= 40 ? 'mid' : 'low'));
+    $canAdmin = auth()->user()->can('access_admin');
+    $canManageSchool = auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_coordinate_academics']);
+    $canTeach = auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_teach', 'can_coordinate_academics']);
+    $showUrl = route('esbtp.classes.show', array_merge(['classe' => $classe->id], request()->query()));
+@endphp
 
-<div class="card-moderne resultat-card animate-slide-up" data-classe-id="{{ $classe->id }}" style="border-left: 4px solid {{ $classe->is_active ? 'var(--success)' : 'var(--neutral)' }};">
-    <!-- En-tête classe -->
-    <div style="display: flex; justify-content: between; align-items: start; margin-bottom: var(--space-md);">
-        <div style="flex: 1;">
-            <div style="display: flex; align-items: center; margin-bottom: var(--space-sm);">
-                <div style="width: 40px; height: 40px; background: {{ $classe->is_active ? 'var(--success)' : 'var(--neutral)' }}; border-radius: var(--radius-circle); display: flex; align-items: center; justify-content: center; margin-right: var(--space-sm);">
-                    <i class="fas fa-graduation-cap" style="color: white; font-size: 16px;"></i>
-                </div>
-                <div>
-                    <div class="font-bold color-primary" style="font-size: var(--text-normal);">{{ $classe->name }}</div>
-                    <div style="font-size: var(--text-small); color: var(--text-secondary);">Code: {{ $classe->code }}</div>
-                </div>
+<article class="ci-card {{ $classe->is_active ? '' : 'ci-card--inactive' }}" data-classe-id="{{ $classe->id }}">
+    {{-- Ribbon statut --}}
+    <span class="ci-card-ribbon ci-card-ribbon--{{ $classe->is_active ? 'active' : 'inactive' }}" aria-hidden="true"></span>
+
+    {{-- Header carte --}}
+    <header class="ci-card-header">
+        <div class="ci-card-identity">
+            <div class="ci-card-icon">
+                <i class="fas fa-chalkboard-teacher"></i>
             </div>
-
-            <!-- Filière et niveau -->
-            <div style="margin-bottom: var(--space-md);">
-                @if ($classe->filiere)
-                    <div style="font-size: var(--text-small); color: var(--text-primary); margin-bottom: var(--space-xs);">
-                        <i class="fas fa-layer-group me-1"></i><strong>{{ $classe->filiere->name }}</strong>
-                        @if ($classe->filiere->parent)
-                            <br><span style="color: var(--text-muted); margin-left: 16px;">Option de {{ $classe->filiere->parent->name }}</span>
-                        @endif
-                    </div>
-                @endif
-                @if ($classe->niveau)
-                    <div style="font-size: var(--text-small); color: var(--text-secondary);">
-                        <i class="fas fa-level-up-alt me-1"></i>{{ $classe->niveau->name }}
-                    </div>
-                @endif
+            <div class="ci-card-titles">
+                <h3 class="ci-card-title">
+                    {{-- Stretched-link : toute la card devient cliquable, les boutons internes avec position:relative + z-index prennent le dessus --}}
+                    <a href="{{ $showUrl }}" class="stretched-link ci-card-link" title="Voir les détails">{{ $classe->name }}</a>
+                </h3>
+                <span class="ci-card-code">{{ $classe->code }}</span>
             </div>
         </div>
 
-        <!-- Statut -->
-        <div>
-            <span class="badge {{ $classe->is_active ? 'success' : 'danger' }}">
+        {{-- Badge statut + menu kebab --}}
+        <div class="ci-card-header-right">
+            <span class="ci-card-status ci-card-status--{{ $classe->is_active ? 'active' : 'inactive' }}">
                 {{ $classe->is_active ? 'Active' : 'Inactive' }}
             </span>
-        </div>
-    </div>
-
-    <!-- Statistiques -->
-    <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-md); margin-bottom: var(--space-md); padding: var(--space-sm); background: rgba(248, 250, 252, 0.5); border-radius: var(--radius-small);">
-        <div class="text-center">
-            <div style="font-size: var(--text-small); color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.5px;">Capacité</div>
-            <div class="font-bold color-primary">{{ $classe->places_totales }}</div>
-        </div>
-        <div class="text-center">
-            <div style="font-size: var(--text-small); color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.5px;">Inscrits</div>
-            <div class="font-bold color-accent">{{ $classe->nombre_etudiants }}</div>
-        </div>
-        <div class="text-center">
-            <div style="font-size: var(--text-small); color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.5px;">Disponibles</div>
-            <div class="font-bold color-{{ $classe->places_disponibles > 0 ? 'success' : 'danger' }}">{{ $classe->places_disponibles }}</div>
-        </div>
-    </div>
-
-    <!-- Actions -->
-    <div style="display: flex; justify-content: space-between; align-items: center; border-top: 1px solid #f3f4f6; padding-top: var(--space-md);">
-        <div style="font-size: var(--text-small); color: var(--text-muted);">
-            @if ($classe->annee)
-                <i class="fas fa-calendar me-1"></i>{{ $classe->annee->name }}
-            @endif
-        </div>
-        <div style="display: flex; gap: var(--space-xs);">
-            {{-- Lien "Voir détails" avec filtres préservés dans l'URL --}}
-            <a href="{{ route('esbtp.classes.show', array_merge(['classe' => $classe->id], request()->query())) }}" class="btn-acasi secondary" style="padding: var(--space-xs);" title="Voir les détails">
-                <i class="fas fa-eye"></i>
-            </a>
-
-            @if(auth()->user()->can('access_admin'))
-            {{-- Bouton "Modifier" ouvre modal AJAX --}}
-            <button type="button" class="btn-acasi primary btn-open-edit-modal" style="padding: var(--space-xs);" data-classe-id="{{ $classe->id }}" title="Modifier">
-                <i class="fas fa-edit"></i>
-            </button>
-            @endif
-
-            @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_coordinate_academics']))
-            <a href="{{ route('esbtp.classes.matieres', ['classe' => $classe->id]) }}" class="btn-acasi secondary" style="padding: var(--space-xs);" title="Gérer les matières">
-                <i class="fas fa-book"></i>
-            </a>
-            @endif
-
-            @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_teach', 'can_coordinate_academics']))
-            <a href="{{ route('esbtp.classes.liste-appel', ['classe' => $classe->id]) }}" class="btn-acasi primary" style="padding: var(--space-xs);" title="Liste d'appel" target="_blank">
-                <i class="fas fa-clipboard-list"></i>
-            </a>
-            <a href="{{ route('esbtp.classes.liste-complete', ['classe' => $classe->id]) }}" class="btn-acasi secondary" style="padding: var(--space-xs);" title="Liste complète des étudiants" target="_blank">
-                <i class="fas fa-users"></i>
-            </a>
-            @endif
-
-            @if(auth()->user()->can('access_admin'))
-                @if($classe->nombre_etudiants == 0)
-                <button type="button" class="btn-acasi danger" style="padding: var(--space-xs);" data-bs-toggle="modal" data-bs-target="#deleteModal{{ $classe->id }}" title="Supprimer">
-                    <i class="fas fa-trash"></i>
-                </button>
-                @else
-                <button type="button" class="btn-acasi secondary" style="padding: var(--space-xs); opacity: 0.5; cursor: not-allowed;" title="Suppression impossible - Classe avec historique d'inscriptions préservé" disabled>
-                    <i class="fas fa-lock"></i>
-                </button>
-                @endif
-            @endif
-        </div>
-    </div>
-</div>
-
-{{-- Modal de suppression --}}
-@if(auth()->user()->can('access_admin') && $classe->nombre_etudiants == 0)
-<div class="modal fade" id="deleteModal{{ $classe->id }}" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel{{ $classe->id }}" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="deleteModalLabel{{ $classe->id }}">Archivage de la classe</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <p>Êtes-vous sûr de vouloir archiver la classe <strong>{{ $classe->name }}</strong> ?</p>
-                <div class="alert alert-info">
-                    <i class="fas fa-info-circle me-2"></i>
-                    <strong>Note:</strong> La classe sera archivée mais l'historique des inscriptions sera préservé pour les rapports et statistiques des années universitaires passées.
-                </div>
-                <p class="text-warning"><strong>Important:</strong> Cette classe ne sera plus visible dans la liste active mais restera accessible dans l'historique.</p>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                <form action="{{ route('esbtp.classes.destroy', $classe->id) }}" method="POST" class="d-inline">
-                    @csrf
-                    @method('DELETE')
-                    <button type="submit" class="btn btn-warning">
-                        <i class="fas fa-archive me-1"></i>Archiver la classe
+            @if($canAdmin || $canManageSchool || $canTeach)
+                <div class="dropdown ci-card-menu">
+                    <button type="button"
+                            class="ci-card-kebab"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                            aria-label="Actions supplémentaires">
+                        <i class="fas fa-ellipsis-v"></i>
                     </button>
-                </form>
+                    <ul class="dropdown-menu dropdown-menu-end ci-dropdown">
+                        @if($canManageSchool)
+                            <li>
+                                <a class="dropdown-item" href="{{ route('esbtp.classes.matieres', ['classe' => $classe->id]) }}">
+                                    <i class="fas fa-book"></i>Gérer les matières
+                                </a>
+                            </li>
+                        @endif
+                        @if($canTeach)
+                            <li>
+                                <a class="dropdown-item" href="{{ route('esbtp.classes.liste-appel', ['classe' => $classe->id]) }}" target="_blank">
+                                    <i class="fas fa-clipboard-list"></i>Liste d'appel
+                                </a>
+                            </li>
+                            <li>
+                                <a class="dropdown-item" href="{{ route('esbtp.classes.liste-complete', ['classe' => $classe->id]) }}" target="_blank">
+                                    <i class="fas fa-users"></i>Liste complète
+                                </a>
+                            </li>
+                        @endif
+                        @if($canAdmin)
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <button type="button"
+                                        class="dropdown-item btn-open-edit-modal"
+                                        data-classe-id="{{ $classe->id }}">
+                                    <i class="fas fa-edit"></i>Modifier
+                                </button>
+                            </li>
+                            <li>
+                                @if($classe->nombre_etudiants == 0)
+                                    <button type="button"
+                                            class="dropdown-item ci-dropdown-item--danger"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#deleteModal{{ $classe->id }}">
+                                        <i class="fas fa-archive"></i>Archiver la classe
+                                    </button>
+                                @else
+                                    <button type="button" class="dropdown-item" disabled title="Classe avec historique d'inscriptions — archivage désactivé">
+                                        <i class="fas fa-lock"></i>Archivage désactivé
+                                    </button>
+                                @endif
+                            </li>
+                        @endif
+                    </ul>
+                </div>
+            @endif
+        </div>
+    </header>
+
+    {{-- Meta : filière + niveau --}}
+    <div class="ci-card-meta">
+        @if($classe->filiere)
+            <div class="ci-card-meta-line">
+                <i class="fas fa-layer-group"></i>
+                <span><strong>{{ $classe->filiere->name }}</strong>@if($classe->filiere->parent)<span class="ci-card-meta-parent"> · Option de {{ $classe->filiere->parent->name }}</span>@endif</span>
+            </div>
+        @endif
+        @if($classe->niveau)
+            <div class="ci-card-meta-line">
+                <i class="fas fa-level-up-alt"></i>
+                <span>{{ $classe->niveau->name }}</span>
+            </div>
+        @endif
+    </div>
+
+    {{-- Stats : capacité + barre d'occupation --}}
+    <div class="ci-card-stats">
+        <div class="ci-card-stat">
+            <span class="ci-card-stat-value">{{ $classe->nombre_etudiants }}</span>
+            <span class="ci-card-stat-label">Inscrits</span>
+        </div>
+        <div class="ci-card-stat ci-card-stat--separator"></div>
+        <div class="ci-card-stat">
+            <span class="ci-card-stat-value">{{ $classe->places_totales }}</span>
+            <span class="ci-card-stat-label">Capacité</span>
+        </div>
+        <div class="ci-card-stat ci-card-stat--separator"></div>
+        <div class="ci-card-stat">
+            <span class="ci-card-stat-value ci-card-stat-value--{{ $classe->places_disponibles > 0 ? 'ok' : 'warn' }}">{{ $classe->places_disponibles }}</span>
+            <span class="ci-card-stat-label">Disponibles</span>
+        </div>
+    </div>
+
+    <div class="ci-card-bar" aria-label="Taux d'occupation : {{ $occupation }}%">
+        <div class="ci-card-bar-fill ci-card-bar-fill--{{ $occLevel }}" style="width: {{ $occupation }}%"></div>
+        <span class="ci-card-bar-pct">{{ $occupation }}%</span>
+    </div>
+
+    {{-- Footer : année --}}
+    @if($classe->annee)
+        <footer class="ci-card-footer">
+            <i class="fas fa-calendar"></i>{{ $classe->annee->name }}
+        </footer>
+    @endif
+</article>
+
+{{-- Modal suppression/archivage (monochrome avec bouton rouge outline pour confirmation Q3a) --}}
+@if($canAdmin && $classe->nombre_etudiants == 0)
+    <div class="modal fade" id="deleteModal{{ $classe->id }}" tabindex="-1" aria-labelledby="deleteModalLabel{{ $classe->id }}" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header ci-modal-header">
+                    <h5 class="modal-title" id="deleteModalLabel{{ $classe->id }}">
+                        <i class="fas fa-archive me-2"></i>Archiver la classe
+                    </h5>
+                    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                </div>
+                <div class="modal-body">
+                    <p>Êtes-vous sûr de vouloir archiver la classe <strong>{{ $classe->name }}</strong> ?</p>
+                    <div class="ci-info-box">
+                        <i class="fas fa-info-circle"></i>
+                        <div>
+                            <strong>L'historique des inscriptions est préservé</strong> pour les rapports et statistiques des années passées. La classe ne sera simplement plus visible dans la liste active.
+                        </div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <form action="{{ route('esbtp.classes.destroy', $classe->id) }}" method="POST" class="d-inline">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" class="btn btn-outline-danger">
+                            <i class="fas fa-archive me-1"></i>Archiver
+                        </button>
+                    </form>
+                </div>
             </div>
         </div>
     </div>
-</div>
 @endif

--- a/resources/views/esbtp/classes/partials/results.blade.php
+++ b/resources/views/esbtp/classes/partials/results.blade.php
@@ -1,28 +1,33 @@
 @if($classes->count() > 0)
-    <div class="resultats-grid" id="classes-grid" style="margin-top: var(--space-lg);">
+    <div class="ci-grid" id="classes-grid">
         @include('esbtp.classes.partials.items', ['classes' => $classes])
     </div>
 
-    <!-- Bouton Charger plus -->
-    <div id="load-more-container" class="text-center" style="margin-top: var(--space-lg);">
-        <button type="button" id="load-more-btn" class="btn-acasi primary" style="display: {{ isset($hasMore) && $hasMore ? 'inline-flex' : 'none' }};" data-has-more="{{ isset($hasMore) ? ($hasMore ? 'true' : 'false') : 'false' }}">
-            <i class="fas fa-angle-down me-2"></i>Charger plus de classes
+    <div id="load-more-container" class="ci-load-more-container">
+        <button type="button"
+                id="load-more-btn"
+                class="ci-load-more-btn"
+                style="display: {{ isset($hasMore) && $hasMore ? 'inline-flex' : 'none' }};"
+                data-has-more="{{ isset($hasMore) ? ($hasMore ? 'true' : 'false') : 'false' }}">
+            <i class="fas fa-angle-down"></i>Charger plus de classes
         </button>
-        <div id="load-more-spinner" class="d-none" style="padding: var(--space-md);">
+        <div id="load-more-spinner" class="ci-load-more-spinner d-none">
             <div class="spinner-border text-primary" role="status">
                 <span class="visually-hidden">Chargement...</span>
             </div>
         </div>
     </div>
 @else
-    <div class="text-center" style="padding: var(--space-xl); color: var(--text-secondary);">
-        <i class="fas fa-graduation-cap" style="font-size: 48px; margin-bottom: var(--space-lg); color: var(--neutral);"></i>
-        <h5 style="color: var(--text-secondary); margin-bottom: var(--space-sm);">Aucune classe trouvée</h5>
-        <p style="color: var(--text-muted);">Commencez par créer votre première classe.</p>
+    <div class="ci-empty">
+        <div class="ci-empty-icon">
+            <i class="fas fa-graduation-cap"></i>
+        </div>
+        <div class="ci-empty-title">Aucune classe trouvée</div>
+        <div class="ci-empty-text">Essayez d'ajuster vos filtres ou créez votre première classe.</div>
         @if(auth()->user()->can('access_admin'))
-            <a href="{{ route('esbtp.classes.create') }}" class="btn-acasi primary" style="margin-top: var(--space-md);">
+            <button type="button" class="ci-btn--white" id="btn-open-create-modal-empty" style="background: var(--ci-primary); color: #fff;">
                 <i class="fas fa-plus-circle"></i>Créer une classe
-            </a>
+            </button>
         @endif
     </div>
 @endif

--- a/resources/views/esbtp/classes/partials/student-table-rows.blade.php
+++ b/resources/views/esbtp/classes/partials/student-table-rows.blade.php
@@ -1,39 +1,62 @@
+{{--
+    Table des étudiants de la classe (vue admin/secrétaire/coordinateur).
+    Design cs-* monochrome + photos avec fallback HSL.
+    Pattern identique à resources/views/esbtp/attendances/partials/student-list.blade.php
+--}}
 @if($classe->etudiants->count() > 0)
     <div class="table-responsive">
-        <table class="table str-table align-middle mb-0" id="studentsDataTable">
+        <table class="table cs-table align-middle mb-0" id="studentsDataTable">
             <thead>
                 <tr>
-                    <th style="width: 50px;"></th>
+                    <th>Étudiant</th>
                     <th>Matricule</th>
-                    <th>Nom complet</th>
                     <th>Genre</th>
-                    <th>Date de naissance</th>
+                    <th>Naissance</th>
                     <th>Contact</th>
-                    <th style="width: 60px; text-align: center;">Actions</th>
+                    <th style="width:60px;text-align:center;">Actions</th>
                 </tr>
             </thead>
             <tbody>
                 @foreach($classe->etudiants as $etudiant)
                     @php
-                        $initials = mb_strtoupper(mb_substr($etudiant->nom, 0, 1) . mb_substr($etudiant->prenoms, 0, 1));
-                        $isMale = $etudiant->genre == 'M';
+                        $nomComplet = trim(($etudiant->nom ?? '').' '.($etudiant->prenoms ?? ''));
+                        $initials = mb_strtoupper(mb_substr($etudiant->nom ?? '', 0, 1).mb_substr($etudiant->prenoms ?? '', 0, 1));
+                        $avatarHue = hexdec(substr(md5($nomComplet ?: (string)$etudiant->id), 0, 4)) % 360;
+                        $isMale = $etudiant->genre === 'M';
                     @endphp
-                    <tr data-etudiant-id="{{ $etudiant->id }}">
+                    <tr data-etudiant-id="{{ $etudiant->id }}"
+                        data-matricule="{{ $etudiant->matricule }}"
+                        data-nom="{{ $nomComplet }}">
                         <td>
-                            <div class="str-avatar {{ $isMale ? 'str-avatar--m' : 'str-avatar--f' }}">
-                                {{ $initials }}
+                            <div class="cs-etu-cell">
+                                <span class="cs-etu-avatar"
+                                      @if($etudiant->photo_url)
+                                          style="background:transparent;padding:0;overflow:hidden;"
+                                      @else
+                                          style="background: hsl({{ $avatarHue }}, 55%, 92%); color: hsl({{ $avatarHue }}, 50%, 35%);"
+                                      @endif>
+                                    @if($etudiant->photo_url)
+                                        <img src="{{ $etudiant->photo_url }}"
+                                             alt="{{ $nomComplet }}"
+                                             width="36" height="36"
+                                             loading="lazy"
+                                             style="width:100%;height:100%;object-fit:cover;border-radius:50%;"
+                                             onerror="this.onerror=null;this.parentElement.style.background='hsl({{ $avatarHue }}, 55%, 92%)';this.parentElement.style.color='hsl({{ $avatarHue }}, 50%, 35%)';this.outerHTML='{{ $initials ?: '?' }}';">
+                                    @else
+                                        {{ $initials ?: '?' }}
+                                    @endif
+                                </span>
+                                <div>
+                                    <div class="cs-etu-name">{{ $etudiant->nom }} <span class="cs-etu-prenom">{{ $etudiant->prenoms }}</span></div>
+                                </div>
                             </div>
                         </td>
                         <td>
-                            <span class="str-matricule">{{ $etudiant->matricule }}</span>
+                            <span class="cs-matricule">{{ $etudiant->matricule }}</span>
                         </td>
                         <td>
-                            <span class="str-name">{{ $etudiant->nom }}</span>
-                            <span class="str-prenom">{{ $etudiant->prenoms }}</span>
-                        </td>
-                        <td>
-                            <span class="str-gender-badge">
-                                <i class="fas {{ $isMale ? 'fa-mars' : 'fa-venus' }}" style="color: var({{ $isMale ? '--primary, #0453cb' : '--success, #10b981' }});"></i>
+                            <span class="cs-gender">
+                                <i class="fas {{ $isMale ? 'fa-mars' : 'fa-venus' }}" style="color: var({{ $isMale ? '--cs-primary' : '--cs-accent' }});"></i>
                                 {{ $isMale ? 'Masculin' : 'Féminin' }}
                             </span>
                         </td>
@@ -42,24 +65,24 @@
                         </td>
                         <td>
                             @if($etudiant->telephone)
-                            <div class="str-contact-line">
-                                <i class="fas fa-phone"></i>
-                                {{ $etudiant->telephone }}
-                            </div>
+                                <div class="cs-contact-line">
+                                    <i class="fas fa-phone"></i>
+                                    {{ $etudiant->telephone }}
+                                </div>
                             @endif
                             @if($etudiant->email)
-                            <div class="str-contact-line">
-                                <i class="fas fa-envelope"></i>
-                                {{ $etudiant->email }}
-                            </div>
+                                <div class="cs-contact-line">
+                                    <i class="fas fa-envelope"></i>
+                                    {{ $etudiant->email }}
+                                </div>
                             @endif
                             @if(!$etudiant->telephone && !$etudiant->email)
-                                <span style="color: var(--text-muted, #94a3b8); font-size: 0.8125rem;">—</span>
+                                <span style="color: var(--cs-muted);font-size:.8rem;">—</span>
                             @endif
                         </td>
-                        <td style="text-align: center;">
+                        <td style="text-align:center;">
                             <a href="{{ route('esbtp.etudiants.show', ['etudiant' => $etudiant->id]) }}"
-                               class="str-btn-view"
+                               class="cs-btn-view"
                                title="Voir la fiche">
                                 <i class="fas fa-eye"></i>
                             </a>
@@ -70,11 +93,11 @@
         </table>
     </div>
 @else
-    <div class="str-empty">
-        <div class="str-empty-icon">
+    <div class="cs-empty">
+        <div class="cs-empty-icon">
             <i class="fas fa-user-graduate"></i>
         </div>
-        <div class="str-empty-title">Aucun étudiant inscrit</div>
-        <div class="str-empty-text">Cette classe n'a pas encore d'étudiants pour l'année courante.</div>
+        <div class="cs-empty-title">Aucun étudiant inscrit</div>
+        <div class="cs-empty-text">Cette classe n'a pas encore d'étudiants pour l'année courante.</div>
     </div>
 @endif

--- a/resources/views/esbtp/classes/partials/year-change-modal.blade.php
+++ b/resources/views/esbtp/classes/partials/year-change-modal.blade.php
@@ -1,0 +1,39 @@
+{{--
+    Modal partagée : instructions pour changer l'année académique courante.
+    Utilisée par classes.index et classes.show.
+    API Bootstrap 5 (data-bs-dismiss).
+--}}
+<div class="modal fade" id="yearChangeModal" tabindex="-1" aria-labelledby="yearChangeModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header ci-modal-header">
+                <h5 class="modal-title" id="yearChangeModalLabel">
+                    <i class="fas fa-calendar-alt me-2"></i>Changer l'année académique
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body">
+                <p class="mb-3"><strong>Pour consulter les données d'une autre année :</strong></p>
+                <ol class="ci-steps">
+                    <li>Aller dans <strong>Menu → Années Universitaires</strong></li>
+                    <li>Trouver l'année souhaitée (ex : 2023-2024)</li>
+                    <li>Cliquer sur <strong>« Activer »</strong> pour la définir comme année courante</li>
+                    <li>Revenir ici, les données se mettront à jour automatiquement</li>
+                </ol>
+                <div class="ci-info-box">
+                    <i class="fas fa-info-circle"></i>
+                    <div>
+                        <strong>Note :</strong> Seule une année peut être « courante » à la fois.
+                        Changer l'année courante affecte l'affichage dans toute l'application.
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+                <a href="{{ route('esbtp.annees-universitaires.index') }}" target="_blank" class="btn btn-primary">
+                    <i class="fas fa-external-link-alt me-1"></i>Aller aux Années
+                </a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/esbtp/classes/show.blade.php
+++ b/resources/views/esbtp/classes/show.blade.php
@@ -2,307 +2,937 @@
 
 @section('title', 'Détails de la classe ' . $classe->name . ' - KLASSCI')
 
-@section('styles')
+@push('styles')
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 <style>
-    /* =============================================
-       KPI SUMMARY CARDS — 4 métriques en haut
-       ============================================= */
-    .planning-kpi-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-        gap: 16px;
-        margin-bottom: 28px;
-    }
+/* =====================================================================
+   CLASSES SHOW — namespace cs-*
+   Design premium monochrome bleu KLASSCI
+   ===================================================================== */
+.dashboard-acasi {
+    --cs-primary: #0453cb;
+    --cs-primary-dark: #033a8e;
+    --cs-accent: #3b7ddb;
+    --cs-text: #1e293b;
+    --cs-muted: #64748b;
+    --cs-surface: #f8fafc;
+    --cs-border: #e2e8f0;
+    --cs-success: #10b981;
+    --cs-warn: #f59e0b;
+    --cs-danger: #ef4444;
+}
 
-    .planning-kpi-card {
-        background: #fff;
-        border-radius: 14px;
-        padding: 18px 20px;
-        border: 1px solid #e2e8f0;
-        box-shadow: 0 1px 4px rgba(0,0,0,.06);
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        position: relative;
-        overflow: hidden;
-    }
+/* ========================================= HERO compact ========================================= */
+.cs-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 1.75rem 2.25rem 1.5rem;
+    color: #fff;
+    margin-bottom: 1.25rem;
+    position: relative;
+    overflow: hidden;
+}
+.cs-hero::before {
+    content: '';
+    position: absolute;
+    top: -50px; right: -30px;
+    width: 200px; height: 200px;
+    border-radius: 50%;
+    background: rgba(255,255,255,.06);
+    pointer-events: none;
+}
+.cs-hero-top {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    gap: 1rem; flex-wrap: wrap;
+    position: relative; z-index: 1;
+}
+.cs-hero-left { flex: 1; min-width: 260px; }
+.cs-breadcrumb {
+    display: flex; align-items: center; gap: .4rem;
+    font-size: .78rem; color: rgba(255,255,255,.7); margin-bottom: .5rem;
+}
+.cs-breadcrumb a { color: rgba(255,255,255,.85); text-decoration: none; transition: color .15s; }
+.cs-breadcrumb a:hover { color: #fff; }
+.cs-breadcrumb i { font-size: .6rem; opacity: .7; }
+.cs-hero h1 {
+    font-size: 1.6rem; font-weight: 700; color: #fff;
+    margin: 0 0 .4rem; line-height: 1.2;
+}
+.cs-hero-chips { display: flex; flex-wrap: wrap; gap: .4rem; }
+.cs-hero-chip {
+    display: inline-flex; align-items: center; gap: .3rem;
+    padding: .25rem .6rem;
+    background: rgba(255,255,255,.14);
+    border: 1px solid rgba(255,255,255,.2);
+    border-radius: 99px;
+    font-size: .75rem; font-weight: 500; color: #fff;
+}
+.cs-hero-chip--status-active { background: rgba(16,185,129,.25); border-color: rgba(16,185,129,.4); }
+.cs-hero-chip--status-inactive { background: rgba(148,163,184,.25); border-color: rgba(148,163,184,.4); }
+.cs-hero-actions { display: flex; gap: .5rem; flex-wrap: wrap; align-items: flex-start; }
+.cs-btn--glass, .cs-btn--white {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .5rem 1rem; border-radius: 10px;
+    font-size: .82rem; font-weight: 600; text-decoration: none;
+    cursor: pointer; transition: all .2s ease; border: 1px solid transparent;
+}
+.cs-btn--glass { background: rgba(255,255,255,.14); color: #fff; border-color: rgba(255,255,255,.18); }
+.cs-btn--glass:hover { background: rgba(255,255,255,.22); color: #fff; transform: translateY(-1px); }
+.cs-btn--white { background: #fff; color: var(--cs-primary); }
+.cs-btn--white:hover { background: #f1f5f9; color: var(--cs-primary-dark); transform: translateY(-1px); box-shadow: 0 4px 14px rgba(0,0,0,.12); }
 
-    .planning-kpi-card::before {
-        content: '';
-        position: absolute;
-        top: 0; left: 0; right: 0;
-        height: 3px;
-        background: var(--kpi-color, #3b82f6);
-        border-radius: 14px 14px 0 0;
-    }
+/* KPIs hero */
+.cs-kpis {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: .7rem; margin-top: 1.3rem;
+    position: relative; z-index: 1;
+}
+.cs-kpi {
+    background: rgba(255,255,255,.1);
+    border: 1px solid rgba(255,255,255,.15);
+    border-radius: 11px; padding: .75rem .9rem;
+    display: flex; align-items: center; gap: .6rem; transition: background .2s;
+}
+.cs-kpi:hover { background: rgba(255,255,255,.15); }
+.cs-kpi-icon {
+    width: 34px; height: 34px; border-radius: 9px;
+    background: rgba(255,255,255,.14);
+    display: flex; align-items: center; justify-content: center;
+    font-size: .9rem; color: #fff; flex-shrink: 0;
+}
+.cs-kpi-body { flex: 1; min-width: 0; }
+.cs-kpi-value { font-size: 1.25rem; font-weight: 700; color: #fff; line-height: 1; }
+.cs-kpi-label {
+    font-size: .65rem; color: rgba(255,255,255,.7);
+    margin-top: .2rem; text-transform: uppercase;
+    letter-spacing: .04em; font-weight: 500;
+}
+.cs-kpi-bar {
+    height: 3px; background: rgba(255,255,255,.2);
+    border-radius: 99px; margin-top: .4rem; overflow: hidden;
+}
+.cs-kpi-bar-fill { height: 100%; background: #fff; border-radius: 99px; transition: width .6s ease; }
 
-    .planning-kpi-icon {
-        width: 36px;
-        height: 36px;
-        border-radius: 10px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 1rem;
-        margin-bottom: 4px;
-        background: color-mix(in srgb, var(--kpi-color, #3b82f6) 12%, transparent);
-        color: var(--kpi-color, #3b82f6);
-    }
+/* ========================================= INFO GRID ========================================= */
+.cs-info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.25rem; }
+.cs-info-card { background: #fff; border: 1px solid var(--cs-border); border-radius: 14px; padding: 1rem 1.25rem; }
+.cs-info-card-header { display: flex; align-items: center; gap: .55rem; margin-bottom: .75rem; }
+.cs-info-card-icon {
+    width: 32px; height: 32px; border-radius: 9px;
+    background: rgba(4,83,203,.1); color: var(--cs-primary);
+    display: flex; align-items: center; justify-content: center;
+    font-size: .82rem; flex-shrink: 0;
+}
+.cs-info-card-title { font-size: .88rem; font-weight: 700; color: var(--cs-text); margin: 0; }
+.cs-info-list { display: flex; flex-direction: column; gap: .4rem; font-size: .85rem; }
+.cs-info-row {
+    display: flex; justify-content: space-between; align-items: center;
+    gap: 1rem; padding: .35rem 0; border-bottom: 1px dashed var(--cs-border);
+}
+.cs-info-row:last-child { border-bottom: none; }
+.cs-info-label { color: var(--cs-muted); font-size: .78rem; font-weight: 500; }
+.cs-info-value { color: var(--cs-text); font-weight: 600; text-align: right; }
 
-    .planning-kpi-value {
-        font-size: 1.75rem;
-        font-weight: 800;
-        color: #1e293b;
-        line-height: 1;
-    }
+/* Teachers chips */
+.cs-teachers { display: flex; flex-wrap: wrap; gap: .4rem; padding-top: .4rem; }
+.cs-teacher-chip {
+    display: inline-flex; align-items: center; gap: .45rem;
+    padding: .3rem .7rem .3rem .3rem;
+    border-radius: 99px; border: 1px solid var(--cs-border);
+    background: #fff; text-decoration: none; color: var(--cs-text);
+    font-size: .78rem; font-weight: 500; transition: all .15s;
+}
+.cs-teacher-chip:hover { border-color: var(--cs-primary); background: rgba(4,83,203,.04); color: var(--cs-primary); }
+.cs-teacher-avatar {
+    width: 24px; height: 24px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    font-size: .68rem; font-weight: 700; color: #fff; flex-shrink: 0;
+}
+.cs-teacher-hours { font-size: .68rem; color: var(--cs-muted); font-weight: 400; }
 
-    .planning-kpi-label {
-        font-size: 0.72rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: .06em;
-        color: #94a3b8;
-    }
+/* ========================================= TABS (Alpine x-show) ========================================= */
+.cs-tabs {
+    background: #fff; border: 1px solid var(--cs-border);
+    border-radius: 14px; margin-bottom: 1.25rem; overflow: hidden;
+}
+.cs-tabs-nav {
+    display: flex; gap: .25rem; padding: .6rem .6rem 0;
+    border-bottom: 1px solid var(--cs-border); background: var(--cs-surface);
+    overflow-x: auto; scrollbar-width: none;
+}
+.cs-tabs-nav::-webkit-scrollbar { display: none; }
+.cs-tab {
+    display: inline-flex; align-items: center; gap: .5rem;
+    padding: .7rem 1.1rem; font-size: .85rem; font-weight: 600;
+    color: var(--cs-muted); background: transparent; border: none;
+    border-bottom: 2px solid transparent;
+    cursor: pointer; transition: all .15s;
+    white-space: nowrap; border-radius: 8px 8px 0 0;
+}
+.cs-tab:hover { color: var(--cs-primary); background: rgba(4,83,203,.04); }
+.cs-tab.cs-tab--active {
+    color: var(--cs-primary); border-bottom-color: var(--cs-primary); background: #fff;
+}
+.cs-tab-badge {
+    background: rgba(4,83,203,.1); color: var(--cs-primary);
+    font-size: .7rem; font-weight: 700; padding: .1rem .4rem; border-radius: 99px;
+}
+.cs-tab.cs-tab--active .cs-tab-badge { background: var(--cs-primary); color: #fff; }
+.cs-tab-panel { padding: 1.25rem 1.5rem; }
+[x-cloak] { display: none !important; }
 
-    /* =============================================
-       ENSEIGNANTS GLOBAUX
-       ============================================= */
-    .planning-teachers-section {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-        margin-bottom: 20px;
-        padding: 14px 16px;
-        background: #f8fafc;
-        border-radius: 12px;
-        border: 1px solid #e2e8f0;
-    }
+/* ========================================= PANEL ÉTUDIANTS ========================================= */
+.cs-students-actions {
+    display: flex; justify-content: space-between; align-items: center;
+    gap: .75rem; flex-wrap: wrap;
+    margin-bottom: 1rem; padding-bottom: 1rem;
+    border-bottom: 1px solid var(--cs-border);
+}
+.cs-students-count { font-size: .85rem; color: var(--cs-muted); }
+.cs-students-count strong { color: var(--cs-text); }
+.cs-students-btns { display: flex; gap: .5rem; flex-wrap: wrap; }
+.cs-btn--primary, .cs-btn--ghost, .cs-btn--outline {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .5rem 1rem; border-radius: 10px;
+    font-size: .83rem; font-weight: 600;
+    cursor: pointer; transition: all .2s; text-decoration: none;
+    border: 1px solid transparent;
+}
+.cs-btn--primary { background: var(--cs-primary); color: #fff; }
+.cs-btn--primary:hover { background: var(--cs-primary-dark); color: #fff; transform: translateY(-1px); box-shadow: 0 4px 12px rgba(4,83,203,.25); }
+.cs-btn--ghost { background: #fff; color: var(--cs-text); border-color: var(--cs-border); }
+.cs-btn--ghost:hover { border-color: var(--cs-primary); color: var(--cs-primary); background: rgba(4,83,203,.04); }
+.cs-btn--outline { background: #fff; color: var(--cs-primary); border-color: var(--cs-primary); }
+.cs-btn--outline:hover { background: var(--cs-primary); color: #fff; }
 
-    .planning-teachers-label {
-        width: 100%;
-        font-size: 0.72rem;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: .06em;
-        color: #94a3b8;
-        margin-bottom: 6px;
-    }
+.cs-table { border-collapse: separate; border-spacing: 0; width: 100%; }
+.cs-table thead th {
+    background: var(--cs-surface); color: var(--cs-muted);
+    font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .05em;
+    padding: .75rem 1rem; border-bottom: 1px solid var(--cs-border);
+    white-space: nowrap; text-align: left;
+}
+.cs-table tbody tr { transition: background .15s; }
+.cs-table tbody tr:hover { background: rgba(4,83,203,.03); }
+.cs-table tbody td {
+    padding: .75rem 1rem; border-bottom: 1px solid var(--cs-surface);
+    vertical-align: middle; color: var(--cs-text); font-size: .87rem;
+}
+.cs-etu-cell { display: flex; align-items: center; gap: .75rem; }
+.cs-etu-avatar {
+    width: 36px; height: 36px; border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-weight: 700; font-size: .78rem;
+    flex-shrink: 0; overflow: hidden;
+}
+.cs-etu-name { font-weight: 600; color: var(--cs-text); line-height: 1.2; margin-bottom: .1rem; }
+.cs-etu-prenom { font-weight: 400; color: #475569; }
 
-    /* =============================================
-       SUBJECT CARDS — layout 2 colonnes
-       ============================================= */
-    .planning-subject-card {
-        background: #fff;
-        border-radius: 14px;
-        border: 1px solid #e2e8f0;
-        padding: 20px 24px;
-        margin-bottom: 10px;
-        box-shadow: 0 1px 4px rgba(0,0,0,.05);
-        display: grid;
-        grid-template-columns: 1fr 260px;
-        gap: 24px;
-        align-items: start;
-        transition: box-shadow .2s;
-    }
+.cs-matricule {
+    display: inline-block; background: var(--cs-surface); color: var(--cs-muted);
+    font-family: 'Courier New', monospace; font-size: .76rem; font-weight: 600;
+    padding: .2rem .5rem; border-radius: 6px; letter-spacing: .03em;
+}
+.cs-gender { display: inline-flex; align-items: center; gap: .3rem; font-size: .82rem; color: var(--cs-muted); }
+.cs-contact-line {
+    display: flex; align-items: center; gap: .35rem;
+    font-size: .8rem; color: var(--cs-muted);
+}
+.cs-contact-line i { width: 12px; text-align: center; color: #94a3b8; font-size: .72rem; }
+.cs-btn-view {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 32px; height: 32px; border-radius: 8px;
+    border: 1px solid var(--cs-border); background: #fff;
+    color: var(--cs-primary); transition: all .15s; font-size: .82rem;
+}
+.cs-btn-view:hover {
+    background: var(--cs-primary); color: #fff; border-color: var(--cs-primary);
+    box-shadow: 0 2px 8px rgba(4,83,203,.25);
+}
+.cs-empty { text-align: center; padding: 3rem 1.5rem; }
+.cs-empty-icon {
+    width: 56px; height: 56px; border-radius: 50%;
+    background: var(--cs-surface);
+    display: inline-flex; align-items: center; justify-content: center;
+    margin-bottom: 1rem; color: var(--cs-muted); font-size: 1.4rem;
+}
+.cs-empty-title { font-weight: 600; color: var(--cs-text); margin-bottom: .3rem; }
+.cs-empty-text { color: var(--cs-muted); font-size: .88rem; }
 
-    .planning-subject-card:hover {
-        box-shadow: 0 4px 12px rgba(0,0,0,.09);
-    }
+/* ========================================= PANEL MATIÈRES ========================================= */
+.cs-matieres-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(320px, 1fr)); gap: .75rem; }
+.cs-matiere-card {
+    background: #fff; border: 1px solid var(--cs-border);
+    border-radius: 12px; padding: .85rem 1rem; transition: all .2s;
+}
+.cs-matiere-card:hover { border-color: #c7d4e5; box-shadow: 0 4px 14px rgba(4,83,203,.06); transform: translateY(-1px); }
+.cs-matiere-head { display: flex; justify-content: space-between; align-items: start; gap: .5rem; margin-bottom: .45rem; }
+.cs-matiere-name { font-weight: 700; color: var(--cs-text); font-size: .92rem; line-height: 1.3; }
+.cs-matiere-code {
+    display: inline-block; background: var(--cs-surface); color: var(--cs-muted);
+    font-family: 'Courier New', monospace; font-size: .7rem; font-weight: 600;
+    padding: .15rem .45rem; border-radius: 5px; margin-top: .2rem;
+}
+.cs-matiere-coef {
+    background: rgba(4,83,203,.1); color: var(--cs-primary);
+    font-size: .78rem; font-weight: 700;
+    padding: .25rem .55rem; border-radius: 7px; flex-shrink: 0;
+}
+.cs-matiere-desc { font-size: .78rem; color: var(--cs-muted); line-height: 1.4; margin: 0; }
 
-    .planning-subject-name {
-        font-size: 1rem;
-        font-weight: 700;
-        color: #1e293b;
-    }
+/* ========================================= PANEL SUIVI HEURES ========================================= */
+.cs-periode-toggle {
+    display: flex; gap: .25rem;
+    background: var(--cs-surface); border: 1px solid var(--cs-border);
+    border-radius: 10px; padding: .25rem;
+    margin-bottom: 1rem; width: fit-content;
+}
+.cs-periode-btn {
+    padding: .4rem 1rem; border: none; background: transparent;
+    color: var(--cs-muted); font-size: .8rem; font-weight: 600;
+    border-radius: 8px; cursor: pointer; transition: all .15s;
+}
+.cs-periode-btn:hover { color: var(--cs-primary); }
+.cs-periode-btn.active {
+    background: #fff; color: var(--cs-primary);
+    box-shadow: 0 1px 3px rgba(15,23,42,.1);
+}
+.cs-planning-kpis {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: .75rem; margin-bottom: 1.25rem;
+}
+.cs-planning-kpi {
+    background: #fff; border: 1px solid var(--cs-border);
+    border-radius: 12px; padding: .85rem 1rem;
+    position: relative; overflow: hidden;
+}
+.cs-planning-kpi::before {
+    content: '';
+    position: absolute; top: 0; left: 0; right: 0;
+    height: 3px;
+    background: var(--kpi-color, var(--cs-primary));
+    border-radius: 12px 12px 0 0;
+}
+.cs-planning-kpi-icon {
+    width: 32px; height: 32px; border-radius: 8px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: .88rem;
+    background: color-mix(in srgb, var(--kpi-color, var(--cs-primary)) 12%, transparent);
+    color: var(--kpi-color, var(--cs-primary));
+    margin-bottom: .35rem;
+}
+.cs-planning-kpi-value { font-size: 1.4rem; font-weight: 800; color: var(--cs-text); line-height: 1; }
+.cs-planning-kpi-label {
+    font-size: .68rem; font-weight: 600;
+    text-transform: uppercase; letter-spacing: .05em;
+    color: var(--cs-muted); margin-top: .25rem;
+}
+.cs-subject-card {
+    background: #fff; border-radius: 12px; border: 1px solid var(--cs-border);
+    padding: 1rem 1.25rem; margin-bottom: .6rem;
+    display: grid; grid-template-columns: 1fr 260px; gap: 1.25rem;
+    align-items: start; transition: box-shadow .2s;
+}
+.cs-subject-card:hover { box-shadow: 0 4px 14px rgba(0,0,0,.08); }
+.cs-subject-name { font-size: .95rem; font-weight: 700; color: var(--cs-text); }
+.cs-subject-code {
+    display: inline-block; background: var(--cs-surface); color: var(--cs-muted);
+    font-family: 'Courier New', monospace; font-size: .68rem; font-weight: 600;
+    padding: .15rem .45rem; border-radius: 5px; margin-left: .4rem;
+}
+.cs-progress-track {
+    height: 9px; background: var(--cs-surface);
+    border-radius: 99px; overflow: hidden;
+    margin: .6rem 0 .35rem;
+}
+.cs-progress-fill { height: 100%; border-radius: 99px; transition: width .6s cubic-bezier(.4,0,.2,1); }
+.cs-progress-fill--low { background: linear-gradient(90deg, #a7d4ff, var(--cs-primary)); }
+.cs-progress-fill--mid { background: linear-gradient(90deg, #5e91de, var(--cs-primary)); }
+.cs-progress-fill--good { background: linear-gradient(90deg, var(--cs-primary), var(--cs-primary-dark)); }
+.cs-progress-fill--done { background: linear-gradient(90deg, #6ee7b7, var(--cs-success)); }
+.cs-percent-badge {
+    display: inline-flex; align-items: center; justify-content: center;
+    min-width: 48px; padding: .2rem .55rem;
+    border-radius: 99px; font-size: .78rem; font-weight: 700; white-space: nowrap;
+}
 
-    .planning-subject-code {
-        font-size: 0.72rem;
-        font-weight: 600;
-        padding: 2px 8px;
-        border-radius: 99px;
-        background: #f1f5f9;
-        color: #64748b;
-    }
+/* ========================================= MODALS ========================================= */
+.cs-modal-header {
+    background: linear-gradient(135deg, #0a3d8f 0%, var(--cs-primary) 100%);
+    color: #fff; border-bottom: none;
+    border-top-left-radius: calc(0.5rem - 1px);
+    border-top-right-radius: calc(0.5rem - 1px);
+}
+.cs-modal-header .modal-title { color: #fff; font-weight: 700; font-size: 1rem; }
+.cs-alert {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .75rem 1rem; border-radius: 10px;
+    margin-bottom: 1rem; font-size: .88rem; font-weight: 500;
+}
+.cs-alert--success { background: #ecfdf5; border: 1px solid #a7f3d0; color: #065f46; }
+.cs-alert--danger { background: #fef2f2; border: 1px solid #fecaca; color: #991b1b; }
+.cs-info-box {
+    display: flex; gap: .6rem;
+    padding: .75rem 1rem; background: rgba(4,83,203,.06);
+    border-left: 3px solid var(--cs-primary); border-radius: 8px;
+    color: var(--cs-text); font-size: .84rem; line-height: 1.5; margin-top: .75rem;
+}
+.cs-info-box i { color: var(--cs-primary); font-size: .95rem; flex-shrink: 0; margin-top: .15rem; }
+.cs-warn-box {
+    display: flex; gap: .6rem;
+    padding: .75rem 1rem; background: #fef3c7;
+    border-left: 3px solid var(--cs-warn); border-radius: 8px;
+    color: #92400e; font-size: .84rem; line-height: 1.5; margin-bottom: 1rem;
+}
+.cs-warn-box i { color: var(--cs-warn); font-size: .95rem; flex-shrink: 0; margin-top: .15rem; }
+.cs-steps { padding-left: 1.2rem; line-height: 1.8; color: var(--cs-text); font-size: .88rem; }
 
-    /* =============================================
-       PROGRESS BAR ENRICHIE
-       ============================================= */
-    .planning-progress-track {
-        height: 10px;
-        background: #f1f5f9;
-        border-radius: 99px;
-        overflow: hidden;
-        margin: 10px 0 6px;
-    }
-
-    .planning-progress-bar {
-        height: 100%;
-        border-radius: 99px;
-        transition: width .7s cubic-bezier(.4,0,.2,1);
-    }
-
-    .planning-progress-bar.level-low  { background: linear-gradient(90deg, #fca5a5, #ef4444); }
-    .planning-progress-bar.level-mid  { background: linear-gradient(90deg, #fcd34d, #f59e0b); }
-    .planning-progress-bar.level-good { background: linear-gradient(90deg, #6ee7b7, #10b981); }
-    .planning-progress-bar.level-done { background: linear-gradient(90deg, #93c5fd, #3b82f6); }
-
-    /* =============================================
-       BADGE % PILL
-       ============================================= */
-    .planning-percent-badge {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        min-width: 52px;
-        padding: 3px 10px;
-        border-radius: 99px;
-        font-size: .82rem;
-        font-weight: 700;
-        white-space: nowrap;
-    }
-
-    /* =============================================
-       TEACHER AVATAR CHIPS
-       ============================================= */
-    .teacher-avatar-chip {
-        display: inline-flex;
-        align-items: center;
-        gap: 7px;
-        padding: 4px 12px 4px 4px;
-        border-radius: 99px;
-        border: 1px solid #e2e8f0;
-        background: #fff;
-        text-decoration: none;
-        color: #1e293b;
-        font-size: .8rem;
-        font-weight: 500;
-        transition: box-shadow .15s, transform .15s, border-color .15s;
-    }
-
-    .teacher-avatar-chip:hover {
-        box-shadow: 0 2px 8px rgba(0,0,0,.1);
-        transform: translateY(-1px);
-        border-color: #cbd5e1;
-        color: #1e293b;
-    }
-
-    .teacher-avatar {
-        width: 26px;
-        height: 26px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: .72rem;
-        font-weight: 700;
-        color: #fff;
-        flex-shrink: 0;
-    }
-
-    .teacher-hours-badge {
-        font-size: .72rem;
-        color: #64748b;
-        font-weight: 400;
-    }
-
-    /* =============================================
-       RESPONSIVE
-       ============================================= */
-    @media (max-width: 768px) {
-        .planning-subject-card {
-            grid-template-columns: 1fr;
-        }
-        .planning-kpi-grid {
-            grid-template-columns: repeat(2, 1fr);
-        }
-    }
-
-    @media (max-width: 480px) {
-        .planning-kpi-grid {
-            grid-template-columns: 1fr 1fr;
-            gap: 10px;
-        }
-        .planning-kpi-value { font-size: 1.4rem; }
-    }
-
-    /* Student table rows (partial loaded via AJAX) */
-    .str-table { border-collapse: separate; border-spacing: 0; }
-    .str-table thead th {
-        background: var(--background, #f8fafc);
-        color: var(--text-secondary, #64748b);
-        font-size: 0.75rem;
-        font-weight: 600;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        padding: 0.75rem 1rem;
-        border-bottom: 2px solid #e2e8f0;
-        white-space: nowrap;
-    }
-    .str-table tbody tr { transition: background 0.15s ease; }
-    .str-table tbody tr:hover { background: #f1f5f9; }
-    .str-table tbody td {
-        padding: 0.75rem 1rem;
-        border-bottom: 1px solid #f1f5f9;
-        vertical-align: middle;
-        color: var(--text-primary, #1e293b);
-        font-size: 0.875rem;
-    }
-    .str-avatar {
-        width: 36px; height: 36px; border-radius: 50%;
-        display: inline-flex; align-items: center; justify-content: center;
-        font-weight: 700; font-size: 0.8rem; color: #fff;
-        flex-shrink: 0; letter-spacing: 0.02em;
-    }
-    .str-avatar--m { background: linear-gradient(135deg, var(--primary, #0453cb), #5e91de); }
-    .str-avatar--f { background: linear-gradient(135deg, var(--success, #10b981), #6ee7b7); }
-    .str-matricule {
-        display: inline-block; background: #f1f5f9; color: #475569;
-        font-family: 'Courier New', monospace; font-size: 0.8rem;
-        font-weight: 600; padding: 0.2rem 0.5rem; border-radius: 4px;
-        letter-spacing: 0.03em;
-    }
-    .str-name { font-weight: 600; color: var(--text-primary, #1e293b); }
-    .str-prenom { font-weight: 400; color: #475569; }
-    .str-contact-line {
-        display: flex; align-items: center; gap: 0.375rem;
-        font-size: 0.8125rem; color: var(--text-secondary, #64748b); line-height: 1.6;
-    }
-    .str-contact-line i { width: 14px; text-align: center; color: var(--text-muted, #94a3b8); font-size: 0.75rem; }
-    .str-gender-badge {
-        display: inline-flex; align-items: center; gap: 0.25rem;
-        font-size: 0.8125rem; color: var(--text-secondary, #64748b);
-    }
-    .str-gender-badge i { font-size: 0.75rem; }
-    .str-btn-view {
-        display: inline-flex; align-items: center; justify-content: center;
-        width: 32px; height: 32px; border-radius: 8px;
-        border: 1px solid #e2e8f0; background: #fff; color: var(--primary, #0453cb);
-        transition: all 0.15s ease; font-size: 0.8rem;
-    }
-    .str-btn-view:hover {
-        background: var(--primary, #0453cb); color: #fff; border-color: var(--primary, #0453cb);
-        box-shadow: 0 2px 8px rgba(4, 83, 203, 0.25);
-    }
-    .str-empty { text-align: center; padding: 3rem 1.5rem; }
-    .str-empty-icon {
-        width: 56px; height: 56px; border-radius: 50%; background: #f1f5f9;
-        display: inline-flex; align-items: center; justify-content: center;
-        margin-bottom: 1rem; color: var(--text-muted, #94a3b8); font-size: 1.5rem;
-    }
-    .str-empty-title { font-weight: 600; color: var(--text-primary, #1e293b); margin-bottom: 0.25rem; }
-    .str-empty-text { color: var(--text-secondary, #64748b); font-size: 0.875rem; }
+/* ========================================= RESPONSIVE ========================================= */
+@media (max-width: 992px) {
+    .cs-hero { padding: 1.5rem 1.5rem 1.25rem; }
+    .cs-hero h1 { font-size: 1.35rem; }
+    .cs-info-grid { grid-template-columns: 1fr; }
+    .cs-subject-card { grid-template-columns: 1fr; }
+}
+@media (max-width: 768px) {
+    .cs-hero-top { flex-direction: column; align-items: stretch; }
+    .cs-hero-actions { justify-content: flex-start; }
+    .cs-kpis { grid-template-columns: repeat(2, 1fr); }
+    .cs-tab-panel { padding: 1rem; }
+    .cs-students-actions { flex-direction: column; align-items: stretch; }
+}
+@media (max-width: 480px) {
+    .cs-hero { padding: 1.25rem; }
+    .cs-hero h1 { font-size: 1.15rem; }
+    .cs-kpis { grid-template-columns: 1fr; }
+    .cs-matieres-grid { grid-template-columns: 1fr; }
+}
 </style>
+@endpush
+
+@section('content')
+<div class="dashboard-acasi">
+    <div class="main-content">
+
+        @php
+            $nombreEtudiants = $classe->etudiants->count();
+            $pourcentage = $classe->places_totales > 0 ? round(($nombreEtudiants / $classe->places_totales) * 100, 1) : 0;
+            $placesLibres = max(0, $classe->places_totales - $nombreEtudiants);
+            $nbMatieres = ($combinationMatieres ?? collect())->count();
+            $kpiTaux = $planningMatiere['stats']['taux_realisation'] ?? 0;
+            $nbEnseignants = isset($planningMatiere['enseignants']) ? $planningMatiere['enseignants']->count() : 0;
+            $queryParams = request()->query();
+            unset($queryParams['classe']);
+            $returnToIndexUrl = route('esbtp.classes.index', $queryParams);
+        @endphp
+
+        {{-- HERO --}}
+        <div class="cs-hero">
+            <div class="cs-hero-top">
+                <div class="cs-hero-left">
+                    <div class="cs-breadcrumb">
+                        <a href="{{ $returnToIndexUrl }}">Classes</a>
+                        <i class="fas fa-chevron-right"></i>
+                        <span>{{ $classe->name }}</span>
+                    </div>
+                    <h1>{{ $classe->name }}</h1>
+                    <div class="cs-hero-chips">
+                        @if($classe->filiere)
+                            <span class="cs-hero-chip"><i class="fas fa-layer-group"></i>{{ $classe->filiere->name }}</span>
+                        @endif
+                        @if($classe->niveau)
+                            <span class="cs-hero-chip"><i class="fas fa-level-up-alt"></i>{{ $classe->niveau->name }}</span>
+                        @endif
+                        <span class="cs-hero-chip cs-hero-chip--status-{{ $classe->is_active ? 'active' : 'inactive' }}">
+                            <i class="fas fa-{{ $classe->is_active ? 'check-circle' : 'times-circle' }}"></i>
+                            {{ $classe->is_active ? 'Active' : 'Inactive' }}
+                        </span>
+                        <span class="cs-hero-chip">
+                            <i class="fas fa-calendar-alt"></i>{{ $anneeAcademique }}
+                            <button type="button" onclick="showYearChangeInfo()" style="background:transparent;border:none;color:rgba(255,255,255,.7);padding:0;margin-left:.2rem;cursor:pointer;" title="Comment changer d'année ?">
+                                <i class="fas fa-info-circle" style="font-size:.72rem;"></i>
+                            </button>
+                        </span>
+                    </div>
+                </div>
+                <div class="cs-hero-actions">
+                    @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_coordinate_academics']))
+                        <a href="{{ route('esbtp.classes.matieres', ['classe' => $classe->id]) }}" class="cs-btn--glass">
+                            <i class="fas fa-book"></i>Gérer matières
+                        </a>
+                    @endif
+                    @if(auth()->user()->can('access_admin'))
+                        <a href="{{ route('esbtp.classes.edit', array_merge(['classe' => $classe->id], ['return_url' => request()->fullUrl()])) }}" class="cs-btn--white">
+                            <i class="fas fa-edit"></i>Modifier
+                        </a>
+                    @endif
+                    <a href="{{ $returnToIndexUrl }}" class="cs-btn--glass" title="Retour à la liste">
+                        <i class="fas fa-arrow-left"></i>
+                    </a>
+                </div>
+            </div>
+
+            <div class="cs-kpis">
+                <div class="cs-kpi">
+                    <div class="cs-kpi-icon"><i class="fas fa-users"></i></div>
+                    <div class="cs-kpi-body">
+                        <div class="cs-kpi-value">{{ $nombreEtudiants }}</div>
+                        <div class="cs-kpi-label">Inscrits</div>
+                    </div>
+                </div>
+                <div class="cs-kpi">
+                    <div class="cs-kpi-icon"><i class="fas fa-chair"></i></div>
+                    <div class="cs-kpi-body">
+                        <div class="cs-kpi-value">{{ $classe->places_totales }}</div>
+                        <div class="cs-kpi-label">Capacité ({{ $placesLibres }} libres)</div>
+                        <div class="cs-kpi-bar"><div class="cs-kpi-bar-fill" style="width:{{ min(100, $pourcentage) }}%"></div></div>
+                    </div>
+                </div>
+                <div class="cs-kpi">
+                    <div class="cs-kpi-icon"><i class="fas fa-book"></i></div>
+                    <div class="cs-kpi-body">
+                        <div class="cs-kpi-value">{{ $nbMatieres }}</div>
+                        <div class="cs-kpi-label">Matières</div>
+                    </div>
+                </div>
+                <div class="cs-kpi">
+                    <div class="cs-kpi-icon"><i class="fas fa-chart-pie"></i></div>
+                    <div class="cs-kpi-body">
+                        <div class="cs-kpi-value">{{ $kpiTaux }}%</div>
+                        <div class="cs-kpi-label">Taux réalisation</div>
+                    </div>
+                </div>
+                <div class="cs-kpi">
+                    <div class="cs-kpi-icon"><i class="fas fa-chalkboard-teacher"></i></div>
+                    <div class="cs-kpi-body">
+                        <div class="cs-kpi-value">{{ $nbEnseignants }}</div>
+                        <div class="cs-kpi-label">Enseignants</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        @if(session('success'))
+            <div class="cs-alert cs-alert--success">
+                <i class="fas fa-check-circle"></i>{{ session('success') }}
+            </div>
+        @endif
+        @if(session('error'))
+            <div class="cs-alert cs-alert--danger">
+                <i class="fas fa-exclamation-triangle"></i>{{ session('error') }}
+            </div>
+        @endif
+
+        {{-- INFO GRID --}}
+        <div class="cs-info-grid">
+            <div class="cs-info-card">
+                <div class="cs-info-card-header">
+                    <div class="cs-info-card-icon"><i class="fas fa-info-circle"></i></div>
+                    <h3 class="cs-info-card-title">Informations générales</h3>
+                </div>
+                <div class="cs-info-list">
+                    <div class="cs-info-row">
+                        <span class="cs-info-label">Code</span>
+                        <span class="cs-info-value" style="font-family:'Courier New',monospace;">{{ $classe->code }}</span>
+                    </div>
+                    <div class="cs-info-row">
+                        <span class="cs-info-label">Filière</span>
+                        <span class="cs-info-value">
+                            @if($classe->filiere)
+                                {{ $classe->filiere->name }}
+                                @if($classe->filiere->parent)<br><small style="font-weight:400;color:var(--cs-muted);">Option de {{ $classe->filiere->parent->name }}</small>@endif
+                            @else
+                                <span style="color:var(--cs-muted);">Non assignée</span>
+                            @endif
+                        </span>
+                    </div>
+                    <div class="cs-info-row">
+                        <span class="cs-info-label">Niveau</span>
+                        <span class="cs-info-value">
+                            @if($classe->niveau)
+                                {{ $classe->niveau->name }}
+                                <small style="font-weight:400;color:var(--cs-muted);display:block;">{{ $classe->niveau->type }} · Année {{ $classe->niveau->year }}</small>
+                            @else
+                                <span style="color:var(--cs-muted);">Non assigné</span>
+                            @endif
+                        </span>
+                    </div>
+                    <div class="cs-info-row">
+                        <span class="cs-info-label">Description</span>
+                        <span class="cs-info-value" style="font-weight:400;">{{ $classe->description ?: '—' }}</span>
+                    </div>
+                    <div class="cs-info-row">
+                        <span class="cs-info-label">Créée le</span>
+                        <span class="cs-info-value" style="font-weight:400;">{{ $classe->created_at->format('d/m/Y') }}</span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="cs-info-card">
+                <div class="cs-info-card-header">
+                    <div class="cs-info-card-icon"><i class="fas fa-chalkboard-teacher"></i></div>
+                    <h3 class="cs-info-card-title">Enseignants ({{ $nbEnseignants }})</h3>
+                </div>
+                <div class="cs-teachers">
+                    @if(!empty($planningMatiere['enseignants']) && $planningMatiere['enseignants']->isNotEmpty())
+                        @foreach($planningMatiere['enseignants'] as $enseignant)
+                            @php
+                                $hue = hexdec(substr(md5($enseignant['name'] ?? (string)$enseignant['id']), 0, 4)) % 360;
+                            @endphp
+                            <a href="{{ route('esbtp.enseignants.show', ['enseignant' => $enseignant['id']]) }}" class="cs-teacher-chip">
+                                <span class="cs-teacher-avatar" style="background: hsl({{ $hue }}, 55%, 45%);">{{ strtoupper(mb_substr($enseignant['name'], 0, 1)) }}</span>
+                                <span>{{ $enseignant['name'] }}</span>
+                                <span class="cs-teacher-hours">{{ number_format($enseignant['heures_realisees'], 1) }}h</span>
+                            </a>
+                        @endforeach
+                    @else
+                        <span style="color:var(--cs-muted);font-size:.85rem;">Aucun enseignant trouvé sur l'emploi du temps.</span>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        {{-- TABS Alpine --}}
+        <div class="cs-tabs"
+             x-data="{
+                tab: (location.hash && ['etudiants','matieres','heures'].includes(location.hash.slice(1))) ? location.hash.slice(1) : 'etudiants',
+                setTab(name) { this.tab = name; history.replaceState(null, '', '#' + name); }
+             }"
+             x-cloak>
+            <div class="cs-tabs-nav">
+                <button type="button" class="cs-tab" :class="{ 'cs-tab--active': tab === 'etudiants' }" @click="setTab('etudiants')">
+                    <i class="fas fa-users"></i>Étudiants
+                    <span class="cs-tab-badge">{{ $nombreEtudiants }}</span>
+                </button>
+                <button type="button" class="cs-tab" :class="{ 'cs-tab--active': tab === 'matieres' }" @click="setTab('matieres')">
+                    <i class="fas fa-book"></i>Matières
+                    <span class="cs-tab-badge">{{ $nbMatieres }}</span>
+                </button>
+                <button type="button" class="cs-tab" :class="{ 'cs-tab--active': tab === 'heures' }" @click="setTab('heures')">
+                    <i class="fas fa-chart-line"></i>Suivi des heures
+                </button>
+            </div>
+
+            {{-- TAB ÉTUDIANTS --}}
+            <div class="cs-tab-panel" x-show="tab === 'etudiants'">
+                <div class="cs-students-actions">
+                    <div class="cs-students-count">
+                        <strong id="studentCountSubtitle">{{ $nombreEtudiants }} étudiant(s)</strong> inscrit(s) dans cette classe pour l'année courante
+                    </div>
+                    <div class="cs-students-btns">
+                        @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_coordinate_academics']))
+                            <button type="button" class="cs-btn--primary" data-bs-toggle="modal" data-bs-target="#addStudentsModal">
+                                <i class="fas fa-user-plus"></i>Ajouter
+                            </button>
+                            <button type="button" class="cs-btn--ghost" data-bs-toggle="modal" data-bs-target="#removeStudentsModal">
+                                <i class="fas fa-exchange-alt"></i>Retirer / Transférer
+                            </button>
+                        @endif
+                        @if($nombreEtudiants > 0 && auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_teach', 'can_coordinate_academics']))
+                            <div class="dropdown">
+                                <button type="button" class="cs-btn--outline" data-bs-toggle="dropdown" aria-expanded="false">
+                                    <i class="fas fa-download"></i>Exporter
+                                </button>
+                                <ul class="dropdown-menu dropdown-menu-end">
+                                    <li><h6 class="dropdown-header" style="font-size:.72rem;text-transform:uppercase;color:var(--cs-muted);">Liste d'appel</h6></li>
+                                    <li><a class="dropdown-item" href="{{ route('esbtp.classes.liste-appel', ['classe' => $classe->id]) }}" target="_blank"><i class="fas fa-eye me-2"></i>Aperçu</a></li>
+                                    <li><a class="dropdown-item" href="{{ route('esbtp.classes.liste-appel.pdf', ['classe' => $classe->id]) }}"><i class="fas fa-file-pdf me-2"></i>PDF</a></li>
+                                    <li><hr class="dropdown-divider"></li>
+                                    <li><h6 class="dropdown-header" style="font-size:.72rem;text-transform:uppercase;color:var(--cs-muted);">Liste complète</h6></li>
+                                    <li><a class="dropdown-item" href="{{ route('esbtp.classes.liste-complete', ['classe' => $classe->id]) }}" target="_blank"><i class="fas fa-eye me-2"></i>Aperçu</a></li>
+                                    <li><a class="dropdown-item" href="{{ route('esbtp.classes.liste-complete.pdf', ['classe' => $classe->id]) }}"><i class="fas fa-file-pdf me-2"></i>PDF</a></li>
+                                    <li><a class="dropdown-item" href="{{ route('esbtp.classes.liste-complete.excel', ['classe' => $classe->id]) }}"><i class="fas fa-file-excel me-2"></i>Excel</a></li>
+                                </ul>
+                            </div>
+                        @endif
+                    </div>
+                </div>
+
+                <div id="studentTableContainer">
+                    @include('esbtp.classes.partials.student-table-rows', ['classe' => $classe])
+                </div>
+            </div>
+
+            {{-- TAB MATIÈRES --}}
+            <div class="cs-tab-panel" x-show="tab === 'matieres'">
+                @if(($combinationMatieres ?? collect())->isNotEmpty())
+                    <div class="cs-info-box" style="margin-top:0;margin-bottom:1rem;">
+                        <i class="fas fa-info-circle"></i>
+                        <div>
+                            Les matières affichées proviennent du catalogue configuré pour cette filière / ce niveau et sont automatiquement prises en compte pour {{ $classe->name }}.
+                        </div>
+                    </div>
+
+                    <div class="cs-matieres-grid">
+                        @foreach($combinationMatieres as $matiere)
+                            <div class="cs-matiere-card">
+                                <div class="cs-matiere-head">
+                                    <div>
+                                        <div class="cs-matiere-name">{{ $matiere->name }}</div>
+                                        <span class="cs-matiere-code">{{ $matiere->code }}</span>
+                                    </div>
+                                    <span class="cs-matiere-coef" title="Coefficient">×{{ number_format($matiere->classe_coefficient ?? $matiere->coefficient ?? $matiere->coefficient_default ?? 1, 2) }}</span>
+                                </div>
+                                @if($matiere->description)
+                                    <p class="cs-matiere-desc">{{ \Illuminate\Support\Str::limit($matiere->description, 110) }}</p>
+                                @endif
+                            </div>
+                        @endforeach
+                    </div>
+                @else
+                    <div class="cs-warn-box">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <div>
+                            Aucune matière n'est encore configurée dans le catalogue pour cette filière / ce niveau.
+                            @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school']))
+                                <br><a href="{{ route('esbtp.matieres.index') }}" style="color:#92400e;text-decoration:underline;">Compléter le paramétrage global</a>
+                                ·
+                                <a href="{{ route('esbtp.classes.matieres', ['classe' => $classe->id]) }}" style="color:#92400e;text-decoration:underline;">Ajuster pour {{ $classe->name }}</a>
+                            @endif
+                        </div>
+                    </div>
+                @endif
+            </div>
+
+            {{-- TAB HEURES --}}
+            <div class="cs-tab-panel" x-show="tab === 'heures'">
+                <div style="display:flex;justify-content:space-between;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1rem;">
+                    <div>
+                        <h4 style="margin:0;font-size:.95rem;font-weight:700;color:var(--cs-text);">Suivi des heures par matière</h4>
+                        <p style="margin:.15rem 0 0;font-size:.78rem;color:var(--cs-muted);">Heures planifiées vs réalisées — année courante</p>
+                    </div>
+                    <div class="cs-periode-toggle" id="classe-periode-form" data-url="{{ route('esbtp.classes.show', ['classe' => $classe->id]) }}">
+                        <button type="button" class="cs-periode-btn periode-btn {{ ($periode ?? 'annee') === 'semestre1' ? 'active' : '' }}" data-periode="semestre1">Semestre 1</button>
+                        <button type="button" class="cs-periode-btn periode-btn {{ ($periode ?? 'annee') === 'semestre2' ? 'active' : '' }}" data-periode="semestre2">Semestre 2</button>
+                        <button type="button" class="cs-periode-btn periode-btn {{ ($periode ?? 'annee') === 'annee' ? 'active' : '' }}" data-periode="annee">Année</button>
+                    </div>
+                </div>
+
+                <div id="classe-planning-content">
+                    @php
+                        $kpiTauxColor = $kpiTaux >= 70 ? 'var(--cs-success)' : ($kpiTaux >= 30 ? 'var(--cs-warn)' : 'var(--cs-danger)');
+                    @endphp
+
+                    <div class="cs-planning-kpis">
+                        <div class="cs-planning-kpi" style="--kpi-color: var(--cs-primary);">
+                            <div class="cs-planning-kpi-icon"><i class="fas fa-calendar-alt"></i></div>
+                            <div class="cs-planning-kpi-value">{{ number_format($planningMatiere['stats']['heures_planifiees'] ?? 0, 1) }}h</div>
+                            <div class="cs-planning-kpi-label">Planifiées</div>
+                        </div>
+                        <div class="cs-planning-kpi" style="--kpi-color: var(--cs-success);">
+                            <div class="cs-planning-kpi-icon"><i class="fas fa-check-circle"></i></div>
+                            <div class="cs-planning-kpi-value">{{ number_format($planningMatiere['stats']['heures_realisees'] ?? 0, 1) }}h</div>
+                            <div class="cs-planning-kpi-label">Réalisées</div>
+                        </div>
+                        <div class="cs-planning-kpi" style="--kpi-color: var(--cs-accent);">
+                            <div class="cs-planning-kpi-icon"><i class="fas fa-layer-group"></i></div>
+                            <div class="cs-planning-kpi-value">{{ $planningMatiere['stats']['nb_seances'] ?? 0 }}</div>
+                            <div class="cs-planning-kpi-label">Séances</div>
+                        </div>
+                        <div class="cs-planning-kpi" style="--kpi-color: {{ $kpiTauxColor }};">
+                            <div class="cs-planning-kpi-icon"><i class="fas fa-chart-pie"></i></div>
+                            <div class="cs-planning-kpi-value" style="color: {{ $kpiTauxColor }};">{{ $kpiTaux }}%</div>
+                            <div class="cs-planning-kpi-label">Taux</div>
+                        </div>
+                    </div>
+
+                    @if(!empty($planningMatiere['matieres']) && $planningMatiere['matieres']->isNotEmpty())
+                        @foreach($planningMatiere['matieres'] as $item)
+                            @php
+                                $pct = min($item['pourcentage_realise'] ?? 0, 100);
+                                $barLevel = $pct >= 100 ? 'done' : ($pct >= 70 ? 'good' : ($pct >= 30 ? 'mid' : 'low'));
+                                $badgeBg = $pct >= 100 ? 'var(--cs-success)' : ($pct >= 70 ? 'var(--cs-primary)' : ($pct >= 30 ? 'var(--cs-warn)' : 'var(--cs-danger)'));
+                            @endphp
+                            <div class="cs-subject-card">
+                                <div>
+                                    <div>
+                                        <span class="cs-subject-name">{{ $item['matiere']->name ?? 'Matière inconnue' }}</span>
+                                        @if(!empty($item['matiere']->code))
+                                            <span class="cs-subject-code">{{ $item['matiere']->code }}</span>
+                                        @endif
+                                        @if(!$item['est_configure'])
+                                            <span style="background:#fef3c7;color:#92400e;font-size:.68rem;font-weight:700;padding:.15rem .4rem;border-radius:5px;margin-left:.4rem;">Non configuré</span>
+                                        @endif
+                                    </div>
+                                    <div class="cs-teachers" style="margin-top:.6rem;">
+                                        @if(isset($item['enseignants']) && $item['enseignants']->isNotEmpty())
+                                            @foreach($item['enseignants'] as $ens)
+                                                @php $ensHue = hexdec(substr(md5($ens['name'] ?? (string)$ens['id']), 0, 4)) % 360; @endphp
+                                                <a href="{{ route('esbtp.enseignants.show', ['enseignant' => $ens['id']]) }}" class="cs-teacher-chip">
+                                                    <span class="cs-teacher-avatar" style="background: hsl({{ $ensHue }}, 55%, 45%);">{{ strtoupper(mb_substr($ens['name'], 0, 1)) }}</span>
+                                                    <span>{{ $ens['name'] }}</span>
+                                                    <span class="cs-teacher-hours">{{ number_format($ens['heures_realisees'], 1) }}h</span>
+                                                </a>
+                                            @endforeach
+                                        @else
+                                            <span style="color:var(--cs-muted);font-size:.78rem;">Aucun enseignant assigné</span>
+                                        @endif
+                                    </div>
+                                </div>
+                                <div>
+                                    <div style="display:flex;align-items:baseline;gap:.4rem;flex-wrap:wrap;">
+                                        <span style="font-size:1.35rem;font-weight:800;color:var(--cs-text);">{{ number_format($item['heures_realisees'], 1) }}h</span>
+                                        <span style="font-size:.78rem;color:var(--cs-muted);">réalisées /</span>
+                                        <span style="font-size:.92rem;font-weight:600;color:var(--cs-muted);">{{ number_format($item['heures_planifiees'], 1) }}h</span>
+                                    </div>
+                                    <div class="cs-progress-track">
+                                        <div class="cs-progress-fill cs-progress-fill--{{ $barLevel }}" style="width:{{ $pct }}%"></div>
+                                    </div>
+                                    <div style="display:flex;justify-content:space-between;align-items:center;margin-top:.3rem;">
+                                        <small style="color:var(--cs-muted);font-size:.72rem;">
+                                            <i class="fas fa-clock"></i> {{ number_format($item['heures_restantes'], 1) }}h restantes · {{ $item['nb_seances'] }} séances
+                                        </small>
+                                        <span class="cs-percent-badge" style="background:color-mix(in srgb, {{ $badgeBg }} 18%, transparent);color:{{ $badgeBg }};border:1px solid color-mix(in srgb, {{ $badgeBg }} 40%, transparent);">{{ $pct }}%</span>
+                                    </div>
+                                </div>
+                            </div>
+                        @endforeach
+                    @else
+                        <div class="cs-empty">
+                            <div class="cs-empty-icon"><i class="fas fa-calendar-times"></i></div>
+                            <div class="cs-empty-title">Aucune donnée d'emploi du temps</div>
+                            <div class="cs-empty-text">Aucune séance trouvée pour cette classe sur la période sélectionnée.</div>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- MODAL AJOUTER ÉTUDIANTS --}}
+<div class="modal fade" id="addStudentsModal" tabindex="-1" aria-labelledby="addStudentsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header cs-modal-header">
+                <h5 class="modal-title" id="addStudentsModalLabel">
+                    <i class="fas fa-user-plus me-2"></i>Ajouter des étudiants à {{ $classe->name }}
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3">
+                    <div class="input-group">
+                        <span class="input-group-text"><i class="fas fa-search"></i></span>
+                        <input type="text" id="addStudentSearchInput" class="form-control" placeholder="Rechercher par nom, matricule, téléphone...">
+                    </div>
+                    <small class="text-muted">Recherche parmi les étudiants inscrits cette année mais pas dans cette classe.</small>
+                </div>
+                <div class="mb-3 p-2" style="background:var(--cs-surface);border-radius:8px;min-height:36px;" id="addSelectedTags">
+                    <span class="text-muted">Aucun étudiant sélectionné</span>
+                </div>
+                <div id="addSearchLoading" style="display:none;" class="text-center py-3">
+                    <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
+                    <span class="ms-2 text-muted">Recherche en cours...</span>
+                </div>
+                <div class="list-group" id="addSearchResults" style="max-height:400px;overflow-y:auto;"></div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary" id="addSubmitBtn" disabled>
+                    <i class="fas fa-plus me-1"></i>Ajouter <span class="badge bg-light text-primary" id="addSelectedCount">0</span> étudiant(s)
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- MODAL RETIRER / TRANSFÉRER --}}
+<div class="modal fade" id="removeStudentsModal" tabindex="-1" aria-labelledby="removeStudentsModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header cs-modal-header">
+                <h5 class="modal-title" id="removeStudentsModalLabel">
+                    <i class="fas fa-exchange-alt me-2"></i>Retirer / Transférer des étudiants
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body">
+                <div class="mb-3 p-3" style="background:var(--cs-surface);border:1px solid var(--cs-border);border-radius:10px;">
+                    <label for="destinationClasseId" class="form-label fw-bold">
+                        <i class="fas fa-exchange-alt me-1 text-primary"></i>Classe de destination
+                    </label>
+                    <select id="destinationClasseId" class="form-select">
+                        <option value="">-- Non affecté (retirer sans transférer) --</option>
+                        @isset($autresClasses)
+                            @php
+                                $grouped = $autresClasses->groupBy(function($c) {
+                                    return optional($c->filiere)->name ?? 'Sans filière';
+                                });
+                            @endphp
+                            @foreach($grouped as $filiereName => $classes)
+                                <optgroup label="{{ $filiereName }}">
+                                    @foreach($classes as $autreClasse)
+                                        <option value="{{ $autreClasse->id }}">
+                                            {{ $autreClasse->name }} ({{ optional($autreClasse->niveau)->name ?? '' }})
+                                        </option>
+                                    @endforeach
+                                </optgroup>
+                            @endforeach
+                        @endisset
+                    </select>
+                    <small class="text-muted mt-1 d-block">
+                        <i class="fas fa-info-circle me-1"></i>Si aucune classe n'est sélectionnée, les étudiants seront marqués « non affectés ».
+                    </small>
+                </div>
+
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="removeSelectAll">
+                        <label class="form-check-label fw-bold" for="removeSelectAll">Tout sélectionner</label>
+                    </div>
+                    <div style="width:250px;">
+                        <input type="text" id="removeSearchInput" class="form-control form-control-sm" placeholder="Filtrer la liste...">
+                    </div>
+                </div>
+
+                <div class="list-group" id="removeStudentsList" style="max-height:400px;overflow-y:auto;">
+                    <div class="text-muted text-center py-3">Chargement...</div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary" id="removeSubmitBtn" disabled>
+                    <i class="fas fa-exchange-alt me-1"></i>Retirer / Transférer <span class="badge bg-light text-primary" id="removeSelectedCount">0</span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+{{-- MODAL CONFIRMATION (bouton rouge outline — Q3a a11y) --}}
+<div class="modal fade" id="removeConfirmModal" tabindex="-1" aria-labelledby="removeConfirmModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header cs-modal-header">
+                <h5 class="modal-title" id="removeConfirmModalLabel">
+                    <i class="fas fa-exclamation-triangle me-2"></i>Confirmation requise
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body" id="removeConfirmBody"></div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-outline-danger" id="removeConfirmBtn">
+                    <i class="fas fa-archive me-1"></i>Confirmer
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@include('esbtp.classes.partials.year-change-modal')
+
 @endsection
 
 @push('scripts')
 <script>
+// Planning toggle S1/S2/Année
 document.addEventListener('DOMContentLoaded', () => {
     const container = document.getElementById('classe-periode-form');
     const content = document.getElementById('classe-planning-content');
-    if (!container || !content) {
-        return;
-    }
+    if (!container || !content) return;
 
     const fetchPlanning = (periode) => {
         const baseUrl = container.dataset.url;
@@ -314,21 +944,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 const parser = new DOMParser();
                 const doc = parser.parseFromString(html, 'text/html');
                 const nextContent = doc.querySelector('#classe-planning-content');
-                if (nextContent) {
-                    content.innerHTML = nextContent.innerHTML;
-                }
-                window.history.replaceState({}, '', url.toString());
+                if (nextContent) content.innerHTML = nextContent.innerHTML;
+                const urlObj = new URL(window.location.href);
+                urlObj.searchParams.set('periode', periode);
+                urlObj.hash = 'heures';
+                window.history.replaceState({}, '', urlObj.toString());
             })
-            .catch(() => {
-                window.location.href = url.toString();
-            });
+            .catch(() => { window.location.href = url.toString(); });
     };
 
     container.addEventListener('click', (event) => {
         const button = event.target.closest('.periode-btn');
-        if (!button) {
-            return;
-        }
+        if (!button) return;
         event.preventDefault();
         event.stopPropagation();
         container.querySelectorAll('.periode-btn').forEach(btn => btn.classList.remove('active'));
@@ -336,1259 +963,418 @@ document.addEventListener('DOMContentLoaded', () => {
         fetchPlanning(button.dataset.periode);
     });
 });
+
+function showYearChangeInfo() {
+    const el = document.getElementById('yearChangeModal');
+    if (el) bootstrap.Modal.getOrCreateInstance(el).show();
+}
+
+function showNotification(type, message) {
+    const cls = type === 'success' ? 'cs-alert--success' : 'cs-alert--danger';
+    const icon = type === 'success' ? 'check-circle' : 'exclamation-circle';
+    const el = document.createElement('div');
+    el.className = 'cs-alert ' + cls;
+    el.style.cssText = 'position:fixed;top:20px;right:20px;z-index:9999;min-width:300px;max-width:500px;box-shadow:0 4px 12px rgba(0,0,0,.15);';
+    el.innerHTML = '<i class="fas fa-' + icon + '"></i><span>' + message + '</span>';
+    document.body.appendChild(el);
+    setTimeout(() => { el.remove(); }, 5000);
+}
 </script>
-@endpush
 
-@section('content')
-<div class="dashboard-acasi">
-    <div class="main-content">
-        <!-- Header Section -->
-        <div class="dashboard-header">
-            <div class="header-left">
-                <h1><i class="fas fa-chalkboard-teacher me-2"></i>Détails de la classe</h1>
-                <p class="header-subtitle">{{ $classe->name }}</p>
-            </div>
-            <div class="header-actions">
-                @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_coordinate_academics']))
-                <a href="{{ route('esbtp.classes.matieres', ['classe' => $classe->id]) }}" class="btn-acasi primary">
-                    <i class="fas fa-book"></i>Gérer les matières
-                </a>
-                @endif
-
-                @if(auth()->user()->can('access_admin'))
-                {{-- Lien "Modifier" avec return_url vers show actuelle --}}
-                <a href="{{ route('esbtp.classes.edit', array_merge(['classe' => $classe->id], ['return_url' => request()->fullUrl()])) }}" class="btn-acasi warning">
-                    <i class="fas fa-edit"></i>Modifier
-                </a>
-                @endif
-
-                {{-- Bouton "Retour à la liste" avec préservation des filtres si présents dans l'URL --}}
-                @php
-                    $queryParams = request()->query();
-                    // Retirer le paramètre 'classe' si présent
-                    unset($queryParams['classe']);
-                    $returnToIndexUrl = route('esbtp.classes.index', $queryParams);
-                @endphp
-                <a href="{{ $returnToIndexUrl }}" class="btn-acasi secondary">
-                    <i class="fas fa-arrow-left"></i>Retour à la liste
-                </a>
-            </div>
-        </div>
-        @if(session('success'))
-            <div class="alert alert-success alert-dismissible fade show">
-                <i class="fas fa-check-circle me-2"></i>
-                {{ session('success') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            </div>
-        @endif
-
-        @if(session('error'))
-            <div class="alert alert-danger alert-dismissible fade show">
-                <i class="fas fa-exclamation-circle me-2"></i>
-                {{ session('error') }}
-                <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-            </div>
-        @endif
-
-        <!-- Filtre année académique -->
-        <div class="main-card mb-4">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-filter"></i>
-                    Filtres d'affichage
-                </div>
-                <div class="main-card-subtitle">Année académique courante</div>
-            </div>
-            <div class="main-card-body">
-                <div class="row align-items-end">
-                    <div class="col-md-8">
-                        <label for="annee_academique" class="form-label text-muted text-uppercase" style="font-size: 12px; font-weight: 600;">Année Académique Courante</label>
-                        <select name="annee_academique" id="annee_academique" class="form-select" style="background-color: #f8f9fa; cursor: not-allowed;" disabled>
-                            <option value="{{ $anneeAcademique }}" selected>
-                                {{ $anneeAcademique }} (Année en cours)
-                            </option>
-                        </select>
-                    </div>
-                    <div class="col-md-4">
-                        <button type="button" class="btn-acasi info" onclick="showYearChangeInfo()" title="Comment changer d'année ?">
-                            <i class="fas fa-info-circle"></i>Changer d'année
-                        </button>
-                    </div>
-                </div>
-                <div class="mt-3">
-                    <small class="text-muted">
-                        <i class="fas fa-info-circle me-1"></i>
-                        Les étudiants affichés dans cette classe correspondent à l'année académique courante.
-                    </small>
-                </div>
-            </div>
-        </div>
-
-        <!-- Statistiques KPI -->
-        <div class="kpi-grid mb-4">
-            <div class="kpi-card card-moderne" style="background: white; border: 1px solid #e5e7eb;">
-                <div class="kpi-title" style="color: #000; font-weight: 600;">Capacité Total</div>
-                <div class="kpi-value" style="color: var(--primary); font-size: 2.5rem; font-weight: bold;">{{ $classe->places_totales }}</div>
-                <div class="kpi-trend" style="color: #6b7280; font-size: 0.875rem;">
-                    <i class="fas fa-users"></i>
-                    Places disponibles
-                </div>
-            </div>
-            
-            <div class="kpi-card card-moderne" style="background: white; border: 1px solid #e5e7eb;">
-                <div class="kpi-title" style="color: #000; font-weight: 600;">Étudiants Inscrits</div>
-                <div class="kpi-value" style="color: var(--primary); font-size: 2.5rem; font-weight: bold;">{{ $classe->etudiants->count() }}</div>
-                <div class="kpi-trend" style="color: #6b7280; font-size: 0.875rem;">
-                    <i class="fas fa-user-graduate"></i>
-                    Année courante
-                </div>
-            </div>
-
-            <div class="kpi-card card-moderne" style="background: white; border: 1px solid #e5e7eb;">
-                <div class="kpi-title" style="color: #000; font-weight: 600;">Taux d'Occupation</div>
-                @php
-                    $nombreEtudiants = $classe->etudiants->count();
-                    $pourcentage = $classe->places_totales > 0 ? round(($nombreEtudiants / $classe->places_totales) * 100, 1) : 0;
-                    $placesLibres = max(0, $classe->places_totales - $nombreEtudiants);
-                @endphp
-                <div class="kpi-value" style="color: var(--primary); font-size: 2.5rem; font-weight: bold;">{{ $pourcentage }}%</div>
-                <div class="kpi-trend" style="color: #6b7280; font-size: 0.875rem;">
-                    <i class="fas fa-chart-pie"></i>
-                    {{ $placesLibres }} places libres
-                </div>
-            </div>
-        </div>
-
-        <!-- Informations de la classe -->
-        <div class="main-card mb-4">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-info-circle"></i>
-                    Informations générales
-                </div>
-                <div class="main-card-subtitle">Détails et caractéristiques de la classe</div>
-            </div>
-            <div class="main-card-body">
-                <div class="row">
-                    <div class="col-md-6">
-                        <table class="table table-hover align-middle mb-0">
-                            <tr>
-                                <th style="width: 30%">Code</th>
-                                <td>{{ $classe->code }}</td>
-                            </tr>
-                            <tr>
-                                <th>Nom</th>
-                                <td>{{ $classe->name }}</td>
-                            </tr>
-                            <tr>
-                                <th>Filière</th>
-                                <td>
-                                    @if ($classe->filiere)
-                                        {{ $classe->filiere->name }}
-                                        @if ($classe->filiere->parent)
-                                            <br><small class="text-muted">Option de {{ $classe->filiere->parent->name }}</small>
-                                        @endif
-                                    @else
-                                        <span class="text-muted">Non assignée</span>
-                                    @endif
-                                </td>
-                            </tr>
-                            <tr>
-                                <th>Niveau d'études</th>
-                                <td>
-                                    @if ($classe->niveau)
-                                        {{ $classe->niveau->name }} ({{ $classe->niveau->type }} - Année {{ $classe->niveau->year }})
-                                    @else
-                                        <span class="text-muted">Non assigné</span>
-                                    @endif
-                                </td>
-                            </tr>
-                            <tr>
-                                <th>Statut</th>
-                                <td>
-                                    @if ($classe->is_active)
-                                        <span class="badge bg-success px-3 py-2">Active</span>
-                                    @else
-                                        <span class="badge bg-danger px-3 py-2">Inactive</span>
-                                    @endif
-                                </td>
-                            </tr>
-                            <tr>
-                                <th>Description</th>
-                                <td>{{ $classe->description ?: 'Aucune description' }}</td>
-                            </tr>
-                        </table>
-                    </div>
-                    <div class="col-md-6">
-                        <div class="alert alert-info">
-                            <h6><i class="fas fa-info-circle me-2"></i>Informations Complémentaires</h6>
-                            <ul class="mb-0">
-                                <li><strong>Code classe :</strong> {{ $classe->code }}</li>
-                                <li><strong>Création :</strong> {{ $classe->created_at->format('d/m/Y') }}</li>
-                                <li><strong>Dernière modification :</strong> {{ $classe->updated_at->format('d/m/Y') }}</li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Matières enseignées -->
-        <div class="main-card mb-4">
-            <div class="main-card-header d-flex align-items-start justify-content-between">
-                <div>
-                    <div class="main-card-title">
-                        <i class="fas fa-book"></i>
-                        Matières prévues pour cette formation
-                    </div>
-                    <div class="main-card-subtitle">
-                        Synthèse des matières du catalogue rattachées à {{ optional($classe->filiere)->name ?? 'cette filière' }} / {{ optional($classe->niveau)->name ?? 'ce niveau' }}
-                    </div>
-                </div>
-                <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-1"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#classeMatieresCollapse"
-                        aria-expanded="true"
-                        aria-controls="classeMatieresCollapse">
-                    <i class="fas fa-chevron-up"></i>
-                </button>
-            </div>
-            <div id="classeMatieresCollapse" class="collapse show">
-                <div class="main-card-body">
-                @if($combinationMatieres->isNotEmpty())
-                    <div class="alert alert-info d-flex justify-content-between align-items-center">
-                        <div>
-                            <i class="fas fa-info-circle me-2"></i>
-                            Les matières affichées proviennent du catalogue configuré pour cette filière / ce niveau et sont automatiquement prises en compte pour {{ $classe->name }}.
-                        </div>
-                        @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_coordinate_academics']))
-                            <a href="{{ route('esbtp.classes.matieres', ['classe' => $classe->id]) }}" class="btn btn-outline-primary btn-sm">
-                                <i class="fas fa-sliders-h me-1"></i>Gérer les matières de la classe
-                            </a>
-                        @endif
-                    </div>
-
-                    <div class="table-responsive">
-                        <table class="table table-hover align-middle mb-0">
-                            <thead class="bg-light">
-                                <tr>
-                                    <th>Code</th>
-                                    <th>Matière</th>
-                                    <th>Coefficient catalogue</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach($combinationMatieres as $matiere)
-                                    <tr>
-                                        <td>{{ $matiere->code }}</td>
-                                        <td>
-                                            <div class="fw-semibold">{{ $matiere->name }}</div>
-                                            @if($matiere->description)
-                                                <small class="text-muted">{{ \Illuminate\Support\Str::limit($matiere->description, 90) }}</small>
-                                            @endif
-                                        </td>
-                                        <td class="text-center">
-                                            <span class="badge bg-primary">
-                                                {{ number_format($matiere->classe_coefficient ?? $matiere->coefficient ?? $matiere->coefficient_default ?? 1, 2) }}
-                                            </span>
-                                        </td>
-                                    </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    </div>
-                @else
-                    <div class="alert alert-warning mb-0">
-                        <i class="fas fa-exclamation-triangle me-2"></i>Aucune matière n'est encore configurée dans le catalogue pour cette filière / ce niveau.
-                        @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school']))
-                            <a href="{{ route('esbtp.matieres.index') }}" class="alert-link">Compléter le paramétrage global</a>
-                            <span class="mx-1">·</span>
-                            <a href="{{ route('esbtp.classes.matieres', ['classe' => $classe->id]) }}" class="alert-link">Ajuster pour {{ $classe->name }}</a>
-                        @else
-                            <a href="{{ route('esbtp.classes.matieres', ['classe' => $classe->id]) }}" class="alert-link">Gérer les matières de {{ $classe->name }}</a>
-                        @endif
-                    </div>
-                @endif
-            </div>
-            </div>
-        </div>
-
-        <!-- Suivi des heures par matière (emploi du temps) -->
-        <div class="main-card mb-4">
-            <div class="main-card-header d-flex align-items-start justify-content-between">
-                <div>
-                    <div class="main-card-title">
-                        <i class="fas fa-chart-line"></i>
-                        Suivi des heures par matière
-                    </div>
-                    <div class="main-card-subtitle">
-                        Heures planifiées vs réalisées et enseignants présents sur l'emploi du temps (année courante)
-                    </div>
-                </div>
-                <div class="d-flex align-items-center gap-2">
-                    <div class="d-flex gap-2" id="classe-periode-form" data-url="{{ route('esbtp.classes.show', ['classe' => $classe->id]) }}">
-                        <button type="button" class="btn btn-sm btn-outline-primary periode-btn {{ ($periode ?? 'annee') === 'semestre1' ? 'active' : '' }}" data-periode="semestre1">S1</button>
-                        <button type="button" class="btn btn-sm btn-outline-primary periode-btn {{ ($periode ?? 'annee') === 'semestre2' ? 'active' : '' }}" data-periode="semestre2">S2</button>
-                        <button type="button" class="btn btn-sm btn-outline-primary periode-btn {{ ($periode ?? 'annee') === 'annee' ? 'active' : '' }}" data-periode="annee">Année</button>
-                    </div>
-                    <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-1"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#classePlanningMatiereCollapse"
-                            aria-expanded="true"
-                            aria-controls="classePlanningMatiereCollapse">
-                        <i class="fas fa-chevron-up"></i>
-                    </button>
-                </div>
-            </div>
-            <div id="classePlanningMatiereCollapse" class="collapse show">
-                <div class="main-card-body" id="classe-planning-content">
-                    @php
-                        $kpiTaux = $planningMatiere['stats']['taux_realisation'] ?? 0;
-                        $kpiTauxColor = $kpiTaux >= 70 ? '#10b981' : ($kpiTaux >= 30 ? '#f59e0b' : '#ef4444');
-                        $avatarPalette = ['#0453cb','#0ea5e9','#10b981','#f59e0b','#ef4444','#06b6d4','#f97316','#14b8a6'];
-                    @endphp
-
-                    {{-- KPI SUMMARY --}}
-                    <div class="planning-kpi-grid">
-                        <div class="planning-kpi-card" style="--kpi-color: #3b82f6">
-                            <div class="planning-kpi-icon"><i class="fas fa-calendar-alt"></i></div>
-                            <div class="planning-kpi-value">{{ number_format($planningMatiere['stats']['heures_planifiees'] ?? 0, 1) }}h</div>
-                            <div class="planning-kpi-label">Heures planifiées</div>
-                        </div>
-                        <div class="planning-kpi-card" style="--kpi-color: #10b981">
-                            <div class="planning-kpi-icon"><i class="fas fa-check-circle"></i></div>
-                            <div class="planning-kpi-value">{{ number_format($planningMatiere['stats']['heures_realisees'] ?? 0, 1) }}h</div>
-                            <div class="planning-kpi-label">Heures réalisées</div>
-                        </div>
-                        <div class="planning-kpi-card" style="--kpi-color: #06b6d4">
-                            <div class="planning-kpi-icon"><i class="fas fa-layer-group"></i></div>
-                            <div class="planning-kpi-value">{{ $planningMatiere['stats']['nb_seances'] ?? 0 }}</div>
-                            <div class="planning-kpi-label">Séances</div>
-                        </div>
-                        <div class="planning-kpi-card" style="--kpi-color: {{ $kpiTauxColor }}">
-                            <div class="planning-kpi-icon"><i class="fas fa-chart-pie"></i></div>
-                            <div class="planning-kpi-value" style="color: {{ $kpiTauxColor }}">{{ $kpiTaux }}%</div>
-                            <div class="planning-kpi-label">Taux de réalisation</div>
-                        </div>
-                    </div>
-
-                    {{-- ENSEIGNANTS GLOBAUX --}}
-                    <div class="planning-teachers-section">
-                        <div class="planning-teachers-label"><i class="fas fa-chalkboard-teacher me-1"></i>Enseignants sur l'emploi du temps</div>
-                        @if(!empty($planningMatiere['enseignants']) && $planningMatiere['enseignants']->isNotEmpty())
-                            @foreach($planningMatiere['enseignants'] as $idx => $enseignant)
-                                @php $avatarColor = $avatarPalette[$idx % count($avatarPalette)]; @endphp
-                                <a href="{{ route('esbtp.enseignants.show', ['enseignant' => $enseignant['id']]) }}" class="teacher-avatar-chip">
-                                    <span class="teacher-avatar" style="background: {{ $avatarColor }}">{{ strtoupper(mb_substr($enseignant['name'], 0, 1)) }}</span>
-                                    <span>{{ $enseignant['name'] }}</span>
-                                    <span class="teacher-hours-badge">· {{ number_format($enseignant['heures_realisees'], 1) }}h / {{ $enseignant['nb_seances'] }} séances</span>
-                                </a>
-                            @endforeach
-                        @else
-                            <span class="text-muted small">Aucun enseignant trouvé sur l'emploi du temps.</span>
-                        @endif
-                    </div>
-
-                    {{-- CARDS PAR MATIÈRE --}}
-                    @if(!empty($planningMatiere['matieres']) && $planningMatiere['matieres']->isNotEmpty())
-                        @foreach($planningMatiere['matieres'] as $item)
-                            @php
-                                $pct = min($item['pourcentage_realise'] ?? 0, 100);
-                                $barLevel = $pct >= 100 ? 'level-done' : ($pct >= 70 ? 'level-good' : ($pct >= 30 ? 'level-mid' : 'level-low'));
-                                $badgeColor = $pct >= 100 ? '#3b82f6' : ($pct >= 70 ? '#10b981' : ($pct >= 30 ? '#f59e0b' : '#ef4444'));
-                            @endphp
-                            <div class="planning-subject-card">
-                                {{-- Colonne gauche : nom + code + enseignants --}}
-                                <div>
-                                    <div class="d-flex align-items-center gap-2 mb-1">
-                                        <span class="planning-subject-name">{{ $item['matiere']->name ?? 'Matière inconnue' }}</span>
-                                        @if(!empty($item['matiere']->code))
-                                            <span class="planning-subject-code">{{ $item['matiere']->code }}</span>
-                                        @endif
-                                        @if(!$item['est_configure'])
-                                            <span class="badge bg-warning text-dark" style="font-size:.7rem">Non configuré</span>
-                                        @endif
-                                    </div>
-                                    <div class="d-flex flex-wrap gap-2 mt-3">
-                                        @if($item['enseignants']->isNotEmpty())
-                                            @foreach($item['enseignants'] as $idx2 => $ens)
-                                                @php $aColor = $avatarPalette[$idx2 % count($avatarPalette)]; @endphp
-                                                <a href="{{ route('esbtp.enseignants.show', ['enseignant' => $ens['id']]) }}" class="teacher-avatar-chip">
-                                                    <span class="teacher-avatar" style="background: {{ $aColor }}">{{ strtoupper(mb_substr($ens['name'], 0, 1)) }}</span>
-                                                    <span>{{ $ens['name'] }}</span>
-                                                    <span class="teacher-hours-badge">· {{ number_format($ens['heures_realisees'], 1) }}h</span>
-                                                </a>
-                                            @endforeach
-                                        @else
-                                            <span class="text-muted small">Aucun enseignant assigné</span>
-                                        @endif
-                                    </div>
-                                </div>
-
-                                {{-- Colonne droite : métriques + barre + badge --}}
-                                <div>
-                                    <div class="d-flex align-items-baseline gap-2 mb-1">
-                                        <span style="font-size:1.5rem;font-weight:800;color:#1e293b">{{ number_format($item['heures_realisees'], 1) }}h</span>
-                                        <span class="text-muted" style="font-size:.85rem">réalisées</span>
-                                        <span class="text-muted mx-1">/</span>
-                                        <span style="font-size:1rem;font-weight:600;color:#64748b">{{ number_format($item['heures_planifiees'], 1) }}h</span>
-                                        <span class="text-muted" style="font-size:.85rem">planifiées</span>
-                                    </div>
-                                    <div class="planning-progress-track">
-                                        <div class="planning-progress-bar {{ $barLevel }}" style="width: {{ $pct }}%"></div>
-                                    </div>
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <small class="text-muted">
-                                            <i class="fas fa-clock me-1" style="font-size:.65rem"></i>{{ number_format($item['heures_restantes'], 1) }}h restantes
-                                            &nbsp;·&nbsp;
-                                            <i class="fas fa-layer-group me-1" style="font-size:.65rem"></i>{{ $item['nb_seances'] }} séances
-                                        </small>
-                                        <span class="planning-percent-badge" style="background:{{ $badgeColor }}18; color:{{ $badgeColor }}; border: 1px solid {{ $badgeColor }}30">
-                                            {{ $pct }}%
-                                        </span>
-                                    </div>
-                                </div>
-                            </div>
-                        @endforeach
-                    @else
-                        <div class="text-center py-5">
-                            <div style="width:56px;height:56px;border-radius:16px;background:#f1f5f9;display:inline-flex;align-items:center;justify-content:center;margin-bottom:12px">
-                                <i class="fas fa-calendar-times fa-lg text-muted"></i>
-                            </div>
-                            <p class="text-muted mb-0 small">Aucune donnée d'emploi du temps trouvée pour cette classe.</p>
-                        </div>
-                    @endif
-                </div>
-            </div>
-        </div>
-
-        <!-- Liste des étudiants -->
-        <div class="main-card mb-4">
-            <div class="main-card-header d-flex align-items-start justify-content-between">
-                <div>
-                    <div class="main-card-title">
-                        <i class="fas fa-users"></i>
-                        Liste des étudiants inscrits
-                    </div>
-                    <div class="main-card-subtitle" id="studentCountSubtitle">{{ $classe->etudiants->count() }} étudiant(s) inscrit(s) dans cette classe pour l'année courante</div>
-                </div>
-                <div class="d-flex align-items-center gap-2">
-                    @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_coordinate_academics']))
-                    <button type="button" class="btn btn-sm btn-success d-inline-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#addStudentsModal" title="Ajouter des étudiants">
-                        <i class="fas fa-user-plus"></i>
-                        <span class="d-none d-md-inline">Ajouter</span>
-                    </button>
-                    <button type="button" class="btn btn-sm btn-warning d-inline-flex align-items-center gap-1" data-bs-toggle="modal" data-bs-target="#removeStudentsModal" title="Retirer / Transférer des étudiants">
-                        <i class="fas fa-user-minus"></i>
-                        <span class="d-none d-md-inline">Retirer / Transférer</span>
-                    </button>
-                    @endif
-                    <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-1"
-                            type="button"
-                            data-bs-toggle="collapse"
-                            data-bs-target="#classeEtudiantsCollapse"
-                            aria-expanded="true"
-                            aria-controls="classeEtudiantsCollapse">
-                        <i class="fas fa-chevron-up"></i>
-                    </button>
-                </div>
-            </div>
-
-            <div id="classeEtudiantsCollapse" class="collapse show">
-
-            <!-- Actions d'export -->
-            @if($classe->etudiants->count() > 0)
-            <div class="main-card-body" style="border-bottom: 1px solid #e5e7eb; background: #f8f9fa;">
-                <div class="d-flex justify-content-between align-items-center">
-                    <div>
-                        <h6 class="mb-1" style="font-weight: 600; color: #374151;">
-                            <i class="fas fa-download me-2" style="color: #0453cb;"></i>Documents d'export
-                        </h6>
-                        <p class="mb-0 text-muted" style="font-size: 0.875rem;">Générer et télécharger les listes pour cette classe</p>
-                    </div>
-                    <div class="d-flex gap-3">
-                        @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school', 'can_teach', 'can_coordinate_academics']))
-
-                        <!-- Dropdown pour Liste d'Appel -->
-                        <div class="btn-group" role="group">
-                            <button type="button" class="btn btn-outline-primary d-flex align-items-center gap-2"
-                                    style="border-color: #0453cb; color: #0453cb; font-weight: 500; padding: 0.5rem 1rem;">
-                                <i class="fas fa-clipboard-list"></i>
-                                <span>Liste d'Appel</span>
-                            </button>
-                            <button type="button" class="btn btn-outline-primary dropdown-toggle dropdown-toggle-split"
-                                    data-bs-toggle="dropdown" aria-expanded="false"
-                                    style="border-color: #0453cb; color: #0453cb;">
-                                <span class="visually-hidden">Toggle Dropdown</span>
-                            </button>
-                            <ul class="dropdown-menu" style="min-width: 180px;">
-                                <li>
-                                    <a class="dropdown-item d-flex align-items-center gap-2"
-                                       href="{{ route('esbtp.classes.liste-appel', ['classe' => $classe->id]) }}"
-                                       target="_blank">
-                                        <i class="fas fa-eye text-primary"></i>
-                                        <span>Aperçu</span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item d-flex align-items-center gap-2"
-                                       href="{{ route('esbtp.classes.liste-appel.pdf', ['classe' => $classe->id]) }}">
-                                        <i class="fas fa-file-pdf text-danger"></i>
-                                        <span>Télécharger PDF</span>
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-
-                        <!-- Dropdown pour Liste Complète -->
-                        <div class="btn-group" role="group">
-                            <button type="button" class="btn btn-outline-success d-flex align-items-center gap-2"
-                                    style="border-color: #10b981; color: #10b981; font-weight: 500; padding: 0.5rem 1rem;">
-                                <i class="fas fa-users"></i>
-                                <span>Liste Complète</span>
-                            </button>
-                            <button type="button" class="btn btn-outline-success dropdown-toggle dropdown-toggle-split"
-                                    data-bs-toggle="dropdown" aria-expanded="false"
-                                    style="border-color: #10b981; color: #10b981;">
-                                <span class="visually-hidden">Toggle Dropdown</span>
-                            </button>
-                            <ul class="dropdown-menu" style="min-width: 180px;">
-                                <li>
-                                    <a class="dropdown-item d-flex align-items-center gap-2"
-                                       href="{{ route('esbtp.classes.liste-complete', ['classe' => $classe->id]) }}"
-                                       target="_blank">
-                                        <i class="fas fa-eye text-primary"></i>
-                                        <span>Aperçu</span>
-                                    </a>
-                                </li>
-                                <li><hr class="dropdown-divider"></li>
-                                <li>
-                                    <a class="dropdown-item d-flex align-items-center gap-2"
-                                       href="{{ route('esbtp.classes.liste-complete.pdf', ['classe' => $classe->id]) }}">
-                                        <i class="fas fa-file-pdf text-danger"></i>
-                                        <span>Télécharger PDF</span>
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item d-flex align-items-center gap-2"
-                                       href="{{ route('esbtp.classes.liste-complete.excel', ['classe' => $classe->id]) }}">
-                                        <i class="fas fa-file-excel text-success"></i>
-                                        <span>Télécharger Excel</span>
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                        @endif
-                    </div>
-                </div>
-            </div>
-            @endif
-            <div class="main-card-body" id="studentTableContainer">
-                @include('esbtp.classes.partials.student-table-rows', ['classe' => $classe])
-            </div>
-            </div>
-        </div>
-    </div>
-</div>
-@endsection
-
-@push('scripts')
 <script>
-    $(document).ready(function() {
-        // Initialiser DataTables sur la table étudiants (si la librairie est chargée)
-        function initStudentDataTable() {
-            if (typeof $.fn.DataTable === 'undefined') return;
-            if ($.fn.DataTable.isDataTable('#studentsDataTable')) {
-                $('#studentsDataTable').DataTable().destroy();
-            }
-            var table = document.getElementById('studentsDataTable');
-            if (table) {
-                $('#studentsDataTable').DataTable({
-                    "responsive": true,
-                    "autoWidth": false,
-                    "language": {
-                        "url": "//cdn.datatables.net/plug-ins/1.10.22/i18n/French.json"
-                    }
-                });
-            }
+// Gestion étudiants : add / remove / transfer
+$(document).ready(function() {
+
+    function initStudentDataTable() {
+        if (typeof $.fn.DataTable === 'undefined') return;
+        if ($.fn.DataTable.isDataTable('#studentsDataTable')) {
+            $('#studentsDataTable').DataTable().destroy();
         }
-        initStudentDataTable();
+        if (document.getElementById('studentsDataTable')) {
+            $('#studentsDataTable').DataTable({
+                "responsive": true,
+                "autoWidth": false,
+                "pageLength": 25,
+                "language": { "url": "//cdn.datatables.net/plug-ins/1.10.22/i18n/French.json" }
+            });
+        }
+    }
+    initStudentDataTable();
 
-        // ==========================================
-        // RAFRAICHIR LA TABLE ÉTUDIANTS (AJAX)
-        // ==========================================
-        function refreshStudentTable() {
-            var container = document.getElementById('studentTableContainer');
-            container.style.opacity = '0.5';
+    function refreshStudentTable() {
+        const container = document.getElementById('studentTableContainer');
+        if (!container) return;
+        container.style.opacity = '0.5';
 
-            fetch("{{ route('esbtp.classes.student-table-html', ['classe' => $classe->id]) }}", {
-                headers: { 'X-Requested-With': 'XMLHttpRequest' }
-            })
-            .then(function(response) { return response.json(); })
-            .then(function(data) {
-                if (data.success) {
-                    container.innerHTML = data.html;
-                    container.style.opacity = '1';
-                    // Mettre à jour le compteur dans le header
-                    var subtitleEl = document.getElementById('studentCountSubtitle');
-                    if (subtitleEl) {
-                        subtitleEl.textContent = data.count + ' étudiant(s) inscrit(s) dans cette classe pour l\'année courante';
-                    }
-                    // Réinitialiser DataTables
-                    initStudentDataTable();
-                    // Mettre à jour la liste dans le modal Retirer
-                    refreshRemoveModalStudentList(data.html);
-                }
-            })
-            .catch(function() {
+        fetch("{{ route('esbtp.classes.student-table-html', ['classe' => $classe->id]) }}", {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success) {
+                container.innerHTML = data.html;
                 container.style.opacity = '1';
-            });
+                const subtitleEl = document.getElementById('studentCountSubtitle');
+                if (subtitleEl) subtitleEl.textContent = data.count + ' étudiant(s)';
+                initStudentDataTable();
+                refreshRemoveModalStudentList(data.html);
+            }
+        })
+        .catch(() => { container.style.opacity = '1'; });
+    }
+
+    function refreshRemoveModalStudentList(tableHtml) {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(tableHtml, 'text/html');
+        const rows = doc.querySelectorAll('tbody tr[data-etudiant-id]');
+        const listContainer = document.getElementById('removeStudentsList');
+        if (!listContainer) return;
+
+        if (rows.length === 0) {
+            listContainer.innerHTML = '<div class="text-muted text-center py-3">Aucun étudiant dans cette classe.</div>';
+            return;
         }
 
-        // Mettre à jour la liste étudiants dans le modal "Retirer"
-        function refreshRemoveModalStudentList(tableHtml) {
-            var parser = new DOMParser();
-            var doc = parser.parseFromString(tableHtml, 'text/html');
-            var rows = doc.querySelectorAll('tbody tr[data-etudiant-id]');
-            var listContainer = document.getElementById('removeStudentsList');
-            if (!listContainer) return;
+        let html = '';
+        rows.forEach(row => {
+            const id = row.getAttribute('data-etudiant-id');
+            const matricule = row.getAttribute('data-matricule') || '';
+            const nom = row.getAttribute('data-nom') || '';
+            html += '<label class="list-group-item d-flex align-items-center gap-2" style="cursor:pointer;">' +
+                '<input type="checkbox" class="form-check-input remove-student-checkbox" value="' + id + '" style="margin:0;">' +
+                '<span class="cs-matricule">' + matricule + '</span>' +
+                '<span class="fw-semibold">' + nom + '</span>' +
+                '</label>';
+        });
+        listContainer.innerHTML = html;
+        updateRemoveSelectedCount();
+    }
 
-            if (rows.length === 0) {
-                listContainer.innerHTML = '<div class="text-muted text-center py-3">Aucun étudiant dans cette classe.</div>';
+    // AJOUTER ÉTUDIANTS
+    let addSearchTimer = null;
+    const addSelectedStudents = {};
+
+    document.getElementById('addStudentSearchInput').addEventListener('input', function() {
+        clearTimeout(addSearchTimer);
+        const query = this.value;
+        addSearchTimer = setTimeout(() => searchAvailableStudents(query), 300);
+    });
+
+    function searchAvailableStudents(query) {
+        const resultsContainer = document.getElementById('addSearchResults');
+        const loadingEl = document.getElementById('addSearchLoading');
+        loadingEl.style.display = 'block';
+        resultsContainer.innerHTML = '';
+
+        fetch("{{ route('esbtp.classes.search-available-students', ['classe' => $classe->id]) }}?q=" + encodeURIComponent(query), {
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
+        })
+        .then(r => r.json())
+        .then(data => {
+            loadingEl.style.display = 'none';
+            if (!data.success) {
+                resultsContainer.innerHTML = '<div class="text-danger p-3">' + (data.message || 'Erreur') + '</div>';
                 return;
             }
-
-            var html = '';
-            rows.forEach(function(row) {
-                var id = row.getAttribute('data-etudiant-id');
-                var cells = row.querySelectorAll('td');
-                // Table layout: [0]=avatar, [1]=matricule, [2]=nom complet
-                var avatar = cells[0] ? cells[0].textContent.trim() : '';
-                var matricule = cells[1] ? cells[1].textContent.trim() : '';
-                var nom = cells[2] ? cells[2].textContent.trim() : '';
-                var isMale = cells[0] && cells[0].querySelector('.str-avatar--m');
-                var avatarClass = isMale ? 'str-avatar--m' : 'str-avatar--f';
-                html += '<label class="list-group-item d-flex align-items-center gap-2" style="cursor: pointer;">' +
-                    '<input type="checkbox" class="form-check-input remove-student-checkbox" value="' + id + '" style="margin: 0;">' +
-                    '<div class="str-avatar ' + avatarClass + '" style="width:28px;height:28px;font-size:0.7rem;">' + avatar + '</div>' +
-                    '<span class="str-matricule">' + matricule + '</span>' +
-                    '<span class="fw-semibold">' + nom + '</span>' +
+            if (data.etudiants.length === 0) {
+                resultsContainer.innerHTML = '<div class="text-muted text-center py-3"><i class="fas fa-search me-2"></i>Aucun étudiant trouvé.</div>';
+                return;
+            }
+            let html = '';
+            data.etudiants.forEach(etudiant => {
+                const isChecked = addSelectedStudents[etudiant.id] ? 'checked' : '';
+                html += '<label class="list-group-item d-flex align-items-center gap-2" style="cursor:pointer;">' +
+                    '<input type="checkbox" class="form-check-input add-student-checkbox" value="' + etudiant.id + '" ' + isChecked + ' style="margin:0;">' +
+                    '<div class="flex-grow-1">' +
+                    '<div class="d-flex align-items-center gap-2">' +
+                    '<span class="cs-matricule">' + (etudiant.matricule || 'N/A') + '</span>' +
+                    '<strong>' + etudiant.nom_complet + '</strong>' +
+                    '</div>' +
+                    '<small class="text-muted">Classe actuelle : ' + etudiant.classe_actuelle + '</small>' +
+                    '</div>' +
                     '</label>';
             });
-            listContainer.innerHTML = html;
-            updateRemoveSelectedCount();
-        }
-
-        // ==========================================
-        // MODAL AJOUTER ÉTUDIANTS
-        // ==========================================
-        var addSearchTimer = null;
-        var addSelectedStudents = {};
-
-        // Recherche avec debounce
-        document.getElementById('addStudentSearchInput').addEventListener('input', function() {
-            clearTimeout(addSearchTimer);
-            var query = this.value;
-            addSearchTimer = setTimeout(function() {
-                searchAvailableStudents(query);
-            }, 300);
+            resultsContainer.innerHTML = html;
+        })
+        .catch(() => {
+            loadingEl.style.display = 'none';
+            resultsContainer.innerHTML = '<div class="text-danger p-3">Erreur de connexion.</div>';
         });
+    }
 
-        function searchAvailableStudents(query) {
-            var resultsContainer = document.getElementById('addSearchResults');
-            var loadingEl = document.getElementById('addSearchLoading');
-            loadingEl.style.display = 'block';
-            resultsContainer.innerHTML = '';
-
-            var url = "{{ route('esbtp.classes.search-available-students', ['classe' => $classe->id]) }}?q=" + encodeURIComponent(query);
-
-            fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } })
-            .then(function(response) { return response.json(); })
-            .then(function(data) {
-                loadingEl.style.display = 'none';
-                if (!data.success) {
-                    resultsContainer.innerHTML = '<div class="text-danger p-3">' + (data.message || 'Erreur') + '</div>';
-                    return;
-                }
-                if (data.etudiants.length === 0) {
-                    resultsContainer.innerHTML = '<div class="text-muted text-center py-3"><i class="fas fa-search me-2"></i>Aucun étudiant trouvé.</div>';
-                    return;
-                }
-                var html = '';
-                data.etudiants.forEach(function(etudiant) {
-                    var isChecked = addSelectedStudents[etudiant.id] ? 'checked' : '';
-                    html += '<label class="list-group-item d-flex align-items-center gap-2" style="cursor: pointer;">' +
-                        '<input type="checkbox" class="form-check-input add-student-checkbox" value="' + etudiant.id + '" ' + isChecked + ' style="margin: 0;">' +
-                        '<div class="flex-grow-1">' +
-                        '<div class="d-flex align-items-center gap-2">' +
-                        '<span class="badge bg-light text-dark" style="font-family: monospace; font-size: 0.8rem;">' + (etudiant.matricule || 'N/A') + '</span>' +
-                        '<strong>' + etudiant.nom_complet + '</strong>' +
-                        '</div>' +
-                        '<small class="text-muted">Classe actuelle : ' + etudiant.classe_actuelle + '</small>' +
-                        '</div>' +
-                        '</label>';
-                });
-                resultsContainer.innerHTML = html;
-            })
-            .catch(function() {
-                loadingEl.style.display = 'none';
-                resultsContainer.innerHTML = '<div class="text-danger p-3">Erreur de connexion.</div>';
-            });
-        }
-
-        // Gérer la sélection/désélection
-        document.getElementById('addSearchResults').addEventListener('change', function(e) {
-            if (e.target.classList.contains('add-student-checkbox')) {
-                var id = e.target.value;
-                var label = e.target.closest('label');
-                var nameEl = label.querySelector('strong');
-                if (e.target.checked) {
-                    addSelectedStudents[id] = nameEl ? nameEl.textContent : 'Étudiant ' + id;
-                } else {
-                    delete addSelectedStudents[id];
-                }
-                updateAddSelectedCount();
-            }
-        });
-
-        function updateAddSelectedCount() {
-            var count = Object.keys(addSelectedStudents).length;
-            var el = document.getElementById('addSelectedCount');
-            if (el) el.textContent = count;
-            document.getElementById('addSubmitBtn').disabled = count === 0;
-
-            // Mettre à jour le tag area
-            var tagsContainer = document.getElementById('addSelectedTags');
-            if (count === 0) {
-                tagsContainer.innerHTML = '<span class="text-muted">Aucun étudiant sélectionné</span>';
+    document.getElementById('addSearchResults').addEventListener('change', function(e) {
+        if (e.target.classList.contains('add-student-checkbox')) {
+            const id = e.target.value;
+            const label = e.target.closest('label');
+            const nameEl = label.querySelector('strong');
+            if (e.target.checked) {
+                addSelectedStudents[id] = nameEl ? nameEl.textContent : 'Étudiant ' + id;
             } else {
-                var html = '';
-                for (var id in addSelectedStudents) {
-                    html += '<span class="badge bg-primary me-1 mb-1" style="font-size: 0.8rem;">' +
-                        addSelectedStudents[id] +
-                        ' <i class="fas fa-times ms-1" style="cursor:pointer;" data-remove-id="' + id + '"></i>' +
-                        '</span>';
-                }
-                tagsContainer.innerHTML = html;
-            }
-        }
-
-        // Supprimer un tag
-        document.getElementById('addSelectedTags').addEventListener('click', function(e) {
-            var removeBtn = e.target.closest('[data-remove-id]');
-            if (removeBtn) {
-                var id = removeBtn.getAttribute('data-remove-id');
                 delete addSelectedStudents[id];
-                // Décocher la checkbox si visible
-                var checkbox = document.querySelector('.add-student-checkbox[value="' + id + '"]');
-                if (checkbox) checkbox.checked = false;
-                updateAddSelectedCount();
             }
-        });
-
-        // Soumettre l'ajout
-        document.getElementById('addSubmitBtn').addEventListener('click', function() {
-            var ids = Object.keys(addSelectedStudents).map(Number);
-            if (ids.length === 0) return;
-
-            var btn = this;
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Ajout en cours...';
-
-            fetch("{{ route('esbtp.classes.add-students', ['classe' => $classe->id]) }}", {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-                    'X-Requested-With': 'XMLHttpRequest'
-                },
-                body: JSON.stringify({ etudiant_ids: ids })
-            })
-            .then(function(response) {
-                if (!response.ok) {
-                    return response.text().then(function(text) {
-                        try { return JSON.parse(text); } catch(e) {
-                            throw new Error('Erreur serveur (' + response.status + ')');
-                        }
-                    });
-                }
-                return response.json();
-            })
-            .then(function(data) {
-                if (data.success) {
-                    // Fermer le modal
-                    var addModal = bootstrap.Modal.getInstance(document.getElementById('addStudentsModal'));
-                    if (addModal) addModal.hide();
-                    // Réinitialiser
-                    addSelectedStudents = {};
-                    updateAddSelectedCount();
-                    document.getElementById('addStudentSearchInput').value = '';
-                    document.getElementById('addSearchResults').innerHTML = '';
-                    // Rafraîchir la table
-                    refreshStudentTable();
-                    // Notification
-                    showNotification('success', data.message);
-                } else {
-                    showNotification('danger', data.message || 'Erreur lors de l\'ajout.');
-                }
-                btn.disabled = false;
-                btn.innerHTML = '<i class="fas fa-plus me-1"></i>Ajouter <span class="badge bg-light text-success" id="addSelectedCount">0</span> étudiant(s)';
-            })
-            .catch(function(err) {
-                console.error('Erreur ajout étudiants:', err);
-                showNotification('danger', err.message || 'Erreur de connexion.');
-                btn.disabled = false;
-                btn.innerHTML = '<i class="fas fa-plus me-1"></i>Ajouter <span class="badge bg-light text-success" id="addSelectedCount">0</span> étudiant(s)';
-            });
-        });
-
-        // Charger les résultats au premier affichage du modal
-        document.getElementById('addStudentsModal').addEventListener('shown.bs.modal', function() {
-            document.getElementById('addStudentSearchInput').focus();
-            if (document.getElementById('addSearchResults').innerHTML === '') {
-                searchAvailableStudents('');
-            }
-        });
-
-        // ==========================================
-        // MODAL RETIRER / TRANSFÉRER ÉTUDIANTS
-        // ==========================================
-
-        // Charger la liste des étudiants actuels à l'ouverture du modal
-        document.getElementById('removeStudentsModal').addEventListener('shown.bs.modal', function() {
-            populateRemoveStudentsList();
-        });
-
-        function populateRemoveStudentsList() {
-            var tableRows = document.querySelectorAll('#studentTableContainer tr[data-etudiant-id]');
-            var listContainer = document.getElementById('removeStudentsList');
-
-            if (tableRows.length === 0) {
-                listContainer.innerHTML = '<div class="text-muted text-center py-3">Aucun étudiant dans cette classe.</div>';
-                return;
-            }
-
-            var html = '';
-            tableRows.forEach(function(row) {
-                var id = row.getAttribute('data-etudiant-id');
-                var cells = row.querySelectorAll('td');
-                // Table layout: [0]=avatar, [1]=matricule, [2]=nom complet
-                var avatar = cells[0] ? cells[0].textContent.trim() : '';
-                var matricule = cells[1] ? cells[1].textContent.trim() : '';
-                var nom = cells[2] ? cells[2].textContent.trim() : '';
-                var isMale = cells[0] && cells[0].querySelector('.str-avatar--m');
-                var avatarClass = isMale ? 'str-avatar--m' : 'str-avatar--f';
-                html += '<label class="list-group-item d-flex align-items-center gap-2" style="cursor: pointer;">' +
-                    '<input type="checkbox" class="form-check-input remove-student-checkbox" value="' + id + '" style="margin: 0;">' +
-                    '<div class="str-avatar ' + avatarClass + '" style="width:28px;height:28px;font-size:0.7rem;">' + avatar + '</div>' +
-                    '<span class="str-matricule">' + matricule + '</span>' +
-                    '<span class="fw-semibold">' + nom + '</span>' +
-                    '</label>';
-            });
-            listContainer.innerHTML = html;
-            updateRemoveSelectedCount();
-        }
-
-        // Sélectionner / Désélectionner tout
-        document.getElementById('removeSelectAll').addEventListener('change', function() {
-            var checkboxes = document.querySelectorAll('.remove-student-checkbox');
-            var checked = this.checked;
-            checkboxes.forEach(function(cb) { cb.checked = checked; });
-            updateRemoveSelectedCount();
-        });
-
-        // Recherche dans la liste retirer
-        document.getElementById('removeSearchInput').addEventListener('input', function() {
-            var query = this.value.toLowerCase();
-            var items = document.querySelectorAll('#removeStudentsList .list-group-item');
-            items.forEach(function(item) {
-                var text = item.textContent.toLowerCase();
-                if (text.includes(query)) {
-                    item.classList.remove('d-none');
-                } else {
-                    item.classList.add('d-none');
-                }
-            });
-        });
-
-        // Mettre à jour le compteur de sélection
-        document.getElementById('removeStudentsList').addEventListener('change', function() {
-            updateRemoveSelectedCount();
-        });
-
-        function updateRemoveSelectedCount() {
-            var count = document.querySelectorAll('.remove-student-checkbox:checked').length;
-            var el = document.getElementById('removeSelectedCount');
-            if (el) el.textContent = count;
-            var btn = document.getElementById('removeSubmitBtn');
-            if (btn) btn.disabled = count === 0;
-        }
-
-        // Soumettre le retrait/transfert — Étape 1 : vérifier les données
-        document.getElementById('removeSubmitBtn').addEventListener('click', function() {
-            var checkboxes = document.querySelectorAll('.remove-student-checkbox:checked');
-            var ids = [];
-            checkboxes.forEach(function(cb) { ids.push(parseInt(cb.value)); });
-
-            if (ids.length === 0) return;
-
-            var destinationSelect = document.getElementById('destinationClasseId');
-            var destinationClasseId = destinationSelect.value || null;
-            var destinationName = destinationClasseId
-                ? destinationSelect.options[destinationSelect.selectedIndex].text.trim()
-                : null;
-
-            var btn = this;
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Vérification...';
-
-            // Vérifier les données académiques avant transfert
-            fetch("{{ route('esbtp.classes.check-student-data', ['classe' => $classe->id]) }}", {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-                    'X-Requested-With': 'XMLHttpRequest'
-                },
-                body: JSON.stringify({ etudiant_ids: ids })
-            })
-            .then(function(r) { return r.json(); })
-            .then(function(checkData) {
-                btn.disabled = false;
-                btn.innerHTML = '<i class="fas fa-exchange-alt me-1"></i>Retirer / Transférer <span class="badge bg-light text-warning" id="removeSelectedCount">' + ids.length + '</span> étudiant(s)';
-
-                // Construire le contenu du modal de confirmation
-                showRemoveConfirmModal(checkData, ids, destinationClasseId, destinationName);
-            })
-            .catch(function(err) {
-                console.error('Erreur vérification:', err);
-                btn.disabled = false;
-                btn.innerHTML = '<i class="fas fa-exchange-alt me-1"></i>Retirer / Transférer <span class="badge bg-light text-warning" id="removeSelectedCount">' + ids.length + '</span> étudiant(s)';
-                showNotification('danger', 'Impossible de vérifier les données.');
-            });
-        });
-
-        // Étape 2 : afficher le modal de confirmation avec les données
-        function showRemoveConfirmModal(checkData, ids, destinationClasseId, destinationName) {
-            var actionText = destinationName
-                ? 'Transférer vers <strong>' + destinationName + '</strong>'
-                : 'Retirer de la classe <strong>(non affectés)</strong>';
-
-            var warningHtml = '';
-            if (checkData.has_any_data) {
-                warningHtml = '<div class="alert alert-danger d-flex align-items-start gap-2 mb-3" style="border-radius: 8px;">' +
-                    '<i class="fas fa-exclamation-triangle mt-1" style="font-size: 1.1rem;"></i>' +
-                    '<div><strong>Données académiques détectées</strong><br>' +
-                    'Les notes, résultats et bulletins de ces étudiants dans cette classe seront <strong>archivés</strong> ' +
-                    'et ne seront plus visibles dans l\'application (moyennes, classements, bulletins).</div></div>';
-            }
-
-            var tableHtml = '<table class="table table-sm mb-0" style="font-size: 0.85rem;">' +
-                '<thead><tr><th>Étudiant</th><th class="text-center">Notes</th><th class="text-center">Résultats</th><th class="text-center">Bulletins</th></tr></thead><tbody>';
-
-            checkData.students.forEach(function(s) {
-                var rowClass = s.has_data ? 'table-warning' : '';
-                tableHtml += '<tr class="' + rowClass + '">' +
-                    '<td>' + s.nom + '</td>' +
-                    '<td class="text-center">' + (s.notes_count > 0 ? '<span class="badge bg-danger">' + s.notes_count + '</span>' : '<span class="text-muted">0</span>') + '</td>' +
-                    '<td class="text-center">' + (s.resultats_count > 0 ? '<span class="badge bg-danger">' + s.resultats_count + '</span>' : '<span class="text-muted">0</span>') + '</td>' +
-                    '<td class="text-center">' + (s.bulletins_count > 0 ? '<span class="badge bg-danger">' + s.bulletins_count + '</span>' : '<span class="text-muted">0</span>') + '</td>' +
-                    '</tr>';
-            });
-            tableHtml += '</tbody></table>';
-
-            // Injecter dans le modal de confirmation
-            var confirmBody = document.getElementById('removeConfirmBody');
-            confirmBody.innerHTML =
-                '<p class="mb-2">' + actionText + ' — <strong>' + ids.length + ' étudiant(s)</strong></p>' +
-                warningHtml + tableHtml;
-
-            // Stocker les données pour la soumission
-            document.getElementById('removeConfirmBtn').dataset.ids = JSON.stringify(ids);
-            document.getElementById('removeConfirmBtn').dataset.destinationClasseId = destinationClasseId || '';
-
-            // Bouton style selon danger
-            var confirmBtn = document.getElementById('removeConfirmBtn');
-            if (checkData.has_any_data) {
-                confirmBtn.className = 'btn btn-danger';
-                confirmBtn.innerHTML = '<i class="fas fa-archive me-1"></i>Confirmer (archiver les données)';
-            } else {
-                confirmBtn.className = 'btn btn-warning';
-                confirmBtn.innerHTML = '<i class="fas fa-exchange-alt me-1"></i>Confirmer le transfert';
-            }
-
-            // Afficher le modal de confirmation
-            var confirmModal = new bootstrap.Modal(document.getElementById('removeConfirmModal'));
-            confirmModal.show();
-        }
-
-        // Étape 3 : confirmer et exécuter le retrait/transfert
-        document.getElementById('removeConfirmBtn').addEventListener('click', function() {
-            var ids = JSON.parse(this.dataset.ids);
-            var destinationClasseId = this.dataset.destinationClasseId || null;
-
-            var btn = this;
-            btn.disabled = true;
-            btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Traitement...';
-
-            var body = { etudiant_ids: ids };
-            if (destinationClasseId) {
-                body.destination_classe_id = parseInt(destinationClasseId);
-            }
-
-            fetch("{{ route('esbtp.classes.remove-students', ['classe' => $classe->id]) }}", {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
-                    'X-Requested-With': 'XMLHttpRequest'
-                },
-                body: JSON.stringify(body)
-            })
-            .then(function(response) {
-                if (!response.ok) {
-                    return response.text().then(function(text) {
-                        try { return JSON.parse(text); } catch(e) {
-                            throw new Error('Erreur serveur (' + response.status + ')');
-                        }
-                    });
-                }
-                return response.json();
-            })
-            .then(function(data) {
-                // Fermer le modal de confirmation
-                var confirmModal = bootstrap.Modal.getInstance(document.getElementById('removeConfirmModal'));
-                if (confirmModal) confirmModal.hide();
-
-                if (data.success) {
-                    // Fermer le modal retirer
-                    var removeModal = bootstrap.Modal.getInstance(document.getElementById('removeStudentsModal'));
-                    if (removeModal) removeModal.hide();
-                    // Réinitialiser
-                    document.getElementById('removeSelectAll').checked = false;
-                    document.getElementById('removeSearchInput').value = '';
-                    // Rafraîchir la table
-                    refreshStudentTable();
-                    showNotification('success', data.message);
-                } else {
-                    showNotification('danger', data.message || 'Erreur lors du retrait.');
-                }
-                btn.disabled = false;
-            })
-            .catch(function(err) {
-                console.error('Erreur retrait étudiants:', err);
-                showNotification('danger', err.message || 'Erreur de connexion.');
-                btn.disabled = false;
-            });
-        });
-
-        // ==========================================
-        // NOTIFICATION TOAST
-        // ==========================================
-        function showNotification(type, message) {
-            var alertDiv = document.createElement('div');
-            alertDiv.className = 'alert alert-' + type + ' alert-dismissible fade show';
-            alertDiv.style.cssText = 'position: fixed; top: 20px; right: 20px; z-index: 9999; min-width: 300px; max-width: 500px; box-shadow: 0 4px 12px rgba(0,0,0,0.15);';
-            alertDiv.innerHTML = '<i class="fas fa-' + (type === 'success' ? 'check-circle' : 'exclamation-circle') + ' me-2"></i>' +
-                message +
-                '<button type="button" class="btn-close" data-bs-dismiss="alert"></button>';
-            document.body.appendChild(alertDiv);
-            setTimeout(function() {
-                if (alertDiv.parentNode) {
-                    alertDiv.classList.remove('show');
-                    setTimeout(function() { alertDiv.remove(); }, 300);
-                }
-            }, 5000);
+            updateAddSelectedCount();
         }
     });
 
-    // Fonction pour afficher le modal d'information sur le changement d'année
-    function showYearChangeInfo() {
-        var el = document.getElementById('yearChangeModal');
-        if (el) {
-            bootstrap.Modal.getOrCreateInstance(el).show();
+    function updateAddSelectedCount() {
+        const count = Object.keys(addSelectedStudents).length;
+        const el = document.getElementById('addSelectedCount');
+        if (el) el.textContent = count;
+        document.getElementById('addSubmitBtn').disabled = count === 0;
+
+        const tagsContainer = document.getElementById('addSelectedTags');
+        if (count === 0) {
+            tagsContainer.innerHTML = '<span class="text-muted">Aucun étudiant sélectionné</span>';
+        } else {
+            let html = '';
+            for (const id in addSelectedStudents) {
+                html += '<span class="badge bg-primary me-1 mb-1" style="font-size:.8rem;">' +
+                    addSelectedStudents[id] +
+                    ' <i class="fas fa-times ms-1" style="cursor:pointer;" data-remove-id="' + id + '"></i>' +
+                    '</span>';
+            }
+            tagsContainer.innerHTML = html;
         }
     }
+
+    document.getElementById('addSelectedTags').addEventListener('click', function(e) {
+        const removeBtn = e.target.closest('[data-remove-id]');
+        if (removeBtn) {
+            const id = removeBtn.getAttribute('data-remove-id');
+            delete addSelectedStudents[id];
+            const checkbox = document.querySelector('.add-student-checkbox[value="' + id + '"]');
+            if (checkbox) checkbox.checked = false;
+            updateAddSelectedCount();
+        }
+    });
+
+    document.getElementById('addSubmitBtn').addEventListener('click', function() {
+        const ids = Object.keys(addSelectedStudents).map(Number);
+        if (ids.length === 0) return;
+
+        const btn = this;
+        btn.disabled = true;
+        btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Ajout en cours...';
+
+        fetch("{{ route('esbtp.classes.add-students', ['classe' => $classe->id]) }}", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: JSON.stringify({ etudiant_ids: ids })
+        })
+        .then(r => r.ok ? r.json() : r.text().then(t => { try { return JSON.parse(t); } catch(e) { throw new Error('HTTP ' + r.status); } }))
+        .then(data => {
+            if (data.success) {
+                const addModal = bootstrap.Modal.getInstance(document.getElementById('addStudentsModal'));
+                if (addModal) addModal.hide();
+                Object.keys(addSelectedStudents).forEach(k => delete addSelectedStudents[k]);
+                updateAddSelectedCount();
+                document.getElementById('addStudentSearchInput').value = '';
+                document.getElementById('addSearchResults').innerHTML = '';
+                refreshStudentTable();
+                showNotification('success', data.message);
+            } else {
+                showNotification('danger', data.message || 'Erreur lors de l\'ajout.');
+            }
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-plus me-1"></i>Ajouter <span class="badge bg-light text-primary" id="addSelectedCount">0</span> étudiant(s)';
+        })
+        .catch(err => {
+            console.error('Erreur ajout étudiants:', err);
+            showNotification('danger', err.message || 'Erreur de connexion.');
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-plus me-1"></i>Ajouter <span class="badge bg-light text-primary" id="addSelectedCount">0</span> étudiant(s)';
+        });
+    });
+
+    document.getElementById('addStudentsModal').addEventListener('shown.bs.modal', function() {
+        document.getElementById('addStudentSearchInput').focus();
+        if (document.getElementById('addSearchResults').innerHTML === '') {
+            searchAvailableStudents('');
+        }
+    });
+
+    // RETIRER / TRANSFÉRER
+    document.getElementById('removeStudentsModal').addEventListener('shown.bs.modal', function() {
+        populateRemoveStudentsList();
+    });
+
+    function populateRemoveStudentsList() {
+        const tableRows = document.querySelectorAll('#studentTableContainer tr[data-etudiant-id]');
+        const listContainer = document.getElementById('removeStudentsList');
+
+        if (tableRows.length === 0) {
+            listContainer.innerHTML = '<div class="text-muted text-center py-3">Aucun étudiant dans cette classe.</div>';
+            return;
+        }
+
+        let html = '';
+        tableRows.forEach(row => {
+            const id = row.getAttribute('data-etudiant-id');
+            const matricule = row.getAttribute('data-matricule') || '';
+            const nom = row.getAttribute('data-nom') || '';
+            html += '<label class="list-group-item d-flex align-items-center gap-2" style="cursor:pointer;">' +
+                '<input type="checkbox" class="form-check-input remove-student-checkbox" value="' + id + '" style="margin:0;">' +
+                '<span class="cs-matricule">' + matricule + '</span>' +
+                '<span class="fw-semibold">' + nom + '</span>' +
+                '</label>';
+        });
+        listContainer.innerHTML = html;
+        updateRemoveSelectedCount();
+    }
+
+    document.getElementById('removeSelectAll').addEventListener('change', function() {
+        document.querySelectorAll('.remove-student-checkbox').forEach(cb => cb.checked = this.checked);
+        updateRemoveSelectedCount();
+    });
+
+    document.getElementById('removeSearchInput').addEventListener('input', function() {
+        const query = this.value.toLowerCase();
+        document.querySelectorAll('#removeStudentsList .list-group-item').forEach(item => {
+            item.classList.toggle('d-none', !item.textContent.toLowerCase().includes(query));
+        });
+    });
+
+    document.getElementById('removeStudentsList').addEventListener('change', updateRemoveSelectedCount);
+
+    function updateRemoveSelectedCount() {
+        const count = document.querySelectorAll('.remove-student-checkbox:checked').length;
+        const el = document.getElementById('removeSelectedCount');
+        if (el) el.textContent = count;
+        const btn = document.getElementById('removeSubmitBtn');
+        if (btn) btn.disabled = count === 0;
+    }
+
+    document.getElementById('removeSubmitBtn').addEventListener('click', function() {
+        const checkboxes = document.querySelectorAll('.remove-student-checkbox:checked');
+        const ids = Array.from(checkboxes).map(cb => parseInt(cb.value));
+        if (ids.length === 0) return;
+
+        const destinationSelect = document.getElementById('destinationClasseId');
+        const destinationClasseId = destinationSelect.value || null;
+        const destinationName = destinationClasseId
+            ? destinationSelect.options[destinationSelect.selectedIndex].text.trim()
+            : null;
+
+        const btn = this;
+        btn.disabled = true;
+        btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Vérification...';
+
+        fetch("{{ route('esbtp.classes.check-student-data', ['classe' => $classe->id]) }}", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: JSON.stringify({ etudiant_ids: ids })
+        })
+        .then(r => r.json())
+        .then(checkData => {
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-exchange-alt me-1"></i>Retirer / Transférer <span class="badge bg-light text-primary" id="removeSelectedCount">' + ids.length + '</span>';
+            showRemoveConfirmModal(checkData, ids, destinationClasseId, destinationName);
+        })
+        .catch(err => {
+            console.error('Erreur vérification:', err);
+            btn.disabled = false;
+            btn.innerHTML = '<i class="fas fa-exchange-alt me-1"></i>Retirer / Transférer <span class="badge bg-light text-primary" id="removeSelectedCount">' + ids.length + '</span>';
+            showNotification('danger', 'Impossible de vérifier les données.');
+        });
+    });
+
+    function showRemoveConfirmModal(checkData, ids, destinationClasseId, destinationName) {
+        const actionText = destinationName
+            ? 'Transférer vers <strong>' + destinationName + '</strong>'
+            : 'Retirer de la classe <strong>(non affectés)</strong>';
+
+        let warningHtml = '';
+        if (checkData.has_any_data) {
+            warningHtml = '<div class="cs-warn-box" style="margin-bottom:1rem;">' +
+                '<i class="fas fa-exclamation-triangle"></i>' +
+                '<div><strong>Données académiques détectées.</strong> Les notes, résultats et bulletins de ces étudiants dans cette classe seront <strong>archivés</strong> et ne seront plus visibles (moyennes, classements, bulletins).</div>' +
+                '</div>';
+        }
+
+        let tableHtml = '<table class="table table-sm mb-0" style="font-size:.85rem;">' +
+            '<thead><tr><th>Étudiant</th><th class="text-center">Notes</th><th class="text-center">Résultats</th><th class="text-center">Bulletins</th></tr></thead><tbody>';
+
+        checkData.students.forEach(s => {
+            const rowClass = s.has_data ? 'table-warning' : '';
+            tableHtml += '<tr class="' + rowClass + '">' +
+                '<td>' + s.nom + '</td>' +
+                '<td class="text-center">' + (s.notes_count > 0 ? '<span class="badge bg-danger">' + s.notes_count + '</span>' : '<span class="text-muted">0</span>') + '</td>' +
+                '<td class="text-center">' + (s.resultats_count > 0 ? '<span class="badge bg-danger">' + s.resultats_count + '</span>' : '<span class="text-muted">0</span>') + '</td>' +
+                '<td class="text-center">' + (s.bulletins_count > 0 ? '<span class="badge bg-danger">' + s.bulletins_count + '</span>' : '<span class="text-muted">0</span>') + '</td>' +
+                '</tr>';
+        });
+        tableHtml += '</tbody></table>';
+
+        document.getElementById('removeConfirmBody').innerHTML =
+            '<p class="mb-2">' + actionText + ' — <strong>' + ids.length + ' étudiant(s)</strong></p>' +
+            warningHtml + tableHtml;
+
+        const confirmBtn = document.getElementById('removeConfirmBtn');
+        confirmBtn.dataset.ids = JSON.stringify(ids);
+        confirmBtn.dataset.destinationClasseId = destinationClasseId || '';
+
+        if (checkData.has_any_data) {
+            confirmBtn.className = 'btn btn-outline-danger';
+            confirmBtn.innerHTML = '<i class="fas fa-archive me-1"></i>Confirmer (archiver)';
+        } else {
+            confirmBtn.className = 'btn btn-primary';
+            confirmBtn.innerHTML = '<i class="fas fa-exchange-alt me-1"></i>Confirmer le transfert';
+        }
+
+        bootstrap.Modal.getOrCreateInstance(document.getElementById('removeConfirmModal')).show();
+    }
+
+    document.getElementById('removeConfirmBtn').addEventListener('click', function() {
+        const ids = JSON.parse(this.dataset.ids);
+        const destinationClasseId = this.dataset.destinationClasseId || null;
+
+        const btn = this;
+        btn.disabled = true;
+        btn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Traitement...';
+
+        const body = { etudiant_ids: ids };
+        if (destinationClasseId) body.destination_classe_id = parseInt(destinationClasseId);
+
+        fetch("{{ route('esbtp.classes.remove-students', ['classe' => $classe->id]) }}", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').content,
+                'X-Requested-With': 'XMLHttpRequest'
+            },
+            body: JSON.stringify(body)
+        })
+        .then(r => r.ok ? r.json() : r.text().then(t => { try { return JSON.parse(t); } catch(e) { throw new Error('HTTP ' + r.status); } }))
+        .then(data => {
+            const confirmModal = bootstrap.Modal.getInstance(document.getElementById('removeConfirmModal'));
+            if (confirmModal) confirmModal.hide();
+
+            if (data.success) {
+                const removeModal = bootstrap.Modal.getInstance(document.getElementById('removeStudentsModal'));
+                if (removeModal) removeModal.hide();
+                document.getElementById('removeSelectAll').checked = false;
+                document.getElementById('removeSearchInput').value = '';
+                refreshStudentTable();
+                showNotification('success', data.message);
+            } else {
+                showNotification('danger', data.message || 'Erreur lors du retrait.');
+            }
+            btn.disabled = false;
+        })
+        .catch(err => {
+            console.error('Erreur retrait étudiants:', err);
+            showNotification('danger', err.message || 'Erreur de connexion.');
+            btn.disabled = false;
+        });
+    });
+});
 </script>
-
-<!-- ==========================================
-     MODAL : AJOUTER DES ÉTUDIANTS
-     ========================================== -->
-<div class="modal fade" id="addStudentsModal" tabindex="-1" aria-labelledby="addStudentsModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-scrollable">
-        <div class="modal-content">
-            <div class="modal-header" style="background: linear-gradient(135deg, #10b981, #059669); color: white;">
-                <h5 class="modal-title" id="addStudentsModalLabel">
-                    <i class="fas fa-user-plus me-2"></i>Ajouter des étudiants à {{ $classe->name }}
-                </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
-            </div>
-            <div class="modal-body">
-                <!-- Barre de recherche -->
-                <div class="mb-3">
-                    <div class="input-group">
-                        <span class="input-group-text"><i class="fas fa-search"></i></span>
-                        <input type="text" id="addStudentSearchInput" class="form-control" placeholder="Rechercher par nom, matricule, téléphone...">
-                    </div>
-                    <small class="text-muted">Recherche parmi les étudiants inscrits cette année mais pas dans cette classe.</small>
-                </div>
-
-                <!-- Tags des étudiants sélectionnés -->
-                <div class="mb-3 p-2" style="background: #f8f9fa; border-radius: 6px; min-height: 36px;" id="addSelectedTags">
-                    <span class="text-muted">Aucun étudiant sélectionné</span>
-                </div>
-
-                <!-- Loading -->
-                <div id="addSearchLoading" style="display: none;" class="text-center py-3">
-                    <div class="spinner-border spinner-border-sm text-primary" role="status"></div>
-                    <span class="ms-2 text-muted">Recherche en cours...</span>
-                </div>
-
-                <!-- Résultats de recherche -->
-                <div class="list-group" id="addSearchResults" style="max-height: 400px; overflow-y: auto;">
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                <button type="button" class="btn btn-success" id="addSubmitBtn" disabled>
-                    <i class="fas fa-plus me-1"></i>Ajouter <span class="badge bg-light text-success" id="addSelectedCount">0</span> étudiant(s)
-                </button>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- ==========================================
-     MODAL : RETIRER / TRANSFÉRER DES ÉTUDIANTS
-     ========================================== -->
-<div class="modal fade" id="removeStudentsModal" tabindex="-1" aria-labelledby="removeStudentsModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-scrollable">
-        <div class="modal-content">
-            <div class="modal-header" style="background: linear-gradient(135deg, #f59e0b, #d97706); color: white;">
-                <h5 class="modal-title" id="removeStudentsModalLabel">
-                    <i class="fas fa-user-minus me-2"></i>Retirer / Transférer des étudiants
-                </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
-            </div>
-            <div class="modal-body">
-                <!-- Destination -->
-                <div class="mb-3 p-3" style="background: #fffbeb; border: 1px solid #fde68a; border-radius: 8px;">
-                    <label for="destinationClasseId" class="form-label fw-bold">
-                        <i class="fas fa-exchange-alt me-1 text-warning"></i>Classe de destination
-                    </label>
-                    <select id="destinationClasseId" class="form-select">
-                        <option value="">-- Non affecté (retirer sans transférer) --</option>
-                        @isset($autresClasses)
-                        @php
-                            $grouped = $autresClasses->groupBy(function($c) {
-                                return optional($c->filiere)->name ?? 'Sans filière';
-                            });
-                        @endphp
-                        @foreach($grouped as $filiereName => $classes)
-                            <optgroup label="{{ $filiereName }}">
-                                @foreach($classes as $autreClasse)
-                                    <option value="{{ $autreClasse->id }}">
-                                        {{ $autreClasse->name }} ({{ optional($autreClasse->niveau)->name ?? '' }})
-                                    </option>
-                                @endforeach
-                            </optgroup>
-                        @endforeach
-                        @endisset
-                    </select>
-                    <small class="text-muted mt-1 d-block">
-                        <i class="fas fa-info-circle me-1"></i>Si aucune classe n'est sélectionnée, les étudiants seront marqués "non affectés".
-                    </small>
-                </div>
-
-                <!-- Sélection rapide + Recherche -->
-                <div class="d-flex justify-content-between align-items-center mb-2">
-                    <div class="form-check">
-                        <input class="form-check-input" type="checkbox" id="removeSelectAll">
-                        <label class="form-check-label fw-bold" for="removeSelectAll">Tout sélectionner</label>
-                    </div>
-                    <div style="width: 250px;">
-                        <input type="text" id="removeSearchInput" class="form-control form-control-sm" placeholder="Filtrer la liste...">
-                    </div>
-                </div>
-
-                <!-- Liste des étudiants actuels -->
-                <div class="list-group" id="removeStudentsList" style="max-height: 400px; overflow-y: auto;">
-                    <div class="text-muted text-center py-3">Chargement...</div>
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                <button type="button" class="btn btn-warning" id="removeSubmitBtn" disabled>
-                    <i class="fas fa-exchange-alt me-1"></i>Retirer / Transférer <span class="badge bg-light text-warning" id="removeSelectedCount">0</span> étudiant(s)
-                </button>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- ==========================================
-     MODAL : CONFIRMATION RETRAIT/TRANSFERT
-     ========================================== -->
-<div class="modal fade" id="removeConfirmModal" tabindex="-1" aria-labelledby="removeConfirmModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header" style="background: linear-gradient(135deg, #dc2626, #b91c1c); color: white;">
-                <h5 class="modal-title" id="removeConfirmModalLabel">
-                    <i class="fas fa-exclamation-triangle me-2"></i>Confirmation requise
-                </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
-            </div>
-            <div class="modal-body" id="removeConfirmBody">
-                <!-- Contenu injecté dynamiquement par JS -->
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                <button type="button" class="btn btn-danger" id="removeConfirmBtn">
-                    <i class="fas fa-archive me-1"></i>Confirmer
-                </button>
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- Modal pour les instructions de changement d'année -->
-<div class="modal fade" id="yearChangeModal" tabindex="-1" role="dialog" aria-labelledby="yearChangeModalLabel" aria-hidden="true">
-    <div class="modal-dialog" role="document">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="yearChangeModalLabel">Comment changer l'année académique ?</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-                <p><strong>Pour consulter les données d'une autre année :</strong></p>
-                <ol style="padding-left: 20px; line-height: 1.6; margin: 15px 0;">
-                    <li><strong>Aller dans</strong> : Menu → Années Universitaires</li>
-                    <li><strong>Trouver l'année souhaitée</strong> (ex: 2023-2024)</li>
-                    <li><strong>Cliquer sur "Activer"</strong> pour la définir comme année courante</li>
-                    <li><strong>Revenir ici</strong> : Les étudiants affichés dans cette classe se mettront à jour automatiquement</li>
-                </ol>
-                <hr style="margin: 15px 0;">
-                <p style="color: #6b7280; font-size: 14px;">
-                    <i class="fas fa-info-circle"></i>
-                    <strong>Note :</strong> Seule une année peut être "courante" à la fois.
-                    Changer l'année courante affecte l'affichage des étudiants dans toute l'application.
-                </p>
-                <div style="background: #f3f4f6; padding: 12px; border-radius: 6px; margin-top: 15px;">
-                    <strong>Exemple pour cette classe :</strong><br>
-                    • Année courante = 2024-2025 → Voir {{ $classe->etudiants->count() }} étudiants<br>
-                    • Changement vers 2023-2024 → Voir les étudiants inscrits en 2023-2024
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
-                <a href="{{ route('esbtp.annees-universitaires.index') }}" target="_blank" class="btn btn-primary">
-                    <i class="fas fa-external-link-alt"></i> Aller aux Années
-                </a>
-            </div>
-        </div>
-    </div>
-</div>
-
 @endpush

--- a/resources/views/esbtp/classes/show.blade.php
+++ b/resources/views/esbtp/classes/show.blade.php
@@ -572,7 +572,13 @@
             <div class="cs-info-card">
                 <div class="cs-info-card-header">
                     <div class="cs-info-card-icon"><i class="fas fa-chalkboard-teacher"></i></div>
-                    <h3 class="cs-info-card-title">Enseignants ({{ $nbEnseignants }})</h3>
+                    <div>
+                        <h3 class="cs-info-card-title">Enseignants ({{ $nbEnseignants }})</h3>
+                        <p style="margin:.15rem 0 0;font-size:.72rem;color:var(--cs-muted);line-height:1.35;">
+                            <i class="fas fa-circle-info" style="color:var(--cs-primary);font-size:.7rem;"></i>
+                            Enseignants ayant tenu au moins une séance dans l'emploi du temps de cette classe (année courante)
+                        </p>
+                    </div>
                 </div>
                 <div class="cs-teachers">
                     @if(!empty($planningMatiere['enseignants']) && $planningMatiere['enseignants']->isNotEmpty())
@@ -587,7 +593,7 @@
                             </a>
                         @endforeach
                     @else
-                        <span style="color:var(--cs-muted);font-size:.85rem;">Aucun enseignant trouvé sur l'emploi du temps.</span>
+                        <span style="color:var(--cs-muted);font-size:.85rem;">Aucun enseignant n'a encore tenu de séance dans l'emploi du temps de cette classe.</span>
                     @endif
                 </div>
             </div>


### PR DESCRIPTION
## Résumé

Refonte complète des pages `/esbtp/classes` (index) et `/esbtp/classes/{id}` (show) selon le design system KLASSCI premium. Couvre tous les items P0 et P1 du rapport d'amélioration approuvé en plan-and-confirm.

**Résultat** : 2 fichiers de 1475+1594 lignes remplacés par du markup structuré, avec namespaces CSS dédiés (`ci-*` / `cs-*`), photos étudiants, modals monochrome, tabs Alpine, et fix du bouton "Retour à la liste" (shipped séparément dans #213).

Closes #214

## Ce qui change côté utilisateur

### Page `/esbtp/classes` (liste)

| Avant | Maintenant |
|-------|------------|
| Header basique texte noir | Hero gradient bleu avec KPIs intégrés |
| Carte "Contexte d'affichage" avec select désactivé | Chip année dans le hero + bouton info ⓘ |
| 8 boutons visibles sur chaque carte | 1 lien + menu kebab (⋮) pour actions secondaires |
| Card pas cliquable (il fallait viser l'œil) | Card entière cliquable via BS5 `.stretched-link` |
| KPIs en bas, après les filtres | 4 KPIs dans le hero (total, étudiants, places, taux) |
| Filtres en grille sur une carte séparée | Toolbar compacte sticky, recherche + chips |
| Bouton "Charger plus" basique | "Charger plus" redesigné pill style hover bleu |

### Page `/esbtp/classes/{id}` (détails)

| Avant | Maintenant |
|-------|------------|
| Header basique | Hero compact : breadcrumb, nom classe, chips filière/niveau/statut/année |
| Carte "Filtres d'affichage" inutile | Supprimée, chip année dans hero |
| 3 KPIs (capacité, étudiants, taux) | 5 KPIs (ajout matières configurées + enseignants) |
| Tout sur 1 page scrollable | 3 tabs : Étudiants / Matières / Suivi heures (URL `#etudiants`) |
| Avatars étudiants = initiales seulement | Photo étudiant si présente, fallback HSL par nom |
| Modal "Ajouter" gradient vert | Modal gradient bleu KLASSCI uniforme |
| Modal "Retirer" gradient orange | Modal gradient bleu + icône exchange |
| Modal "Confirmer archive" gradient rouge | Modal gradient bleu, bouton confirm `btn-outline-danger` |
| Palette avatar enseignants 8 couleurs | HSL monochrome par nom (pattern attendances) |
| 2 dropdowns exports séparés | 1 dropdown avec sections "Liste d'appel" / "Liste complète" |
| "Retour à la liste" → route étudiant (bug UX) | Route admin correcte (shipped en PR #213) |

### Design system respecté

- **Namespace CSS** : `ci-*` (index), `cs-*` (show) — documenté dans `.claude/rules/premium-redesign.md`
- **Monochrome bleu KLASSCI** : aucun gradient vert/orange/rouge (sauf bouton destructif avec outline-danger pour a11y, décision Q3a)
- **Hero pattern** : copié de `planning-header` (ph-*) adapté
- **Photos étudiants** : pattern identique à `attendances/partials/student-list.blade.php`

## Décisions user (plan-and-confirm)

- **Q1** — Pas d'infinite scroll, "Load more" restylé (recommandation critic + NN/g pour accessibilité)
- **Q2** — DataTables conservé sur la table étudiants (perf 3G Abidjan)
- **Q3** — Bouton `btn-outline-danger` conservé pour confirmation archivage (a11y)
- **Q4** — Fix route déjà shippé en PR #213 ✅
- **Q5** — PR workflow sur branche `feat/classes-premium-redesign`

## Fichiers modifiés

- `resources/views/esbtp/classes/index.blade.php` — rewrite (1475 → 1200 lignes)
- `resources/views/esbtp/classes/show.blade.php` — rewrite (1594 → 1300 lignes)
- `resources/views/esbtp/classes/partials/classe-card.blade.php` — rewrite (stretched-link + kebab)
- `resources/views/esbtp/classes/partials/results.blade.php` — namespace `ci-*`
- `resources/views/esbtp/classes/partials/student-table-rows.blade.php` — photos + HSL + data-*
- `resources/views/esbtp/classes/partials/year-change-modal.blade.php` — **nouveau** (extraction du dupliqué)

## Non touché (intentionnellement)

- `resources/views/esbtp/classes/student_show.blade.php` (vue étudiant read-only)
- `app/Http/Controllers/ESBTPClasseController.php` (aucune logique controller modifiée)
- Routes (fix route "Retour" déjà dans PR #213)

## Tests à faire après merge sur `presentation`

- [ ] `/esbtp/classes` se charge avec hero + 4 KPIs + toolbar + grid cards
- [ ] Filtrer par filière/niveau/statut/capacité → AJAX refresh sans reload
- [ ] Recherche texte → debounce 400ms + AJAX refresh
- [ ] Cliquer une card entière → détails (pas juste l'œil)
- [ ] Menu kebab s'ouvre, actions fonctionnent (matières, listes, modifier, archiver)
- [ ] Boutons "Nouvelle classe" et "Sync BTS/LMD" OK dans le hero
- [ ] Modal création/édition fonctionnent en AJAX (pas de reload)
- [ ] "Charger plus de classes" restylé fonctionne
- [ ] Bannière overcapacité apparaît si classes en surcapa + modal détails
- [ ] `/esbtp/classes/{id}` hero compact + 5 KPIs + 3 tabs
- [ ] Tabs Alpine : clic → change de panel + URL hash updated
- [ ] Photos étudiants affichées (fallback HSL si pas de photo)
- [ ] Modal Ajouter étudiants → recherche + tags + submit AJAX
- [ ] Modal Retirer → sélection + destination → confirm modal → archive
- [ ] Dropdown export → Liste d'appel aperçu/PDF + Liste complète aperçu/PDF/Excel
- [ ] Toggle S1/S2/Année dans tab Heures → AJAX refresh planning
- [ ] Bouton "Retour à la liste" → vers `/esbtp/classes` avec filtres préservés
- [ ] Responsive mobile : hero se reflow, grid 1 col, tabs scrollable

## Risques

- Aucun changement sur le controller ou les routes (sauf le fix déjà shippé)
- Les IDs JS ont tous été préservés (studentTableContainer, addStudentsModal, removeStudentsModal, etc.)
- Les permissions ont été préservées (access_admin, can_manage_school, can_teach, can_coordinate_academics)
- `student_show.blade.php` non touché (vue étudiant différente)
- Possible N+1 sur `\$etudiant->photo_url` (accessor fait file_exists) — acceptable pour 30-80 étudiants, à optimiser en backlog

## À vérifier en superAdmin

C'est le rôle qui révèle les doublons de sections et les leaks permissions. Tester aussi en secrétaire et coordinateur.