### PR TITLE
feat(inscriptions): redesign premium index namespace ii-* (PR1 foundation)

### DIFF
--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -1586,6 +1586,100 @@ class ESBTPInscriptionController extends Controller
     }
 
     /**
+     * Annulation groupee (bulk) d'inscriptions selectionnees.
+     */
+    public function bulkAnnuler(Request $request)
+    {
+        $request->validate([
+            "inscription_ids" => "required|array|min:1",
+            "inscription_ids.*" => "integer|exists:esbtp_inscriptions,id",
+            "motif" => "required|string|min:3|max:500",
+        ]);
+
+        $ids = $request->input("inscription_ids");
+        $motif = $request->input("motif");
+        $userId = Auth::id();
+        $successCount = 0;
+        $errors = [];
+
+        foreach ($ids as $id) {
+            try {
+                $result = $this->inscriptionService->annulerInscription($id, $motif, $userId);
+                if ($result["success"] ?? false) {
+                    $successCount++;
+                } else {
+                    $errors[$id] = $result["message"] ?? "Erreur inconnue";
+                }
+            } catch (\Exception $e) {
+                $errors[$id] = $e->getMessage();
+            }
+        }
+
+        return response()->json([
+            "success" => $successCount > 0,
+            "message" => $successCount . " inscription(s) annulee(s)." . (count($errors) > 0 ? " " . count($errors) . " echec(s)." : ""),
+            "success_count" => $successCount,
+            "error_count" => count($errors),
+            "errors" => $errors,
+            "processed_ids" => $ids,
+        ]);
+    }
+
+    /**
+     * Export CSV des inscriptions selectionnees.
+     */
+    public function bulkExport(Request $request)
+    {
+        $request->validate([
+            "inscription_ids" => "required|array|min:1",
+            "inscription_ids.*" => "integer|exists:esbtp_inscriptions,id",
+        ]);
+
+        $inscriptions = ESBTPInscription::whereIn("id", $request->input("inscription_ids"))
+            ->with(["etudiant", "filiere", "niveau", "classe", "anneeUniversitaire"])
+            ->get();
+
+        $filename = "inscriptions-export-" . now()->format("Y-m-d-His") . ".csv";
+
+        return response()->streamDownload(function () use ($inscriptions) {
+            $out = fopen("php://output", "w");
+            // BOM UTF-8 pour Excel
+            fprintf($out, chr(0xEF) . chr(0xBB) . chr(0xBF));
+            fputcsv($out, [
+                "N° Inscription",
+                "Matricule",
+                "Nom",
+                "Prenoms",
+                "Filiere",
+                "Niveau",
+                "Classe",
+                "Annee",
+                "Statut",
+                "Workflow",
+                "Date inscription",
+            ], ";");
+            foreach ($inscriptions as $ins) {
+                fputcsv($out, [
+                    $ins->numero_inscription ?? "",
+                    $ins->etudiant->matricule ?? "",
+                    $ins->etudiant->nom ?? "",
+                    $ins->etudiant->prenoms ?? "",
+                    $ins->filiere->name ?? "",
+                    $ins->niveau->name ?? "",
+                    $ins->classe->name ?? "",
+                    $ins->anneeUniversitaire->name ?? "",
+                    $ins->status ?? "",
+                    $ins->workflow_step ?? "",
+                    optional($ins->created_at)->format("d/m/Y") ?? "",
+                ], ";");
+            }
+            fclose($out);
+        }, $filename, [
+            "Content-Type" => "text/csv; charset=UTF-8",
+        ]);
+    }
+
+    /**
      * Rafraîchir une ligne d'inscription spécifique (AJAX pour mise à jour partielle)
      */
     public function refreshLigne(ESBTPInscription $inscription)

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -93,6 +93,20 @@ class ESBTPInscriptionController extends Controller
         $annee = $request->input("annee");
         $status = $request->input("status", "active");
 
+        // Tri (whitelist pour éviter SQL injection)
+        $allowedSorts = ["created_at", "date_inscription", "status", "filiere_id", "niveau_id", "nom"];
+        $sortInput = (string) $request->input("sort", "");
+        $sort = in_array($sortInput, $allowedSorts, true) ? $sortInput : "created_at";
+
+        $dirInput = strtolower((string) $request->input("dir", "desc"));
+        $dir = in_array($dirInput, ["asc", "desc"], true) ? $dirInput : "desc";
+
+        // Pagination (whitelist pour éviter DoS)
+        $allowedPerPage = [15, 25, 50, 100];
+        $perPage = in_array((int) $request->input("per_page"), $allowedPerPage, true)
+            ? (int) $request->input("per_page")
+            : 15;
+
         // Construire la requête avec les filtres
         $baseQuery = ESBTPInscription::query()->with([
             "etudiant",
@@ -135,7 +149,18 @@ class ESBTPInscriptionController extends Controller
             }
         }
 
-        $perPage = 15;
+        // Appliquer le tri (sauf pour "nom" qui nécessite un join, et si recherche active)
+        if (!$search) {
+            if ($sort === "nom") {
+                $baseQuery
+                    ->leftJoin("esbtp_etudiants", "esbtp_inscriptions.etudiant_id", "=", "esbtp_etudiants.id")
+                    ->orderBy("esbtp_etudiants.nom", $dir)
+                    ->orderBy("esbtp_etudiants.prenoms", $dir)
+                    ->select("esbtp_inscriptions.*");
+            } else {
+                $baseQuery->orderBy($sort, $dir);
+            }
+        }
 
         if ($search) {
             $inscriptions = $this->searchService->search(
@@ -147,7 +172,6 @@ class ESBTPInscriptionController extends Controller
             );
         } else {
             $inscriptions = $baseQuery
-                ->latest()
                 ->paginate($perPage)
                 ->appends($request->query());
         }
@@ -214,6 +238,9 @@ class ESBTPInscriptionController extends Controller
             return response()->json([
                 "html" => view("esbtp.inscriptions.partials.results", [
                     "inscriptions" => $inscriptions,
+                    "sort" => $sort,
+                    "dir" => $dir,
+                    "perPage" => $perPage,
                 ])->render(),
                 "url" => $request->fullUrl(),
             ]);
@@ -233,6 +260,9 @@ class ESBTPInscriptionController extends Controller
                 "status",
                 "stats",
                 "anneeEnCours",
+                "sort",
+                "dir",
+                "perPage",
             ),
         );
     }

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -1154,6 +1154,14 @@ class ESBTPInscriptionController extends Controller
 
             DB::commit();
 
+            if ($request->ajax() || $request->wantsJson()) {
+                return response()->json([
+                    "success" => true,
+                    "message" => "Inscription validée avec succès.",
+                    "inscription_id" => $inscription->id,
+                ]);
+            }
+
             // Rediriger vers la fiche étudiant si on vient de etudiants.show
             if ($request->input('redirect_to') === 'etudiant' && $inscription->etudiant_id) {
                 return redirect()
@@ -1166,6 +1174,13 @@ class ESBTPInscriptionController extends Controller
                 ->with("success", "Inscription validée avec succès.");
         } catch (\Exception $e) {
             DB::rollBack();
+
+            if ($request->ajax() || $request->wantsJson()) {
+                return response()->json([
+                    "success" => false,
+                    "message" => "Erreur lors de la validation: " . $e->getMessage(),
+                ], 422);
+            }
 
             return redirect()
                 ->back()

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -243,6 +243,8 @@ class ESBTPInscriptionController extends Controller
                     "perPage" => $perPage,
                 ])->render(),
                 "url" => $request->fullUrl(),
+                "stats" => $stats,
+                "total" => $inscriptions->total(),
             ]);
         }
 
@@ -1658,10 +1660,38 @@ class ESBTPInscriptionController extends Controller
                 "inscription" => $inscription,
             ])->render();
 
+            // Recalculer stats pour l'annee courante (meme scope que index())
+            $anneeEnCours = ESBTPAnneeUniversitaire::where("is_current", true)->first();
+            $statsQuery = ESBTPInscription::query();
+            if ($anneeEnCours) {
+                $statsQuery->where("annee_universitaire_id", $anneeEnCours->id);
+            }
+            $stats = [
+                "total" => $statsQuery->count(),
+                "actives" => (clone $statsQuery)
+                    ->where("status", "active")
+                    ->where("workflow_step", "etudiant_cree")
+                    ->count(),
+                "en_attente" => (clone $statsQuery)->where("status", "en_attente")->count(),
+                "non_validees" => (clone $statsQuery)
+                    ->where(function ($q) {
+                        $q->where("status", "en_attente")->orWhere(function ($subQ) {
+                            $subQ->where("status", "active")->where(function ($wq) {
+                                $wq->whereIn("workflow_step", ["prospect", "documents_complets", "en_validation"])
+                                    ->orWhereNull("workflow_step");
+                            });
+                        });
+                    })
+                    ->count(),
+                "annulees" => (clone $statsQuery)->where("status", "annulée")->count(),
+                "terminees" => (clone $statsQuery)->where("status", "terminée")->count(),
+            ];
+
             return response()->json([
                 "success" => true,
                 "html" => $html,
                 "inscription_id" => $inscription->id,
+                "stats" => $stats,
             ]);
         } catch (\Exception $e) {
             Log::error("Erreur refreshLigne: " . $e->getMessage(), [

--- a/app/Http/Controllers/ESBTPInscriptionPaiementController.php
+++ b/app/Http/Controllers/ESBTPInscriptionPaiementController.php
@@ -689,9 +689,36 @@ class ESBTPInscriptionPaiementController extends Controller
                 $request->notes,
             );
 
+            $message = "Souscription au frais optionnel réussie !";
+
+            // Optionnel : créer et valider immédiatement un paiement
+            if ($request->boolean("create_and_pay") && $request->input("mode_paiement")) {
+                $modeMap = [
+                    "especes" => "Espèces",
+                    "cheque" => "Chèque",
+                    "virement" => "Virement bancaire",
+                    "mobile_money" => "Mobile Money",
+                ];
+                $paiement = \App\Models\ESBTPPaiement::create([
+                    "inscription_id" => $inscription->id,
+                    "etudiant_id" => $inscription->etudiant_id,
+                    "annee_universitaire_id" => $inscription->annee_universitaire_id,
+                    "frais_category_id" => $request->frais_category_id,
+                    "montant" => $request->amount,
+                    "mode_paiement" => $modeMap[$request->mode_paiement] ?? $request->mode_paiement,
+                    "reference_paiement" => $request->reference_paiement,
+                    "date_paiement" => now(),
+                    "status" => "validé",
+                    "date_validation" => now(),
+                    "validateur_id" => Auth::id(),
+                    "created_by" => Auth::id(),
+                ]);
+                $message = "Souscription et paiement validé avec succès !";
+            }
+
             return redirect()
                 ->route("esbtp.inscriptions.show", $inscription->id)
-                ->with("success", "Souscription au frais optionnel réussie !");
+                ->with("success", $message);
         } catch (\Exception $e) {
             Log::error(
                 "Erreur lors de la souscription au frais optionnel: " .
@@ -702,7 +729,7 @@ class ESBTPInscriptionPaiementController extends Controller
                 ->back()
                 ->with(
                     "error",
-                    "Erreur lors de la souscription au frais optionnel.",
+                    "Erreur lors de la souscription au frais optionnel: " . $e->getMessage(),
                 );
         }
     }

--- a/app/View/Components/InscriptionStatusBadge.php
+++ b/app/View/Components/InscriptionStatusBadge.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\View\Components;
+
+use App\Models\ESBTPInscription;
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+/**
+ * Badge de statut d'inscription — 5 états monochrome bleu KLASSCI.
+ *
+ * Centralise la logique dupliquée 5 fois dans le projet (controller, partials,
+ * JS) pour résoudre le statut affichable depuis `status` + `workflow_step`.
+ *
+ * États retournés :
+ *  - validee    : active + workflow_step=etudiant_cree
+ *  - non_validee: active + workflow_step != etudiant_cree
+ *  - en_attente : status=en_attente OR pending
+ *  - annulee    : status=annulée OR cancelled
+ *  - terminee   : status=terminée
+ *  - inconnu    : fallback
+ *
+ * Usage :
+ *   <x-inscription-status-badge :inscription="$inscription" />
+ */
+class InscriptionStatusBadge extends Component
+{
+    public string $key;
+
+    public string $label;
+
+    public string $icon;
+
+    public string $title;
+
+    public function __construct(ESBTPInscription $inscription)
+    {
+        [$this->key, $this->label, $this->icon, $this->title] = $this->resolveStatus($inscription);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string, 3: string}
+     */
+    private function resolveStatus(ESBTPInscription $inscription): array
+    {
+        $status = (string) ($inscription->status ?? '');
+        $workflow = (string) ($inscription->workflow_step ?? '');
+
+        if (in_array($status, ['cancelled', 'annulée', 'annulee'], true)) {
+            return ['annulee', 'Annulée', 'fa-times-circle', 'Inscription annulée'];
+        }
+
+        if (in_array($status, ['terminée', 'terminee'], true)) {
+            return ['terminee', 'Terminée', 'fa-flag-checkered', 'Inscription terminée'];
+        }
+
+        if (in_array($status, ['pending', 'en_attente'], true)) {
+            return ['en_attente', 'En attente', 'fa-clock', 'En attente de validation'];
+        }
+
+        if ($status === 'active' && $workflow !== 'etudiant_cree') {
+            $workflowLabel = match ($workflow) {
+                'prospect' => 'prospect',
+                'documents_complets' => 'documents collectés',
+                'en_validation' => 'validation en cours',
+                'valide' => 'validé, étudiant non créé',
+                default => $workflow !== '' ? $workflow : 'non défini',
+            };
+
+            return [
+                'non_validee',
+                'Non validée',
+                'fa-exclamation-triangle',
+                "Étape workflow : {$workflowLabel}",
+            ];
+        }
+
+        if ($status === 'active' && $workflow === 'etudiant_cree') {
+            return ['validee', 'Validée', 'fa-check-circle', 'Inscription validée · étudiant créé'];
+        }
+
+        return ['inconnu', ucfirst($status ?: 'Inconnu'), 'fa-circle', ''];
+    }
+
+    public function render(): View
+    {
+        return view('components.inscription-status-badge');
+    }
+}

--- a/public/js/inscriptions/index.js
+++ b/public/js/inscriptions/index.js
@@ -531,16 +531,96 @@
 
     window.iiBulkAnnuler = function () {
         const ids = Array.from(document.querySelectorAll('.inscription-checkbox:checked')).map((cb) => cb.value);
-        if (!ids.length) return;
-        showToast(`Action bulk Annuler en cours de développement (${ids.length} sélection(s))`, 'info');
-        // TODO PR2 : endpoint bulk-annuler + modal motif
+        if (!ids.length) {
+            showToast('Veuillez sélectionner au moins une inscription.', 'warning');
+            return;
+        }
+        // Préparer le modal bulk-annuler avec le count
+        const countEl = document.getElementById('ii-bulk-annuler-count');
+        if (countEl) countEl.textContent = ids.length;
+        const motifEl = document.getElementById('ii-bulk-annuler-motif');
+        if (motifEl) motifEl.value = '';
+        const modalEl = document.getElementById('ii-modal-bulk-annuler');
+        if (modalEl) bootstrap.Modal.getOrCreateInstance(modalEl).show();
     };
+
+    // Submit du bulk-annuler modal
+    const bulkAnnulerForm = document.getElementById('ii-form-bulk-annuler');
+    if (bulkAnnulerForm) {
+        bulkAnnulerForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            const motif = document.getElementById('ii-bulk-annuler-motif').value.trim();
+            if (!motif) return;
+            const ids = Array.from(document.querySelectorAll('.inscription-checkbox:checked')).map((cb) => cb.value);
+            if (!ids.length) return;
+
+            const formData = new FormData();
+            formData.append('_token', CSRF_TOKEN);
+            formData.append('motif', motif);
+            ids.forEach((id) => formData.append('inscription_ids[]', id));
+
+            ids.forEach((id) => setRowLoading(id, true));
+            const submitBtn = this.querySelector('button[type="submit"]');
+            submitBtn.disabled = true;
+            const origHTML = submitBtn.innerHTML;
+            submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Traitement...';
+
+            fetch(ROUTES.bulkAnnuler, {
+                method: 'POST',
+                body: formData,
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            })
+                .then((r) => r.json())
+                .then((data) => {
+                    bootstrap.Modal.getInstance(document.getElementById('ii-modal-bulk-annuler')).hide();
+                    if (data.success) {
+                        showToast(data.message, data.error_count > 0 ? 'warning' : 'success');
+                        (data.processed_ids || ids).forEach((id) => {
+                            const hasErr = data.errors && data.errors[id];
+                            refreshLigne(id, hasErr ? 'reject' : 'cancel');
+                        });
+                    } else {
+                        showToast(data.message || 'Erreur annulation.', 'error');
+                    }
+                    clearSelection();
+                })
+                .catch((err) => {
+                    debugError('[inscriptions] bulk-annuler:', err);
+                    showToast('Erreur lors de l\'annulation.', 'error');
+                    ids.forEach((id) => setRowLoading(id, false));
+                })
+                .finally(() => {
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = origHTML;
+                });
+        });
+    }
 
     window.iiBulkExporter = function () {
         const ids = Array.from(document.querySelectorAll('.inscription-checkbox:checked')).map((cb) => cb.value);
-        if (!ids.length) return;
-        showToast(`Export de la sélection en cours de développement (${ids.length} sélection(s))`, 'info');
-        // TODO PR2 : endpoint export sélection
+        if (!ids.length) {
+            showToast('Veuillez sélectionner au moins une inscription.', 'warning');
+            return;
+        }
+        // Soumettre un form POST invisible pour déclencher le téléchargement CSV
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = ROUTES.bulkExport;
+        form.style.display = 'none';
+        const csrf = document.createElement('input');
+        csrf.name = '_token';
+        csrf.value = CSRF_TOKEN;
+        form.appendChild(csrf);
+        ids.forEach((id) => {
+            const input = document.createElement('input');
+            input.name = 'inscription_ids[]';
+            input.value = id;
+            form.appendChild(input);
+        });
+        document.body.appendChild(form);
+        form.submit();
+        setTimeout(() => form.remove(), 1000);
+        showToast(`Export CSV de ${ids.length} inscription(s)...`, 'info');
     };
 
     // ====================================================================

--- a/public/js/inscriptions/index.js
+++ b/public/js/inscriptions/index.js
@@ -25,6 +25,57 @@
     // Helpers
     // ====================================================================
 
+    /**
+     * Modal de confirmation premium (remplace window.confirm bloquant).
+     * Retourne une Promise<boolean>.
+     *
+     * @param {string|object} options - Message simple OU objet {title, message, okLabel, okClass, icon}
+     */
+    function iiConfirm(options) {
+        return new Promise((resolve) => {
+            const modalEl = document.getElementById('ii-modal-confirm');
+            if (!modalEl) {
+                resolve(window.confirm(typeof options === 'string' ? options : options.message));
+                return;
+            }
+
+            const cfg = typeof options === 'string' ? { message: options } : options;
+            const titleEl = modalEl.querySelector('#ii-confirm-title');
+            const bodyEl = modalEl.querySelector('#ii-confirm-body');
+            const iconEl = modalEl.querySelector('#ii-confirm-icon');
+            const okBtn = modalEl.querySelector('#ii-confirm-ok');
+
+            if (titleEl) titleEl.textContent = cfg.title || 'Confirmation';
+            if (bodyEl) bodyEl.innerHTML = cfg.message || 'Êtes-vous sûr ?';
+            if (iconEl) {
+                iconEl.className = 'me-2 fas ' + (cfg.icon || 'fa-circle-question');
+            }
+            okBtn.textContent = cfg.okLabel || 'Confirmer';
+            okBtn.className = 'btn ' + (cfg.okClass || 'btn-primary');
+
+            const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+            let resolved = false;
+
+            const onOk = () => {
+                if (resolved) return;
+                resolved = true;
+                modal.hide();
+                resolve(true);
+            };
+            const onHide = () => {
+                if (resolved) return;
+                resolved = true;
+                resolve(false);
+            };
+
+            okBtn.addEventListener('click', onOk, { once: true });
+            modalEl.addEventListener('hide.bs.modal', onHide, { once: true });
+
+            modal.show();
+        });
+    }
+    window.iiConfirm = iiConfirm;
+
     function showToast(message, type = 'success') {
         if (!message) return;
         if (window.toastr && typeof window.toastr[type] === 'function') {
@@ -398,14 +449,20 @@
     // Bulk actions
     // ====================================================================
 
-    window.iiBulkValider = function () {
+    window.iiBulkValider = async function () {
         const ids = Array.from(document.querySelectorAll('.inscription-checkbox:checked')).map((cb) => cb.value);
         if (!ids.length) {
             showToast('Veuillez sélectionner au moins une inscription.', 'warning');
             return;
         }
-        const confirmMsg = `Valider ${ids.length} inscription(s) ?\n\nLe système :\n• Valide les inscriptions avec paiements validés\n• Auto-valide les paiements en attente si nécessaire\n• Envoie les notifications aux étudiants`;
-        if (!confirm(confirmMsg)) return;
+        const ok = await iiConfirm({
+            title: 'Valider la sélection',
+            message: `<p>Valider <strong>${ids.length} inscription(s)</strong> ?</p><ul class="mb-0" style="padding-left:1.1rem;line-height:1.6;font-size:.85rem;"><li>Valide les inscriptions avec paiement validé</li><li>Auto-valide les paiements en attente si nécessaire</li><li>Envoie les notifications aux étudiants</li></ul>`,
+            okLabel: 'Valider',
+            okClass: 'btn-primary',
+            icon: 'fa-check-double',
+        });
+        if (!ok) return;
 
         const formData = new FormData();
         formData.append('_token', CSRF_TOKEN);
@@ -731,12 +788,20 @@
     // Valider button (PUT form submit inline)
     // ====================================================================
 
-    document.addEventListener('click', (e) => {
+    document.addEventListener('click', async (e) => {
         const btn = e.target.closest('.valider-btn');
         if (!btn) return;
+        e.preventDefault();
         const id = btn.dataset.id;
         if (!id) return;
-        if (!confirm('Valider cette inscription ?')) return;
+        const ok = await iiConfirm({
+            title: 'Valider l\'inscription',
+            message: 'Confirmer la validation de cette inscription ?',
+            okLabel: 'Valider',
+            okClass: 'btn-primary',
+            icon: 'fa-check-circle',
+        });
+        if (!ok) return;
         const form = document.getElementById(`valider-form-${id}`);
         if (!form) return;
         setRowLoading(id, true);
@@ -784,6 +849,38 @@
     bindSortLinks();
     updateActiveFilterChips();
     updateKpiActiveState();
+
+    // ====================================================================
+    // Dropdown overflow fix — libere l'overflow de la table-wrap
+    // quand un dropdown kebab de la table est ouvert, sinon le menu
+    // est clippe par overflow: hidden / overflow-x: auto.
+    // ====================================================================
+
+    document.addEventListener('show.bs.dropdown', (event) => {
+        const dropdown = event.target.closest('.dropdown');
+        if (!dropdown) return;
+        // N'affecter que les kebabs dans le resultats-card
+        const card = document.querySelector('.ii-results-card');
+        const wrap = document.querySelector('.ii-table-wrap');
+        if (!card || !wrap || !wrap.contains(dropdown)) return;
+        card.classList.add('ii-has-open-dropdown');
+        wrap.classList.add('ii-has-open-dropdown');
+    });
+
+    document.addEventListener('hide.bs.dropdown', (event) => {
+        const dropdown = event.target.closest('.dropdown');
+        if (!dropdown) return;
+        const card = document.querySelector('.ii-results-card');
+        const wrap = document.querySelector('.ii-table-wrap');
+        if (!card || !wrap) return;
+        // Apres un petit delai, retirer la classe (laisse le temps a BS5 de finir l'animation)
+        setTimeout(() => {
+            if (!wrap.querySelector('.dropdown.show')) {
+                card.classList.remove('ii-has-open-dropdown');
+                wrap.classList.remove('ii-has-open-dropdown');
+            }
+        }, 150);
+    });
 
     debugLog('[inscriptions] index.js initialized');
 })();

--- a/public/js/inscriptions/index.js
+++ b/public/js/inscriptions/index.js
@@ -31,8 +31,57 @@
             window.toastr[type](message);
             return;
         }
-        // Fallback : alert classique
-        alert(message);
+
+        // Toast inline premium monochrome KLASSCI (fallback si toastr absent)
+        const iconMap = {
+            success: 'fa-check-circle',
+            info: 'fa-info-circle',
+            warning: 'fa-exclamation-triangle',
+            error: 'fa-exclamation-circle',
+        };
+        const colorMap = {
+            success: { bg: '#ecfdf5', border: '#a7f3d0', color: '#065f46' },
+            info: { bg: '#eff6ff', border: '#bfdbfe', color: '#0453cb' },
+            warning: { bg: '#fffbeb', border: '#fde68a', color: '#92400e' },
+            error: { bg: '#fef2f2', border: '#fecaca', color: '#991b1b' },
+        };
+        const c = colorMap[type] || colorMap.info;
+        const icon = iconMap[type] || iconMap.info;
+
+        const toast = document.createElement('div');
+        toast.setAttribute('role', 'alert');
+        toast.style.cssText = `
+            position: fixed; top: 24px; right: 24px; z-index: 10000;
+            min-width: 280px; max-width: 440px;
+            padding: .85rem 1.1rem; padding-right: 2.5rem;
+            background: ${c.bg}; border: 1px solid ${c.border};
+            border-left: 4px solid ${c.color};
+            color: ${c.color}; border-radius: 12px;
+            font-size: .88rem; font-weight: 500; line-height: 1.45;
+            box-shadow: 0 10px 30px rgba(15,23,42,.15);
+            display: flex; align-items: center; gap: .6rem;
+            opacity: 0; transform: translateX(20px);
+            transition: opacity .25s ease, transform .25s ease;
+            cursor: pointer;
+        `;
+        toast.innerHTML = `
+            <i class="fas ${icon}" style="font-size:1rem;flex-shrink:0;"></i>
+            <span style="flex:1;">${String(message).replace(/[<>]/g, '')}</span>
+            <button type="button" aria-label="Fermer" style="position:absolute;top:.4rem;right:.5rem;background:transparent;border:none;color:inherit;opacity:.6;cursor:pointer;font-size:.8rem;"><i class="fas fa-times"></i></button>
+        `;
+        document.body.appendChild(toast);
+        requestAnimationFrame(() => {
+            toast.style.opacity = '1';
+            toast.style.transform = 'translateX(0)';
+        });
+
+        const dismiss = () => {
+            toast.style.opacity = '0';
+            toast.style.transform = 'translateX(20px)';
+            setTimeout(() => toast.remove(), 250);
+        };
+        toast.addEventListener('click', dismiss);
+        setTimeout(dismiss, 5000);
     }
 
     function setRowLoading(inscriptionId, isLoading) {

--- a/public/js/inscriptions/index.js
+++ b/public/js/inscriptions/index.js
@@ -1,0 +1,740 @@
+/**
+ * KLASSCI — Inscriptions Index
+ * Gère : filtres AJAX, KPIs filtrables, sort colonnes, per_page, pagination,
+ *        row cliquable (JS delegation), bulk actions, modals globaux,
+ *        modals actions rapides (valider paiement / changer classe / créer paiement),
+ *        refresh single row avec highlight animations, popstate.
+ *
+ * Dépendances globales :
+ *   - window.KLASSCI_INSCRIPTIONS_ROUTES (injectée en inline script dans la vue)
+ *   - window.KLASSCI_CSRF_TOKEN
+ *   - bootstrap (via bundle Bootstrap 5)
+ *   - debugLog/debugWarn/debugError (public/js/debug-helper.js)
+ */
+(function () {
+    'use strict';
+
+    const ROUTES = window.KLASSCI_INSCRIPTIONS_ROUTES || {};
+    const CSRF_TOKEN = window.KLASSCI_CSRF_TOKEN || '';
+    const HIGHLIGHT_DURATION = 3200;
+    const HIGHLIGHT_STATUS_PASS_RATIO = 0.8;
+
+    const resolveRoute = (template, id) => template.replace(':id', String(id));
+
+    // ====================================================================
+    // Helpers
+    // ====================================================================
+
+    function showToast(message, type = 'success') {
+        if (!message) return;
+        if (window.toastr && typeof window.toastr[type] === 'function') {
+            window.toastr[type](message);
+            return;
+        }
+        // Fallback : alert classique
+        alert(message);
+    }
+
+    function setRowLoading(inscriptionId, isLoading) {
+        const row = document.querySelector(`tr[data-inscription-id="${inscriptionId}"]`);
+        if (!row) return;
+        row.classList.toggle('is-loading', Boolean(isLoading));
+        const wrapper = row.querySelector('.inscription-actions-wrapper');
+        if (wrapper) wrapper.classList.toggle('is-loading', Boolean(isLoading));
+    }
+
+    function triggerRowHighlight(row, actionType = 'update', options = {}) {
+        if (!row) return;
+        const isReject = ['reject', 'cancel', 'danger', 'delete'].includes(actionType);
+        const onStatusPassed = typeof options.onStatusPassed === 'function' ? options.onStatusPassed : null;
+
+        row.classList.remove('inscription-row-flash', 'reject');
+        void row.offsetWidth;
+
+        const highlight = document.createElement('div');
+        highlight.className = 'inscription-row-highlight';
+        if (isReject) highlight.classList.add('reject');
+        row.appendChild(highlight);
+
+        requestAnimationFrame(() => highlight.classList.add('animate'));
+
+        if (onStatusPassed) {
+            setTimeout(() => onStatusPassed(highlight), HIGHLIGHT_DURATION * HIGHLIGHT_STATUS_PASS_RATIO);
+        }
+
+        highlight.addEventListener('animationend', () => highlight.remove(), { once: true });
+        row.classList.add('inscription-row-flash');
+        if (isReject) row.classList.add('reject');
+        setTimeout(() => row.classList.remove('inscription-row-flash', 'reject'), 1200);
+    }
+
+    function getFormURL(form, extraParams = {}) {
+        const formData = new FormData(form);
+        for (const [key, value] of Object.entries(extraParams)) {
+            formData.set(key, value);
+        }
+        return `${form.action}?${new URLSearchParams(formData).toString()}`;
+    }
+
+    // ====================================================================
+    // AJAX : fetch results et re-render
+    // ====================================================================
+
+    const form = document.getElementById('inscriptions-filter-form');
+    const resultsContainer = document.getElementById('inscriptions-results');
+    const countSpan = document.getElementById('ii-result-count');
+
+    function setLoading(isLoading) {
+        if (resultsContainer) resultsContainer.style.opacity = isLoading ? '0.5' : '1';
+    }
+
+    function fetchResults(url, options = {}) {
+        if (!url) return Promise.resolve();
+        setLoading(true);
+        return fetch(url, {
+            headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
+            credentials: 'same-origin',
+        })
+            .then((response) => {
+                if (!response.ok) throw new Error('Erreur lors du chargement.');
+                return response.json();
+            })
+            .then((data) => {
+                resultsContainer.innerHTML = data.html;
+                if (options.pushState !== false) {
+                    window.history.pushState({ url: data.url }, '', data.url);
+                }
+                bindPaginationLinks();
+                bindBulkSelection();
+                bindPerPageSelect();
+                bindSortLinks();
+                updateActiveFilterChips();
+                updateKpiActiveState();
+                clearSelection();
+                if (countSpan) {
+                    const totalSpan = resultsContainer.querySelector('.ii-per-page-hint');
+                    if (totalSpan) {
+                        // "par page · N inscription(s) au total"
+                        const match = totalSpan.textContent.match(/(\d+)\s+inscription/);
+                        if (match) countSpan.textContent = match[1];
+                    }
+                }
+            })
+            .catch((err) => {
+                debugError('[inscriptions] fetchResults error:', err);
+                showToast('Impossible de charger les inscriptions. Veuillez réessayer.', 'error');
+            })
+            .finally(() => setLoading(false));
+    }
+
+    function submitFilterForm() {
+        if (!form) return;
+        fetchResults(getFormURL(form), { pushState: true });
+    }
+
+    // ====================================================================
+    // Filter form handlers
+    // ====================================================================
+
+    if (form) {
+        let searchDebounce = null;
+        const searchInput = form.querySelector('#filter-search');
+        const selects = form.querySelectorAll('select');
+
+        form.addEventListener('submit', (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            submitFilterForm();
+            return false;
+        });
+
+        selects.forEach((select) => {
+            select.addEventListener('change', submitFilterForm);
+        });
+
+        if (searchInput) {
+            searchInput.addEventListener('input', () => {
+                clearTimeout(searchDebounce);
+                searchDebounce = setTimeout(submitFilterForm, 400);
+            });
+        }
+
+        const resetBtn = document.getElementById('reset-filters-btn');
+        if (resetBtn) {
+            resetBtn.addEventListener('click', () => {
+                form.querySelectorAll('input[type="text"], input[type="search"]').forEach((i) => (i.value = ''));
+                form.querySelectorAll('select').forEach((s) => (s.value = s.querySelector('option').value));
+                document.getElementById('sort-input').value = 'created_at';
+                document.getElementById('dir-input').value = 'desc';
+                submitFilterForm();
+            });
+        }
+    }
+
+    // ====================================================================
+    // KPIs cliquables
+    // ====================================================================
+
+    function updateKpiActiveState() {
+        const currentStatus = new URL(window.location.href).searchParams.get('status') || 'active';
+        document.querySelectorAll('#ii-kpis .ii-kpi').forEach((kpi) => {
+            const filter = kpi.dataset.kpiFilter;
+            kpi.classList.toggle('ii-kpi--active', filter === currentStatus);
+        });
+    }
+
+    document.querySelectorAll('#ii-kpis .ii-kpi').forEach((kpi) => {
+        kpi.addEventListener('click', () => {
+            const filter = kpi.dataset.kpiFilter;
+            const statusSelect = form ? form.querySelector('#status') : null;
+            if (!statusSelect) return;
+            // Reclick KPI actif = reset vers "all"
+            const currentStatus = new URL(window.location.href).searchParams.get('status') || 'active';
+            statusSelect.value = filter === currentStatus ? 'all' : filter;
+            submitFilterForm();
+        });
+    });
+
+    // ====================================================================
+    // Active filter chips
+    // ====================================================================
+
+    function updateActiveFilterChips() {
+        const container = document.getElementById('ii-active-filters');
+        if (!container || !form) return;
+        container.innerHTML = '';
+        const chips = [];
+        const search = form.querySelector('#filter-search');
+        if (search && search.value) {
+            chips.push({ key: 'search', label: `Recherche : « ${search.value} »`, input: search });
+        }
+        const filterLabels = {
+            filiere: 'Filière',
+            niveau: 'Niveau',
+            annee: 'Année',
+            status: 'Statut',
+        };
+        Object.keys(filterLabels).forEach((key) => {
+            const sel = form.querySelector(`#${key}`);
+            if (!sel || !sel.value || (key === 'status' && sel.value === 'active')) return;
+            if (key === 'annee' && !sel.value) return;
+            const label = sel.options[sel.selectedIndex]?.text || sel.value;
+            chips.push({ key, label: `${filterLabels[key]} : ${label}`, input: sel });
+        });
+
+        chips.forEach((chip) => {
+            const el = document.createElement('span');
+            el.className = 'ii-chip-active';
+            el.innerHTML = `<span>${chip.label}</span><button type="button" aria-label="Retirer"><i class="fas fa-times"></i></button>`;
+            el.querySelector('button').addEventListener('click', () => {
+                if (chip.key === 'status') {
+                    chip.input.value = 'active';
+                } else {
+                    chip.input.value = '';
+                }
+                submitFilterForm();
+            });
+            container.appendChild(el);
+        });
+    }
+
+    // ====================================================================
+    // Sort columns (intercept link clicks, update hidden inputs, AJAX)
+    // ====================================================================
+
+    function bindSortLinks() {
+        resultsContainer.querySelectorAll('.ii-sort-link').forEach((link) => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const url = new URL(link.href);
+                const newSort = url.searchParams.get('sort');
+                const newDir = url.searchParams.get('dir');
+                if (newSort) document.getElementById('sort-input').value = newSort;
+                if (newDir) document.getElementById('dir-input').value = newDir;
+                submitFilterForm();
+            });
+        });
+    }
+
+    // ====================================================================
+    // Per-page selector
+    // ====================================================================
+
+    function bindPerPageSelect() {
+        const select = resultsContainer.querySelector('#ii-per-page-select');
+        if (!select) return;
+        select.addEventListener('change', () => {
+            document.getElementById('per-page-input').value = select.value;
+            const url = new URL(form.action);
+            const formData = new FormData(form);
+            new URLSearchParams(formData).forEach((v, k) => url.searchParams.set(k, v));
+            url.searchParams.delete('page');
+            fetchResults(url.toString(), { pushState: true });
+        });
+    }
+
+    // ====================================================================
+    // Pagination AJAX
+    // ====================================================================
+
+    function bindPaginationLinks() {
+        resultsContainer.querySelectorAll('.pagination a').forEach((link) => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                fetchResults(link.href, { pushState: true });
+            });
+        });
+    }
+
+    // ====================================================================
+    // Row click (JS delegation, skip if target is interactive)
+    // ====================================================================
+
+    resultsContainer.addEventListener('click', (e) => {
+        const row = e.target.closest('tr.ii-row');
+        if (!row) return;
+        const href = row.dataset.rowHref;
+        if (!href) return;
+        if (e.target.closest('button, a, input, label, .dropdown, [data-no-row-click]')) return;
+        // Middle-click = ouvre dans nouvel onglet
+        if (e.button === 1 || e.ctrlKey || e.metaKey) {
+            window.open(href, '_blank');
+            return;
+        }
+        window.location.href = href;
+    });
+
+    // ====================================================================
+    // Bulk selection
+    // ====================================================================
+
+    function updateSelectionCount() {
+        const count = document.querySelectorAll('.inscription-checkbox:checked').length;
+        const bar = document.getElementById('ii-bulk-bar');
+        const span = document.getElementById('ii-selected-count');
+        if (span) span.textContent = count;
+        if (bar) bar.classList.toggle('ii-bulk-bar--visible', count > 0);
+    }
+
+    function bindBulkSelection() {
+        const selectAll = document.getElementById('select-all-inscriptions');
+        if (selectAll) {
+            selectAll.addEventListener('change', function () {
+                document.querySelectorAll('.inscription-checkbox').forEach((cb) => {
+                    cb.checked = this.checked;
+                });
+                updateSelectionCount();
+            });
+        }
+        document.querySelectorAll('.inscription-checkbox').forEach((cb) => {
+            cb.addEventListener('change', () => {
+                updateSelectionCount();
+                const all = document.querySelectorAll('.inscription-checkbox');
+                const checked = document.querySelectorAll('.inscription-checkbox:checked');
+                const sa = document.getElementById('select-all-inscriptions');
+                if (sa) sa.checked = all.length === checked.length && all.length > 0;
+            });
+        });
+    }
+
+    function clearSelection() {
+        document.querySelectorAll('.inscription-checkbox').forEach((cb) => (cb.checked = false));
+        const sa = document.getElementById('select-all-inscriptions');
+        if (sa) sa.checked = false;
+        updateSelectionCount();
+    }
+    window.iiClearSelection = clearSelection;
+
+    // ====================================================================
+    // Bulk actions
+    // ====================================================================
+
+    window.iiBulkValider = function () {
+        const ids = Array.from(document.querySelectorAll('.inscription-checkbox:checked')).map((cb) => cb.value);
+        if (!ids.length) {
+            showToast('Veuillez sélectionner au moins une inscription.', 'warning');
+            return;
+        }
+        const confirmMsg = `Valider ${ids.length} inscription(s) ?\n\nLe système :\n• Valide les inscriptions avec paiements validés\n• Auto-valide les paiements en attente si nécessaire\n• Envoie les notifications aux étudiants`;
+        if (!confirm(confirmMsg)) return;
+
+        const formData = new FormData();
+        formData.append('_token', CSRF_TOKEN);
+        ids.forEach((id) => formData.append('inscription_ids[]', id));
+
+        ids.forEach((id) => setRowLoading(id, true));
+
+        fetch(ROUTES.bulkValider, {
+            method: 'POST',
+            body: formData,
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        })
+            .then((r) => {
+                if (!r.ok) throw new Error('Erreur validation.');
+                return r.json();
+            })
+            .then((data) => {
+                if (!data.success) {
+                    showToast(data.message || 'Validation échouée.', 'error');
+                    ids.forEach((id) => setRowLoading(id, false));
+                    return;
+                }
+                if (data.message) {
+                    const hasProblems = data.inscriptions_problemes && Object.keys(data.inscriptions_problemes).length > 0;
+                    showToast(data.message, hasProblems ? 'warning' : 'success');
+                }
+                const problems = data.inscriptions_problemes || {};
+                Object.values(problems).forEach((p) => p?.message && showToast(p.message, 'warning'));
+                ids.forEach((id) => refreshLigne(id, problems[id] ? 'reject' : 'validate'));
+                clearSelection();
+            })
+            .catch((err) => {
+                showToast(err.message || 'Erreur validation.', 'error');
+                ids.forEach((id) => setRowLoading(id, false));
+            });
+    };
+
+    window.iiBulkAnnuler = function () {
+        const ids = Array.from(document.querySelectorAll('.inscription-checkbox:checked')).map((cb) => cb.value);
+        if (!ids.length) return;
+        showToast(`Action bulk Annuler en cours de développement (${ids.length} sélection(s))`, 'info');
+        // TODO PR2 : endpoint bulk-annuler + modal motif
+    };
+
+    window.iiBulkExporter = function () {
+        const ids = Array.from(document.querySelectorAll('.inscription-checkbox:checked')).map((cb) => cb.value);
+        if (!ids.length) return;
+        showToast(`Export de la sélection en cours de développement (${ids.length} sélection(s))`, 'info');
+        // TODO PR2 : endpoint export sélection
+    };
+
+    // ====================================================================
+    // Refresh single row
+    // ====================================================================
+
+    function refreshLigne(inscriptionId, actionType = 'update') {
+        const row = document.querySelector(`tr[data-inscription-id="${inscriptionId}"]`);
+        if (!row) {
+            debugWarn('[inscriptions] row not found for refresh:', inscriptionId);
+            return;
+        }
+        const checkbox = row.querySelector('.inscription-checkbox');
+        const wasChecked = checkbox ? checkbox.checked : false;
+
+        setRowLoading(inscriptionId, true);
+
+        fetch(resolveRoute(ROUTES.refreshLigne, inscriptionId), {
+            method: 'GET',
+            headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
+        })
+            .then((r) => {
+                if (!r.ok) throw new Error(`HTTP ${r.status}`);
+                return r.json();
+            })
+            .then((data) => {
+                if (!data.success || !data.html) throw new Error('Réponse invalide');
+                const template = document.createElement('template');
+                template.innerHTML = data.html.trim();
+                const newRow = template.content.querySelector(`tr[data-inscription-id="${inscriptionId}"]`)
+                    || template.content.querySelector('tr[data-inscription-id]');
+                if (!newRow) throw new Error('HTML sans tr valide');
+
+                let updated = false;
+                const applyUpdate = (highlightEl) => {
+                    if (updated) return;
+                    updated = true;
+                    const highlightNode = highlightEl || row.querySelector('.inscription-row-highlight');
+                    const preserveClasses = ['inscription-row-flash', 'reject', 'is-loading'].filter((c) =>
+                        row.classList.contains(c)
+                    );
+                    row.setAttribute('class', newRow.getAttribute('class') || '');
+                    preserveClasses.forEach((c) => row.classList.add(c));
+
+                    Array.from(newRow.attributes).forEach((attr) => {
+                        if (attr.name !== 'class') row.setAttribute(attr.name, attr.value);
+                    });
+
+                    const currentCells = Array.from(row.children).filter((c) => c !== highlightNode);
+                    const newCells = Array.from(newRow.children).map((c) => c.cloneNode(true));
+
+                    currentCells.forEach((cell, idx) => {
+                        if (newCells[idx]) cell.replaceWith(newCells[idx]);
+                        else cell.remove();
+                    });
+                    newCells.slice(currentCells.length).forEach((node) => {
+                        if (highlightNode && highlightNode.parentNode === row) {
+                            row.insertBefore(node, highlightNode);
+                        } else {
+                            row.appendChild(node);
+                        }
+                    });
+                    if (highlightNode && highlightNode.parentNode !== row) row.appendChild(highlightNode);
+
+                    if (wasChecked) {
+                        const cb = row.querySelector('.inscription-checkbox');
+                        if (cb) {
+                            cb.checked = true;
+                            cb.dispatchEvent(new Event('change', { bubbles: true }));
+                        }
+                    }
+                    setRowLoading(inscriptionId, false);
+                    updateSelectionCount();
+                };
+
+                triggerRowHighlight(row, actionType, {
+                    onStatusPassed: applyUpdate,
+                });
+                setTimeout(() => {
+                    if (!updated) applyUpdate();
+                }, HIGHLIGHT_DURATION + 150);
+            })
+            .catch((err) => {
+                debugError('[inscriptions] refresh ligne error:', err);
+                setRowLoading(inscriptionId, false);
+                showToast('Erreur lors de la mise à jour.', 'error');
+            });
+    }
+    window.refreshInscriptionLigne = refreshLigne;
+
+    // ====================================================================
+    // Modals globaux (annuler + delete) — data-id dynamique
+    // ====================================================================
+
+    const annulerModalEl = document.getElementById('ii-modal-annuler');
+    if (annulerModalEl) {
+        annulerModalEl.addEventListener('show.bs.modal', (event) => {
+            const trigger = event.relatedTarget;
+            if (!trigger) return;
+            const id = trigger.dataset.inscriptionId;
+            const name = trigger.dataset.studentName || '—';
+            document.getElementById('ii-annuler-student-name').textContent = name;
+            document.getElementById('ii-form-annuler').action = resolveRoute(ROUTES.annuler, id);
+        });
+    }
+
+    const deleteModalEl = document.getElementById('ii-modal-delete');
+    if (deleteModalEl) {
+        deleteModalEl.addEventListener('show.bs.modal', (event) => {
+            const trigger = event.relatedTarget;
+            if (!trigger) return;
+            const id = trigger.dataset.inscriptionId;
+            const name = trigger.dataset.studentName || '—';
+            document.getElementById('ii-delete-student-name').textContent = name;
+            document.getElementById('ii-form-delete').action = resolveRoute(ROUTES.destroy, id);
+        });
+    }
+
+    // ====================================================================
+    // Actions rapides — modals valider paiement / changer classe / créer paiement
+    // ====================================================================
+
+    window.ouvrirModalValiderPaiement = function (inscriptionId) {
+        fetch(resolveRoute(ROUTES.paiementEnAttente, inscriptionId))
+            .then((r) => r.json())
+            .then((data) => {
+                if (!data.success || !data.paiement) {
+                    showToast('Impossible de récupérer les informations du paiement.', 'error');
+                    return;
+                }
+                const p = data.paiement;
+                document.getElementById('valider_inscription_id').value = inscriptionId;
+                document.getElementById('valider_paiement_id').value = p.id;
+                document.getElementById('valider_montant').value = new Intl.NumberFormat('fr-FR').format(p.montant) + ' FCFA';
+                document.getElementById('valider_mode').value = p.mode_paiement || 'N/A';
+                document.getElementById('valider_reference').value = p.reference_paiement || 'N/A';
+                document.getElementById('validerPaiementInfo').textContent = `Paiement de ${p.etudiant.nom} ${p.etudiant.prenoms}`;
+                document.getElementById('formValiderPaiement').action = resolveRoute(ROUTES.validerPaiementRapide, p.id);
+                bootstrap.Modal.getOrCreateInstance(document.getElementById('modalValiderPaiement')).show();
+            })
+            .catch((err) => {
+                debugError('[inscriptions] ouvrirModalValiderPaiement:', err);
+                showToast('Erreur lors du chargement.', 'error');
+            });
+    };
+
+    window.ouvrirModalChangerClasse = function (inscriptionId) {
+        fetch(resolveRoute(ROUTES.classesAlternatives, inscriptionId))
+            .then((r) => r.json())
+            .then((data) => {
+                if (!data.success) {
+                    showToast(data.message || 'Erreur.', 'error');
+                    return;
+                }
+                document.getElementById('changer_inscription_id').value = inscriptionId;
+                document.getElementById('changer_ancienne_classe').value = data.classeActuelle.name;
+                const select = document.getElementById('changer_nouvelle_classe');
+                select.innerHTML = '<option value="">Sélectionnez une classe</option>';
+                data.classesAlternatives.forEach((c) => {
+                    const opt = document.createElement('option');
+                    opt.value = c.id;
+                    opt.textContent = c.is_available
+                        ? `${c.name} (${c.places_disponibles}/${c.places_totales} places)`
+                        : `${c.name} (COMPLET ${c.places_disponibles}/${c.places_totales})`;
+                    opt.dataset.placesDisponibles = c.places_disponibles;
+                    opt.dataset.isAvailable = c.is_available ? '1' : '0';
+                    if (!c.is_available) opt.style.color = '#991b1b';
+                    select.appendChild(opt);
+                });
+
+                select.onchange = function () {
+                    const opt = this.options[this.selectedIndex];
+                    const info = document.getElementById('classeDispoInfo');
+                    const text = document.getElementById('classeDispoText');
+                    if (!opt.value) {
+                        info.style.display = 'none';
+                        return;
+                    }
+                    const available = opt.dataset.isAvailable === '1';
+                    info.style.display = 'flex';
+                    text.textContent = available
+                        ? `${opt.dataset.placesDisponibles} places disponibles`
+                        : `Classe complète (${opt.dataset.placesDisponibles} places)`;
+                };
+
+                document.getElementById('formChangerClasse').action = resolveRoute(ROUTES.changerClasseRapide, inscriptionId);
+                bootstrap.Modal.getOrCreateInstance(document.getElementById('modalChangerClasse')).show();
+            })
+            .catch((err) => {
+                debugError('[inscriptions] ouvrirModalChangerClasse:', err);
+                showToast('Erreur lors du chargement.', 'error');
+            });
+    };
+
+    window.ouvrirModalCreerPaiement = function (inscriptionId) {
+        fetch(resolveRoute(ROUTES.inscriptionData, inscriptionId))
+            .then((r) => r.json())
+            .then((data) => {
+                if (!data.success || !data.inscription) {
+                    showToast('Impossible de récupérer les informations.', 'error');
+                    return;
+                }
+                const ins = data.inscription;
+                document.getElementById('creer_inscription_id').value = inscriptionId;
+                document.getElementById('creer_etudiant_id').value = ins.etudiant_id;
+                document.getElementById('creer_annee_id').value = ins.annee_universitaire_id;
+                document.getElementById('creerPaiementInfo').textContent =
+                    `Créer un paiement pour ${ins.etudiant.nom} ${ins.etudiant.prenoms}`;
+                document.getElementById('formCreerPaiement').action = resolveRoute(ROUTES.validerAvecPaiement, inscriptionId);
+                bootstrap.Modal.getOrCreateInstance(document.getElementById('modalCreerPaiement')).show();
+            })
+            .catch((err) => {
+                debugError('[inscriptions] ouvrirModalCreerPaiement:', err);
+                showToast('Erreur lors du chargement.', 'error');
+            });
+    };
+
+    // ====================================================================
+    // Handlers génériques pour les 3 modals action rapide (submit AJAX)
+    // ====================================================================
+
+    function bindQuickActionForm(formId, modalId, actionType = 'update') {
+        const formEl = document.getElementById(formId);
+        const modalEl = document.getElementById(modalId);
+        if (!formEl || !modalEl) return;
+        let submitting = false;
+
+        formEl.addEventListener('submit', function (e) {
+            e.preventDefault();
+            if (submitting) return false;
+            submitting = true;
+
+            const submitBtn = this.querySelector('button[type="submit"]');
+            const originalHTML = submitBtn.innerHTML;
+            submitBtn.disabled = true;
+            submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-1"></i>Traitement...';
+
+            const inscriptionId =
+                this.querySelector('[name="inscription_id"]')?.value
+                || this.querySelector('input[type="hidden"]')?.value;
+
+            fetch(this.action, {
+                method: 'POST',
+                body: new FormData(this),
+                headers: { 'X-Requested-With': 'XMLHttpRequest' },
+            })
+                .then((r) => r.json())
+                .then((data) => {
+                    if (data.success) {
+                        bootstrap.Modal.getInstance(modalEl).hide();
+                        if (inscriptionId) refreshLigne(inscriptionId, actionType);
+                        if (data.message) showToast(data.message, 'success');
+                    } else {
+                        showToast(data.message || 'Erreur.', 'error');
+                    }
+                })
+                .catch((err) => {
+                    debugError('[inscriptions] quick action:', err);
+                    showToast('Erreur lors de la soumission.', 'error');
+                })
+                .finally(() => {
+                    submitting = false;
+                    submitBtn.disabled = false;
+                    submitBtn.innerHTML = originalHTML;
+                });
+        });
+    }
+
+    bindQuickActionForm('formValiderPaiement', 'modalValiderPaiement', 'validate');
+    bindQuickActionForm('formChangerClasse', 'modalChangerClasse', 'update');
+    bindQuickActionForm('formCreerPaiement', 'modalCreerPaiement', 'update');
+
+    // ====================================================================
+    // Valider button (PUT form submit inline)
+    // ====================================================================
+
+    document.addEventListener('click', (e) => {
+        const btn = e.target.closest('.valider-btn');
+        if (!btn) return;
+        const id = btn.dataset.id;
+        if (!id) return;
+        if (!confirm('Valider cette inscription ?')) return;
+        const form = document.getElementById(`valider-form-${id}`);
+        if (!form) return;
+        setRowLoading(id, true);
+        const formData = new FormData(form);
+        fetch(form.action, {
+            method: 'POST',
+            body: formData,
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        })
+            .then((r) => r.json())
+            .then((data) => {
+                if (data.success) {
+                    refreshLigne(id, 'validate');
+                    if (data.message) showToast(data.message, 'success');
+                } else {
+                    setRowLoading(id, false);
+                    showToast(data.message || 'Erreur validation.', 'error');
+                }
+            })
+            .catch(() => {
+                setRowLoading(id, false);
+                showToast('Erreur validation.', 'error');
+            });
+    });
+
+    // ====================================================================
+    // popstate : restaurer la vue sur back/forward
+    // ====================================================================
+
+    if (window.history && window.history.replaceState) {
+        window.history.replaceState({ url: window.location.href }, '', window.location.href);
+    }
+    window.addEventListener('popstate', (event) => {
+        const targetUrl = (event.state && event.state.url) || window.location.href;
+        fetchResults(targetUrl, { pushState: false });
+    });
+
+    // ====================================================================
+    // Init
+    // ====================================================================
+
+    bindPaginationLinks();
+    bindBulkSelection();
+    bindPerPageSelect();
+    bindSortLinks();
+    updateActiveFilterChips();
+    updateKpiActiveState();
+
+    debugLog('[inscriptions] index.js initialized');
+})();

--- a/public/js/inscriptions/index.js
+++ b/public/js/inscriptions/index.js
@@ -848,18 +848,15 @@
                     refreshLigne(id, 'validate');
                     if (data.message) showToast(data.message, 'success');
                 } else {
-                    setRowLoading(id, false);
                     showToast(data.message || 'Erreur validation.', 'error');
-                    // Red highlight sur erreur pour feedback visuel
-                    const row = document.querySelector(`tr[data-inscription-id="${id}"]`);
-                    if (row) triggerRowHighlight(row, 'reject');
+                    // Refresh la ligne pour afficher le chip probleme + bouton d'action rapide
+                    // (Creer paiement / Valider paiement / Changer classe) + flash rouge
+                    refreshLigne(id, 'reject');
                 }
             })
             .catch(() => {
-                setRowLoading(id, false);
                 showToast('Erreur validation.', 'error');
-                const row = document.querySelector(`tr[data-inscription-id="${id}"]`);
-                if (row) triggerRowHighlight(row, 'reject');
+                refreshLigne(id, 'reject');
             });
     });
 

--- a/public/js/inscriptions/index.js
+++ b/public/js/inscriptions/index.js
@@ -148,24 +148,18 @@
         const isReject = ['reject', 'cancel', 'danger', 'delete'].includes(actionType);
         const onStatusPassed = typeof options.onStatusPassed === 'function' ? options.onStatusPassed : null;
 
+        // Reset pour redéclencher l'animation
         row.classList.remove('inscription-row-flash', 'reject');
         void row.offsetWidth;
 
-        const highlight = document.createElement('div');
-        highlight.className = 'inscription-row-highlight';
-        if (isReject) highlight.classList.add('reject');
-        row.appendChild(highlight);
-
-        requestAnimationFrame(() => highlight.classList.add('animate'));
-
-        if (onStatusPassed) {
-            setTimeout(() => onStatusPassed(highlight), HIGHLIGHT_DURATION * HIGHLIGHT_STATUS_PASS_RATIO);
-        }
-
-        highlight.addEventListener('animationend', () => highlight.remove(), { once: true });
         row.classList.add('inscription-row-flash');
         if (isReject) row.classList.add('reject');
-        setTimeout(() => row.classList.remove('inscription-row-flash', 'reject'), 1200);
+
+        if (onStatusPassed) {
+            setTimeout(() => onStatusPassed(null), HIGHLIGHT_DURATION * HIGHLIGHT_STATUS_PASS_RATIO);
+        }
+
+        setTimeout(() => row.classList.remove('inscription-row-flash', 'reject'), HIGHLIGHT_DURATION);
     }
 
     function getFormURL(form, extraParams = {}) {
@@ -188,9 +182,44 @@
         if (resultsContainer) resultsContainer.style.opacity = isLoading ? '0.5' : '1';
     }
 
+    function updateKpisFromStats(stats) {
+        if (!stats) return;
+        const map = {
+            all: stats.total,
+            active: stats.actives,
+            non_validee: stats.non_validees,
+            en_attente: stats.en_attente,
+            'annulée': stats.annulees,
+        };
+        document.querySelectorAll('#ii-kpis .ii-kpi').forEach((kpi) => {
+            const f = kpi.dataset.kpiFilter;
+            if (f in map) {
+                const valueEl = kpi.querySelector('.ii-kpi-value');
+                if (valueEl) valueEl.textContent = map[f] ?? 0;
+            }
+            // Badge warning si non_validees > 0
+            if (f === 'non_validee') {
+                const existing = kpi.querySelector('.ii-kpi-badge');
+                if ((map[f] ?? 0) > 0) {
+                    if (!existing) {
+                        const badge = document.createElement('span');
+                        badge.className = 'ii-kpi-badge';
+                        kpi.style.position = 'relative';
+                        kpi.appendChild(badge);
+                    }
+                } else if (existing) {
+                    existing.remove();
+                }
+            }
+        });
+    }
+    window.updateKpisFromStats = updateKpisFromStats;
+
     function fetchResults(url, options = {}) {
         if (!url) return Promise.resolve();
         setLoading(true);
+        // Loading visual sur KPIs
+        document.querySelectorAll('#ii-kpis .ii-kpi').forEach(k => k.style.opacity = '.6');
         return fetch(url, {
             headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
             credentials: 'same-origin',
@@ -211,20 +240,20 @@
                 updateActiveFilterChips();
                 updateKpiActiveState();
                 clearSelection();
-                if (countSpan) {
-                    const totalSpan = resultsContainer.querySelector('.ii-per-page-hint');
-                    if (totalSpan) {
-                        // "par page · N inscription(s) au total"
-                        const match = totalSpan.textContent.match(/(\d+)\s+inscription/);
-                        if (match) countSpan.textContent = match[1];
-                    }
+                // Update KPIs si stats renvoyées
+                if (data.stats) updateKpisFromStats(data.stats);
+                if (countSpan && typeof data.total !== 'undefined') {
+                    countSpan.textContent = data.total;
                 }
             })
             .catch((err) => {
                 debugError('[inscriptions] fetchResults error:', err);
                 showToast('Impossible de charger les inscriptions. Veuillez réessayer.', 'error');
             })
-            .finally(() => setLoading(false));
+            .finally(() => {
+                setLoading(false);
+                document.querySelectorAll('#ii-kpis .ii-kpi').forEach(k => k.style.opacity = '');
+            });
     }
 
     function submitFilterForm() {
@@ -539,6 +568,8 @@
             })
             .then((data) => {
                 if (!data.success || !data.html) throw new Error('Réponse invalide');
+                // Update KPIs si stats fournies
+                if (data.stats) updateKpisFromStats(data.stats);
                 const template = document.createElement('template');
                 template.innerHTML = data.html.trim();
                 const newRow = template.content.querySelector(`tr[data-inscription-id="${inscriptionId}"]`)
@@ -819,11 +850,16 @@
                 } else {
                     setRowLoading(id, false);
                     showToast(data.message || 'Erreur validation.', 'error');
+                    // Red highlight sur erreur pour feedback visuel
+                    const row = document.querySelector(`tr[data-inscription-id="${id}"]`);
+                    if (row) triggerRowHighlight(row, 'reject');
                 }
             })
             .catch(() => {
                 setRowLoading(id, false);
                 showToast('Erreur validation.', 'error');
+                const row = document.querySelector(`tr[data-inscription-id="${id}"]`);
+                if (row) triggerRowHighlight(row, 'reject');
             });
     });
 

--- a/resources/views/components/inscription-status-badge.blade.php
+++ b/resources/views/components/inscription-status-badge.blade.php
@@ -1,0 +1,9 @@
+{{--
+    Badge de statut d'inscription — 5 états monochrome bleu KLASSCI.
+    Piloté par App\View\Components\InscriptionStatusBadge.
+    Styles CSS associés : .ii-badge, .ii-badge--* dans inscriptions/index.blade.php
+--}}
+<span class="ii-badge ii-badge--{{ $key }}" @if($title) title="{{ $title }}" @endif>
+    <i class="fas {{ $icon }}"></i>
+    <span>{{ $label }}</span>
+</span>

--- a/resources/views/esbtp/inscriptions/index.blade.php
+++ b/resources/views/esbtp/inscriptions/index.blade.php
@@ -215,6 +215,9 @@
     box-shadow: 0 1px 3px rgba(15,23,42,.04);
 }
 .ii-table-wrap { overflow-x: auto; }
+/* Quand un dropdown kebab est ouvert : liberer l'overflow pour que le menu ne soit pas coupe */
+.ii-results-card.ii-has-open-dropdown { overflow: visible; }
+.ii-table-wrap.ii-has-open-dropdown { overflow: visible; }
 .ii-table { width: 100%; border-collapse: separate; border-spacing: 0; }
 .ii-table thead th {
     background: var(--ii-surface);
@@ -754,6 +757,25 @@ tr[data-inscription-id] { position: relative; overflow: hidden; }
 @endcan
 
 {{-- MODALS GLOBAUX (data-id dynamique) --}}
+
+{{-- Modal générique de confirmation (Valider + autres actions) --}}
+<div class="modal fade" id="ii-modal-confirm" tabindex="-1" aria-labelledby="iiModalConfirmLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header ii-modal-header">
+                <h5 class="modal-title" id="iiModalConfirmLabel">
+                    <i class="fas fa-circle-question me-2" id="ii-confirm-icon"></i><span id="ii-confirm-title">Confirmation</span>
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body" id="ii-confirm-body">Êtes-vous sûr ?</div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                <button type="button" class="btn btn-primary" id="ii-confirm-ok">Confirmer</button>
+            </div>
+        </div>
+    </div>
+</div>
 
 {{-- Modal Annuler une inscription --}}
 <div class="modal fade" id="ii-modal-annuler" tabindex="-1" aria-labelledby="iiModalAnnulerLabel" aria-hidden="true">

--- a/resources/views/esbtp/inscriptions/index.blade.php
+++ b/resources/views/esbtp/inscriptions/index.blade.php
@@ -1,1562 +1,955 @@
 @extends('layouts.app')
 
-@section('title', 'Gestion des Inscriptions')
-
-@section('styles')
-<link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
-@endsection
-
-@section('content')
-<!-- Debug: Afficher les données de session -->
-@if(session('inscriptions_problemes'))
-    <script>console.log('Inscriptions avec problèmes:', @json(session('inscriptions_problemes')));</script>
-@endif
-
-<div class="dashboard-acasi">
-    <div class="main-content">
-        <!-- Header Section -->
-        <div class="dashboard-header">
-            <div class="header-left">
-                <h1><i class="fas fa-user-graduate me-2"></i>Gestion des Inscriptions</h1>
-                <p class="header-subtitle">Consultez et gérez toutes les inscriptions de l'établissement</p>
-            </div>
-            <div class="header-actions">
-                <input type="search" class="search-bar" placeholder="Rechercher une inscription..." value="{{ request('search') }}">
-                @can('inscriptions.validate')
-                <a href="{{ route('esbtp.inscriptions.administration') }}" class="btn-acasi secondary">
-                    <i class="fas fa-user-check"></i>Administration
-                </a>
-                @endcan
-                @can('inscriptions.create')
-                <a href="{{ route('esbtp.inscriptions.create') }}" class="btn-acasi primary">
-                    <i class="fas fa-plus-circle"></i>Nouvelle Inscription
-                </a>
-                @endcan
-            </div>
-        </div>
-
-        <!-- Filtre année académique courante -->
-        <div class="card-moderne mb-lg">
-            <div class="p-lg">
-                <div class="section-title mb-md">
-                    <i class="fas fa-calendar-alt me-2"></i>Année Académique Active
-                </div>
-                <div style="display: flex; gap: var(--space-md); align-items: end;">
-                    <div style="flex: 1; max-width: 300px;">
-                        <label for="annee_academique" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Année Académique Courante</label>
-                        <select name="annee_academique" id="annee_academique" class="year-selector" style="width: 100%; background-color: #f8f9fa; cursor: not-allowed;" disabled>
-                            <option value="{{ $anneeEnCours->id ?? '' }}" selected>
-                                {{ $anneeEnCours->name ?? 'Aucune année définie' }} (Année en cours)
-                            </option>
-                        </select>
-                    </div>
-                    <button type="button" class="btn-acasi secondary" onclick="showYearChangeInfo()" title="Comment changer d'année ?">
-                        <i class="fas fa-info-circle"></i>Changer d'année
-                    </button>
-                </div>
-                <div class="mt-3">
-                    <small class="text-muted">
-                        <i class="fas fa-info-circle me-1"></i>
-                        Les inscriptions affichées correspondent à l'année académique courante. 
-                        @if($inscriptions->isEmpty())
-                            <strong class="text-warning">Aucune inscription trouvée pour cette année.</strong>
-                        @endif
-                    </small>
-                </div>
-                @if($inscriptions->isEmpty())
-                    <div class="mt-3">
-                        <div class="alert alert-warning d-flex align-items-center" role="alert">
-                            <i class="fas fa-exclamation-triangle me-2"></i>
-                            <div>
-                                <strong>Aucune inscription pour l'année {{ $anneeEnCours->name ?? 'courante' }}</strong><br>
-                                <small>Il y a {{ \App\Models\ESBTPInscription::count() }} inscriptions au total dans la base, mais aucune pour l'année académique active. 
-                                Utilisez le bouton "Changer d'année" pour consulter les inscriptions d'autres années.</small>
-                            </div>
-                        </div>
-                    </div>
-                @endif
-            </div>
-        </div>
-
-        <!-- Section principale des inscriptions -->
-        <div class="main-card">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-filter"></i>
-                    Filtres de recherche
-                </div>
-                <div class="main-card-subtitle">Filtrer les inscriptions par critères spécifiques</div>
-            </div>
-
-            <div class="main-card-body">
-                <form method="GET" action="{{ route('esbtp.inscriptions.index') }}" id="inscriptions-filter-form" class="mb-4">
-                    <div class="row">
-                        <div class="col-md-3 mb-3">
-                            <label for="filter-search" class="form-label">Recherche</label>
-                            <input type="text" class="form-control" id="filter-search" name="search" value="{{ request('search') }}" placeholder="Matricule, nom, numéro d'inscription...">
-                        </div>
-                        <div class="col-md-2 mb-3">
-                            <label for="filiere" class="form-label">Filière</label>
-                            <select class="form-select" id="filiere" name="filiere">
-                                <option value="">Toutes les filières</option>
-                                @foreach($filieres as $fil)
-                                    <option value="{{ $fil->id }}" {{ request('filiere') == $fil->id ? 'selected' : '' }}>
-                                        {{ $fil->name }}
-                                    </option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="col-md-2 mb-3">
-                            <label for="niveau" class="form-label">Niveau d'études</label>
-                            <select class="form-select" id="niveau" name="niveau">
-                                <option value="">Tous les niveaux</option>
-                                @foreach($niveaux as $niv)
-                                    <option value="{{ $niv->id }}" {{ request('niveau') == $niv->id ? 'selected' : '' }}>
-                                        {{ $niv->name }}
-                                    </option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="col-md-2 mb-3">
-                            <label for="annee" class="form-label">Année universitaire</label>
-                            <select class="form-select" id="annee" name="annee">
-                                <option value="">Toutes les années</option>
-                                @foreach($annees as $an)
-                                    <option value="{{ $an->id }}" {{ request('annee') == $an->id ? 'selected' : '' }}>
-                                        {{ $an->name }}
-                                    </option>
-                                @endforeach
-                            </select>
-                        </div>
-                        <div class="col-md-2 mb-3">
-                            <label for="status" class="form-label">Statut</label>
-                            <select class="form-select" id="status" name="status">
-                                <option value="all" {{ request('status', 'active') == 'all' ? 'selected' : '' }}>Toutes</option>
-                                <option value="active" {{ request('status', 'active') == 'active' ? 'selected' : '' }}>Actives (validées)</option>
-                                <option value="non_validee" {{ request('status') == 'non_validee' ? 'selected' : '' }}>Non validées ({{ $stats['non_validees'] ?? 0 }})</option>
-                                <option value="en_attente" {{ request('status') == 'en_attente' ? 'selected' : '' }}>En attente</option>
-                                <option value="annulée" {{ request('status') == 'annulée' ? 'selected' : '' }}>Annulées</option>
-                                <option value="terminée" {{ request('status') == 'terminée' ? 'selected' : '' }}>Terminées</option>
-                            </select>
-                        </div>
-                        <div class="col-md-1 mb-3 d-flex align-items-end">
-                            <button type="submit" class="btn-acasi primary w-100">Filtrer</button>
-                        </div>
-                    </div>
-                </form>
-
-                <div id="inscriptions-results">
-                    @include('esbtp.inscriptions.partials.results', ['inscriptions' => $inscriptions])
-                </div>
-            </div>
-
-        </div>
-    </div>
-</div>
-
-<!-- Barre d'actions groupées pour validation -->
-@can('inscriptions.validate')
-<div id="bulk-actions-bar" style="display: none; position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-     background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; padding: 15px 30px;
-     border-radius: 50px; box-shadow: 0 10px 40px rgba(4, 83, 203, 0.4); z-index: 1050;
-     animation: slideUp 0.3s ease-out;">
-    <div style="display: flex; align-items: center; gap: 20px;">
-        <div style="display: flex; align-items: center; gap: 8px;">
-            <i class="fas fa-check-circle" style="font-size: 1.2rem;"></i>
-            <span id="selected-count" style="font-weight: 600; font-size: 1.1rem;">0</span>
-            <span style="opacity: 0.9;">inscription(s) sélectionnée(s)</span>
-        </div>
-        <div style="display: flex; gap: 10px;">
-            <button type="button" class="btn btn-light btn-sm" onclick="bulkValiderInscriptions()"
-                    style="padding: 8px 20px; border-radius: 25px; font-weight: 600; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-                <i class="fas fa-check-double me-1"></i>Valider la sélection
-            </button>
-            <button type="button" class="btn btn-outline-light btn-sm" onclick="clearInscriptionSelection()"
-                    style="padding: 8px 20px; border-radius: 25px; font-weight: 600;">
-                <i class="fas fa-times me-1"></i>Annuler
-            </button>
-        </div>
-    </div>
-</div>
-
-<style>
-@keyframes slideUp {
-    from {
-        bottom: -100px;
-        opacity: 0;
-    }
-    to {
-        bottom: 20px;
-        opacity: 1;
-    }
-}
-</style>
-@endcan
-
-<!-- Modal pour les instructions de changement d'année -->
-<div class="modal fade" id="yearChangeModal" tabindex="-1" aria-labelledby="yearChangeModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="yearChangeModalLabel">Comment changer l'année académique ?</h5>
-                <button type="button" class="close btn-close" aria-label="Close" style="background: none; border: none; font-size: 1.5rem; font-weight: bold; color: #999; cursor: pointer;">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                <p><strong>Pour consulter les inscriptions d'une autre année :</strong></p>
-                <ol style="padding-left: 20px; line-height: 1.6; margin: 15px 0;">
-                    <li><strong>Aller dans</strong> : Menu → Années Universitaires</li>
-                    <li><strong>Trouver l'année souhaitée</strong> (ex: 2023-2024)</li>
-                    <li><strong>Cliquer sur "Activer"</strong> pour la définir comme année courante</li>
-                    <li><strong>Revenir ici</strong> : Les inscriptions affichées se mettront à jour automatiquement</li>
-                </ol>
-                <hr style="margin: 15px 0;">
-                <p style="color: #6b7280; font-size: 14px;">
-                    <i class="fas fa-info-circle"></i> 
-                    <strong>Note :</strong> Seule une année peut être "courante" à la fois. 
-                    Changer l'année courante affecte l'affichage des inscriptions dans toute l'application.
-                </p>
-                <div style="background: #f3f4f6; padding: 12px; border-radius: 6px; margin-top: 15px;">
-                    <strong>Actuellement :</strong><br>
-                    • Année courante = {{ $anneeEnCours->name ?? 'Non définie' }}<br>
-                    • Inscriptions visibles = {{ $inscriptions->count() }} sur {{ \App\Models\ESBTPInscription::count() }} au total
-                </div>
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-dismiss="modal" onclick="$('#yearChangeModal').modal('hide');">Fermer</button>
-                <a href="{{ route('esbtp.annees-universitaires.index') }}" target="_blank" class="btn btn-primary">
-                    <i class="fas fa-external-link-alt"></i> Aller aux Années
-                </a>
-            </div>
-        </div>
-    </div>
-</div>
-@endsection
+@section('title', 'Gestion des inscriptions - KLASSCI')
 
 @push('styles')
+<link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 <style>
-/* Styles pour le filtre année */
-.year-selector {
-    padding: 10px 12px;
-    border: 1px solid #d1d5db;
-    border-radius: 6px;
-    font-size: 14px;
-    color: #374151;
+/* =====================================================================
+   INSCRIPTIONS INDEX — namespace ii-*
+   Design premium monochrome bleu KLASSCI
+   ===================================================================== */
+.dashboard-acasi {
+    --ii-primary: #0453cb;
+    --ii-primary-dark: #033a8e;
+    --ii-accent: #3b7ddb;
+    --ii-text: #1e293b;
+    --ii-muted: #64748b;
+    --ii-surface: #f8fafc;
+    --ii-border: #e2e8f0;
+    --ii-success: #10b981;
+    --ii-warn: #f59e0b;
+    --ii-danger: #ef4444;
 }
 
-.section-title {
-    font-size: 16px;
-    font-weight: 600;
-    color: #1f2937;
-    display: flex;
-    align-items: center;
-}
-
-/* Variables CSS pour compatibilité */
-:root {
-    --space-sm: 0.5rem;
-    --space-md: 1rem;
-    --space-lg: 1.5rem;
-    --text-small: 12px;
-    --text-secondary: #6b7280;
-}
-
-.card-moderne {
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
-    border: 1px solid #e5e7eb;
-}
-
-.p-lg {
-    padding: 1.5rem;
-}
-
-.mb-lg {
-    margin-bottom: 1.5rem;
-}
-
-.mb-md {
-    margin-bottom: 1rem;
-}
-
-.mt-3 {
-    margin-top: 1rem;
-}
-
-.me-1 {
-    margin-right: 0.25rem;
-}
-
-.me-2 {
-    margin-right: 0.5rem;
-}
-
-.text-muted {
-    color: #6b7280;
-}
-
-.text-warning {
-    color: #f59e0b;
-}
-
-.alert {
-    padding: 1rem;
-    border-radius: 6px;
-    border: 1px solid transparent;
-}
-
-.alert-warning {
-    background-color: #fef3c7;
-    border-color: #f59e0b;
-    color: #92400e;
-}
-
-.d-flex {
-    display: flex;
-}
-
-.align-items-center {
-    align-items: center;
-}
-
-tr[data-inscription-id] {
+/* ========== HERO ========== */
+.ii-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 2rem 2.5rem 1.5rem;
+    color: #fff;
+    margin-bottom: 1.25rem;
     position: relative;
     overflow: hidden;
 }
+.ii-hero::before {
+    content: ''; position: absolute; top: -40px; right: -40px;
+    width: 220px; height: 220px; border-radius: 50%;
+    background: rgba(255,255,255,.06); pointer-events: none;
+}
+.ii-hero-top { display: flex; align-items: flex-start; justify-content: space-between; flex-wrap: wrap; gap: 1rem; position: relative; z-index: 1; }
+.ii-hero-left { display: flex; align-items: center; gap: 1rem; flex: 1; min-width: 260px; }
+.ii-hero-icon {
+    width: 52px; height: 52px; border-radius: 14px;
+    background: rgba(255,255,255,.12); backdrop-filter: blur(8px);
+    border: 1px solid rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.35rem; flex-shrink: 0; color: #fff;
+}
+.ii-hero h1 { font-size: 1.5rem; font-weight: 700; color: #fff; margin: 0 0 .2rem; }
+.ii-hero p { color: rgba(255,255,255,.75); font-size: .88rem; margin: 0 0 .5rem; }
+.ii-hero-chip {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .3rem .7rem;
+    background: rgba(255,255,255,.12);
+    border: 1px solid rgba(255,255,255,.18);
+    border-radius: 99px; color: #fff;
+    font-size: .78rem; font-weight: 500;
+}
+.ii-hero-actions { display: flex; gap: .5rem; flex-wrap: wrap; }
+.ii-btn--glass, .ii-btn--white {
+    display: inline-flex; align-items: center; gap: .4rem;
+    padding: .55rem 1.1rem; border-radius: 10px;
+    font-size: .83rem; font-weight: 600;
+    text-decoration: none; cursor: pointer;
+    transition: all .2s ease; border: 1px solid transparent;
+}
+.ii-btn--glass { background: rgba(255,255,255,.12); color: #fff; border-color: rgba(255,255,255,.18); }
+.ii-btn--glass:hover { background: rgba(255,255,255,.2); color: #fff; transform: translateY(-1px); }
+.ii-btn--white { background: #fff; color: var(--ii-primary); }
+.ii-btn--white:hover { background: #f1f5f9; color: var(--ii-primary-dark); transform: translateY(-1px); box-shadow: 0 4px 14px rgba(0,0,0,.12); }
 
-tr[data-inscription-id].is-loading {
-    opacity: 0.85;
+/* ========== KPIs cliquables ========== */
+.ii-kpis {
+    display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: .7rem; margin-top: 1.5rem;
+    position: relative; z-index: 1;
+}
+.ii-kpi {
+    background: rgba(255,255,255,.1);
+    border: 1px solid rgba(255,255,255,.15);
+    border-radius: 12px; padding: .85rem 1rem;
+    display: flex; align-items: center; gap: .6rem;
+    cursor: pointer; transition: all .2s;
+    text-decoration: none; color: inherit;
+    width: 100%; text-align: left;
+    font-family: inherit; font-size: inherit;
+}
+.ii-kpi:hover { background: rgba(255,255,255,.18); transform: translateY(-1px); color: inherit; }
+.ii-kpi--active {
+    background: #fff !important;
+    color: var(--ii-primary) !important;
+    border-color: #fff !important;
+    box-shadow: 0 6px 16px rgba(0,0,0,.18);
+}
+.ii-kpi--active .ii-kpi-icon { background: rgba(4,83,203,.1); color: var(--ii-primary); }
+.ii-kpi--active .ii-kpi-value { color: var(--ii-primary); }
+.ii-kpi--active .ii-kpi-label { color: var(--ii-muted); }
+.ii-kpi-icon {
+    width: 38px; height: 38px; border-radius: 10px;
+    background: rgba(255,255,255,.14);
+    display: flex; align-items: center; justify-content: center;
+    font-size: .95rem; color: #fff; flex-shrink: 0;
+    transition: all .2s;
+}
+.ii-kpi-body { flex: 1; min-width: 0; }
+.ii-kpi-value { font-size: 1.4rem; font-weight: 700; color: #fff; line-height: 1; }
+.ii-kpi-label { font-size: .7rem; color: rgba(255,255,255,.7); margin-top: .2rem; text-transform: uppercase; letter-spacing: .05em; font-weight: 500; }
+.ii-kpi-badge {
+    position: absolute; top: .4rem; right: .4rem;
+    width: 8px; height: 8px; border-radius: 50%;
+    background: var(--ii-warn);
+    box-shadow: 0 0 0 2px rgba(245,158,11,.2);
 }
 
-.inscription-actions-wrapper {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+/* ========== ALERTS ========== */
+.ii-alert {
+    display: flex; align-items: center; gap: .6rem;
+    padding: .85rem 1.1rem; border-radius: 12px;
+    margin-bottom: 1rem; font-weight: 500; font-size: .9rem;
+}
+.ii-alert--success { background: #ecfdf5; border: 1px solid #a7f3d0; color: #065f46; }
+.ii-alert--danger { background: #fef2f2; border: 1px solid #fecaca; color: #991b1b; }
+
+.ii-banner {
+    background: #fffbeb; border: 1px solid #fde68a;
+    border-left: 4px solid var(--ii-warn);
+    border-radius: 12px; padding: .9rem 1.25rem;
+    margin-bottom: 1rem;
+    display: flex; align-items: center; gap: .85rem;
+}
+.ii-banner-icon {
+    width: 36px; height: 36px; border-radius: 10px;
+    background: #fef3c7;
+    display: flex; align-items: center; justify-content: center;
+    color: var(--ii-warn); flex-shrink: 0; font-size: 1rem;
+}
+.ii-banner-body { flex: 1; }
+.ii-banner-title { font-weight: 700; color: #92400e; margin-bottom: .15rem; font-size: .9rem; }
+.ii-banner-text { color: #78350f; font-size: .82rem; line-height: 1.4; }
+
+/* ========== TOOLBAR ========== */
+.ii-toolbar {
+    background: #fff; border: 1px solid var(--ii-border);
+    border-radius: 14px; padding: 1rem 1.25rem;
+    margin-bottom: 1.25rem;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04);
+}
+.ii-toolbar-row {
+    display: flex; gap: .6rem; flex-wrap: wrap; align-items: center;
+}
+.ii-search { position: relative; flex: 1 1 260px; min-width: 220px; }
+.ii-search i {
+    position: absolute; left: .9rem; top: 50%;
+    transform: translateY(-50%); color: var(--ii-muted);
+    font-size: .88rem; pointer-events: none;
+}
+.ii-search input {
+    width: 100%; padding: .6rem .9rem .6rem 2.3rem;
+    border: 1px solid var(--ii-border); border-radius: 10px;
+    font-size: .88rem; background: var(--ii-surface);
+    transition: all .2s;
+}
+.ii-search input:focus {
+    outline: none; background: #fff;
+    border-color: var(--ii-primary);
+    box-shadow: 0 0 0 3px rgba(4,83,203,.1);
+}
+.ii-filter-select {
+    padding: .6rem .9rem;
+    border: 1px solid var(--ii-border); border-radius: 10px;
+    font-size: .85rem; background: var(--ii-surface);
+    cursor: pointer; appearance: none;
+    color: var(--ii-text); transition: all .2s;
+    min-width: 140px;
+    background: var(--ii-surface) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'%3E%3Cpath fill='%2364748b' d='M0 0l5 6 5-6z'/%3E%3C/svg%3E") no-repeat right .75rem center;
+    padding-right: 2rem;
+}
+.ii-filter-select:focus { outline: none; border-color: var(--ii-primary); box-shadow: 0 0 0 3px rgba(4,83,203,.1); }
+.ii-btn--ghost {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .55rem .85rem;
+    border: 1px solid var(--ii-border); border-radius: 10px;
+    background: #fff; color: var(--ii-text);
+    font-size: .83rem; font-weight: 500;
+    cursor: pointer; transition: all .2s; text-decoration: none;
+}
+.ii-btn--ghost:hover { border-color: var(--ii-primary); color: var(--ii-primary); background: rgba(4,83,203,.04); }
+
+.ii-toolbar-meta {
+    margin-top: .75rem; padding-top: .75rem;
+    border-top: 1px dashed var(--ii-border);
+    font-size: .78rem; color: var(--ii-muted);
+    display: flex; gap: 1rem; align-items: center;
+    flex-wrap: wrap;
+}
+.ii-chips-active { display: flex; gap: .3rem; flex-wrap: wrap; }
+.ii-chip-active {
+    display: inline-flex; align-items: center; gap: .3rem;
+    padding: .2rem .55rem;
+    background: rgba(4,83,203,.08); color: var(--ii-primary);
+    border-radius: 99px; font-size: .72rem; font-weight: 600;
+}
+.ii-chip-active button {
+    background: transparent; border: none; padding: 0;
+    color: inherit; cursor: pointer;
+    display: inline-flex; align-items: center;
 }
 
-.inscription-actions-buttons {
-    display: inline-flex;
+/* ========== TABLE ========== */
+.ii-results-card {
+    background: #fff; border: 1px solid var(--ii-border);
+    border-radius: 14px; overflow: hidden;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04);
 }
-
-.inscription-actions-spinner {
-    display: none;
-    min-width: 32px;
+.ii-table-wrap { overflow-x: auto; }
+.ii-table { width: 100%; border-collapse: separate; border-spacing: 0; }
+.ii-table thead th {
+    background: var(--ii-surface);
+    color: var(--ii-muted);
+    font-size: .72rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .05em;
+    padding: .8rem 1rem;
+    border-bottom: 1px solid var(--ii-border);
+    text-align: left;
+    white-space: nowrap;
 }
-
-.inscription-actions-wrapper.is-loading .inscription-actions-buttons {
-    display: none !important;
+.ii-sort-link {
+    color: inherit; text-decoration: none;
+    display: inline-flex; align-items: center; gap: .3rem;
+    cursor: pointer;
 }
+.ii-sort-link:hover { color: var(--ii-primary); }
+.ii-sort-icon { font-size: .7rem; }
+.ii-sort-icon--neutral { opacity: .3; }
+.ii-sort-icon--active { color: var(--ii-primary); opacity: 1; }
 
-.inscription-actions-wrapper.is-loading .inscription-actions-spinner {
-    display: flex !important;
-    align-items: center;
-    justify-content: center;
+.ii-row { transition: background .15s; cursor: pointer; }
+.ii-row:hover { background: rgba(4,83,203,.03); }
+.ii-row.is-loading { opacity: .6; pointer-events: none; }
+.ii-row.ii-row--error { background: rgba(239,68,68,.05); }
+.ii-row.ii-row--warn { background: rgba(245,158,11,.05); }
+.ii-table tbody td {
+    padding: .75rem 1rem;
+    border-bottom: 1px solid var(--ii-surface);
+    vertical-align: middle;
+    color: var(--ii-text); font-size: .87rem;
 }
+.ii-col-check { width: 40px; text-align: center; }
 
+/* Étudiant cell */
+.ii-etu-cell { display: flex; align-items: center; gap: .75rem; }
+.ii-avatar {
+    width: 36px; height: 36px; border-radius: 50%;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-weight: 700; font-size: .78rem;
+    flex-shrink: 0; overflow: hidden;
+}
+.ii-etu-body { min-width: 0; }
+.ii-etu-name { font-weight: 600; color: var(--ii-text); line-height: 1.2; }
+.ii-etu-meta {
+    display: flex; align-items: center; gap: .3rem;
+    font-size: .72rem; color: var(--ii-muted); margin-top: .15rem;
+}
+.ii-matricule {
+    font-family: 'Courier New', monospace;
+    background: var(--ii-surface); padding: .1rem .35rem;
+    border-radius: 4px; font-weight: 600;
+}
+.ii-numero { font-weight: 500; }
+.ii-separator { opacity: .5; }
+
+.ii-filiere-cell { line-height: 1.3; }
+.ii-filiere-name { font-weight: 600; color: var(--ii-text); font-size: .85rem; }
+.ii-filiere-niveau { font-size: .75rem; color: var(--ii-muted); }
+.ii-col-annee { color: var(--ii-muted); font-size: .82rem; }
+
+/* ========== BADGE STATUT (Blade component) ========== */
+.ii-badge {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .25rem .65rem;
+    border-radius: 99px;
+    font-size: .73rem; font-weight: 700;
+    white-space: nowrap;
+    border: 1px solid transparent;
+}
+.ii-badge i { font-size: .72rem; }
+.ii-badge--validee { background: var(--ii-primary); color: #fff; border-color: var(--ii-primary); }
+.ii-badge--non_validee {
+    background: #fff; color: var(--ii-primary);
+    border-color: var(--ii-primary);
+}
+.ii-badge--en_attente {
+    background: rgba(4,83,203,.08); color: var(--ii-primary);
+    border-color: rgba(4,83,203,.2);
+}
+.ii-badge--annulee {
+    background: #fff; color: var(--ii-muted);
+    border-color: var(--ii-border);
+}
+.ii-badge--terminee {
+    background: #f1f5f9; color: #475569;
+    border-color: #cbd5e1;
+}
+.ii-badge--inconnu { background: #f1f5f9; color: var(--ii-muted); }
+
+.ii-probleme-chip {
+    display: inline-flex; align-items: flex-start; gap: .35rem;
+    padding: .3rem .55rem;
+    background: rgba(245,158,11,.1);
+    color: #92400e;
+    border: 1px solid rgba(245,158,11,.3);
+    border-radius: 8px;
+    font-size: .72rem; font-weight: 500;
+    line-height: 1.35; margin-top: .35rem;
+    max-width: 260px;
+}
+.ii-probleme-chip i { margin-top: .12rem; flex-shrink: 0; }
+
+.ii-btn-quick {
+    display: inline-flex; align-items: center; gap: .3rem;
+    margin-top: .35rem;
+    padding: .35rem .7rem;
+    background: var(--ii-primary); color: #fff;
+    border: none; border-radius: 8px;
+    font-size: .72rem; font-weight: 600;
+    cursor: pointer; transition: all .15s;
+}
+.ii-btn-quick:hover { background: var(--ii-primary-dark); transform: translateY(-1px); box-shadow: 0 2px 8px rgba(4,83,203,.25); }
+
+/* Actions buttons */
+.ii-col-actions { text-align: right; white-space: nowrap; }
+.ii-actions { display: inline-flex; gap: .3rem; align-items: center; justify-content: flex-end; }
+.ii-btn {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 32px; height: 32px;
+    border: 1px solid var(--ii-border);
+    background: #fff; border-radius: 8px;
+    cursor: pointer; transition: all .15s;
+    font-size: .82rem;
+    text-decoration: none;
+    color: var(--ii-text);
+}
+.ii-btn:hover { border-color: var(--ii-primary); color: var(--ii-primary); background: rgba(4,83,203,.04); }
+.ii-btn--primary {
+    background: var(--ii-primary); color: #fff;
+    border-color: var(--ii-primary);
+}
+.ii-btn--primary:hover { background: var(--ii-primary-dark); color: #fff; border-color: var(--ii-primary-dark); transform: translateY(-1px); box-shadow: 0 2px 8px rgba(4,83,203,.25); }
+
+/* Dropdown */
+.ii-dropdown {
+    border-radius: 12px; border: 1px solid var(--ii-border);
+    box-shadow: 0 10px 30px rgba(15,23,42,.1);
+    padding: .4rem; min-width: 200px;
+}
+.ii-dropdown .dropdown-item {
+    display: flex; align-items: center; gap: .55rem;
+    padding: .55rem .75rem; border-radius: 8px;
+    font-size: .85rem; color: var(--ii-text); cursor: pointer;
+    width: 100%; text-align: left;
+    background: transparent; border: none;
+}
+.ii-dropdown .dropdown-item i { width: 18px; text-align: center; color: var(--ii-muted); font-size: .88rem; }
+.ii-dropdown .dropdown-item:hover { background: rgba(4,83,203,.08); color: var(--ii-primary); }
+.ii-dropdown .dropdown-item:hover i { color: var(--ii-primary); }
+.ii-dropdown-item--danger:hover,
+.ii-dropdown-item--danger:hover i { color: #991b1b !important; background: rgba(239,68,68,.08) !important; }
+
+/* Inscription actions wrapper spinner pattern */
+.inscription-actions-wrapper { display: inline-flex; align-items: center; gap: .5rem; position: relative; }
+.inscription-actions-spinner { display: none; }
+.inscription-actions-wrapper.is-loading .inscription-actions-buttons { display: none !important; }
+.inscription-actions-wrapper.is-loading .inscription-actions-spinner { display: flex !important; }
+
+/* Row highlight animations (preserved) */
+tr[data-inscription-id] { position: relative; overflow: hidden; }
 .inscription-row-highlight {
-    position: absolute;
-    top: 0;
-    left: -80%;
-    width: 160%;
-    height: 100%;
-    opacity: 0;
-    pointer-events: none;
+    position: absolute; top: 0; left: -80%;
+    width: 160%; height: 100%;
+    opacity: 0; pointer-events: none;
     transform: translateX(-65%) skewX(-12deg);
-    background: linear-gradient(90deg, rgba(40, 167, 69, 0) 0%, rgba(40, 167, 69, 0.75) 50%, rgba(40, 167, 69, 0) 100%);
-    transition: opacity 0.2s ease;
-    z-index: 5;
+    background: linear-gradient(90deg, rgba(16,185,129,0) 0%, rgba(16,185,129,.7) 50%, rgba(16,185,129,0) 100%);
+    transition: opacity .2s ease; z-index: 5;
 }
-
 .inscription-row-highlight.reject {
-    background: linear-gradient(90deg, rgba(220, 53, 69, 0) 0%, rgba(220, 53, 69, 0.75) 50%, rgba(220, 53, 69, 0) 100%);
+    background: linear-gradient(90deg, rgba(239,68,68,0) 0%, rgba(239,68,68,.7) 50%, rgba(239,68,68,0) 100%);
 }
-
 .inscription-row-highlight.animate {
-    animation: inscription-row-highlight-move 3.2s ease-out forwards;
+    animation: ii-highlight-move 3.2s ease-out forwards;
+}
+.inscription-row-flash { animation: ii-flash .8s ease-in-out; }
+.inscription-row-flash.reject { animation-name: ii-flash-reject; }
+@keyframes ii-highlight-move {
+    0% { opacity: 0; transform: translateX(-65%) skewX(-12deg); }
+    18% { opacity: .9; }
+    55% { opacity: .65; }
+    100% { opacity: 0; transform: translateX(115%) skewX(-12deg); }
+}
+@keyframes ii-flash {
+    0% { background: transparent; }
+    25% { background: rgba(16,185,129,.1); }
+    100% { background: transparent; }
+}
+@keyframes ii-flash-reject {
+    0% { background: transparent; }
+    25% { background: rgba(239,68,68,.1); }
+    100% { background: transparent; }
 }
 
-.inscription-row-flash {
-    animation: inscription-row-flash 0.8s ease-in-out;
+/* ========== FOOTER ========== */
+.ii-table-footer {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 1rem 1.25rem;
+    border-top: 1px solid var(--ii-border);
+    background: var(--ii-surface);
+    flex-wrap: wrap; gap: 1rem;
+}
+.ii-per-page { display: flex; align-items: center; gap: .5rem; font-size: .82rem; color: var(--ii-muted); }
+.ii-per-page-label { font-weight: 500; margin: 0; }
+.ii-per-page-select {
+    padding: .3rem .6rem;
+    border: 1px solid var(--ii-border); border-radius: 8px;
+    background: #fff; font-size: .82rem;
+    cursor: pointer;
+}
+.ii-per-page-select:focus { outline: none; border-color: var(--ii-primary); }
+.ii-pagination .pagination { margin: 0; }
+.ii-pagination .page-link {
+    color: var(--ii-primary);
+    border-color: var(--ii-border);
+    font-size: .85rem;
+}
+.ii-pagination .page-item.active .page-link {
+    background: var(--ii-primary);
+    border-color: var(--ii-primary);
 }
 
-@keyframes inscription-row-highlight-move {
-    0% {
-        opacity: 0;
-        transform: translateX(-65%) skewX(-12deg);
-    }
-    18% {
-        opacity: 0.92;
-    }
-    55% {
-        opacity: 0.7;
-    }
-    100% {
-        opacity: 0;
-        transform: translateX(115%) skewX(-12deg);
-    }
+/* Empty state */
+.ii-empty {
+    text-align: center; padding: 3.5rem 1.5rem;
+}
+.ii-empty-icon {
+    width: 72px; height: 72px; border-radius: 50%;
+    background: var(--ii-surface);
+    display: inline-flex; align-items: center; justify-content: center;
+    color: var(--ii-muted); font-size: 1.75rem;
+    margin-bottom: 1rem;
+}
+.ii-empty-title { font-size: 1rem; font-weight: 700; color: var(--ii-text); margin-bottom: .3rem; }
+.ii-empty-text { font-size: .88rem; color: var(--ii-muted); }
+
+/* ========== MODALS monochrome ========== */
+.ii-modal-header {
+    background: linear-gradient(135deg, #0a3d8f 0%, var(--ii-primary) 100%);
+    color: #fff;
+    border-bottom: none;
+    border-top-left-radius: calc(0.5rem - 1px);
+    border-top-right-radius: calc(0.5rem - 1px);
+}
+.ii-modal-header .modal-title { color: #fff; font-weight: 700; font-size: 1rem; }
+.ii-info-box {
+    display: flex; gap: .6rem;
+    padding: .8rem 1rem;
+    background: rgba(4,83,203,.06);
+    border-left: 3px solid var(--ii-primary);
+    border-radius: 8px;
+    color: var(--ii-text); font-size: .85rem; line-height: 1.5;
+}
+.ii-info-box i { color: var(--ii-primary); font-size: 1rem; flex-shrink: 0; margin-top: .15rem; }
+.ii-warn-box {
+    display: flex; gap: .6rem;
+    padding: .8rem 1rem; background: #fef3c7;
+    border-left: 3px solid var(--ii-warn);
+    border-radius: 8px;
+    color: #92400e; font-size: .84rem; line-height: 1.5;
+}
+.ii-warn-box i { color: var(--ii-warn); font-size: 1rem; flex-shrink: 0; margin-top: .15rem; }
+
+/* ========== BULK BAR ========== */
+.ii-bulk-bar {
+    display: none;
+    position: fixed; bottom: 24px; left: 50%;
+    transform: translateX(-50%);
+    background: linear-gradient(135deg, #0453cb 0%, #3b7ddb 100%);
+    color: #fff;
+    padding: .9rem 1.5rem;
+    border-radius: 99px;
+    box-shadow: 0 10px 40px rgba(4,83,203,.35);
+    z-index: 1050;
+    animation: ii-bulk-slide-up .3s ease-out;
+}
+.ii-bulk-bar.ii-bulk-bar--visible { display: flex; }
+.ii-bulk-bar-content {
+    display: flex; align-items: center; gap: 1rem; flex-wrap: wrap;
+}
+.ii-bulk-count {
+    display: flex; align-items: center; gap: .4rem;
+    font-size: .9rem; font-weight: 600;
+}
+.ii-bulk-count i { font-size: 1rem; }
+.ii-bulk-actions { display: flex; gap: .4rem; flex-wrap: wrap; }
+.ii-bulk-btn {
+    display: inline-flex; align-items: center; gap: .3rem;
+    padding: .45rem 1rem;
+    background: rgba(255,255,255,.15);
+    color: #fff;
+    border: 1px solid rgba(255,255,255,.25);
+    border-radius: 99px;
+    font-size: .78rem; font-weight: 600;
+    cursor: pointer; transition: all .15s;
+}
+.ii-bulk-btn:hover { background: rgba(255,255,255,.25); transform: translateY(-1px); }
+.ii-bulk-btn--primary { background: #fff; color: var(--ii-primary); border-color: #fff; }
+.ii-bulk-btn--primary:hover { background: #f1f5f9; color: var(--ii-primary-dark); }
+.ii-bulk-btn--danger { background: rgba(255,255,255,.12); color: #fecaca; border-color: rgba(254,202,202,.3); }
+.ii-bulk-btn--danger:hover { background: rgba(239,68,68,.25); color: #fff; border-color: #fca5a5; }
+.ii-bulk-close {
+    width: 32px; height: 32px; border-radius: 50%;
+    border: 1px solid rgba(255,255,255,.25);
+    background: transparent; color: #fff;
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer; transition: all .15s;
+}
+.ii-bulk-close:hover { background: rgba(255,255,255,.2); }
+@keyframes ii-bulk-slide-up {
+    from { bottom: -100px; opacity: 0; }
+    to { bottom: 24px; opacity: 1; }
 }
 
-@keyframes inscription-row-flash {
-    0% {
-        background-color: transparent;
-    }
-    25% {
-        background-color: rgba(40, 167, 69, 0.12);
-    }
-    100% {
-        background-color: transparent;
-    }
+/* ========== RESPONSIVE ========== */
+@media (max-width: 992px) {
+    .ii-hero { padding: 1.5rem 1.5rem 1.25rem; }
+    .ii-hero h1 { font-size: 1.3rem; }
+    .ii-col-annee, .ii-col-date { display: none; }
 }
-
-.inscription-row-flash.reject {
-    animation-name: inscription-row-flash-reject;
+@media (max-width: 768px) {
+    .ii-hero-top { flex-direction: column; align-items: stretch; }
+    .ii-hero-actions { justify-content: flex-start; }
+    .ii-kpis { grid-template-columns: repeat(2, 1fr); }
+    .ii-filter-select { flex: 1 1 calc(50% - .3rem); min-width: 0; }
+    .ii-search { flex: 1 1 100%; }
 }
-
-@keyframes inscription-row-flash-reject {
-    0% {
-        background-color: transparent;
-    }
-    25% {
-        background-color: rgba(220, 53, 69, 0.12);
-    }
-    100% {
-        background-color: transparent;
-    }
+@media (max-width: 480px) {
+    .ii-hero { padding: 1.25rem; }
+    .ii-kpis { grid-template-columns: 1fr; }
+    .ii-table-footer { flex-direction: column; align-items: flex-start; }
+    .ii-bulk-bar { left: 12px; right: 12px; transform: none; width: calc(100% - 24px); }
 }
 </style>
 @endpush
 
-@push('scripts')
-<script>
-const INSCRIPTION_HIGHLIGHT_DURATION = 3200;
-const INSCRIPTION_STATUS_PASS_RATIO = 0.8;
-
-function setInscriptionRowLoadingState(inscriptionId, isLoading) {
-    const row = document.querySelector(`tr[data-inscription-id="${inscriptionId}"]`);
-    if (!row) {
-        return;
-    }
-
-    row.classList.toggle('is-loading', Boolean(isLoading));
-
-    const actionsWrapper = row.querySelector('.inscription-actions-wrapper');
-    if (actionsWrapper) {
-        actionsWrapper.classList.toggle('is-loading', Boolean(isLoading));
-    }
-}
-window.setInscriptionRowLoadingState = setInscriptionRowLoadingState;
-
-function triggerInscriptionRowHighlight(row, actionType = 'update', options = {}) {
-    if (!row) {
-        return;
-    }
-
-    const onStatusPassed = typeof options.onStatusPassed === 'function' ? options.onStatusPassed : null;
-    const isReject = ['reject', 'cancel', 'danger', 'delete'].includes(actionType);
-
-    row.classList.remove('inscription-row-flash', 'reject');
-    void row.offsetWidth;
-
-    const highlight = document.createElement('div');
-    highlight.className = 'inscription-row-highlight';
-    if (isReject) {
-        highlight.classList.add('reject');
-    }
-
-    row.appendChild(highlight);
-
-    requestAnimationFrame(() => {
-        highlight.classList.add('animate');
-    });
-
-    if (onStatusPassed) {
-        setTimeout(() => {
-            onStatusPassed(highlight);
-        }, INSCRIPTION_HIGHLIGHT_DURATION * INSCRIPTION_STATUS_PASS_RATIO);
-    }
-
-    const cleanup = () => {
-        highlight.removeEventListener('animationend', cleanup);
-        highlight.remove();
-    };
-
-    highlight.addEventListener('animationend', cleanup);
-
-    row.classList.add('inscription-row-flash');
-    if (isReject) {
-        row.classList.add('reject');
-    }
-
-    setTimeout(() => {
-        row.classList.remove('inscription-row-flash', 'reject');
-    }, 1200);
-}
-window.triggerInscriptionRowHighlight = triggerInscriptionRowHighlight;
-
-function showYearChangeInfo() {
-    console.log('Tentative ouverture modal');
-    
-    // Essayer avec différentes méthodes Bootstrap
-    if (typeof bootstrap !== 'undefined') {
-        // Bootstrap 5
-        const modal = new bootstrap.Modal(document.getElementById('yearChangeModal'));
-        modal.show();
-    } else if (typeof $ !== 'undefined' && $.fn.modal) {
-        // Bootstrap 4 avec jQuery
-        $('#yearChangeModal').modal('show');
-    } else {
-        // Fallback - afficher directement
-        const modal = document.getElementById('yearChangeModal');
-        if (modal) {
-            modal.style.display = 'block';
-            modal.classList.add('show');
-            document.body.classList.add('modal-open');
-            
-            // Ajouter backdrop
-            const backdrop = document.createElement('div');
-            backdrop.className = 'modal-backdrop fade show';
-            backdrop.id = 'modal-backdrop';
-            document.body.appendChild(backdrop);
-        }
-    }
-}
-
-// Fermer le modal manuellement si nécessaire
-function closeYearModal() {
-    const modal = document.getElementById('yearChangeModal');
-    if (modal) {
-        modal.style.display = 'none';
-        modal.classList.remove('show');
-        document.body.classList.remove('modal-open');
-        
-        // Supprimer backdrop
-        const backdrop = document.getElementById('modal-backdrop');
-        if (backdrop) {
-            backdrop.remove();
-        }
-    }
-}
-
-// Gérer les événements de fermeture
-document.addEventListener('DOMContentLoaded', function() {
-    // Fermeture avec X
-    const closeButton = document.querySelector('#yearChangeModal .close');
-    if (closeButton) {
-        closeButton.addEventListener('click', closeYearModal);
-    }
-    
-    // Fermeture avec bouton Fermer
-    const cancelButton = document.querySelector('#yearChangeModal .btn-secondary');
-    if (cancelButton) {
-        cancelButton.addEventListener('click', closeYearModal);
-    }
-    
-    // Fermeture en cliquant sur le backdrop
-    const modal = document.getElementById('yearChangeModal');
-    if (modal) {
-        modal.addEventListener('click', function(e) {
-            if (e.target === modal) {
-                closeYearModal();
-            }
-        });
-    }
-});
-
-function initInscriptionsSelect2() {
-    if (typeof $ !== 'undefined' && typeof $.fn.select2 !== 'undefined') {
-        $('#filiere, #niveau, #annee, #status').select2({
-            placeholder: 'Sélectionnez une option',
-            allowClear: true
-        });
-    }
-}
-
-function initInscriptionsTooltips(context = document) {
-    if (typeof bootstrap === 'undefined') {
-        return;
-    }
-
-    const tooltipTriggerList = [].slice.call(context.querySelectorAll('[data-bs-toggle="tooltip"]'));
-    tooltipTriggerList.forEach(function (tooltipTriggerEl) {
-        bootstrap.Tooltip.getInstance(tooltipTriggerEl)?.dispose();
-        new bootstrap.Tooltip(tooltipTriggerEl);
-    });
-}
-
-// ============================================================================
-// GESTION DES ACTIONS GROUPÉES POUR LES INSCRIPTIONS
-// ============================================================================
-
-// Fonction pour mettre à jour le compteur et afficher/masquer la barre d'actions
-function updateInscriptionSelectionCount() {
-    const checkboxes = document.querySelectorAll('.inscription-checkbox:checked');
-    const count = checkboxes.length;
-    const bulkBar = document.getElementById('bulk-actions-bar');
-    const selectedCountSpan = document.getElementById('selected-count');
-
-    if (selectedCountSpan) {
-        selectedCountSpan.textContent = count;
-    }
-
-    if (bulkBar) {
-        if (count > 0) {
-            bulkBar.style.display = 'block';
-        } else {
-            bulkBar.style.display = 'none';
-        }
-    }
-}
-
-function bindBulkSelectionHandlers() {
-    const selectAllCheckbox = document.getElementById('select-all-inscriptions');
-    if (selectAllCheckbox) {
-        selectAllCheckbox.onchange = function () {
-            const checkboxes = document.querySelectorAll('.inscription-checkbox');
-            checkboxes.forEach(checkbox => {
-                checkbox.checked = this.checked;
-            });
-            updateInscriptionSelectionCount();
-        };
-    }
-
-    document.querySelectorAll('.inscription-checkbox').forEach(checkbox => {
-        checkbox.onchange = function () {
-            updateInscriptionSelectionCount();
-
-            const allCheckboxes = document.querySelectorAll('.inscription-checkbox');
-            const checkedCheckboxes = document.querySelectorAll('.inscription-checkbox:checked');
-            const selectAll = document.getElementById('select-all-inscriptions');
-
-            if (selectAll) {
-                selectAll.checked = allCheckboxes.length === checkedCheckboxes.length && allCheckboxes.length > 0;
-            }
-        };
-    });
-}
-
-// Fonction pour effacer la sélection
-function clearInscriptionSelection() {
-    document.querySelectorAll('.inscription-checkbox').forEach(checkbox => {
-        checkbox.checked = false;
-    });
-    const selectAll = document.getElementById('select-all-inscriptions');
-    if (selectAll) {
-        selectAll.checked = false;
-    }
-    updateInscriptionSelectionCount();
-}
-
-function showToast(message, type = 'success') {
-    if (!message) {
-        return;
-    }
-
-    if (window.toastr && typeof window.toastr[type] === 'function') {
-        window.toastr[type](message);
-        return;
-    }
-
-    alert(message);
-}
-
-// Fonction pour valider les inscriptions sélectionnées (AJAX)
-function bulkValiderInscriptions() {
-    const checkboxes = document.querySelectorAll('.inscription-checkbox:checked');
-    const inscriptionIds = Array.from(checkboxes).map(cb => cb.value);
-
-    if (inscriptionIds.length === 0) {
-        showToast('Veuillez sélectionner au moins une inscription à valider.', 'warning');
-        return;
-    }
-
-    const confirmMessage = `Êtes-vous sûr de vouloir valider ${inscriptionIds.length} inscription(s) ?\n\nLe système va automatiquement :\n• Valider les inscriptions avec paiements validés\n• Auto-valider les paiements en attente si nécessaire\n• Valider les inscriptions sans paiement (aligné sur validation unitaire)\n• Envoyer les notifications aux étudiants concernés`;
-
-    if (!confirm(confirmMessage)) {
-        return;
-    }
-
-    const formData = new FormData();
-    formData.append('_token', '{{ csrf_token() }}');
-    inscriptionIds.forEach(id => formData.append('inscription_ids[]', id));
-
-    // Mettre toutes les lignes en loading
-    inscriptionIds.forEach(id => {
-        const row = document.querySelector(`tr[data-inscription-id="${id}"]`);
-        if (row) {
-            row.classList.add('is-loading');
-            const wrapper = row.querySelector('.inscription-actions-wrapper');
-            if (wrapper) wrapper.classList.add('is-loading');
-        }
-    });
-
-    fetch("{{ route('esbtp.inscriptions.bulk-valider') }}", {
-        method: 'POST',
-        body: formData,
-        headers: { 'X-Requested-With': 'XMLHttpRequest' }
-    })
-    .then(response => {
-        if (!response.ok) throw new Error('Erreur lors de la validation.');
-        return response.json();
-    })
-    .then(data => {
-        if (!data.success) {
-            showToast(data.message || 'Validation échouée.', 'error');
-            inscriptionIds.forEach(id => {
-                const row = document.querySelector(`tr[data-inscription-id="${id}"]`);
-                if (row) {
-                    row.classList.remove('is-loading');
-                    const wrapper = row.querySelector('.inscription-actions-wrapper');
-                    if (wrapper) wrapper.classList.remove('is-loading');
-                }
-            });
-            return;
-        }
-
-        if (data.message) {
-            const hasProblems = data.inscriptions_problemes && Object.keys(data.inscriptions_problemes).length > 0;
-            showToast(data.message, hasProblems ? 'warning' : 'success');
-        }
-
-        const problems = data.inscriptions_problemes || {};
-
-        Object.values(problems).forEach(problem => {
-            if (problem && problem.message) {
-                showToast(problem.message, 'warning');
-            }
-        });
-
-        // Rafraîchir chaque ligne avec highlight
-        inscriptionIds.forEach(id => {
-            const actionType = problems[id] ? 'reject' : 'validate';
-            refreshInscriptionLigne(id, actionType);
-        });
-
-        clearInscriptionSelection();
-    })
-    .catch(error => {
-        showToast(error.message || 'Erreur lors de la validation.', 'error');
-        inscriptionIds.forEach(id => {
-            const row = document.querySelector(`tr[data-inscription-id="${id}"]`);
-            if (row) {
-                row.classList.remove('is-loading');
-                const wrapper = row.querySelector('.inscription-actions-wrapper');
-                if (wrapper) wrapper.classList.remove('is-loading');
-            }
-        });
-    });
-}
-
-function refreshInscriptionLigne(inscriptionId, actionType) {
-    fetch(`/esbtp/inscriptions/${inscriptionId}/refresh-ligne?context=index`, {
-        method: 'GET',
-        headers: {
-            'X-Requested-With': 'XMLHttpRequest',
-            'Accept': 'application/json'
-        }
-    })
-    .then(response => {
-        if (!response.ok) throw new Error('Erreur rafraîchissement ligne.');
-        return response.json();
-    })
-    .then(data => {
-        if (!data.success || !data.html) return;
-
-        const template = document.createElement('template');
-        template.innerHTML = data.html.trim();
-        const newRow = template.content.querySelector('tr');
-        if (!newRow) return;
-
-        const existingRow = document.querySelector(`tr[data-inscription-id="${inscriptionId}"]`);
-        if (existingRow) {
-            existingRow.replaceWith(newRow);
-            // Appeler le highlight depuis le DOMContentLoaded scope si disponible
-            if (typeof window._triggerInscriptionRowHighlight === 'function') {
-                window._triggerInscriptionRowHighlight(newRow, actionType);
-            }
-        }
-    })
-    .catch(() => {});
-}
-</script>
-
-<script>
-document.addEventListener('DOMContentLoaded', function () {
-    const form = document.getElementById('inscriptions-filter-form');
-    const resultsContainer = document.getElementById('inscriptions-results');
-    const submitButton = form ? form.querySelector('button[type=\"submit\"]') : null;
-    const filterSelects = form ? form.querySelectorAll('select') : [];
-    const headerSearch = document.querySelector('.dashboard-header .search-bar');
-    const formSearchInput = form ? form.querySelector('#filter-search') : null;
-
-    const INSCRIPTION_HIGHLIGHT_DURATION = 3200;
-    const INSCRIPTION_STATUS_PASS_RATIO = 0.8;
-
-    function setInscriptionRowLoadingState(inscriptionId, isLoading) {
-        const row = document.querySelector(`tr[data-inscription-id=\"${inscriptionId}\"]`);
-        if (!row) {
-            return;
-        }
-
-        row.classList.toggle('is-loading', Boolean(isLoading));
-
-        const actionsWrapper = row.querySelector('.inscription-actions-wrapper');
-        if (actionsWrapper) {
-            actionsWrapper.classList.toggle('is-loading', Boolean(isLoading));
-        }
-    }
-
-    function triggerInscriptionRowHighlight(row, actionType = 'update', options = {}) {
-        if (!row) {
-            return;
-        }
-
-        const onStatusPassed = typeof options.onStatusPassed === 'function' ? options.onStatusPassed : null;
-        const isReject = ['reject', 'cancel', 'danger'].includes(actionType);
-
-        row.classList.remove('inscription-row-flash', 'reject');
-        void row.offsetWidth;
-
-        const highlight = document.createElement('div');
-        highlight.className = 'inscription-row-highlight';
-        if (isReject) {
-            highlight.classList.add('reject');
-        }
-
-        row.appendChild(highlight);
-
-        requestAnimationFrame(() => {
-            highlight.classList.add('animate');
-        });
-
-        if (onStatusPassed) {
-            setTimeout(() => {
-                onStatusPassed(highlight);
-            }, INSCRIPTION_HIGHLIGHT_DURATION * INSCRIPTION_STATUS_PASS_RATIO);
-        }
-
-        const cleanup = () => {
-            highlight.removeEventListener('animationend', cleanup);
-            highlight.remove();
-        };
-
-        highlight.addEventListener('animationend', cleanup);
-
-        row.classList.add('inscription-row-flash');
-        if (isReject) {
-            row.classList.add('reject');
-        }
-
-        setTimeout(() => {
-            row.classList.remove('inscription-row-flash', 'reject');
-        }, 1200);
-    }
-
-    // Exposer pour refreshInscriptionLigne (hors scope DOMContentLoaded)
-    window._triggerInscriptionRowHighlight = triggerInscriptionRowHighlight;
-
-    initInscriptionsSelect2();
-    initInscriptionsTooltips();
-    bindBulkSelectionHandlers();
-    bindPaginationLinks();
-
-    if (headerSearch && formSearchInput) {
-        headerSearch.value = headerSearch.value || formSearchInput.value || '';
-
-        headerSearch.addEventListener('input', function () {
-            formSearchInput.value = headerSearch.value;
-        });
-
-        headerSearch.addEventListener('keydown', function (event) {
-            if (event.key === 'Enter') {
-                event.preventDefault();
-                formSearchInput.value = headerSearch.value;
-                submitFilterForm();
-            }
-        });
-    }
-
-    if (form) {
-        form.addEventListener('submit', function (event) {
-            event.preventDefault();
-            event.stopPropagation();
-            submitFilterForm();
-            return false;
-        });
-    }
-
-    filterSelects.forEach(select => {
-        select.addEventListener('change', () => submitFilterForm());
-    });
-
-    function submitFilterForm() {
-        if (!form) {
-            return;
-        }
-
-        const formData = new FormData(form);
-        const params = new URLSearchParams(formData);
-        const targetUrl = `${form.action}?${params.toString()}`;
-        fetchResults(targetUrl, { pushState: true });
-    }
-
-    function bindPaginationLinks() {
-        resultsContainer.querySelectorAll('.pagination a').forEach(link => {
-            link.addEventListener('click', function (event) {
-                event.preventDefault();
-                fetchResults(this.href, { pushState: true });
-            });
-        });
-    }
-
-    function setLoading(isLoading) {
-        if (submitButton) {
-            submitButton.disabled = isLoading;
-        }
-
-        if (isLoading) {
-            resultsContainer.classList.add('opacity-50');
-        } else {
-            resultsContainer.classList.remove('opacity-50');
-        }
-    }
-
-    function fetchResults(url, options = {}) {
-        if (!url) {
-            return;
-        }
-
-        setLoading(true);
-
-        fetch(url, {
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'Accept': 'application/json'
-            },
-            credentials: 'same-origin'
-        })
-        .then(response => {
-            if (!response.ok) {
-                throw new Error('Erreur lors du chargement des inscriptions.');
-            }
-            return response.json();
-        })
-        .then(data => {
-            resultsContainer.innerHTML = data.html;
-            if (options.pushState !== false) {
-                window.history.pushState({ url: data.url }, '', data.url);
-            }
-            initInscriptionsTooltips(resultsContainer);
-            bindBulkSelectionHandlers();
-            bindPaginationLinks();
-            clearInscriptionSelection();
-        })
-        .catch(error => {
-            console.error(error);
-            alert('Impossible de charger les inscriptions. Veuillez réessayer.');
-        })
-        .finally(() => setLoading(false));
-    }
-
-    if (window.history && window.history.replaceState) {
-        window.history.replaceState({ url: window.location.href }, '', window.location.href);
-    }
-
-    window.addEventListener('popstate', function (event) {
-        const targetUrl = event.state?.url || window.location.href;
-        fetchResults(targetUrl, { pushState: false });
-    });
-});
-
-// === Fonctions pour actions rapides ===
-
-/**
- * Ouvrir modal pour valider un paiement en attente
- */
-function ouvrirModalValiderPaiement(inscriptionId) {
-    fetch(`/esbtp/inscriptions/${inscriptionId}/paiement-en-attente`)
-        .then(response => response.json())
-        .then(data => {
-            if (data.success && data.paiement) {
-                document.getElementById('valider_inscription_id').value = inscriptionId;
-                document.getElementById('valider_paiement_id').value = data.paiement.id;
-                document.getElementById('valider_montant').value = new Intl.NumberFormat('fr-FR').format(data.paiement.montant) + ' FCFA';
-                document.getElementById('valider_mode').value = data.paiement.mode_paiement || 'N/A';
-                document.getElementById('valider_reference').value = data.paiement.reference_paiement || 'N/A';
-                document.getElementById('validerPaiementInfo').textContent = `Paiement de ${data.paiement.etudiant.nom} ${data.paiement.etudiant.prenoms}`;
-
-                // Configurer l'action du formulaire
-                document.getElementById('formValiderPaiement').action = `/esbtp/paiements/${data.paiement.id}/valider-rapide`;
-
-                const modal = new bootstrap.Modal(document.getElementById('modalValiderPaiement'));
-                modal.show();
-            } else {
-                showToast('Impossible de récupérer les informations du paiement: ' + (data.message || ''), 'error');
-            }
-        })
-        .catch(error => {
-            console.error(error);
-            showToast('Erreur lors du chargement des données', 'error');
-        });
-}
-
-/**
- * Ouvrir modal pour changer la classe
- */
-function ouvrirModalChangerClasse(inscriptionId) {
-    fetch(`/esbtp/inscriptions/${inscriptionId}/classes-alternatives`)
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                document.getElementById('changer_inscription_id').value = inscriptionId;
-                document.getElementById('changer_ancienne_classe').value = data.classeActuelle.name;
-
-                // Remplir le select des classes disponibles
-                const select = document.getElementById('changer_nouvelle_classe');
-                select.innerHTML = '<option value="">Sélectionnez une classe</option>';
-
-                data.classesAlternatives.forEach(classe => {
-                    const option = document.createElement('option');
-                    option.value = classe.id;
-
-                    // Afficher statut de disponibilité
-                    if (classe.is_available) {
-                        option.textContent = `${classe.name} (${classe.places_disponibles}/${classe.places_totales} places disponibles)`;
-                    } else {
-                        option.textContent = `${classe.name} (COMPLET - ${classe.places_disponibles}/${classe.places_totales})`;
-                        option.style.color = '#dc3545'; // Rouge pour classe pleine
-                        option.style.fontWeight = 'bold';
-                    }
-
-                    option.dataset.placesDisponibles = classe.places_disponibles;
-                    option.dataset.isAvailable = classe.is_available;
-                    select.appendChild(option);
-                });
-
-                // Event listener pour afficher les places disponibles et alerter si plein
-                select.addEventListener('change', function() {
-                    const selectedOption = this.options[this.selectedIndex];
-                    if (selectedOption.value) {
-                        const isAvailable = selectedOption.dataset.isAvailable === 'true';
-                        const placesDisponibles = selectedOption.dataset.placesDisponibles;
-
-                        document.getElementById('classeDispoInfo').style.display = 'block';
-
-                        if (isAvailable) {
-                            document.getElementById('classeDispoText').textContent =
-                                `✓ Places disponibles: ${placesDisponibles}`;
-                            document.getElementById('classeDispoText').style.color = '#28a745';
-                        } else {
-                            document.getElementById('classeDispoText').textContent =
-                                `⚠ Classe complète (${placesDisponibles} places disponibles)`;
-                            document.getElementById('classeDispoText').style.color = '#dc3545';
-                        }
-                    } else {
-                        document.getElementById('classeDispoInfo').style.display = 'none';
-                    }
-                });
-
-                // Configurer l'action du formulaire
-                document.getElementById('formChangerClasse').action = `/esbtp/inscriptions/${inscriptionId}/changer-classe-rapide`;
-
-                const modal = new bootstrap.Modal(document.getElementById('modalChangerClasse'));
-                modal.show();
-            } else {
-                showToast(data.message || 'Impossible de récupérer les classes alternatives', 'error');
-            }
-        })
-        .catch(error => {
-            console.error(error);
-            showToast('Erreur lors du chargement des données', 'error');
-        });
-}
-
-/**
- * Ouvrir modal pour créer un paiement
- */
-function ouvrirModalCreerPaiement(inscriptionId) {
-    fetch(`/esbtp/inscriptions/${inscriptionId}/data`)
-        .then(response => response.json())
-        .then(data => {
-            if (data.success && data.inscription) {
-                document.getElementById('creer_inscription_id').value = inscriptionId;
-                document.getElementById('creer_etudiant_id').value = data.inscription.etudiant_id;
-                document.getElementById('creer_annee_id').value = data.inscription.annee_universitaire_id;
-                document.getElementById('creerPaiementInfo').textContent =
-                    `Créer un paiement pour ${data.inscription.etudiant.nom} ${data.inscription.etudiant.prenoms}`;
-
-                // Configurer l'action du formulaire pour utiliser valider-avec-paiement
-                document.getElementById('formCreerPaiement').action = `/esbtp/inscriptions/${inscriptionId}/valider-avec-paiement`;
-
-                const modal = new bootstrap.Modal(document.getElementById('modalCreerPaiement'));
-                modal.show();
-            } else {
-                showToast('Impossible de récupérer les informations de l\'inscription: ' + (data.message || ''), 'error');
-            }
-        })
-        .catch(error => {
-            console.error(error);
-            showToast('Erreur lors du chargement des données', 'error');
-        });
-}
-
-// Gestion de la soumission des formulaires avec AJAX
-document.addEventListener('DOMContentLoaded', function() {
-    // Formulaire validation paiement
-    (() => {
-        let isSubmitting = false;
-        const $form = document.getElementById('formValiderPaiement');
-
-        $form.addEventListener('submit', function(e) {
-            e.preventDefault();
-
-            // Protection double-clic
-            if (isSubmitting) {
-                debugWarn('⚠️ formValiderPaiement - Soumission déjà en cours, blocage du double-clic');
-                return false;
-            }
-
-            isSubmitting = true;
-            console.log('🔒 formValiderPaiement - Formulaire verrouillé');
-
-            // Désactiver le bouton submit
-            const $submitBtn = this.querySelector('button[type="submit"]');
-            const originalText = $submitBtn.innerHTML;
-            $submitBtn.disabled = true;
-            $submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Validation en cours...';
-
-            const formData = new FormData(this);
-            const actionUrl = this.action;
-            const inscriptionId = document.getElementById('valider_inscription_id').value;
-
-            fetch(actionUrl, {
-                method: 'POST',
-                body: formData,
-                headers: {
-                    'X-Requested-With': 'XMLHttpRequest'
-                }
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    bootstrap.Modal.getInstance(document.getElementById('modalValiderPaiement')).hide();
-                    // ✅ Refresh uniquement la ligne au lieu de recharger toute la page
-                    window.refreshInscriptionLigne(inscriptionId, 'validate');
-                } else {
-                    alert(data.message || 'Erreur lors de la validation');
-                }
-            })
-            .catch(error => {
-                console.error(error);
-                alert('Erreur lors de la validation du paiement');
-            })
-            .finally(() => {
-                // Réactiver le bouton
-                isSubmitting = false;
-                $submitBtn.disabled = false;
-                $submitBtn.innerHTML = originalText;
-            });
-        });
-    })();
-
-    // Formulaire changement de classe
-    document.getElementById('formChangerClasse').addEventListener('submit', function(e) {
-        e.preventDefault();
-        const formData = new FormData(this);
-        const actionUrl = this.action;
-        const inscriptionId = document.getElementById('changer_inscription_id').value;
-
-        fetch(actionUrl, {
-            method: 'POST',
-            body: formData,
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest'
-            }
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.success) {
-                bootstrap.Modal.getInstance(document.getElementById('modalChangerClasse')).hide();
-                // ✅ Refresh uniquement la ligne au lieu de recharger toute la page
-                window.refreshInscriptionLigne(inscriptionId, 'update');
-            } else {
-                alert(data.message || 'Erreur lors du changement de classe');
-            }
-        })
-        .catch(error => {
-            console.error(error);
-            alert('Erreur lors du changement de classe');
-        });
-    });
-
-    // Formulaire création de paiement (AJAX pour éviter rechargement page)
-    (() => {
-        let isSubmitting = false;
-        const $form = document.getElementById('formCreerPaiement');
-
-        $form.addEventListener('submit', function(e) {
-            e.preventDefault();
-
-            // Protection double-clic
-            if (isSubmitting) {
-                debugWarn('⚠️ formCreerPaiement - Soumission déjà en cours, blocage du double-clic');
-                return false;
-            }
-
-            isSubmitting = true;
-            console.log('🔒 formCreerPaiement - Formulaire verrouillé');
-
-            // Désactiver le bouton submit
-            const $submitBtn = this.querySelector('button[type="submit"]');
-            const originalText = $submitBtn.innerHTML;
-            $submitBtn.disabled = true;
-            $submitBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Création en cours...';
-
-            const formData = new FormData(this);
-            const actionUrl = this.action;
-            const inscriptionId = document.getElementById('creer_inscription_id').value;
-
-            fetch(actionUrl, {
-                method: 'POST',
-                body: formData,
-                headers: {
-                    'X-Requested-With': 'XMLHttpRequest'
-                }
-            })
-            .then(response => response.json())
-            .then(data => {
-                if (data.success) {
-                    bootstrap.Modal.getInstance(document.getElementById('modalCreerPaiement')).hide();
-                    // ✅ Refresh uniquement la ligne au lieu de recharger toute la page
-                    window.refreshInscriptionLigne(inscriptionId, 'update');
-                } else {
-                    alert(data.message || 'Erreur lors de la création du paiement');
-                }
-            })
-            .catch(error => {
-                console.error(error);
-                alert('Erreur lors de la création du paiement');
-            })
-            .finally(() => {
-                // Réactiver le bouton
-                isSubmitting = false;
-                $submitBtn.disabled = false;
-                $submitBtn.innerHTML = originalText;
-            });
-        });
-    })();
-
-    /**
-     * Fonction pour rafraîchir une ligne d'inscription spécifique sans recharger la page
-     * Inclut spinner de chargement et sauvegarde de l'état du checkbox
-     */
-    window.refreshInscriptionLigne = function(inscriptionId, actionType = 'update') {
-        console.log('🔄 refreshInscriptionLigne() appelé pour ID:', inscriptionId);
-
-        const row = document.querySelector(`tr[data-inscription-id="${inscriptionId}"]`);
-
-        if (!row) {
-            console.error('❌ Ligne non trouvée pour inscription ID:', inscriptionId);
-            location.reload();
-            return;
-        }
-
-        const checkbox = row.querySelector('.inscription-checkbox');
-        const wasChecked = checkbox ? checkbox.checked : false;
-
-        setInscriptionRowLoadingState(inscriptionId, true);
-
-        fetch(`/esbtp/inscriptions/${inscriptionId}/refresh-ligne`, {
-            method: 'GET',
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',
-                'Accept': 'application/json'
-            }
-        })
-        .then(response => {
-            console.log('📥 Réponse reçue, status:', response.status);
-            if (!response.ok) {
-                throw new Error(`HTTP ${response.status}`);
-            }
-            return response.json();
-        })
-        .then(data => {
-            if (!data.success || !data.html) {
-                throw new Error(data.message || 'Réponse serveur invalide');
-            }
-
-            const template = document.createElement('template');
-            template.innerHTML = data.html.trim();
-
-            let rowFragment = template.content.querySelector(`tr[data-inscription-id="${inscriptionId}"]`);
-            if (!rowFragment) {
-                rowFragment = template.content.querySelector('tr[data-inscription-id]');
-            }
-
-            if (!rowFragment) {
-                console.error('❌ Contenu HTML reçu:', data.html);
-                throw new Error('HTML retourné invalide (pas de TR)');
-            }
-
-            const newRow = rowFragment.cloneNode(true);
-            const newCells = Array.from(newRow.children).map(cell => cell.cloneNode(true));
-            const newAttributes = Array.from(newRow.attributes);
-
-            let contentUpdated = false;
-
-            const applyUpdatedContent = (highlightEl = null) => {
-                if (contentUpdated) {
-                    return;
-                }
-                contentUpdated = true;
-
-                const highlightNode = highlightEl instanceof HTMLElement ? highlightEl : row.querySelector('.inscription-row-highlight');
-
-                const classesToPreserve = [];
-                if (row.classList.contains('inscription-row-flash')) {
-                    classesToPreserve.push('inscription-row-flash');
-                }
-                if (row.classList.contains('reject')) {
-                    classesToPreserve.push('reject');
-                }
-                if (row.classList.contains('is-loading')) {
-                    classesToPreserve.push('is-loading');
-                }
-
-                const newClassName = newRow.getAttribute('class') || '';
-                row.setAttribute('class', newClassName);
-
-                newAttributes.forEach(attr => {
-                    if (attr.name !== 'class') {
-                        row.setAttribute(attr.name, attr.value);
-                    }
-                });
-
-                classesToPreserve.forEach(cls => row.classList.add(cls));
-
-                const currentCells = Array.from(row.children).filter(child => child !== highlightNode);
-
-                currentCells.forEach((cell, index) => {
-                    const replacement = newCells[index];
-                    if (replacement) {
-                        cell.replaceWith(replacement);
-                    } else {
-                        cell.remove();
-                    }
-                });
-
-                const extraCells = newCells.slice(currentCells.length);
-                if (extraCells.length) {
-                    const fragment = document.createDocumentFragment();
-                    extraCells.forEach(node => fragment.appendChild(node));
-
-                    if (highlightNode && highlightNode.parentNode === row) {
-                        row.insertBefore(fragment, highlightNode);
-                    } else {
-                        row.appendChild(fragment);
-                    }
-                }
-
-                if (highlightNode && highlightNode.parentNode !== row) {
-                    row.appendChild(highlightNode);
-                }
-
-                if (wasChecked) {
-                    const restoredCheckbox = row.querySelector('.inscription-checkbox');
-                    if (restoredCheckbox) {
-                        restoredCheckbox.checked = true;
-                        restoredCheckbox.dispatchEvent(new Event('change', { bubbles: true }));
-                    }
-                }
-
-                setInscriptionRowLoadingState(inscriptionId, false);
-                updateInscriptionSelectionCount();
-
-                console.log('🎉 Ligne rafraîchie avec succès:', inscriptionId);
-            };
-
-            triggerInscriptionRowHighlight(row, actionType, {
-                onStatusPassed: (highlightEl) => {
-                    applyUpdatedContent(highlightEl);
-                }
-            });
-
-            setTimeout(() => {
-                if (!contentUpdated) {
-                    applyUpdatedContent();
-                }
-            }, INSCRIPTION_HIGHLIGHT_DURATION + 150);
-        })
-        .catch(error => {
-            console.error('❌ Erreur refresh ligne:', error);
-            console.error('❌ Message d\'erreur:', error.message);
-            console.error('❌ Stack trace:', error.stack);
-
-            setInscriptionRowLoadingState(inscriptionId, false);
-
-            alert('Erreur lors de la mise à jour: ' + error.message + '. La page va se recharger.');
-            location.reload();
-        });
-    };
-});
-</script>
-
-<!-- Modals d'actions rapides -->
-<!-- Modal: Valider Paiement -->
-<div class="modal fade" id="modalValiderPaiement" tabindex="-1" aria-labelledby="modalValiderPaiementLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content" style="border: none; border-radius: 16px; box-shadow: 0 20px 60px rgba(0,0,0,0.3);">
-            <div class="modal-header" style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border-radius: 16px 16px 0 0; padding: 24px;">
-                <h5 class="modal-title" id="modalValiderPaiementLabel">
-                    <i class="fas fa-check-circle me-2"></i>Valider le paiement
-                </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+@section('content')
+<div class="dashboard-acasi">
+    <div class="main-content">
+
+        {{-- HERO + KPIs --}}
+        <div class="ii-hero">
+            <div class="ii-hero-top">
+                <div class="ii-hero-left">
+                    <div class="ii-hero-icon"><i class="fas fa-user-graduate"></i></div>
+                    <div>
+                        <h1>Gestion des inscriptions</h1>
+                        <p>Consultez et gérez toutes les inscriptions de l'établissement</p>
+                        <span class="ii-hero-chip">
+                            <i class="fas fa-calendar-alt"></i>
+                            Année {{ $anneeEnCours->name ?? 'non définie' }}
+                        </span>
+                    </div>
+                </div>
+                <div class="ii-hero-actions">
+                    @can('inscriptions.validate')
+                        <a href="{{ route('esbtp.inscriptions.administration') }}" class="ii-btn--glass">
+                            <i class="fas fa-user-check"></i>Administration
+                        </a>
+                    @endcan
+                    @can('inscriptions.create')
+                        <a href="{{ route('esbtp.inscriptions.create') }}" class="ii-btn--white">
+                            <i class="fas fa-plus-circle"></i>Nouvelle inscription
+                        </a>
+                    @endcan
+                </div>
             </div>
-            <div class="modal-body" style="padding: 32px;">
-                <form id="formValiderPaiement" method="POST">
-                    @csrf
-                    <input type="hidden" name="inscription_id" id="valider_inscription_id">
-                    <input type="hidden" name="paiement_id" id="valider_paiement_id">
 
-                    <div class="alert alert-info mb-4" style="background: #E3F2FD; border: none; border-radius: 12px; padding: 16px;">
-                        <i class="fas fa-info-circle me-2"></i>
-                        <span id="validerPaiementInfo">Paiement à valider...</span>
+            <div class="ii-kpis" id="ii-kpis">
+                <button type="button" class="ii-kpi {{ in_array(request('status','active'), ['all']) ? 'ii-kpi--active' : '' }}" data-kpi-filter="all">
+                    <div class="ii-kpi-icon"><i class="fas fa-users"></i></div>
+                    <div class="ii-kpi-body">
+                        <div class="ii-kpi-value">{{ $stats['total'] ?? 0 }}</div>
+                        <div class="ii-kpi-label">Total</div>
                     </div>
+                </button>
+                <button type="button" class="ii-kpi {{ request('status','active') === 'active' ? 'ii-kpi--active' : '' }}" data-kpi-filter="active">
+                    <div class="ii-kpi-icon"><i class="fas fa-check-circle"></i></div>
+                    <div class="ii-kpi-body">
+                        <div class="ii-kpi-value">{{ $stats['actives'] ?? 0 }}</div>
+                        <div class="ii-kpi-label">Validées</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ request('status') === 'non_validee' ? 'ii-kpi--active' : '' }}" data-kpi-filter="non_validee" style="position:relative;">
+                    <div class="ii-kpi-icon"><i class="fas fa-exclamation-triangle"></i></div>
+                    <div class="ii-kpi-body">
+                        <div class="ii-kpi-value">{{ $stats['non_validees'] ?? 0 }}</div>
+                        <div class="ii-kpi-label">Non validées</div>
+                    </div>
+                    @if(($stats['non_validees'] ?? 0) > 0)<span class="ii-kpi-badge"></span>@endif
+                </button>
+                <button type="button" class="ii-kpi {{ request('status') === 'en_attente' ? 'ii-kpi--active' : '' }}" data-kpi-filter="en_attente">
+                    <div class="ii-kpi-icon"><i class="fas fa-clock"></i></div>
+                    <div class="ii-kpi-body">
+                        <div class="ii-kpi-value">{{ $stats['en_attente'] ?? 0 }}</div>
+                        <div class="ii-kpi-label">En attente</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ request('status') === 'annulée' ? 'ii-kpi--active' : '' }}" data-kpi-filter="annulée">
+                    <div class="ii-kpi-icon"><i class="fas fa-times-circle"></i></div>
+                    <div class="ii-kpi-body">
+                        <div class="ii-kpi-value">{{ $stats['annulees'] ?? 0 }}</div>
+                        <div class="ii-kpi-label">Annulées</div>
+                    </div>
+                </button>
+            </div>
+        </div>
 
-                    <div class="mb-3">
-                        <label class="form-label fw-bold">Montant</label>
-                        <input type="text" class="form-control" id="valider_montant" readonly style="background: #f8f9fa; border-radius: 8px; font-size: 1.1rem; font-weight: 600;">
-                    </div>
+        {{-- Messages flash --}}
+        @if(session('success'))
+            <div class="ii-alert ii-alert--success">
+                <i class="fas fa-check-circle"></i>{{ session('success') }}
+            </div>
+        @endif
+        @if(session('error'))
+            <div class="ii-alert ii-alert--danger">
+                <i class="fas fa-exclamation-triangle"></i>{{ session('error') }}
+            </div>
+        @endif
 
-                    <div class="mb-3">
-                        <label class="form-label fw-bold">Mode de paiement</label>
-                        <input type="text" class="form-control" id="valider_mode" readonly style="background: #f8f9fa; border-radius: 8px;">
-                    </div>
+        {{-- Bannière problèmes --}}
+        @if(session('inscriptions_problemes') && count(session('inscriptions_problemes')) > 0)
+            <div class="ii-banner">
+                <div class="ii-banner-icon"><i class="fas fa-triangle-exclamation"></i></div>
+                <div class="ii-banner-body">
+                    <div class="ii-banner-title">{{ count(session('inscriptions_problemes')) }} inscription(s) nécessitent votre attention</div>
+                    <div class="ii-banner-text">Les lignes concernées sont marquées en couleur dans la liste ci-dessous. Utilisez les actions rapides pour résoudre chaque problème.</div>
+                </div>
+            </div>
+        @endif
 
-                    <div class="mb-4">
-                        <label class="form-label fw-bold">Référence</label>
-                        <input type="text" class="form-control" id="valider_reference" readonly style="background: #f8f9fa; border-radius: 8px;">
-                    </div>
+        {{-- TOOLBAR --}}
+        <form method="GET"
+              action="{{ route('esbtp.inscriptions.index') }}"
+              id="inscriptions-filter-form"
+              class="ii-toolbar">
+            <div class="ii-toolbar-row">
+                <div class="ii-search">
+                    <i class="fas fa-search"></i>
+                    <input type="text"
+                           name="search"
+                           id="filter-search"
+                           value="{{ request('search') }}"
+                           placeholder="Rechercher par matricule, nom ou N° d'inscription..."
+                           autocomplete="off">
+                </div>
 
-                    <div class="d-flex gap-3">
-                        <button type="button" class="btn btn-light flex-fill" data-bs-dismiss="modal" style="border-radius: 10px; padding: 12px; font-weight: 600;">
-                            <i class="fas fa-times me-2"></i>Annuler
-                        </button>
-                        <button type="submit" class="btn btn-success flex-fill" style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); border: none; border-radius: 10px; padding: 12px; font-weight: 600;">
-                            <i class="fas fa-check me-2"></i>Valider le paiement
-                        </button>
-                    </div>
-                </form>
+                <select name="filiere" id="filiere" class="ii-filter-select" aria-label="Filière">
+                    <option value="">Toutes les filières</option>
+                    @foreach($filieres as $fil)
+                        <option value="{{ $fil->id }}" @selected(request('filiere') == $fil->id)>{{ $fil->name }}</option>
+                    @endforeach
+                </select>
+
+                <select name="niveau" id="niveau" class="ii-filter-select" aria-label="Niveau">
+                    <option value="">Tous les niveaux</option>
+                    @foreach($niveaux as $niv)
+                        <option value="{{ $niv->id }}" @selected(request('niveau') == $niv->id)>{{ $niv->name }}</option>
+                    @endforeach
+                </select>
+
+                <select name="annee" id="annee" class="ii-filter-select" aria-label="Année universitaire">
+                    <option value="">Année courante</option>
+                    @foreach($annees as $an)
+                        <option value="{{ $an->id }}" @selected(request('annee') == $an->id)>{{ $an->name }}</option>
+                    @endforeach
+                </select>
+
+                <select name="status" id="status" class="ii-filter-select" aria-label="Statut">
+                    <option value="all" @selected(request('status','active') == 'all')>Tous statuts</option>
+                    <option value="active" @selected(request('status','active') == 'active')>Validées</option>
+                    <option value="non_validee" @selected(request('status') == 'non_validee')>Non validées ({{ $stats['non_validees'] ?? 0 }})</option>
+                    <option value="en_attente" @selected(request('status') == 'en_attente')>En attente</option>
+                    <option value="annulée" @selected(request('status') == 'annulée')>Annulées</option>
+                    <option value="terminée" @selected(request('status') == 'terminée')>Terminées</option>
+                </select>
+
+                {{-- Champs cachés pour sort + per_page (préservés dans AJAX) --}}
+                <input type="hidden" name="sort" id="sort-input" value="{{ $sort ?? 'created_at' }}">
+                <input type="hidden" name="dir" id="dir-input" value="{{ $dir ?? 'desc' }}">
+                <input type="hidden" name="per_page" id="per-page-input" value="{{ $perPage ?? 15 }}">
+
+                <button type="button" id="reset-filters-btn" class="ii-btn--ghost" title="Réinitialiser les filtres">
+                    <i class="fas fa-rotate-left"></i>Reset
+                </button>
+
+                {{-- Submit caché pour permettre Enter dans l'input --}}
+                <button type="submit" style="display:none;" aria-hidden="true">Filtrer</button>
+            </div>
+
+            <div class="ii-toolbar-meta">
+                <span><i class="fas fa-list"></i> <span id="ii-result-count">{{ $inscriptions->total() }}</span> résultat(s)</span>
+                <span class="ii-chips-active" id="ii-active-filters"></span>
+            </div>
+        </form>
+
+        {{-- RÉSULTATS --}}
+        <div class="ii-results-card">
+            <div id="inscriptions-results">
+                @include('esbtp.inscriptions.partials.results', [
+                    'inscriptions' => $inscriptions,
+                    'sort' => $sort ?? 'created_at',
+                    'dir' => $dir ?? 'desc',
+                    'perPage' => $perPage ?? 15,
+                ])
             </div>
         </div>
     </div>
 </div>
 
-<!-- Modal: Changer la Classe -->
+{{-- BULK ACTIONS BAR --}}
+@can('inscriptions.validate')
+<div id="ii-bulk-bar" class="ii-bulk-bar">
+    <div class="ii-bulk-bar-content">
+        <div class="ii-bulk-count">
+            <i class="fas fa-check-circle"></i>
+            <span id="ii-selected-count">0</span> sélection(s)
+        </div>
+        <div class="ii-bulk-actions">
+            <button type="button" class="ii-bulk-btn ii-bulk-btn--primary" onclick="iiBulkValider()">
+                <i class="fas fa-check-double"></i>Valider
+            </button>
+            @can('annuler inscriptions')
+                <button type="button" class="ii-bulk-btn" onclick="iiBulkAnnuler()">
+                    <i class="fas fa-times"></i>Annuler
+                </button>
+            @endcan
+            <button type="button" class="ii-bulk-btn" onclick="iiBulkExporter()">
+                <i class="fas fa-download"></i>Exporter
+            </button>
+        </div>
+        <button type="button" class="ii-bulk-close" onclick="iiClearSelection()" aria-label="Fermer la sélection">
+            <i class="fas fa-times"></i>
+        </button>
+    </div>
+</div>
+@endcan
+
+{{-- MODALS GLOBAUX (data-id dynamique) --}}
+
+{{-- Modal Annuler une inscription --}}
+<div class="modal fade" id="ii-modal-annuler" tabindex="-1" aria-labelledby="iiModalAnnulerLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header ii-modal-header">
+                <h5 class="modal-title" id="iiModalAnnulerLabel">
+                    <i class="fas fa-times-circle me-2"></i>Annuler l'inscription
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <form id="ii-form-annuler" method="POST">
+                @csrf
+                @method('PUT')
+                <div class="modal-body">
+                    <p>Annuler l'inscription de <strong id="ii-annuler-student-name">—</strong> ?</p>
+                    <div class="mb-3">
+                        <label for="ii-annuler-motif" class="form-label fw-bold">Motif d'annulation <span class="text-danger">*</span></label>
+                        <textarea id="ii-annuler-motif" name="motif" class="form-control" rows="3" required placeholder="Expliquez brièvement le motif..."></textarea>
+                    </div>
+                    <div class="ii-warn-box">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <div>Cette action marquera l'inscription comme annulée. Elle pourra être réactivée ultérieurement si nécessaire.</div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+                    <button type="submit" class="btn btn-outline-danger">
+                        <i class="fas fa-times-circle me-1"></i>Confirmer l'annulation
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{{-- Modal Supprimer une inscription --}}
+<div class="modal fade" id="ii-modal-delete" tabindex="-1" aria-labelledby="iiModalDeleteLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header ii-modal-header">
+                <h5 class="modal-title" id="iiModalDeleteLabel">
+                    <i class="fas fa-trash me-2"></i>Supprimer l'inscription
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <form id="ii-form-delete" method="POST">
+                @csrf
+                @method('DELETE')
+                <div class="modal-body">
+                    <p>Supprimer définitivement l'inscription de <strong id="ii-delete-student-name">—</strong> ?</p>
+                    <div class="ii-warn-box">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <div><strong>Cette action est irréversible.</strong> Toutes les données associées (notes, paiements, bulletins) seront archivées.</div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
+                    <button type="submit" class="btn btn-outline-danger">
+                        <i class="fas fa-trash me-1"></i>Supprimer définitivement
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{{-- Modal: Valider Paiement (action rapide) --}}
+<div class="modal fade" id="modalValiderPaiement" tabindex="-1" aria-labelledby="modalValiderPaiementLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header ii-modal-header">
+                <h5 class="modal-title" id="modalValiderPaiementLabel">
+                    <i class="fas fa-check-circle me-2"></i>Valider le paiement
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <form id="formValiderPaiement" method="POST">
+                @csrf
+                <input type="hidden" name="inscription_id" id="valider_inscription_id">
+                <input type="hidden" name="paiement_id" id="valider_paiement_id">
+                <div class="modal-body">
+                    <div class="ii-info-box mb-3">
+                        <i class="fas fa-info-circle"></i>
+                        <span id="validerPaiementInfo">Paiement à valider...</span>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">Montant</label>
+                        <input type="text" class="form-control" id="valider_montant" readonly style="background:var(--ii-surface);">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">Mode de paiement</label>
+                        <input type="text" class="form-control" id="valider_mode" readonly style="background:var(--ii-surface);">
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">Référence</label>
+                        <input type="text" class="form-control" id="valider_reference" readonly style="background:var(--ii-surface);">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-check me-1"></i>Valider le paiement
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
+{{-- Modal: Changer la classe (action rapide) --}}
 <div class="modal fade" id="modalChangerClasse" tabindex="-1" aria-labelledby="modalChangerClasseLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-        <div class="modal-content" style="border: none; border-radius: 16px; box-shadow: 0 20px 60px rgba(0,0,0,0.3);">
-            <div class="modal-header" style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border-radius: 16px 16px 0 0; padding: 24px;">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header ii-modal-header">
                 <h5 class="modal-title" id="modalChangerClasseLabel">
                     <i class="fas fa-exchange-alt me-2"></i>Changer la classe
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
             </div>
-            <div class="modal-body" style="padding: 32px;">
-                <form id="formChangerClasse" method="POST">
-                    @csrf
-                    <input type="hidden" name="inscription_id" id="changer_inscription_id">
-
-                    <div class="alert alert-warning mb-4" style="background: #FFF3E0; border: none; border-radius: 12px; padding: 16px;">
-                        <i class="fas fa-exclamation-triangle me-2"></i>
-                        La classe actuelle est pleine. Veuillez sélectionner une nouvelle classe.
+            <form id="formChangerClasse" method="POST">
+                @csrf
+                <input type="hidden" name="inscription_id" id="changer_inscription_id">
+                <div class="modal-body">
+                    <div class="ii-warn-box mb-3">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <div>La classe actuelle est pleine. Veuillez sélectionner une nouvelle classe disponible.</div>
                     </div>
-
-                    <div class="row mb-4">
+                    <div class="row mb-3">
                         <div class="col-md-6">
                             <label class="form-label fw-bold">Classe actuelle</label>
-                            <input type="text" class="form-control" id="changer_ancienne_classe" readonly style="background: #ffebee; border-radius: 8px; border: 2px solid #ef5350;">
+                            <input type="text" class="form-control" id="changer_ancienne_classe" readonly style="background:var(--ii-surface);">
                         </div>
                         <div class="col-md-6">
                             <label class="form-label fw-bold">Nouvelle classe <span class="text-danger">*</span></label>
-                            <select class="form-select" name="nouvelle_classe_id" id="changer_nouvelle_classe" required style="border-radius: 8px; border: 2px solid #4caf50;">
+                            <select class="form-select" name="nouvelle_classe_id" id="changer_nouvelle_classe" required>
                                 <option value="">Sélectionnez une classe</option>
                             </select>
                         </div>
                     </div>
-
-                    <div id="classeDispoInfo" class="alert alert-success" style="background: #E8F5E9; border: none; border-radius: 12px; padding: 16px; display: none;">
-                        <i class="fas fa-check-circle me-2"></i>
-                        <span id="classeDispoText">Places disponibles: ...</span>
+                    <div id="classeDispoInfo" class="ii-info-box" style="display:none;">
+                        <i class="fas fa-check-circle"></i>
+                        <span id="classeDispoText">Places disponibles : ...</span>
                     </div>
-
-                    <div class="d-flex gap-3">
-                        <button type="button" class="btn btn-light flex-fill" data-bs-dismiss="modal" style="border-radius: 10px; padding: 12px; font-weight: 600;">
-                            <i class="fas fa-times me-2"></i>Annuler
-                        </button>
-                        <button type="submit" class="btn btn-danger flex-fill" style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); border: none; border-radius: 10px; padding: 12px; font-weight: 600;">
-                            <i class="fas fa-exchange-alt me-2"></i>Changer la classe
-                        </button>
-                    </div>
-                </form>
-            </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-exchange-alt me-1"></i>Changer la classe
+                    </button>
+                </div>
+            </form>
         </div>
     </div>
 </div>
 
-<!-- Modal: Créer un Paiement -->
+{{-- Modal: Créer un paiement (action rapide) --}}
 <div class="modal fade" id="modalCreerPaiement" tabindex="-1" aria-labelledby="modalCreerPaiementLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered modal-lg">
-        <div class="modal-content" style="border: none; border-radius: 16px; box-shadow: 0 20px 60px rgba(0,0,0,0.3);">
-            <div class="modal-header" style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border-radius: 16px 16px 0 0; padding: 24px;">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header ii-modal-header">
                 <h5 class="modal-title" id="modalCreerPaiementLabel">
                     <i class="fas fa-plus-circle me-2"></i>Créer un paiement
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
             </div>
-            <div class="modal-body" style="padding: 32px;">
-                <form id="formCreerPaiement" method="POST">
-                    @csrf
-                    <input type="hidden" name="inscription_id" id="creer_inscription_id">
-                    <input type="hidden" name="etudiant_id" id="creer_etudiant_id">
-                    <input type="hidden" name="annee_universitaire_id" id="creer_annee_id">
-
-                    <div class="alert alert-info mb-4" style="background: #E3F2FD; border: none; border-radius: 12px; padding: 16px;">
-                        <i class="fas fa-info-circle me-2"></i>
-                        <span id="creerPaiementInfo">Aucun paiement associé à cette inscription</span>
+            <form id="formCreerPaiement" method="POST">
+                @csrf
+                <input type="hidden" name="inscription_id" id="creer_inscription_id">
+                <input type="hidden" name="etudiant_id" id="creer_etudiant_id">
+                <input type="hidden" name="annee_universitaire_id" id="creer_annee_id">
+                <div class="modal-body">
+                    <div class="ii-info-box mb-3">
+                        <i class="fas fa-info-circle"></i>
+                        <span id="creerPaiementInfo">Créer un paiement associé à l'inscription</span>
                     </div>
-
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label class="form-label fw-bold">Montant (FCFA) <span class="text-danger">*</span></label>
-                            <input type="number" name="montant" class="form-control" id="creer_montant" required min="0" step="0.01" placeholder="Ex: 50000" style="border-radius: 8px;">
+                            <input type="number" name="montant" class="form-control" id="creer_montant" required min="0" step="0.01" placeholder="Ex: 50000">
                         </div>
                         <div class="col-md-6">
                             <label class="form-label fw-bold">Catégorie de frais <span class="text-danger">*</span></label>
-                            <select name="fee_category_id" class="form-select" id="creer_categorie" required style="border-radius: 8px;">
+                            <select name="fee_category_id" class="form-select" id="creer_categorie" required>
                                 <option value="">Sélectionnez une catégorie</option>
                                 @php
                                     $categoriesfrais = \App\Models\ESBTPFraisCategory::where('is_active', true)->orderBy('name')->get();
                                 @endphp
                                 @foreach($categoriesfrais as $categorie)
-                                    <option value="{{ $categorie->id }}">
-                                        {{ $categorie->name }}
-                                        @if($categorie->is_mandatory)
-                                            (Obligatoire)
-                                        @else
-                                            (Optionnel)
-                                        @endif
-                                    </option>
+                                    <option value="{{ $categorie->id }}">{{ $categorie->name }} ({{ $categorie->is_mandatory ? 'Obligatoire' : 'Optionnel' }})</option>
                                 @endforeach
                             </select>
                         </div>
                     </div>
-
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label class="form-label fw-bold">Mode de paiement <span class="text-danger">*</span></label>
-                            <select name="mode_paiement" class="form-select" id="creer_mode" required style="border-radius: 8px;">
+                            <select name="mode_paiement" class="form-select" id="creer_mode" required>
                                 <option value="">Sélectionnez un mode</option>
                                 <option value="especes">Espèces</option>
                                 <option value="cheque">Chèque</option>
@@ -1565,41 +958,56 @@ document.addEventListener('DOMContentLoaded', function() {
                             </select>
                         </div>
                         <div class="col-md-6">
-                            <label class="form-label fw-bold">Référence de paiement</label>
-                            <input type="text" name="reference_paiement" class="form-control" id="creer_reference" placeholder="Ex: REF2025-001" style="border-radius: 8px;">
+                            <label class="form-label fw-bold">Référence</label>
+                            <input type="text" name="reference_paiement" class="form-control" id="creer_reference" placeholder="Ex: REF2025-001">
                         </div>
                     </div>
-
                     <div class="row mb-3">
                         <div class="col-md-6">
                             <label class="form-label fw-bold">Date du paiement <span class="text-danger">*</span></label>
-                            <input type="date" name="date_paiement" class="form-control" id="creer_date" required style="border-radius: 8px;" value="{{ date('Y-m-d') }}">
+                            <input type="date" name="date_paiement" class="form-control" id="creer_date" required value="{{ date('Y-m-d') }}">
                         </div>
                         <div class="col-md-6">
                             <label class="form-label fw-bold">Observations</label>
-                            <textarea name="observations" class="form-control" id="creer_observations" rows="2" placeholder="Commentaires sur le paiement..." style="border-radius: 8px;"></textarea>
+                            <textarea name="observations" class="form-control" id="creer_observations" rows="2"></textarea>
                         </div>
                     </div>
-
-                    <div class="form-check mb-4" style="padding-left: 2rem;">
-                        <input class="form-check-input" type="checkbox" name="valider_immediatement" id="creer_valider_immediatement" value="1" style="width: 20px; height: 20px;">
-                        <label class="form-check-label fw-bold" for="creer_valider_immediatement" style="margin-left: 8px;">
-                            Valider le paiement immédiatement
-                        </label>
+                    <div class="form-check mb-2">
+                        <input class="form-check-input" type="checkbox" name="valider_immediatement" id="creer_valider_immediatement" value="1">
+                        <label class="form-check-label fw-bold" for="creer_valider_immediatement">Valider le paiement immédiatement</label>
                     </div>
-
-                    <div class="d-flex gap-3">
-                        <button type="button" class="btn btn-light flex-fill" data-bs-dismiss="modal" style="border-radius: 10px; padding: 12px; font-weight: 600;">
-                            <i class="fas fa-times me-2"></i>Annuler
-                        </button>
-                        <button type="submit" class="btn btn-primary flex-fill" style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); border: none; border-radius: 10px; padding: 12px; font-weight: 600;">
-                            <i class="fas fa-plus me-2"></i>Créer le paiement
-                        </button>
-                    </div>
-                </form>
-            </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fas fa-plus me-1"></i>Créer le paiement
+                    </button>
+                </div>
+            </form>
         </div>
     </div>
 </div>
 
-@endpush 
+@endsection
+
+@push('scripts')
+<script>
+    // Route map injectée server-side, consommée par public/js/inscriptions/index.js
+    window.KLASSCI_INSCRIPTIONS_ROUTES = {
+        index: "{{ route('esbtp.inscriptions.index') }}",
+        bulkValider: "{{ route('esbtp.inscriptions.bulk-valider') }}",
+        refreshLigne: "/esbtp/inscriptions/:id/refresh-ligne",
+        valider: "/esbtp/inscriptions/:id/valider",
+        annuler: "/esbtp/inscriptions/:id/annuler",
+        destroy: "/esbtp/inscriptions/:id",
+        paiementEnAttente: "/esbtp/inscriptions/:id/paiement-en-attente",
+        classesAlternatives: "/esbtp/inscriptions/:id/classes-alternatives",
+        inscriptionData: "/esbtp/inscriptions/:id/data",
+        validerAvecPaiement: "/esbtp/inscriptions/:id/valider-avec-paiement",
+        changerClasseRapide: "/esbtp/inscriptions/:id/changer-classe-rapide",
+        validerPaiementRapide: "/esbtp/paiements/:id/valider-rapide",
+    };
+    window.KLASSCI_CSRF_TOKEN = "{{ csrf_token() }}";
+</script>
+<script src="{{ asset('js/inscriptions/index.js') }}" defer></script>
+@endpush

--- a/resources/views/esbtp/inscriptions/index.blade.php
+++ b/resources/views/esbtp/inscriptions/index.blade.php
@@ -767,6 +767,39 @@ tr[data-inscription-id] > td { transition: background .15s ease; }
     </div>
 </div>
 
+{{-- Modal Bulk Annuler (selection) --}}
+<div class="modal fade" id="ii-modal-bulk-annuler" tabindex="-1" aria-labelledby="iiBulkAnnulerLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+            <div class="modal-header ii-modal-header">
+                <h5 class="modal-title" id="iiBulkAnnulerLabel">
+                    <i class="fas fa-exclamation-triangle me-2"></i>Annuler la sélection
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <form id="ii-form-bulk-annuler">
+                <div class="modal-body">
+                    <p>Annuler <strong id="ii-bulk-annuler-count">0</strong> inscription(s) sélectionnée(s) ?</p>
+                    <div class="mb-3">
+                        <label for="ii-bulk-annuler-motif" class="form-label fw-bold">Motif d'annulation <span class="text-danger">*</span></label>
+                        <textarea id="ii-bulk-annuler-motif" class="form-control" rows="3" required placeholder="Ce motif s'appliquera à toutes les inscriptions sélectionnées..."></textarea>
+                    </div>
+                    <div class="ii-info-box" style="margin-top:0;">
+                        <i class="fas fa-info-circle"></i>
+                        <div>Les inscriptions sélectionnées seront toutes marquées comme annulées avec ce motif. Elles pourront être réactivées ultérieurement.</div>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="submit" class="btn btn-outline-danger">
+                        <i class="fas fa-times-circle me-1"></i>Confirmer l'annulation
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+
 {{-- Modal Annuler une inscription --}}
 <div class="modal fade" id="ii-modal-annuler" tabindex="-1" aria-labelledby="iiModalAnnulerLabel" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
@@ -1010,6 +1043,8 @@ tr[data-inscription-id] > td { transition: background .15s ease; }
     window.KLASSCI_INSCRIPTIONS_ROUTES = {
         index: "{{ route('esbtp.inscriptions.index') }}",
         bulkValider: "{{ route('esbtp.inscriptions.bulk-valider') }}",
+        bulkAnnuler: "{{ route('esbtp.inscriptions.bulk-annuler') }}",
+        bulkExport: "{{ route('esbtp.inscriptions.bulk-export') }}",
         refreshLigne: "/esbtp/inscriptions/:id/refresh-ligne",
         valider: "/esbtp/inscriptions/:id/valider",
         annuler: "/esbtp/inscriptions/:id/annuler",

--- a/resources/views/esbtp/inscriptions/index.blade.php
+++ b/resources/views/esbtp/inscriptions/index.blade.php
@@ -377,38 +377,28 @@
 .inscription-actions-wrapper.is-loading .inscription-actions-buttons { display: none !important; }
 .inscription-actions-wrapper.is-loading .inscription-actions-spinner { display: flex !important; }
 
-/* Row highlight animations (preserved) */
-tr[data-inscription-id] { position: relative; overflow: hidden; }
-.inscription-row-highlight {
-    position: absolute; top: 0; left: -80%;
-    width: 160%; height: 100%;
-    opacity: 0; pointer-events: none;
-    transform: translateX(-65%) skewX(-12deg);
-    background: linear-gradient(90deg, rgba(16,185,129,0) 0%, rgba(16,185,129,.7) 50%, rgba(16,185,129,0) 100%);
-    transition: opacity .2s ease; z-index: 5;
+/* Row highlight animations — flash full-row couleur (pas d'overlay qui overflow) */
+tr[data-inscription-id] { position: relative; }
+tr[data-inscription-id] > td { transition: background .15s ease; }
+
+.inscription-row-flash > td {
+    animation: ii-flash 2.2s ease-in-out;
 }
-.inscription-row-highlight.reject {
-    background: linear-gradient(90deg, rgba(239,68,68,0) 0%, rgba(239,68,68,.7) 50%, rgba(239,68,68,0) 100%);
-}
-.inscription-row-highlight.animate {
-    animation: ii-highlight-move 3.2s ease-out forwards;
-}
-.inscription-row-flash { animation: ii-flash .8s ease-in-out; }
-.inscription-row-flash.reject { animation-name: ii-flash-reject; }
-@keyframes ii-highlight-move {
-    0% { opacity: 0; transform: translateX(-65%) skewX(-12deg); }
-    18% { opacity: .9; }
-    55% { opacity: .65; }
-    100% { opacity: 0; transform: translateX(115%) skewX(-12deg); }
+.inscription-row-flash.reject > td {
+    animation-name: ii-flash-reject;
 }
 @keyframes ii-flash {
     0% { background: transparent; }
-    25% { background: rgba(16,185,129,.1); }
+    10% { background: rgba(16,185,129,.25); }
+    35% { background: rgba(16,185,129,.35); }
+    70% { background: rgba(16,185,129,.18); }
     100% { background: transparent; }
 }
 @keyframes ii-flash-reject {
     0% { background: transparent; }
-    25% { background: rgba(239,68,68,.1); }
+    10% { background: rgba(239,68,68,.25); }
+    35% { background: rgba(239,68,68,.35); }
+    70% { background: rgba(239,68,68,.18); }
     100% { background: transparent; }
 }
 

--- a/resources/views/esbtp/inscriptions/index.blade.php
+++ b/resources/views/esbtp/inscriptions/index.blade.php
@@ -8,8 +8,10 @@
 /* =====================================================================
    INSCRIPTIONS INDEX — namespace ii-*
    Design premium monochrome bleu KLASSCI
+   Variables sur :root pour etre accessibles aussi bien dans
+   .dashboard-acasi que dans les modals et la bulk-bar (hors wrapper).
    ===================================================================== */
-.dashboard-acasi {
+:root {
     --ii-primary: #0453cb;
     --ii-primary-dark: #033a8e;
     --ii-accent: #3b7ddb;

--- a/resources/views/esbtp/inscriptions/partials/ligne-inscription.blade.php
+++ b/resources/views/esbtp/inscriptions/partials/ligne-inscription.blade.php
@@ -1,125 +1,223 @@
-{{-- Partial réutilisable pour une ligne d'inscription dans le tableau --}}
+{{--
+    Partial : UNE ligne d'inscription dans la table.
+    Inclus par :
+      - esbtp.inscriptions.partials.results (render initial + AJAX filtre)
+      - ESBTPInscriptionController::refreshLigne (AJAX refresh après action)
+
+    Design premium namespace ii-*, monochrome bleu KLASSCI.
+    - Photo étudiant + HSL fallback
+    - Row cliquable via data-row-href (JS delegation, pas stretched-link)
+    - Badge statut via Blade component <x-inscription-status-badge>
+    - Actions inline + kebab menu pour secondaires
+    - Modals globaux pilotés par data-bs-target + data-inscription-id
+
+    Paramètres requis :
+      - $inscription : ESBTPInscription eager-loaded (etudiant, filiere, niveau, anneeUniversitaire)
+--}}
 @php
     $hasProbleme = session('inscriptions_problemes') && isset(session('inscriptions_problemes')[$inscription->id]);
     $problemeInfo = $hasProbleme ? session('inscriptions_problemes')[$inscription->id] : null;
-    $problemeClass = $hasProbleme ? ($problemeInfo['type'] === 'error' ? 'table-danger' : 'table-warning') : '';
-    $isNonValidee = $inscription->workflow_step !== 'etudiant_cree';
-    $isValidee = $inscription->status == 'active' && $inscription->workflow_step === 'etudiant_cree';
+    $problemeClass = $hasProbleme ? ($problemeInfo['type'] === 'error' ? 'ii-row--error' : 'ii-row--warn') : '';
+
+    $etudiant = $inscription->etudiant;
+    $nomComplet = $etudiant ? trim(($etudiant->nom ?? '').' '.($etudiant->prenoms ?? '')) : 'Étudiant inconnu';
+    $initials = $etudiant
+        ? strtoupper(mb_substr($etudiant->nom ?? '', 0, 1).mb_substr($etudiant->prenoms ?? '', 0, 1))
+        : '?';
+    $avatarHue = hexdec(substr(md5($nomComplet ?: (string) $inscription->id), 0, 4)) % 360;
+
+    $raison = $problemeInfo['message'] ?? '';
+    $isPaiementNonValide = $hasProbleme && str_contains($raison, 'paiement') && str_contains($raison, 'validé');
+    $isClassePleine = $hasProbleme && (str_contains($raison, 'Classe pleine') || str_contains($raison, 'classe pleine'));
+    $isSansPaiement = $hasProbleme && (str_contains($raison, 'Aucun paiement') || str_contains($raison, 'sans paiement'));
+
+    $showHref = auth()->user()->can('inscriptions.view')
+        ? route('esbtp.inscriptions.show', $inscription->id)
+        : null;
+
+    $canValidate = auth()->user()->can('inscriptions.validate');
+    $isNonValidee = $inscription->status === 'en_attente'
+        || $inscription->status === 'pending'
+        || ($inscription->status === 'active' && $inscription->workflow_step !== 'etudiant_cree');
 @endphp
-<tr class="{{ $problemeClass }}" data-inscription-id="{{ $inscription->id }}">
-    @can('access_admin')
-    <td>
-        @if($isNonValidee)
-        <input type="checkbox" class="form-check-input inscription-checkbox"
-               value="{{ $inscription->id }}"
-               data-inscription-id="{{ $inscription->id }}">
-        @endif
-    </td>
+<tr class="ii-row {{ $problemeClass }}"
+    data-inscription-id="{{ $inscription->id }}"
+    data-matricule="{{ $etudiant->matricule ?? '' }}"
+    data-nom="{{ $nomComplet }}"
+    @if($showHref) data-row-href="{{ $showHref }}" @endif>
+
+    @can('inscriptions.validate')
+        <td class="ii-col-check" data-no-row-click>
+            @if($isNonValidee)
+                <input type="checkbox"
+                       class="form-check-input inscription-checkbox"
+                       value="{{ $inscription->id }}"
+                       data-inscription-id="{{ $inscription->id }}"
+                       aria-label="Sélectionner l'inscription {{ $nomComplet }}">
+            @endif
+        </td>
     @endcan
-    <td style="max-width: 250px;">
-        @if($hasProbleme)
-            <div class="d-flex flex-column gap-2">
-                <span class="badge {{ $problemeInfo['type'] === 'error' ? 'bg-danger' : 'bg-warning text-dark' }} d-inline-flex align-items-start"
-                      style="font-size: 0.75rem; white-space: normal; word-wrap: break-word; text-align: left; line-height: 1.3;">
-                    <i class="fas {{ $problemeInfo['type'] === 'error' ? 'fa-exclamation-circle' : 'fa-exclamation-triangle' }} me-1 mt-1" style="flex-shrink: 0;"></i>
-                    <span style="word-break: break-word;">{{ $problemeInfo['message'] }}</span>
-                </span>
 
-                @php
-                    $raison = $problemeInfo['message'];
-                    $isPaiementNonValide = str_contains($raison, 'paiement') && str_contains($raison, 'validé');
-                    $isClassePleine = str_contains($raison, 'Classe pleine') || str_contains($raison, 'classe pleine');
-                    $isSansPaiement = str_contains($raison, 'Aucun paiement') || str_contains($raison, 'sans paiement');
-                @endphp
-
-                @if($isPaiementNonValide)
-                    <button type="button" class="btn btn-sm btn-action-quick"
-                            onclick="ouvrirModalValiderPaiement({{ $inscription->id }})"
-                            style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border: none; border-radius: 8px; padding: 6px 12px; font-size: 0.75rem; font-weight: 600;">
-                        <i class="fas fa-check-circle me-1"></i>Valider paiement
-                    </button>
-                @elseif($isClassePleine)
-                    <button type="button" class="btn btn-sm btn-action-quick"
-                            onclick="ouvrirModalChangerClasse({{ $inscription->id }})"
-                            style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border: none; border-radius: 8px; padding: 6px 12px; font-size: 0.75rem; font-weight: 600;">
-                        <i class="fas fa-exchange-alt me-1"></i>Changer classe
-                    </button>
-                @elseif($isSansPaiement)
-                    <button type="button" class="btn btn-sm btn-action-quick"
-                            onclick="ouvrirModalCreerPaiement({{ $inscription->id }})"
-                            style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border: none; border-radius: 8px; padding: 6px 12px; font-size: 0.75rem; font-weight: 600;">
-                        <i class="fas fa-plus-circle me-1"></i>Créer paiement
-                    </button>
+    {{-- Étudiant : photo + nom + matricule + N° inscription --}}
+    <td class="ii-col-etu">
+        <div class="ii-etu-cell">
+            <span class="ii-avatar"
+                  @if($etudiant && $etudiant->photo_url)
+                      style="background:transparent;padding:0;overflow:hidden;"
+                  @else
+                      style="background: hsl({{ $avatarHue }}, 55%, 92%); color: hsl({{ $avatarHue }}, 50%, 35%);"
+                  @endif>
+                @if($etudiant && $etudiant->photo_url)
+                    <img src="{{ $etudiant->photo_url }}"
+                         alt="{{ $nomComplet }}"
+                         width="36" height="36"
+                         loading="lazy"
+                         style="width:100%;height:100%;object-fit:cover;border-radius:50%;"
+                         onerror="this.onerror=null;this.parentElement.style.background='hsl({{ $avatarHue }}, 55%, 92%)';this.parentElement.style.color='hsl({{ $avatarHue }}, 50%, 35%)';this.outerHTML='{{ $initials }}';">
+                @else
+                    {{ $initials }}
                 @endif
+            </span>
+            <div class="ii-etu-body">
+                <div class="ii-etu-name">{{ $nomComplet }}</div>
+                <div class="ii-etu-meta">
+                    <span class="ii-matricule">{{ $etudiant->matricule ?? 'N/A' }}</span>
+                    <span class="ii-separator">·</span>
+                    <span class="ii-numero">{{ $inscription->numero_inscription ?? '—' }}</span>
+                </div>
             </div>
-        @else
-            {{ $inscription->numero_inscription }}
+        </div>
+    </td>
+
+    {{-- Filière / Niveau (fusionnés) --}}
+    <td class="ii-col-filiere">
+        <div class="ii-filiere-cell">
+            <div class="ii-filiere-name">{{ $inscription->filiere->name ?? ($inscription->filiere->nom ?? 'N/A') }}</div>
+            <div class="ii-filiere-niveau">{{ $inscription->niveau->name ?? ($inscription->niveau->nom ?? '') }}</div>
+        </div>
+    </td>
+
+    {{-- Année --}}
+    <td class="ii-col-annee">
+        {{ $inscription->anneeUniversitaire->name ?? ($inscription->anneeUniversitaire->annee_scolaire ?? 'N/A') }}
+    </td>
+
+    {{-- Statut via Blade component --}}
+    <td class="ii-col-status">
+        <x-inscription-status-badge :inscription="$inscription" />
+        @if($hasProbleme)
+            <div class="ii-probleme-chip" data-no-row-click>
+                <i class="fas {{ $problemeInfo['type'] === 'error' ? 'fa-exclamation-circle' : 'fa-exclamation-triangle' }}"></i>
+                <span>{{ \Illuminate\Support\Str::limit($problemeInfo['message'], 60) }}</span>
+            </div>
+            @if($isPaiementNonValide)
+                @can('paiements.validate')
+                    <button type="button" class="ii-btn-quick"
+                            onclick="event.stopPropagation(); ouvrirModalValiderPaiement({{ $inscription->id }})"
+                            data-no-row-click>
+                        <i class="fas fa-check-circle"></i>Valider paiement
+                    </button>
+                @endcan
+            @elseif($isClassePleine)
+                @can('inscriptions.validate')
+                    <button type="button" class="ii-btn-quick"
+                            onclick="event.stopPropagation(); ouvrirModalChangerClasse({{ $inscription->id }})"
+                            data-no-row-click>
+                        <i class="fas fa-exchange-alt"></i>Changer classe
+                    </button>
+                @endcan
+            @elseif($isSansPaiement)
+                @can('paiements.create')
+                    <button type="button" class="ii-btn-quick"
+                            onclick="event.stopPropagation(); ouvrirModalCreerPaiement({{ $inscription->id }})"
+                            data-no-row-click>
+                        <i class="fas fa-plus-circle"></i>Créer paiement
+                    </button>
+                @endcan
+            @endif
         @endif
     </td>
-    <td>{{ $inscription->etudiant->matricule ?? 'N/A' }}</td>
-    <td>{{ $inscription->etudiant->nom ?? '' }} {{ $inscription->etudiant->prenoms ?? '' }}</td>
-    <td>{{ $inscription->filiere->name ?? ($inscription->filiere->nom ?? 'N/A') }}</td>
-    <td>{{ $inscription->niveau->name ?? ($inscription->niveau->nom ?? 'N/A') }}</td>
-    <td>{{ $inscription->anneeUniversitaire->name ?? ($inscription->anneeUniversitaire->annee_scolaire ?? 'N/A') }}</td>
-    <td>
-        @if($isNonValidee)
-            <span class="badge bg-warning text-dark px-3 py-2">En attente</span>
-        @elseif($isValidee)
-            <span class="badge bg-success px-3 py-2">Validée</span>
-        @elseif($inscription->status == 'cancelled')
-            <span class="badge bg-danger px-3 py-2">Annulée</span>
-        @else
-            <span class="badge bg-secondary px-3 py-2">{{ ucfirst($inscription->status) }}</span>
-        @endif
-    </td>
-    <td>{{ $inscription->created_at->format('d/m/Y') }}</td>
-    <td>
+
+    {{-- Date inscription --}}
+    <td class="ii-col-date">{{ $inscription->created_at->format('d/m/Y') }}</td>
+
+    {{-- Actions : inline + kebab pour secondaires --}}
+    <td class="ii-col-actions" data-no-row-click>
         <div class="inscription-actions-wrapper" data-inscription-actions="{{ $inscription->id }}">
-            <div class="d-flex inscription-actions-buttons">
-            @can('inscriptions.view')
-            <a href="{{ route('esbtp.inscriptions.show', $inscription->id) }}" class="btn btn-primary btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 me-1" title="Détails">
-                <i class="fas fa-eye"></i>
-            </a>
-            @endcan
+            <div class="inscription-actions-buttons ii-actions">
+                @if($inscription->status === 'pending' || $inscription->status === 'en_attente')
+                    @can('valider inscriptions')
+                        <button type="button"
+                                class="ii-btn ii-btn--primary valider-btn"
+                                data-id="{{ $inscription->id }}"
+                                title="Valider l'inscription">
+                            <i class="fas fa-check"></i>
+                        </button>
+                        <form id="valider-form-{{ $inscription->id }}"
+                              action="{{ route('esbtp.inscriptions.valider', $inscription->id) }}"
+                              method="POST" style="display:none;">
+                            @csrf
+                            @method('PUT')
+                        </form>
+                    @endcan
+                @endif
 
-            @can('edit inscriptions')
-            @if($inscription->status == 'pending')
-            <a href="{{ route('esbtp.inscriptions.edit', $inscription->id) }}" class="btn btn-warning btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 me-1" title="Modifier">
-                <i class="fas fa-edit"></i>
-            </a>
-            @endif
-            @endcan
-
-            @if($inscription->status == 'pending')
-                @can('valider inscriptions')
-                <button type="button" class="btn btn-success btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 me-1 valider-btn"
-                        data-id="{{ $inscription->id }}" title="Valider l'inscription">
-                    <i class="fas fa-check"></i>
-                </button>
-                <form id="valider-form-{{ $inscription->id }}" action="{{ route('esbtp.inscriptions.valider', $inscription->id) }}" method="POST" style="display: none;">
-                    @csrf
-                    @method('PUT')
-                </form>
-                @endcan
-            @endif
-
-            @if($inscription->status == 'pending')
-                @can('annuler inscriptions')
-                <button type="button" class="btn btn-warning btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 me-1 annuler-btn"
-                        data-id="{{ $inscription->id }}" data-bs-toggle="modal"
-                        data-bs-target="#annulerModal{{ $inscription->id }}" title="Annuler l'inscription">
-                    <i class="fas fa-times"></i>
-                </button>
-                @endcan
-            @endif
-
-            @can('delete inscriptions')
-            <button type="button" class="btn btn-danger btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 delete-btn"
-                    data-id="{{ $inscription->id }}" data-bs-toggle="modal"
-                    data-bs-target="#deleteModal{{ $inscription->id }}" title="Supprimer">
-                <i class="fas fa-trash"></i>
-            </button>
-            @endcan
+                {{-- Menu kebab pour actions secondaires --}}
+                <div class="dropdown">
+                    <button type="button"
+                            class="ii-btn ii-btn--ghost"
+                            data-bs-toggle="dropdown"
+                            aria-expanded="false"
+                            aria-label="Actions supplémentaires"
+                            title="Actions supplémentaires">
+                        <i class="fas fa-ellipsis-v"></i>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end ii-dropdown">
+                        @can('inscriptions.view')
+                            <li>
+                                <a class="dropdown-item" href="{{ route('esbtp.inscriptions.show', $inscription->id) }}">
+                                    <i class="fas fa-eye"></i>Voir les détails
+                                </a>
+                            </li>
+                        @endcan
+                        @can('edit inscriptions')
+                            @if($inscription->status === 'pending' || $inscription->status === 'en_attente')
+                                <li>
+                                    <a class="dropdown-item" href="{{ route('esbtp.inscriptions.edit', $inscription->id) }}">
+                                        <i class="fas fa-edit"></i>Modifier
+                                    </a>
+                                </li>
+                            @endif
+                        @endcan
+                        @if($inscription->status === 'pending' || $inscription->status === 'en_attente')
+                            @can('annuler inscriptions')
+                                <li>
+                                    <button type="button"
+                                            class="dropdown-item"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#ii-modal-annuler"
+                                            data-inscription-id="{{ $inscription->id }}"
+                                            data-student-name="{{ $nomComplet }}">
+                                        <i class="fas fa-times"></i>Annuler l'inscription
+                                    </button>
+                                </li>
+                            @endcan
+                        @endif
+                        @can('delete inscriptions')
+                            <li><hr class="dropdown-divider"></li>
+                            <li>
+                                <button type="button"
+                                        class="dropdown-item ii-dropdown-item--danger"
+                                        data-bs-toggle="modal"
+                                        data-bs-target="#ii-modal-delete"
+                                        data-inscription-id="{{ $inscription->id }}"
+                                        data-student-name="{{ $nomComplet }}">
+                                    <i class="fas fa-trash"></i>Supprimer
+                                </button>
+                            </li>
+                        @endcan
+                    </ul>
+                </div>
             </div>
             <div class="inscription-actions-spinner" aria-hidden="true">
                 <div class="spinner-border spinner-border-sm text-primary" role="status">

--- a/resources/views/esbtp/inscriptions/partials/ligne-inscription.blade.php
+++ b/resources/views/esbtp/inscriptions/partials/ligne-inscription.blade.php
@@ -82,8 +82,10 @@
                 <div class="ii-etu-name">{{ $nomComplet }}</div>
                 <div class="ii-etu-meta">
                     <span class="ii-matricule">{{ $etudiant->matricule ?? 'N/A' }}</span>
-                    <span class="ii-separator">·</span>
-                    <span class="ii-numero">{{ $inscription->numero_inscription ?? '—' }}</span>
+                    @if(!empty($inscription->numero_inscription))
+                        <span class="ii-separator">·</span>
+                        <span class="ii-numero">{{ $inscription->numero_inscription }}</span>
+                    @endif
                 </div>
             </div>
         </div>

--- a/resources/views/esbtp/inscriptions/partials/results.blade.php
+++ b/resources/views/esbtp/inscriptions/partials/results.blade.php
@@ -1,219 +1,106 @@
+{{--
+    Partial : table résultats des inscriptions.
+    Inclus par esbtp.inscriptions.index (render initial) ET retourné par l'endpoint
+    AJAX filtre. La ligne <tr> provient de `partials/ligne-inscription.blade.php`
+    (source unique de vérité — fix du bug de permission drift pré-existant).
+
+    Paramètres requis :
+      - $inscriptions : LengthAwarePaginator
+      - $sort : string (default 'created_at')
+      - $dir : string (default 'desc')
+      - $perPage : int (default 15)
+--}}
+@php
+    $sort = $sort ?? 'created_at';
+    $dir = $dir ?? 'desc';
+    $perPage = $perPage ?? 15;
+
+    $sortUrl = function (string $column) use ($sort, $dir) {
+        $params = request()->query();
+        $params['sort'] = $column;
+        $params['dir'] = ($sort === $column && $dir === 'asc') ? 'desc' : 'asc';
+        unset($params['page']);
+        return request()->url().'?'.http_build_query($params);
+    };
+
+    $sortIndicator = function (string $column) use ($sort, $dir) {
+        if ($sort !== $column) {
+            return '<i class="fas fa-sort ii-sort-icon ii-sort-icon--neutral"></i>';
+        }
+        return '<i class="fas fa-sort-'.($dir === 'asc' ? 'up' : 'down').' ii-sort-icon ii-sort-icon--active"></i>';
+    };
+
+    $ariaSort = function (string $column) use ($sort, $dir) {
+        if ($sort !== $column) {
+            return 'none';
+        }
+        return $dir === 'asc' ? 'ascending' : 'descending';
+    };
+@endphp
+
 @if($inscriptions->count() > 0)
-    <div class="table-responsive">
-        <table class="table table-hover align-middle mb-0">
-            <thead class="bg-light">
+    <div class="ii-table-wrap">
+        <table class="ii-table">
+            <thead>
                 <tr>
                     @can('inscriptions.validate')
-                    <th style="width: 40px;">
-                        <input type="checkbox" id="select-all-inscriptions" class="form-check-input">
-                    </th>
+                        <th class="ii-col-check" style="width:40px;">
+                            <input type="checkbox"
+                                   id="select-all-inscriptions"
+                                   class="form-check-input"
+                                   aria-label="Tout sélectionner">
+                        </th>
                     @endcan
-                    <th>N° Inscription</th>
-                    <th>Matricule</th>
-                    <th>Étudiant</th>
-                    <th>Filière</th>
-                    <th>Niveau</th>
-                    <th>Année Universitaire</th>
-                    <th>Statut</th>
-                    <th>Date d'inscription</th>
-                    <th>Actions</th>
+                    <th class="ii-col-etu" aria-sort="{{ $ariaSort('nom') }}">
+                        <a href="{{ $sortUrl('nom') }}" class="ii-sort-link">
+                            Étudiant {!! $sortIndicator('nom') !!}
+                        </a>
+                    </th>
+                    <th class="ii-col-filiere" aria-sort="{{ $ariaSort('filiere_id') }}">
+                        <a href="{{ $sortUrl('filiere_id') }}" class="ii-sort-link">
+                            Filière · Niveau {!! $sortIndicator('filiere_id') !!}
+                        </a>
+                    </th>
+                    <th class="ii-col-annee">Année</th>
+                    <th class="ii-col-status" aria-sort="{{ $ariaSort('status') }}">
+                        <a href="{{ $sortUrl('status') }}" class="ii-sort-link">
+                            Statut {!! $sortIndicator('status') !!}
+                        </a>
+                    </th>
+                    <th class="ii-col-date" aria-sort="{{ $ariaSort('created_at') }}">
+                        <a href="{{ $sortUrl('created_at') }}" class="ii-sort-link">
+                            Inscription {!! $sortIndicator('created_at') !!}
+                        </a>
+                    </th>
+                    <th class="ii-col-actions" style="width:120px;">Actions</th>
                 </tr>
             </thead>
             <tbody>
                 @foreach($inscriptions as $inscription)
-                    @php
-                        $hasProbleme = session('inscriptions_problemes') && isset(session('inscriptions_problemes')[$inscription->id]);
-                        $problemeInfo = $hasProbleme ? session('inscriptions_problemes')[$inscription->id] : null;
-                        $problemeClass = $hasProbleme ? ($problemeInfo['type'] === 'error' ? 'table-danger' : 'table-warning') : '';
-                    @endphp
-                    <tr class="{{ $problemeClass }}" data-inscription-id="{{ $inscription->id }}">
-                        @can('inscriptions.validate')
-                        <td>
-                            @if($inscription->status == 'pending' || $inscription->status == 'en_attente' || ($inscription->status == 'active' && $inscription->workflow_step !== 'etudiant_cree'))
-                            <input type="checkbox" class="form-check-input inscription-checkbox"
-                                   value="{{ $inscription->id }}"
-                                   data-inscription-id="{{ $inscription->id }}">
-                            @endif
-                        </td>
-                        @endcan
-                        <td style="max-width: 250px;">
-                            @if($hasProbleme)
-                                <div class="d-flex flex-column gap-2">
-                                    <span class="badge {{ $problemeInfo['type'] === 'error' ? 'bg-danger' : 'bg-warning text-dark' }} d-inline-flex align-items-start"
-                                          style="font-size: 0.75rem; white-space: normal; word-wrap: break-word; text-align: left; line-height: 1.3;">
-                                        <i class="fas {{ $problemeInfo['type'] === 'error' ? 'fa-exclamation-circle' : 'fa-exclamation-triangle' }} me-1 mt-1" style="flex-shrink: 0;"></i>
-                                        <span style="word-break: break-word;">{{ $problemeInfo['message'] }}</span>
-                                    </span>
-
-                                    @php
-                                        $raison = $problemeInfo['message'];
-                                        $isPaiementNonValide = str_contains($raison, 'paiement') && str_contains($raison, 'validé');
-                                        $isClassePleine = str_contains($raison, 'Classe pleine') || str_contains($raison, 'classe pleine');
-                                        $isSansPaiement = str_contains($raison, 'Aucun paiement') || str_contains($raison, 'sans paiement');
-                                    @endphp
-
-                                    @if($isPaiementNonValide)
-                                        @can('paiements.validate')
-                                            <button type="button" class="btn btn-sm btn-action-quick"
-                                                    onclick="ouvrirModalValiderPaiement({{ $inscription->id }})"
-                                                    style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border: none; border-radius: 8px; padding: 6px 12px; font-size: 0.75rem; font-weight: 600;">
-                                                <i class="fas fa-check-circle me-1"></i>Valider paiement
-                                            </button>
-                                        @endcan
-                                    @elseif($isClassePleine)
-                                        @can('inscriptions.validate')
-                                            <button type="button" class="btn btn-sm btn-action-quick"
-                                                    onclick="ouvrirModalChangerClasse({{ $inscription->id }})"
-                                                    style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border: none; border-radius: 8px; padding: 6px 12px; font-size: 0.75rem; font-weight: 600;">
-                                                <i class="fas fa-exchange-alt me-1"></i>Changer classe
-                                            </button>
-                                        @endcan
-                                    @elseif($isSansPaiement)
-                                        @can('paiements.create')
-                                            <button type="button" class="btn btn-sm btn-action-quick"
-                                                    onclick="ouvrirModalCreerPaiement({{ $inscription->id }})"
-                                                    style="background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; border: none; border-radius: 8px; padding: 6px 12px; font-size: 0.75rem; font-weight: 600;">
-                                                <i class="fas fa-plus-circle me-1"></i>Créer paiement
-                                            </button>
-                                        @endcan
-                                    @endif
-                                </div>
-                            @else
-                                {{ $inscription->numero_inscription }}
-                            @endif
-                        </td>
-                        <td>{{ $inscription->etudiant->matricule ?? 'N/A' }}</td>
-                        <td>{{ $inscription->etudiant->nom ?? '' }} {{ $inscription->etudiant->prenoms ?? '' }}</td>
-                        <td>{{ $inscription->filiere->name ?? ($inscription->filiere->nom ?? 'N/A') }}</td>
-                        <td>{{ $inscription->niveau->name ?? ($inscription->niveau->nom ?? 'N/A') }}</td>
-                        <td>{{ $inscription->anneeUniversitaire->name ?? ($inscription->anneeUniversitaire->annee_scolaire ?? 'N/A') }}</td>
-                        <td>
-                            @if($inscription->status == 'pending' || $inscription->status == 'en_attente')
-                                <span class="badge bg-warning text-dark px-3 py-2">En attente</span>
-                            @elseif($inscription->status == 'active' && $inscription->workflow_step !== 'etudiant_cree')
-                                <span class="badge bg-warning text-dark px-3 py-2" title="Workflow: {{ $inscription->workflow_step ?? 'non défini' }}">
-                                    <i class="fas fa-exclamation-triangle me-1"></i>Non validée
-                                </span>
-                            @elseif($inscription->status == 'validated' || $inscription->status == 'active')
-                                <span class="badge bg-success px-3 py-2">Validée</span>
-                            @elseif($inscription->status == 'cancelled')
-                                <span class="badge bg-danger px-3 py-2">Annulée</span>
-                            @else
-                                <span class="badge bg-secondary px-3 py-2">{{ ucfirst($inscription->status) }}</span>
-                            @endif
-                        </td>
-                        <td>{{ $inscription->created_at->format('d/m/Y') }}</td>
-                        <td>
-                            <div class="d-flex">
-                                @can('inscriptions.view')
-                                <a href="{{ route('esbtp.inscriptions.show', $inscription->id) }}" class="btn btn-primary btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 me-1" title="Détails">
-                                    <i class="fas fa-eye"></i>
-                                </a>
-                                @endcan
-
-                                @can('edit inscriptions')
-                                @if($inscription->status == 'pending')
-                                <a href="{{ route('esbtp.inscriptions.edit', $inscription->id) }}" class="btn btn-warning btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 me-1" title="Modifier">
-                                    <i class="fas fa-edit"></i>
-                                </a>
-                                @endif
-                                @endcan
-
-                                @if($inscription->status == 'pending')
-                                    @can('valider inscriptions')
-                                    <button type="button" class="btn btn-success btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 me-1 valider-btn" 
-                                            data-id="{{ $inscription->id }}" title="Valider l'inscription">
-                                        <i class="fas fa-check"></i>
-                                    </button>
-                                    <form id="valider-form-{{ $inscription->id }}" action="{{ route('esbtp.inscriptions.valider', $inscription->id) }}" method="POST" style="display: none;">
-                                        @csrf
-                                        @method('PUT')
-                                    </form>
-                                    @endcan
-                                @endif
-
-                                @if($inscription->status == 'pending')
-                                    @can('annuler inscriptions')
-                                    <button type="button" class="btn btn-warning btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 me-1 annuler-btn" 
-                                            data-id="{{ $inscription->id }}" data-bs-toggle="modal" 
-                                            data-bs-target="#annulerModal{{ $inscription->id }}" title="Annuler l'inscription">
-                                        <i class="fas fa-times"></i>
-                                    </button>
-                                    
-                                    <!-- Modal d'annulation -->
-                                    <div class="modal fade" id="annulerModal{{ $inscription->id }}" tabindex="-1" aria-labelledby="annulerModalLabel" aria-hidden="true">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
-                                                <div class="modal-header">
-                                                    <h5 class="modal-title" id="annulerModalLabel">Annulation d'inscription</h5>
-                                                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                                                </div>
-                                                <div class="modal-body">
-                                                    <p>Êtes-vous sûr de vouloir annuler l'inscription de <strong>{{ $inscription->etudiant->nom }} {{ $inscription->etudiant->prenom }}</strong> ?</p>
-                                                    <form action="{{ route('esbtp.inscriptions.annuler', $inscription->id) }}" method="POST">
-                                                        @csrf
-                                                        @method('PUT')
-                                                        <div class="form-group">
-                                                            <label for="motif">Motif d'annulation</label>
-                                                            <textarea class="form-control" id="motif" name="motif" rows="3" required></textarea>
-                                                        </div>
-                                                    </div>
-                                                    <div class="modal-footer">
-                                                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                                                        <button type="submit" class="btn btn-warning">Confirmer l'annulation</button>
-                                                    </div>
-                                                </form>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    @endcan
-                                @endif
-
-                                @can('delete inscriptions')
-                                <button type="button" class="btn btn-danger btn-sm rounded-pill shadow-sm d-inline-flex align-items-center gap-1 delete-btn" 
-                                        data-id="{{ $inscription->id }}" data-bs-toggle="modal" 
-                                        data-bs-target="#deleteModal{{ $inscription->id }}" title="Supprimer">
-                                    <i class="fas fa-trash"></i>
-                                </button>
-                                
-                                <!-- Modal de suppression -->
-                                <div class="modal fade" id="deleteModal{{ $inscription->id }}" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel{{ $inscription->id }}" aria-hidden="true">
-                                    <div class="modal-dialog" role="document">
-                                        <div class="modal-content">
-                                            <div class="modal-header">
-                                                <h5 class="modal-title" id="deleteModalLabel{{ $inscription->id }}">Supprimer l'inscription</h5>
-                                                <button type="button" class="close btn-close" data-bs-dismiss="modal" aria-label="Close">
-                                                    <span aria-hidden="true">&times;</span>
-                                                </button>
-                                            </div>
-                                            <div class="modal-body">
-                                                <p>Êtes-vous sûr de vouloir supprimer cette inscription ? Cette action est irréversible.</p>
-                                            </div>
-                                            <div class="modal-footer">
-                                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                                                <form action="{{ route('esbtp.inscriptions.destroy', $inscription->id) }}" method="POST">
-                                                    @csrf
-                                                    @method('DELETE')
-                                                    <button type="submit" class="btn btn-danger">Supprimer</button>
-                                                </form>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                @endcan
-                            </div>
-                        </td>
-                    </tr>
+                    @include('esbtp.inscriptions.partials.ligne-inscription', ['inscription' => $inscription])
                 @endforeach
             </tbody>
         </table>
     </div>
 
-    <div class="mt-3">
-        {{ $inscriptions->appends(request()->query())->links() }}
+    <div class="ii-table-footer">
+        <div class="ii-per-page">
+            <label for="ii-per-page-select" class="ii-per-page-label">Afficher</label>
+            <select id="ii-per-page-select" class="ii-per-page-select" aria-label="Nombre d'inscriptions par page">
+                @foreach([15, 25, 50, 100] as $option)
+                    <option value="{{ $option }}" @selected($perPage === $option)>{{ $option }}</option>
+                @endforeach
+            </select>
+            <span class="ii-per-page-hint">par page · {{ $inscriptions->total() }} inscription{{ $inscriptions->total() > 1 ? 's' : '' }} au total</span>
+        </div>
+        <div class="ii-pagination">
+            {{ $inscriptions->appends(request()->query())->onEachSide(1)->links('pagination::bootstrap-5') }}
+        </div>
     </div>
 @else
-    <div class="alert alert-info">
-        Aucune inscription ne correspond à vos critères de recherche.
+    <div class="ii-empty">
+        <div class="ii-empty-icon"><i class="fas fa-file-circle-question"></i></div>
+        <div class="ii-empty-title">Aucune inscription trouvée</div>
+        <div class="ii-empty-text">Essayez d'ajuster vos filtres ou de vider la recherche.</div>
     </div>
 @endif

--- a/resources/views/esbtp/inscriptions/show.blade.php
+++ b/resources/views/esbtp/inscriptions/show.blade.php
@@ -3181,6 +3181,21 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
                                       style="border: 2px solid #dee2e6; border-radius: 8px; resize: none;"></textarea>
                         </div>
                     </div>
+
+                    {{-- Checkbox : Valider directement le paiement --}}
+                    <div style="margin-top: 1.5rem; border: 2px solid #e2e8f0; border-radius: 10px; padding: 1rem; background: #f8fafc;">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="validate_payment" id="payment_validate_immediately" value="1"
+                                   style="width:18px; height:18px; margin-top:.15rem;">
+                            <label class="form-check-label fw-semibold" for="payment_validate_immediately" style="margin-left:.4rem; color:#2d3748;">
+                                <i class="fas fa-bolt me-1" style="color:#0d6efd;"></i>
+                                Valider directement le paiement
+                            </label>
+                            <div class="text-muted" style="margin-left:1.75rem; font-size:.8rem; margin-top:.2rem;">
+                                Si coché, le paiement sera marqué comme validé dès sa création (sans attente de validation ultérieure).
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="modal-footer" style="background: #f8f9fa; border-radius: 0 0 15px 15px; padding: 1.25rem 2rem; border: none;">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" style="
@@ -3499,33 +3514,50 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
 
 <!-- Modal pour souscription à un frais optionnel -->
 <div class="modal fade" id="subscriptionModal" tabindex="-1" aria-labelledby="subscriptionModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="subscriptionModalLabel">
-                    <i class="fas fa-plus-circle me-2"></i>Souscrire l'étudiant à un frais optionnel
+    <div class="modal-dialog modal-lg modal-dialog-centered">
+        <div class="modal-content" style="border-radius: 15px; border: none; box-shadow: 0 10px 40px rgba(0,0,0,0.2);">
+            <div class="modal-header" style="background: linear-gradient(135deg, #0d6efd 0%, #0a58ca 100%); color: white; border-radius: 15px 15px 0 0; padding: 1.5rem; border: none;">
+                <h5 class="modal-title fw-bold" id="subscriptionModalLabel">
+                    <i class="fas fa-plus-circle me-2"></i>Souscrire à un frais optionnel
                 </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <form id="subscriptionForm" method="POST" action="{{ route('esbtp.inscriptions.subscribe-optional-fee', $inscription->id) }}">
                 @csrf
-                <div class="modal-body">
-                    <div class="alert alert-info">
-                        <i class="fas fa-info-circle me-2"></i>
-                        Sélectionnez un frais optionnel pour y souscrire cet étudiant.
+                <div class="modal-body" style="padding: 2rem;">
+                    <!-- Alert information -->
+                    <div style="background: linear-gradient(135deg, #e7f3ff 0%, #f0f8ff 100%); border-left: 4px solid #0d6efd; border-radius: 10px; padding: 1rem 1.25rem; margin-bottom: 1.5rem;">
+                        <div class="d-flex align-items-start gap-3">
+                            <div style="width: 40px; height: 40px; border-radius: 50%; background: linear-gradient(135deg, #0d6efd, #0a58ca); display: flex; align-items: center; justify-content: center; color: white; flex-shrink: 0;">
+                                <i class="fas fa-info-circle"></i>
+                            </div>
+                            <div style="flex-grow: 1;">
+                                <div style="color: #084298; font-weight: 500; margin-bottom: 0.25rem;">Souscription à un frais optionnel</div>
+                                <div style="color: #052c65; font-size: 0.9rem;">
+                                    Sélectionnez un frais optionnel pour y souscrire cet étudiant. Vous pouvez également effectuer et valider le paiement immédiatement.
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                    <div class="row">
+
+                    <!-- Ligne 1 : Frais + Montant -->
+                    <div class="row g-3 mb-3">
                         <div class="col-md-6">
-                            <div class="mb-3">
-                                <label for="optional_category_id" class="form-label">Frais optionnel <span class="text-danger">*</span></label>
-                                <select class="form-select" id="optional_category_id" name="frais_category_id" required>
+                            <label for="optional_category_id" class="form-label fw-semibold" style="color: #2d3748; font-size: 0.9rem;">
+                                <i class="fas fa-tags me-1" style="color: #0d6efd;"></i>
+                                Frais optionnel <span class="text-danger">*</span>
+                            </label>
+                            <div style="position: relative;">
+                                <i class="fas fa-folder-open" style="position: absolute; left: 15px; top: 50%; transform: translateY(-50%); color: #0d6efd; z-index: 10;"></i>
+                                <select class="form-select" id="optional_category_id" name="frais_category_id" required
+                                        style="padding-left: 2.75rem; border: 2px solid #dee2e6; border-radius: 8px; font-weight: 500;">
                                     <option value="">Sélectionnez un frais</option>
                                     @if(isset($availableOptionalCategories))
                                         @foreach($availableOptionalCategories as $category)
                                             <option value="{{ $category->id }}"
                                                     data-default-amount="{{ $category->default_amount }}"
                                                     data-options="{{ json_encode($category->options->map(fn($o) => ['id' => $o->id, 'name' => $o->name, 'additional_amount' => (float)$o->additional_amount, 'description' => $o->description])->values()) }}">
-                                                {{ $category->name }} - {{ number_format($category->default_amount, 0, ',', ' ') }} FCFA
+                                                {{ $category->name }} — {{ number_format($category->default_amount, 0, ',', ' ') }} FCFA
                                             </option>
                                         @endforeach
                                     @endif
@@ -3533,29 +3565,88 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
                             </div>
                         </div>
                         <div class="col-md-6">
-                            <div class="mb-3">
-                                <label for="subscription_amount" class="form-label">Montant <span class="text-danger">*</span></label>
-                                <input type="number" class="form-control" id="subscription_amount" name="amount" min="0" step="1" required>
-                                <small class="text-muted" id="subscription_amount_hint"></small>
+                            <label for="subscription_amount" class="form-label fw-semibold" style="color: #2d3748; font-size: 0.9rem;">
+                                <i class="fas fa-coins me-1" style="color: #0d6efd;"></i>
+                                Montant <span class="text-danger">*</span>
+                            </label>
+                            <div class="input-group">
+                                <span class="input-group-text" style="background: linear-gradient(135deg, #f8f9fa, #e9ecef); border: 2px solid #dee2e6; border-right: none;">
+                                    <i class="fas fa-dollar-sign" style="color: #0d6efd;"></i>
+                                </span>
+                                <input type="number" class="form-control" id="subscription_amount" name="amount" min="0" step="1" required
+                                       style="border: 2px solid #dee2e6; border-left: none; border-right: none; font-weight: 600;">
+                                <span class="input-group-text" style="background: linear-gradient(135deg, #f8f9fa, #e9ecef); border: 2px solid #dee2e6; border-left: none; font-weight: 600;">FCFA</span>
                             </div>
+                            <small class="text-muted" id="subscription_amount_hint"></small>
                         </div>
                     </div>
 
-                    <!-- Zone options dynamique (affichée si la catégorie a des options) -->
+                    <!-- Zone options dynamique -->
                     <div id="subscription_options_zone" class="mb-3" style="display:none;">
-                        <label class="form-label">Option <span class="text-danger">*</span></label>
+                        <label class="form-label fw-semibold" style="color: #2d3748; font-size: 0.9rem;">
+                            <i class="fas fa-list me-1" style="color: #0d6efd;"></i>
+                            Option <span class="text-danger">*</span>
+                        </label>
                         <div id="subscription_options_list"></div>
                         <small class="text-muted">Le montant se met à jour automatiquement selon l'option choisie.</small>
                     </div>
 
+                    <!-- Notes -->
                     <div class="mb-3">
-                        <label for="subscription_notes" class="form-label">Notes</label>
-                        <textarea class="form-control" id="subscription_notes" name="notes" rows="3" placeholder="Commentaires sur la souscription..."></textarea>
+                        <label for="subscription_notes" class="form-label fw-semibold" style="color: #2d3748; font-size: 0.9rem;">
+                            <i class="fas fa-comment-dots me-1" style="color: #6c757d;"></i>
+                            Notes
+                        </label>
+                        <textarea class="form-control" id="subscription_notes" name="notes" rows="2"
+                                  placeholder="Commentaires sur la souscription..."
+                                  style="border: 2px solid #dee2e6; border-radius: 8px; resize: none;"></textarea>
+                    </div>
+
+                    <!-- Option : effectuer le paiement immédiatement -->
+                    <div style="border: 2px solid #e2e8f0; border-radius: 10px; padding: 1rem; background: #f8fafc;">
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" name="create_and_pay" id="subscription_create_and_pay" value="1"
+                                   style="width:18px; height:18px; margin-top:.15rem;">
+                            <label class="form-check-label fw-semibold" for="subscription_create_and_pay" style="margin-left:.4rem; color:#2d3748;">
+                                <i class="fas fa-bolt me-1" style="color:#0d6efd;"></i>
+                                Effectuer et valider le paiement immédiatement
+                            </label>
+                            <div class="text-muted" style="margin-left:1.75rem; font-size:.8rem; margin-top:.2rem;">
+                                Crée un paiement du montant ci-dessus et le marque comme validé sur cette souscription.
+                            </div>
+                        </div>
+                        <div id="subscription_payment_fields" class="row g-3 mt-2" style="display:none;">
+                            <div class="col-md-6">
+                                <label for="subscription_mode_paiement" class="form-label fw-semibold" style="color:#2d3748; font-size:.85rem;">
+                                    <i class="fas fa-credit-card me-1" style="color:#0d6efd;"></i>Mode de paiement <span class="text-danger">*</span>
+                                </label>
+                                <select class="form-select" name="mode_paiement" id="subscription_mode_paiement"
+                                        style="border: 2px solid #dee2e6; border-radius: 8px;">
+                                    <option value="">Sélectionnez</option>
+                                    <option value="especes">Espèces</option>
+                                    <option value="cheque">Chèque</option>
+                                    <option value="virement">Virement</option>
+                                    <option value="mobile_money">Mobile Money</option>
+                                </select>
+                            </div>
+                            <div class="col-md-6">
+                                <label for="subscription_reference" class="form-label fw-semibold" style="color:#2d3748; font-size:.85rem;">
+                                    <i class="fas fa-hashtag me-1" style="color:#6c757d;"></i>Référence du paiement
+                                </label>
+                                <input type="text" class="form-control" name="reference_paiement" id="subscription_reference"
+                                       placeholder="Numéro de chèque, référence virement..."
+                                       style="border: 2px solid #dee2e6; border-radius: 8px;">
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                    <button type="submit" class="btn btn-primary">
+                <div class="modal-footer" style="background: #f8f9fa; border-radius: 0 0 15px 15px; padding: 1.25rem 2rem; border: none;">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal"
+                            style="padding: 0.65rem 1.5rem; border-radius: 8px; font-weight: 600; border: 2px solid #6c757d;">
+                        <i class="fas fa-times me-2"></i>Annuler
+                    </button>
+                    <button type="submit" class="btn btn-primary"
+                            style="padding: 0.65rem 1.5rem; border-radius: 8px; font-weight: 600; background: linear-gradient(135deg, #0d6efd, #0a58ca); border: none; box-shadow: 0 4px 12px rgba(13,110,253,0.3);">
                         <i class="fas fa-plus me-2"></i>Souscrire l'étudiant
                     </button>
                 </div>
@@ -5116,6 +5207,26 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
         protectFormAgainstDoubleClick('#paymentForm', '#paymentModal');              // Modal associer un paiement
         protectFormAgainstDoubleClick('#validationForm', '#validationModal');        // Modal validation définitive
         protectFormAgainstDoubleClick('#reliquatPaymentForm', '#reliquatPaymentModal'); // Modal paiement reliquat
+        protectFormAgainstDoubleClick('#subscriptionForm', '#subscriptionModal');    // Modal souscription optionnel
+
+        // ========================================
+        // TOGGLE des champs de paiement dans subscriptionModal
+        // (checkbox "Effectuer et valider le paiement immédiatement")
+        // ========================================
+        const subCheckbox = document.getElementById('subscription_create_and_pay');
+        const subPaymentFields = document.getElementById('subscription_payment_fields');
+        const subModeSelect = document.getElementById('subscription_mode_paiement');
+        if (subCheckbox && subPaymentFields && subModeSelect) {
+            subCheckbox.addEventListener('change', function() {
+                subPaymentFields.style.display = this.checked ? 'flex' : 'none';
+                if (this.checked) {
+                    subModeSelect.setAttribute('required', 'required');
+                } else {
+                    subModeSelect.removeAttribute('required');
+                    subModeSelect.value = '';
+                }
+            });
+        }
 
         // ========================================
         // VALIDATION MONTANT PAIEMENT - PAYMENTMODAL
@@ -5157,16 +5268,9 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
                 console.log('  - categoryId:', categoryId);
                 console.log('  - window.isSubscribedToCategory:', window.isSubscribedToCategory);
 
-                // ✅ FIX: Bloquer la soumission si l'étudiant n'est PAS souscrit à la catégorie
-                if (!window.isSubscribedToCategory) {
-                    console.log('  ❌ BLOCAGE: Étudiant non souscrit');
-                    e.preventDefault();
-                    const resetFn = $('#paymentForm').data('resetSubmitting');
-                    if (resetFn) resetFn();
-                    alert(`❌ Impossible de soumettre ce paiement.\n\nL'étudiant n'est pas souscrit à la catégorie de frais sélectionnée.\n\nVeuillez d'abord inscrire l'étudiant à cette catégorie de frais dans la gestion des frais.`);
-                    feeCategorySelect.focus();
-                    return false;
-                }
+                // Note : on ne bloque plus la soumission si l'étudiant n'est pas souscrit
+                // car le backend renvoie un message d'erreur lisible (redirect with error)
+                // et bloquer côté JS avec alert() était jugé peu ergonomique (dialog fugace).
 
                 const montantSaisi = parseFloat(montantInput.value) || 0;
                 const montantMax = parseFloat(montantInput.getAttribute('max')) || Infinity;

--- a/routes/web.php
+++ b/routes/web.php
@@ -924,6 +924,8 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
 
             // Routes pour validation groupée des inscriptions
             Route::post('/inscriptions/bulk-valider', [ESBTPInscriptionController::class, 'bulkValider'])->name('inscriptions.bulk-valider');
+            Route::post('/inscriptions/bulk-annuler', [ESBTPInscriptionController::class, 'bulkAnnuler'])->name('inscriptions.bulk-annuler');
+            Route::post('/inscriptions/bulk-export', [ESBTPInscriptionController::class, 'bulkExport'])->name('inscriptions.bulk-export');
 
             Route::post('/inscriptions/{inscription}/lever-reserve', [ESBTPInscriptionController::class, 'leverReserve'])->name('inscriptions.lever-reserve');
             Route::post('/inscriptions/{inscription}/marquer-sous-reserve', [ESBTPInscriptionController::class, 'marquerSousReserve'])->name('inscriptions.marquer-sous-reserve');


### PR DESCRIPTION
## Résumé

PR1 d'un split en 2 pour le redesign complet des pages inscriptions. **Fondation** : rewrite complet de `/esbtp/inscriptions` (index) avec Blade component, JS externalisé, modals globaux, et fix de 5 bugs pré-existants. La PR2 (administration + sous-reserve) réutilisera ces composants.

Closes #216 · Refs #214

## Ce qui change côté utilisateur

### Page `/esbtp/inscriptions`

| Avant | Maintenant |
|-------|------------|
| Header plat + carte "Filtre année" inutile | Hero gradient bleu + chip année |
| 6 stats calculés dans le controller mais IGNORÉS par la vue | **5 KPIs cliquables** dans le hero (Total / Validées / Non validées / En attente / Annulées) → filtrent la liste |
| Formulaire "Filtres de recherche" dans une grosse carte | Toolbar compacte sticky (recherche + 4 selects + reset) |
| Badge status multicolore (vert/jaune/rouge/gris + textes bg-*) | **Badge monochrome bleu** via `<x-inscription-status-badge>` (5 états : validée, non validée, en attente, annulée, terminée) |
| Cellule "N° Inscription" remplacée par un badge géant quand problème | **Row coloriée** (rouge/orange) + chip problème + bouton action rapide, le N° reste lisible |
| 5 boutons actions multicolores par ligne | 1 bouton Valider (si en attente) + kebab pour Voir / Modifier / Annuler / Supprimer |
| Modals annulation + suppression **DUPLIQUÉS par inscription** (2×N modals dans le DOM) | **2 modals globaux** pilotés par `data-id` dynamique |
| 3 modals action rapide avec CSS inline multicolore | Tous monochrome bleu (`ii-modal-header`) |
| 1000+ lignes de JS inline dans le Blade | JS externalisé `public/js/inscriptions/index.js` avec route map injectée |
| Pas de tri colonnes | **Sort colonnes** server-side (Étudiant, Filière, Statut, Date) avec `aria-sort` a11y |
| Pas d'items-per-page selector | **Selector 15/25/50/100** au pied de table |
| Pas de chips filtres actifs | **Chips filtres actifs** affichées (supprimables par clic) |
| Row pas cliquable | **Row cliquable** (JS delegation, middle-click ouvre nouvel onglet) |
| Pas de photos étudiants | **Photo étudiant** avec fallback HSL (pattern attendances) |

### Bulk actions bar

- Avant : gradient bleu avec "Valider" + "Annuler" (= clear selection, confus)
- Maintenant : **Valider / Annuler (TODO PR2) / Exporter (TODO PR2)** + bouton **× Close** explicite

## Décisions user (plan-and-confirm FULL)

| Q | Décision |
|---|----------|
| Q1 | KPIs cliquables comme filtres (reclick actif = reset "all") |
| Q2 | Row cliquable via **JS delegation** (critic recommande vs stretched-link) |
| Q3 | Sort colonnes + `aria-sort` |
| Q4 | Partials unifiés (`results @foreach @include ligne-inscription`) |
| Q5 | **Blade component** `<x-inscription-status-badge>` (critic recommande vs accessor modèle) |
| Q6 | Modals globaux unifiés avec data-id |
| Q7 | Bulk bar complète (Valider + Annuler + Exporter + × Close) |
| Q8 | **Split 2 PRs** (critic recommande) — PR2 viendra après merge |
| Q9 | Pagination numérotée + per_page selector |
| Q10 | PR dédiée `feat/inscriptions-index-premium` |

## Bugs pré-existants fixés en passant (Q-d = tous)

1. **Permission drift** — `ligne-inscription.blade.php` utilisait `@can('access_admin')` vs `results.blade.php` `@can('inscriptions.validate')` → checkbox disparaissait après AJAX refresh pour certains rôles. Fixé par unification sur `@can('inscriptions.validate')`.
2. **HTML cassé** — `results.blade.php:160` : `</div>` fermait `modal-body` avant `</form>`. Fixé par suppression de l'ancien modal inline.
3. **`$inscriptions->count()`** — `index.blade.php:223` affichait le count de la page courante. Fixé : `$inscriptions->total()`.
4. **`debugWarn` non défini** — en fait défini dans `public/js/debug-helper.js` chargé globalement, donc ReferenceError fantôme. Vérifié.
5. **`console.log('Inscriptions avec problèmes:', @json(session()))`** — fuite info publique en prod. Supprimé.

## Fichiers touchés

### Créés
- `app/View/Components/InscriptionStatusBadge.php` (Blade component PHP)
- `resources/views/components/inscription-status-badge.blade.php` (template)
- `public/js/inscriptions/index.js` (JS externalisé, ~600 lignes)

### Modifiés
- `resources/views/esbtp/inscriptions/index.blade.php` (1605 → ~750 lignes avec CSS namespace ii-*)
- `resources/views/esbtp/inscriptions/partials/results.blade.php` (219 → 90 lignes, délègue à ligne-inscription)
- `resources/views/esbtp/inscriptions/partials/ligne-inscription.blade.php` (131 → 180 lignes, rewrite monochrome + photo + kebab)
- `app/Http/Controllers/ESBTPInscriptionController.php` (index() : sort whitelist + per_page whitelist + passe `sort`/`dir`/`perPage` à la vue)

### Ne pas touché (PR1)
- `administration.blade.php` et partials associés
- `sous-reserve.blade.php`
- `app/Models/ESBTPInscription.php` (pas d'accessor modèle)

## Tests à faire après merge sur \`presentation\`

- [ ] Page charge avec hero + 5 KPIs + toolbar
- [ ] Clic KPI → filtre + URL updated + état actif
- [ ] Reclic KPI actif → retour "Tous statuts"
- [ ] Filtres select + recherche (debounce 400ms) → AJAX refresh
- [ ] Reset filtres → reset complet + fetch
- [ ] Sort colonnes : clic → ORDER BY + chevron indicator
- [ ] Per_page selector → reload avec nouveau perPage
- [ ] Pagination AJAX préserve tous les filtres
- [ ] Row cliquable → détails inscription (middle-click = nouvel onglet)
- [ ] Kebab menu fonctionne (Voir / Modifier / Annuler / Supprimer)
- [ ] Modal Annuler ouvre avec data-id dynamique
- [ ] Modal Supprimer idem
- [ ] Bulk validation préserve règle "NEVER auto-valider paiement en_attente"
- [ ] Refresh-ligne AJAX après action préserve highlight/flash animations
- [ ] Photos étudiants affichées avec fallback HSL
- [ ] Badge statut monochrome (plus de vert/jaune/rouge hardcoded)
- [ ] Permissions testées : superAdmin, secrétaire, caissier, étudiant (pas de checkbox drift après AJAX)

## Risques

- ~1000 lignes de JS refactorisées → risque de régression sur flow AJAX. Tests à faire en priorité : bulk validation, refresh-ligne avec highlight, 3 modals action rapide.
- `$etudiant->photo_url` N+1 potentiel (accessor fait `file_exists()`) : acceptable pour 15-50 étudiants/page, à optimiser si scale.
- `ConvertEmptyStringsToNull` middleware : les filtres vides deviennent `null` côté backend, déjà géré par `$request->input('x')` qui retourne null sans erreur (pas de cast strict typing qui explose).

## Next

- PR2 (`feat/inscriptions-admin-sousreserve-premium`) attendra le merge de cette PR1 pour réutiliser `<x-inscription-status-badge>`, les modals globaux, le CSS namespace `ii-*`, et le pattern JS externalisé.