### PR TITLE
feat(inscriptions): redesign premium administration + sous-reserve (PR2)

### DIFF
--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -1251,7 +1251,7 @@ class ESBTPInscriptionController extends Controller
     public function administration(Request $request)
     {
         // Récupérer les filtres
-        $search = $request->input("search");
+        $search = (string) $request->input("search", "");
         $filiere = $request->input("filiere");
         $niveau = $request->input("niveau");
         $annee = $request->input("annee");
@@ -1282,7 +1282,7 @@ class ESBTPInscriptionController extends Controller
             });
 
         // Appliquer les filtres
-        if ($search) {
+        if ($search !== "") {
             $query->whereHas("etudiant", function ($q) use ($search) {
                 $q->where("matricule", "like", "%{$search}%")
                     ->orWhere("nom", "like", "%{$search}%")
@@ -1326,8 +1326,31 @@ class ESBTPInscriptionController extends Controller
             });
         }
 
+        // Tri server-side (whitelist anti SQL injection)
+        $sortableColumns = [
+            "created_at",
+            "updated_at",
+            "workflow_step",
+            "status",
+        ];
+        $sort = (string) $request->input("sort", "created_at");
+        if (!in_array($sort, $sortableColumns, true)) {
+            $sort = "created_at";
+        }
+        $dir = strtolower((string) $request->input("dir", "desc"));
+        if (!in_array($dir, ["asc", "desc"], true)) {
+            $dir = "desc";
+        }
+        $query->orderBy($sort, $dir);
+
+        // Pagination (whitelist per_page)
+        $perPage = (int) $request->input("per_page", 25);
+        if (!in_array($perPage, [15, 25, 50, 100], true)) {
+            $perPage = 25;
+        }
+
         // Récupérer les inscriptions
-        $inscriptions = $query->latest()->paginate(20);
+        $inscriptions = $query->paginate($perPage)->appends($request->query());
 
         $inscriptions->getCollection()->transform(function ($inscription) {
             $availability = $this->workflowService->checkClassAvailability(
@@ -1411,6 +1434,7 @@ class ESBTPInscriptionController extends Controller
                     ],
                 )->render(),
                 "url" => $request->fullUrl(),
+                "stats" => $stats,
             ]);
         }
 
@@ -2164,32 +2188,66 @@ class ESBTPInscriptionController extends Controller
 
         // Par défaut : toutes les années (pas filtré sur l'année courante)
         $anneeFilterId = $request->input('annee_id');
-        $search = $request->input('search');
+        $search = (string) $request->input('search', '');
+        $condition = (string) $request->input('condition', '');
+        $hasPayment = (string) $request->input('has_payment', '');
+
+        // Tri server-side (whitelist)
+        $sortableColumns = ['created_at', 'condition_reserve', 'workflow_step'];
+        $sort = (string) $request->input('sort', 'created_at');
+        if (!in_array($sort, $sortableColumns, true)) {
+            $sort = 'created_at';
+        }
+        $dir = strtolower((string) $request->input('dir', 'desc'));
+        if (!in_array($dir, ['asc', 'desc'], true)) {
+            $dir = 'desc';
+        }
+
+        // Pagination whitelist
+        $perPage = (int) $request->input('per_page', 25);
+        if (!in_array($perPage, [15, 25, 50, 100], true)) {
+            $perPage = 25;
+        }
 
         $query = ESBTPInscription::with([
                 'etudiant', 'classe', 'filiere', 'niveauEtude', 'anneeUniversitaire', 'paiements'
             ])
             ->where('is_sous_reserve', true)
             ->when($anneeFilterId, fn($q) => $q->where('annee_universitaire_id', $anneeFilterId))
-            ->when($search, fn($q) => $q->whereHas('etudiant', fn($eq) =>
+            ->when($search !== '', fn($q) => $q->whereHas('etudiant', fn($eq) =>
                 $eq->where('nom', 'like', "%{$search}%")
                    ->orWhere('prenoms', 'like', "%{$search}%")
                    ->orWhere('matricule', 'like', "%{$search}%")
             ))
-            ->orderBy('created_at', 'desc');
+            ->when($condition !== '', fn($q) => $q->where('condition_reserve', $condition))
+            ->when($hasPayment === 'yes', fn($q) => $q->whereHas('paiements', fn($pq) => $pq->where('status', 'validé')))
+            ->when($hasPayment === 'no', fn($q) => $q->whereDoesntHave('paiements', fn($pq) => $pq->where('status', 'validé')))
+            ->orderBy($sort, $dir);
 
-        $inscriptions = $query->get();
+        $inscriptions = $query->paginate($perPage)->appends($request->query());
 
-        // Stats calculées depuis la collection chargée (0 query supplémentaire)
-        $avecPaiement = $inscriptions->filter(fn($i) => $i->paiements->where('status', 'validé')->isNotEmpty())->count();
+        // Stats globales (non filtrees par filtres, juste is_sous_reserve)
+        $statsBase = ESBTPInscription::where('is_sous_reserve', true)
+            ->when($anneeFilterId, fn($q) => $q->where('annee_universitaire_id', $anneeFilterId));
         $stats = [
-            'total' => $inscriptions->count(),
-            'avec_paiement' => $avecPaiement,
-            'sans_paiement' => $inscriptions->count() - $avecPaiement,
+            'total' => (clone $statsBase)->count(),
+            'avec_paiement' => (clone $statsBase)->whereHas('paiements', fn($q) => $q->where('status', 'validé'))->count(),
+            'sans_paiement' => (clone $statsBase)->whereDoesntHave('paiements', fn($q) => $q->where('status', 'validé'))->count(),
         ];
 
+        if ($request->ajax()) {
+            return response()->json([
+                'html' => view('esbtp.inscriptions.partials.sous-reserve-results', [
+                    'inscriptions' => $inscriptions,
+                    'anneeEnCours' => $anneeEnCours,
+                ])->render(),
+                'url' => $request->fullUrl(),
+                'stats' => $stats,
+            ]);
+        }
+
         return view('esbtp.inscriptions.sous-reserve', compact(
-            'inscriptions', 'annees', 'anneeEnCours', 'anneeFilterId', 'search', 'stats'
+            'inscriptions', 'annees', 'anneeEnCours', 'anneeFilterId', 'search', 'condition', 'hasPayment', 'stats'
         ));
     }
 
@@ -2216,9 +2274,15 @@ class ESBTPInscriptionController extends Controller
      */
     public function leverReservesBulk(Request $request)
     {
-        $ids = $request->input('inscription_ids', []);
+        $ids = (array) $request->input('inscription_ids', []);
 
         if (empty($ids)) {
+            if ($request->ajax() || $request->wantsJson()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Aucune inscription sélectionnée.',
+                ], 422);
+            }
             return redirect()->back()->with('error', 'Aucune inscription sélectionnée.');
         }
 
@@ -2226,9 +2290,18 @@ class ESBTPInscriptionController extends Controller
             ->where('is_sous_reserve', true)
             ->update(['is_sous_reserve' => false, 'condition_reserve' => null]);
 
-        return redirect()->back()->with('success',
-            $count . ' inscription(s) ont été confirmée(s). La réserve a été levée.'
-        );
+        $message = $count . ' inscription(s) ont été confirmée(s). La réserve a été levée.';
+
+        if ($request->ajax() || $request->wantsJson()) {
+            return response()->json([
+                'success' => true,
+                'message' => $message,
+                'count' => $count,
+                'processed_ids' => array_map('intval', $ids),
+            ]);
+        }
+
+        return redirect()->back()->with('success', $message);
     }
 
     /**

--- a/app/View/Components/WorkflowStepBadge.php
+++ b/app/View/Components/WorkflowStepBadge.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\View\Components;
+
+use App\Models\ESBTPInscription;
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+/**
+ * Badge d'etape de workflow d'inscription — monochrome bleu KLASSCI.
+ *
+ * Utilise sur la page administration ou l'on a besoin de voir specifiquement
+ * a quelle etape de validation se trouve l'inscription (prospect / documents_complets /
+ * en_validation / etudiant_cree), pas juste status=active.
+ */
+class WorkflowStepBadge extends Component
+{
+    public string $key;
+
+    public string $label;
+
+    public string $icon;
+
+    public function __construct(ESBTPInscription $inscription)
+    {
+        [$this->key, $this->label, $this->icon] = $this->resolveWorkflow($inscription);
+    }
+
+    /**
+     * @return array{0: string, 1: string, 2: string}
+     */
+    private function resolveWorkflow(ESBTPInscription $inscription): array
+    {
+        return match ((string) ($inscription->workflow_step ?? '')) {
+            'prospect' => ['prospect', 'Prospect', 'fa-user-plus'],
+            'documents_complets' => ['documents', 'Documents complets', 'fa-folder-open'],
+            'en_validation' => ['validation', 'En validation', 'fa-hourglass-half'],
+            'etudiant_cree' => ['validee', 'Validee', 'fa-check-circle'],
+            default => ['inconnu', 'Non defini', 'fa-circle'],
+        };
+    }
+
+    public function render(): View
+    {
+        return view('components.workflow-step-badge');
+    }
+}

--- a/public/css/inscriptions-common.css
+++ b/public/css/inscriptions-common.css
@@ -1,0 +1,660 @@
+/* =============================================================================
+   inscriptions-common.css — Styles partages par les pages inscriptions
+   Charge sur : index / administration / sous-reserve
+   Namespace : ii-* (inscriptions-index), shared across all 3 pages
+   ============================================================================= */
+
+:root {
+    --ii-primary: #0453cb;
+    --ii-primary-d: #033a8e;
+    --ii-accent: #3b7ddb;
+    --ii-secondary: #5e91de;
+    --ii-dark: #0f172a;
+    --ii-text: #1e293b;
+    --ii-muted: #64748b;
+    --ii-success: #10b981;
+    --ii-surface: #f8fafc;
+    --ii-warning: #f59e0b;
+    --ii-danger: #dc2626;
+}
+
+/* ============================= HERO ============================= */
+.ii-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 1.75rem 2rem 1.25rem;
+    color: #fff;
+    margin-bottom: 1.25rem;
+    position: relative;
+    overflow: hidden;
+}
+.ii-hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.12), transparent 60%);
+    pointer-events: none;
+}
+.ii-hero-top {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    position: relative;
+    z-index: 1;
+}
+.ii-hero-left {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+.ii-hero-icon {
+    width: 52px;
+    height: 52px;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.14);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.35rem;
+    flex-shrink: 0;
+    color: #fff;
+}
+.ii-hero h1 {
+    font-size: 1.45rem;
+    font-weight: 700;
+    color: #fff;
+    margin: 0;
+    letter-spacing: -0.01em;
+}
+.ii-hero p {
+    color: rgba(255, 255, 255, 0.75);
+    font-size: 0.88rem;
+    margin: 0.15rem 0 0;
+}
+.ii-hero-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 99px;
+    padding: 0.3rem 0.75rem;
+    font-size: 0.78rem;
+    color: rgba(255, 255, 255, 0.92);
+    margin-top: 0.4rem;
+}
+.ii-hero-actions {
+    display: flex;
+    gap: 0.55rem;
+    flex-wrap: wrap;
+    align-items: flex-start;
+}
+
+/* ============================= Buttons glass / white ============================= */
+.ii-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.5rem 1rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    border-radius: 10px;
+    border: 1px solid transparent;
+    text-decoration: none;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    white-space: nowrap;
+}
+.ii-btn--glass {
+    background: rgba(255, 255, 255, 0.15);
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.25);
+}
+.ii-btn--glass:hover {
+    background: rgba(255, 255, 255, 0.25);
+    color: #fff;
+}
+.ii-btn--white {
+    background: #fff;
+    color: var(--ii-primary);
+}
+.ii-btn--white:hover {
+    background: #f1f5f9;
+    color: var(--ii-primary-d);
+}
+.ii-btn--primary {
+    background: var(--ii-primary);
+    color: #fff;
+}
+.ii-btn--primary:hover {
+    background: var(--ii-primary-d);
+    color: #fff;
+}
+.ii-btn--outline {
+    background: transparent;
+    color: var(--ii-primary);
+    border-color: var(--ii-primary);
+}
+.ii-btn--outline:hover {
+    background: var(--ii-primary);
+    color: #fff;
+}
+.ii-btn--ghost {
+    background: transparent;
+    color: var(--ii-muted);
+    border: none;
+}
+.ii-btn--ghost:hover {
+    color: var(--ii-text);
+    background: var(--ii-surface);
+}
+
+/* ============================= KPIs cliquables ============================= */
+.ii-kpis {
+    display: flex;
+    gap: 0.65rem;
+    margin-top: 1.25rem;
+    flex-wrap: wrap;
+    position: relative;
+    z-index: 1;
+}
+.ii-kpi {
+    flex: 1;
+    min-width: 130px;
+    background: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 12px;
+    padding: 0.75rem 0.9rem;
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-align: left;
+    font-family: inherit;
+}
+.ii-kpi:hover {
+    background: rgba(255, 255, 255, 0.18);
+    transform: translateY(-1px);
+}
+.ii-kpi.is-active {
+    background: rgba(255, 255, 255, 0.95);
+    color: var(--ii-primary-d);
+}
+.ii-kpi.is-active .ii-kpi-value,
+.ii-kpi.is-active .ii-kpi-label,
+.ii-kpi.is-active .ii-kpi-icon {
+    color: var(--ii-primary-d);
+}
+.ii-kpi.is-active .ii-kpi-icon {
+    background: rgba(4, 83, 203, 0.1);
+}
+.ii-kpi-icon {
+    width: 34px;
+    height: 34px;
+    border-radius: 9px;
+    background: rgba(255, 255, 255, 0.14);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-size: 0.88rem;
+    flex-shrink: 0;
+}
+.ii-kpi-content {
+    flex: 1;
+    min-width: 0;
+}
+.ii-kpi-value {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: #fff;
+    line-height: 1;
+}
+.ii-kpi-label {
+    font-size: 0.72rem;
+    color: rgba(255, 255, 255, 0.72);
+    margin-top: 0.2rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+}
+
+/* ============================= Toolbar ============================= */
+.ii-toolbar {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    padding: 0.85rem 1rem;
+    margin-bottom: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    align-items: center;
+}
+.ii-search {
+    flex: 2;
+    min-width: 220px;
+    position: relative;
+}
+.ii-search input {
+    width: 100%;
+    padding: 0.55rem 0.85rem 0.55rem 2.25rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 9px;
+    font-size: 0.85rem;
+    transition: all 0.15s ease;
+}
+.ii-search input:focus {
+    outline: none;
+    border-color: var(--ii-primary);
+    box-shadow: 0 0 0 3px rgba(4, 83, 203, 0.1);
+}
+.ii-search i {
+    position: absolute;
+    left: 0.85rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--ii-muted);
+    font-size: 0.85rem;
+}
+.ii-select {
+    padding: 0.55rem 0.75rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 9px;
+    font-size: 0.85rem;
+    background: #fff;
+    color: var(--ii-text);
+    min-width: 120px;
+}
+.ii-select:focus {
+    outline: none;
+    border-color: var(--ii-primary);
+}
+
+/* ============================= Chips filtres actifs ============================= */
+.ii-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin: 0 0 0.75rem;
+}
+.ii-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: rgba(4, 83, 203, 0.08);
+    color: var(--ii-primary-d);
+    border-radius: 99px;
+    padding: 0.25rem 0.7rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+.ii-chip button {
+    background: none;
+    border: none;
+    color: inherit;
+    padding: 0;
+    font-size: 0.7rem;
+    cursor: pointer;
+    opacity: 0.7;
+}
+.ii-chip button:hover {
+    opacity: 1;
+}
+
+/* ============================= Results card ============================= */
+.ii-results-card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04), 0 1px 2px rgba(15, 23, 42, 0.06);
+}
+.ii-results-card.ii-has-open-dropdown {
+    overflow: visible;
+}
+.ii-results-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.85rem 1.1rem;
+    border-bottom: 1px solid #e2e8f0;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+.ii-results-count {
+    font-size: 0.82rem;
+    color: var(--ii-muted);
+    font-weight: 500;
+}
+.ii-results-count strong {
+    color: var(--ii-text);
+    font-weight: 700;
+}
+.ii-per-page {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-size: 0.78rem;
+    color: var(--ii-muted);
+}
+.ii-per-page select {
+    padding: 0.3rem 0.5rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 7px;
+    font-size: 0.78rem;
+    background: #fff;
+}
+
+/* ============================= Table ============================= */
+.ii-table-wrap {
+    overflow-x: auto;
+}
+.ii-table-wrap.ii-has-open-dropdown {
+    overflow: visible;
+}
+.ii-table {
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+}
+.ii-table thead th {
+    background: var(--ii-surface);
+    color: var(--ii-muted);
+    font-size: 0.72rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    padding: 0.7rem 0.9rem;
+    border-bottom: 1px solid #e2e8f0;
+    white-space: nowrap;
+    text-align: left;
+    user-select: none;
+}
+.ii-table thead th.is-sortable {
+    cursor: pointer;
+}
+.ii-table thead th.is-sortable:hover {
+    color: var(--ii-primary);
+}
+.ii-table thead th .ii-sort-icon {
+    font-size: 0.68rem;
+    margin-left: 0.3rem;
+    opacity: 0.45;
+}
+.ii-table thead th[aria-sort="ascending"] .ii-sort-icon,
+.ii-table thead th[aria-sort="descending"] .ii-sort-icon {
+    opacity: 1;
+    color: var(--ii-primary);
+}
+.ii-table tbody tr {
+    transition: background 0.15s ease;
+    cursor: pointer;
+}
+.ii-table tbody tr:hover {
+    background: rgba(4, 83, 203, 0.025);
+}
+.ii-table tbody td {
+    padding: 0.85rem 0.9rem;
+    border-bottom: 1px solid #f1f5f9;
+    font-size: 0.85rem;
+    color: var(--ii-text);
+    vertical-align: middle;
+}
+.ii-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+/* ============================= Student cell (photo + name) ============================= */
+.ii-student {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+}
+.ii-student-photo {
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+    background: var(--ii-surface);
+    font-size: 0.82rem;
+    font-weight: 700;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-transform: uppercase;
+}
+.ii-student-name {
+    font-weight: 600;
+    color: var(--ii-text);
+    line-height: 1.3;
+}
+.ii-student-meta {
+    font-size: 0.72rem;
+    color: var(--ii-muted);
+    font-weight: 400;
+    margin-top: 0.1rem;
+    letter-spacing: 0.2px;
+}
+
+/* ============================= Status / workflow badges ============================= */
+.ii-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 99px;
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+}
+.ii-badge--validee {
+    background: rgba(4, 83, 203, 0.1);
+    color: var(--ii-primary-d);
+}
+.ii-badge--non_validee {
+    background: rgba(245, 158, 11, 0.1);
+    color: #92400e;
+}
+.ii-badge--en_attente {
+    background: rgba(100, 116, 139, 0.1);
+    color: #475569;
+}
+.ii-badge--annulee {
+    background: rgba(220, 38, 38, 0.08);
+    color: var(--ii-danger);
+}
+.ii-badge--terminee {
+    background: rgba(59, 125, 219, 0.12);
+    color: var(--ii-primary-d);
+}
+.ii-badge--inconnu {
+    background: rgba(100, 116, 139, 0.08);
+    color: var(--ii-muted);
+}
+
+.ii-wfbadge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.3rem 0.65rem;
+    border-radius: 8px;
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+.ii-wfbadge--prospect {
+    background: rgba(100, 116, 139, 0.1);
+    color: #475569;
+}
+.ii-wfbadge--documents {
+    background: rgba(59, 125, 219, 0.1);
+    color: var(--ii-primary-d);
+}
+.ii-wfbadge--validation {
+    background: rgba(245, 158, 11, 0.1);
+    color: #92400e;
+}
+.ii-wfbadge--validee {
+    background: rgba(16, 185, 129, 0.1);
+    color: #065f46;
+}
+.ii-wfbadge--inconnu {
+    background: rgba(100, 116, 139, 0.08);
+    color: var(--ii-muted);
+}
+
+.ii-paiement-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    padding: 0.28rem 0.65rem;
+    border-radius: 8px;
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+.ii-paiement-chip--paye {
+    background: rgba(16, 185, 129, 0.1);
+    color: #065f46;
+}
+.ii-paiement-chip--attente {
+    background: rgba(245, 158, 11, 0.1);
+    color: #92400e;
+}
+.ii-paiement-chip--aucun {
+    background: rgba(220, 38, 38, 0.08);
+    color: var(--ii-danger);
+}
+
+/* ============================= Action buttons ============================= */
+.ii-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+}
+.ii-action-btn {
+    width: 32px;
+    height: 32px;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    background: #fff;
+    color: var(--ii-muted);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+.ii-action-btn:hover {
+    border-color: var(--ii-primary);
+    color: var(--ii-primary);
+}
+.ii-action-btn--primary:hover {
+    background: rgba(4, 83, 203, 0.05);
+}
+.ii-action-btn--danger:hover {
+    border-color: var(--ii-danger);
+    color: var(--ii-danger);
+    background: rgba(220, 38, 38, 0.04);
+}
+
+/* ============================= Pagination ============================= */
+.ii-pagination {
+    display: flex;
+    justify-content: center;
+    padding: 1rem;
+    border-top: 1px solid #f1f5f9;
+}
+.ii-pagination .pagination {
+    margin: 0;
+    gap: 0.25rem;
+}
+.ii-pagination .pagination .page-link {
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    color: var(--ii-muted);
+    font-weight: 500;
+    font-size: 0.82rem;
+}
+.ii-pagination .pagination .page-item.active .page-link {
+    background: var(--ii-primary);
+    border-color: var(--ii-primary);
+    color: #fff;
+}
+
+/* ============================= Empty state ============================= */
+.ii-empty {
+    text-align: center;
+    padding: 3rem 1rem;
+}
+.ii-empty-icon {
+    width: 72px;
+    height: 72px;
+    margin: 0 auto 1rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, rgba(4, 83, 203, 0.08), rgba(59, 125, 219, 0.12));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ii-primary);
+    font-size: 1.8rem;
+}
+.ii-empty h4 {
+    font-size: 1rem;
+    color: var(--ii-text);
+    margin: 0 0 0.35rem;
+    font-weight: 600;
+}
+.ii-empty p {
+    font-size: 0.85rem;
+    color: var(--ii-muted);
+    margin: 0;
+}
+
+/* ============================= Bulk bar ============================= */
+.ii-bulk-bar {
+    position: fixed;
+    bottom: 1.2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: linear-gradient(135deg, var(--ii-primary) 0%, var(--ii-accent) 100%);
+    color: #fff;
+    padding: 0.85rem 1.3rem;
+    border-radius: 99px;
+    box-shadow: 0 10px 40px rgba(4, 83, 203, 0.35);
+    z-index: 1040;
+    display: none;
+    align-items: center;
+    gap: 1rem;
+    animation: iiSlideUp 0.25s ease-out;
+}
+.ii-bulk-bar.is-visible {
+    display: inline-flex;
+}
+.ii-bulk-count {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+@keyframes iiSlideUp {
+    from { opacity: 0; transform: translate(-50%, 20px); }
+    to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+/* ============================= Responsive ============================= */
+@media (max-width: 768px) {
+    .ii-hero { padding: 1.25rem 1.25rem 1rem; }
+    .ii-hero h1 { font-size: 1.2rem; }
+    .ii-hero-top { flex-direction: column; }
+    .ii-kpi { min-width: calc(50% - 0.35rem); }
+    .ii-toolbar { flex-direction: column; align-items: stretch; }
+    .ii-select { min-width: 100%; }
+    .ii-bulk-bar { left: 0.75rem; right: 0.75rem; transform: none; border-radius: 14px; flex-wrap: wrap; }
+}
+@media (max-width: 480px) {
+    .ii-kpi { min-width: 100%; }
+}

--- a/public/js/inscriptions/administration.js
+++ b/public/js/inscriptions/administration.js
@@ -1,0 +1,333 @@
+/**
+ * administration.js — gestion UI de la page inscriptions/administration.
+ * Depend de : common.js (iiConfirm, showToast, updateKpisFromStats).
+ *
+ * Responsable :
+ *  - AJAX filtering (search, selects, KPIs cliquables, sort, per_page)
+ *  - pushState + popstate
+ *  - Row click navigation
+ *  - Bulk annuler + export CSV
+ *
+ * La validation (openBulkValidationModal, openPaymentModal, openCancelModal...)
+ * reste dans le <script> inline de la page qui gere les modals complexes.
+ */
+(function () {
+    'use strict';
+
+    const ROUTES = window.KLASSCI_ADMIN_ROUTES || {};
+    const resultsEl = document.getElementById('inscriptions-admin-results');
+    const cardEl = document.getElementById('ia-results-card');
+    const totalEl = document.getElementById('ia-total');
+    const searchInput = document.getElementById('ia-search');
+    const filiereSelect = document.getElementById('ia-filiere');
+    const niveauSelect = document.getElementById('ia-niveau');
+    const anneeSelect = document.getElementById('ia-annee');
+    const perPageSelect = document.getElementById('ia-per-page');
+    const resetBtn = document.getElementById('ia-reset');
+
+    let searchTimer = null;
+    let currentFilters = readFiltersFromUrl();
+
+    // =========================================================================
+    // URL & filter management
+    // =========================================================================
+    function readFiltersFromUrl() {
+        const params = new URLSearchParams(window.location.search);
+        return {
+            search: params.get('search') || '',
+            filiere: params.get('filiere') || '',
+            niveau: params.get('niveau') || '',
+            annee: params.get('annee') || '',
+            workflow_step: params.get('workflow_step') || '',
+            has_payment: params.get('has_payment') || '',
+            sort: params.get('sort') || 'created_at',
+            dir: params.get('dir') || 'desc',
+            per_page: params.get('per_page') || '25',
+            page: params.get('page') || '1',
+        };
+    }
+
+    function buildUrl(filters) {
+        const params = new URLSearchParams();
+        Object.entries(filters).forEach(([k, v]) => {
+            if (v !== '' && v !== null && v !== undefined) params.set(k, v);
+        });
+        return ROUTES.administration + (params.toString() ? '?' + params.toString() : '');
+    }
+
+    function updateUrl() {
+        window.history.pushState({}, '', buildUrl(currentFilters));
+    }
+
+    function fetchResults(opts) {
+        opts = opts || {};
+        if (!opts.keepPage) currentFilters.page = '1';
+        updateUrl();
+
+        if (cardEl) cardEl.style.opacity = '0.6';
+
+        fetch(buildUrl(currentFilters), {
+            headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
+        })
+            .then((r) => r.json())
+            .then((data) => {
+                if (data.html && resultsEl) resultsEl.innerHTML = data.html;
+                if (data.stats) {
+                    window.updateKpisFromStats(data.stats);
+                    if (totalEl && typeof data.stats.total_en_attente !== 'undefined') {
+                        totalEl.textContent = data.stats.total_en_attente;
+                    }
+                }
+                clearSelection();
+                // Rebind legacy handlers after replacement
+                if (typeof window.bindInscriptionActions === 'function') window.bindInscriptionActions();
+                if (typeof window.bindBulkSelectionHandlers === 'function') window.bindBulkSelectionHandlers();
+                if (typeof window.updateInscriptionSelectionCount === 'function') window.updateInscriptionSelectionCount();
+            })
+            .catch((err) => {
+                console.error('ia fetchResults error', err);
+                window.showToast('Erreur lors du rechargement', 'error');
+            })
+            .finally(() => {
+                if (cardEl) cardEl.style.opacity = '1';
+            });
+    }
+
+    // =========================================================================
+    // Filter events
+    // =========================================================================
+    if (searchInput) {
+        searchInput.addEventListener('input', () => {
+            clearTimeout(searchTimer);
+            searchTimer = setTimeout(() => {
+                currentFilters.search = searchInput.value.trim();
+                fetchResults();
+            }, 400);
+        });
+    }
+
+    [filiereSelect, niveauSelect, anneeSelect].forEach((sel) => {
+        if (!sel) return;
+        sel.addEventListener('change', () => {
+            if (sel === filiereSelect) currentFilters.filiere = sel.value;
+            if (sel === niveauSelect) currentFilters.niveau = sel.value;
+            if (sel === anneeSelect) currentFilters.annee = sel.value;
+            fetchResults();
+        });
+    });
+
+    if (perPageSelect) {
+        perPageSelect.addEventListener('change', () => {
+            currentFilters.per_page = perPageSelect.value;
+            fetchResults();
+        });
+    }
+
+    if (resetBtn) {
+        resetBtn.addEventListener('click', () => {
+            currentFilters = { sort: 'created_at', dir: 'desc', per_page: '25', page: '1' };
+            if (searchInput) searchInput.value = '';
+            if (filiereSelect) filiereSelect.value = '';
+            if (niveauSelect) niveauSelect.value = '';
+            if (anneeSelect) anneeSelect.value = '';
+            document.querySelectorAll('.ii-kpi').forEach((k) => k.classList.remove('is-active'));
+            const totalKpi = document.querySelector('.ii-kpi[data-kpi="total_en_attente"]');
+            if (totalKpi) totalKpi.classList.add('is-active');
+            fetchResults();
+        });
+    }
+
+    // =========================================================================
+    // KPIs cliquables
+    // =========================================================================
+    document.querySelectorAll('.ii-kpi[data-filter-type]').forEach((kpi) => {
+        kpi.addEventListener('click', () => {
+            const type = kpi.dataset.filterType;
+            const value = kpi.dataset.filterValue || '';
+
+            if (type === 'clear') {
+                currentFilters.workflow_step = '';
+                currentFilters.has_payment = '';
+                document.querySelectorAll('.ii-kpi').forEach((k) => k.classList.remove('is-active'));
+                kpi.classList.add('is-active');
+            } else if (type === 'workflow_step') {
+                if (currentFilters.workflow_step === value) {
+                    currentFilters.workflow_step = '';
+                    kpi.classList.remove('is-active');
+                    const totalKpi = document.querySelector('.ii-kpi[data-filter-type="clear"]');
+                    if (totalKpi) totalKpi.classList.add('is-active');
+                } else {
+                    currentFilters.workflow_step = value;
+                    currentFilters.has_payment = '';
+                    document.querySelectorAll('.ii-kpi').forEach((k) => k.classList.remove('is-active'));
+                    kpi.classList.add('is-active');
+                }
+            } else if (type === 'has_payment') {
+                if (currentFilters.has_payment === value) {
+                    currentFilters.has_payment = '';
+                    kpi.classList.remove('is-active');
+                    const totalKpi = document.querySelector('.ii-kpi[data-filter-type="clear"]');
+                    if (totalKpi) totalKpi.classList.add('is-active');
+                } else {
+                    currentFilters.has_payment = value;
+                    currentFilters.workflow_step = '';
+                    document.querySelectorAll('.ii-kpi').forEach((k) => k.classList.remove('is-active'));
+                    kpi.classList.add('is-active');
+                }
+            }
+            fetchResults();
+        });
+    });
+
+    // =========================================================================
+    // Sort columns (delegation, results-area only)
+    // =========================================================================
+    document.addEventListener('click', (e) => {
+        const th = e.target.closest('#inscriptions-admin-results .is-sortable');
+        if (!th) return;
+        currentFilters.sort = th.dataset.sort;
+        currentFilters.dir = th.dataset.nextDir || 'asc';
+        fetchResults();
+    });
+
+    // =========================================================================
+    // Row click navigation
+    // =========================================================================
+    document.addEventListener('click', (e) => {
+        const row = e.target.closest('#inscriptions-admin-results tr[data-href]');
+        if (!row) return;
+        if (e.target.closest('[data-no-row-click], a, button, input, .dropdown')) return;
+        window.location.href = row.dataset.href;
+    });
+
+    // =========================================================================
+    // Pagination (AJAX)
+    // =========================================================================
+    document.addEventListener('click', (e) => {
+        const link = e.target.closest('#inscriptions-admin-results .pagination a');
+        if (!link) return;
+        e.preventDefault();
+        try {
+            const url = new URL(link.href, window.location.origin);
+            const page = url.searchParams.get('page') || '1';
+            currentFilters.page = page;
+            fetchResults({ keepPage: true });
+        } catch (_) {
+            window.location.href = link.href;
+        }
+    });
+
+    // =========================================================================
+    // Override legacy bulk-bar display to use flex when visible
+    // =========================================================================
+    const originalUpdate = window.updateInscriptionSelectionCount;
+    window.updateInscriptionSelectionCount = function () {
+        if (typeof originalUpdate === 'function') originalUpdate();
+        const bulkBar = document.getElementById('bulk-actions-bar');
+        if (!bulkBar) return;
+        const count = document.querySelectorAll('.inscription-checkbox:checked').length;
+        if (count > 0) {
+            bulkBar.classList.add('is-visible');
+            bulkBar.style.display = '';
+        } else {
+            bulkBar.classList.remove('is-visible');
+            bulkBar.style.display = 'none';
+        }
+    };
+
+    function clearSelection() {
+        document.querySelectorAll('.inscription-checkbox').forEach((cb) => (cb.checked = false));
+        const sa = document.getElementById('select-all-inscriptions');
+        if (sa) sa.checked = false;
+        if (typeof window.updateInscriptionSelectionCount === 'function') window.updateInscriptionSelectionCount();
+    }
+
+    function getSelectedIds() {
+        return Array.from(document.querySelectorAll('.inscription-checkbox:checked')).map((cb) => cb.value);
+    }
+
+    // =========================================================================
+    // Bulk annuler + export
+    // =========================================================================
+    window.iaBulkAnnuler = function () {
+        const ids = getSelectedIds();
+        if (ids.length === 0) {
+            window.showToast('Aucune inscription sélectionnée', 'warning');
+            return;
+        }
+        const modalEl = document.getElementById('ia-modal-bulk-annuler');
+        if (!modalEl) return;
+        document.getElementById('ia-bulk-annuler-count').textContent = ids.length;
+        document.getElementById('ia-bulk-annuler-motif').value = '';
+        const modal = bootstrap.Modal.getOrCreateInstance(modalEl);
+        modal.show();
+
+        const submitBtn = document.getElementById('ia-bulk-annuler-submit');
+        const handler = async () => {
+            const motif = document.getElementById('ia-bulk-annuler-motif').value.trim();
+            if (motif.length < 3) {
+                window.showToast('Motif requis (minimum 3 caractères)', 'warning');
+                return;
+            }
+            submitBtn.disabled = true;
+            try {
+                const res = await fetch(ROUTES.bulkAnnuler, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': ROUTES.csrf,
+                        'X-Requested-With': 'XMLHttpRequest',
+                        'Accept': 'application/json',
+                    },
+                    body: JSON.stringify({ inscription_ids: ids, motif }),
+                });
+                const data = await res.json();
+                if (res.ok && data.success) {
+                    modal.hide();
+                    window.showToast(`${data.success_count} inscription(s) annulée(s)`, 'success');
+                    fetchResults();
+                } else {
+                    window.showToast(data.message || 'Erreur lors du bulk', 'error');
+                }
+            } catch (err) {
+                console.error(err);
+                window.showToast('Erreur réseau', 'error');
+            } finally {
+                submitBtn.disabled = false;
+            }
+        };
+
+        submitBtn.onclick = handler;
+    };
+
+    window.iaBulkExporter = function () {
+        const ids = getSelectedIds();
+        if (ids.length === 0) {
+            window.showToast('Aucune inscription sélectionnée', 'warning');
+            return;
+        }
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = ROUTES.bulkExport;
+        form.style.display = 'none';
+        form.innerHTML = `<input type="hidden" name="_token" value="${ROUTES.csrf}">`;
+        ids.forEach((id) => {
+            const inp = document.createElement('input');
+            inp.type = 'hidden';
+            inp.name = 'inscription_ids[]';
+            inp.value = id;
+            form.appendChild(inp);
+        });
+        document.body.appendChild(form);
+        form.submit();
+        form.remove();
+    };
+
+    // =========================================================================
+    // Browser back/forward
+    // =========================================================================
+    window.addEventListener('popstate', () => {
+        currentFilters = readFiltersFromUrl();
+        fetchResults({ keepPage: true });
+    });
+})();

--- a/public/js/inscriptions/common.js
+++ b/public/js/inscriptions/common.js
@@ -1,0 +1,168 @@
+/**
+ * common.js — helpers partages par les pages inscriptions (index, administration, sous-reserve).
+ *
+ * Expose sur window :
+ *  - iiConfirm(options) : Promise<bool> — modal BS5 premium
+ *  - showToast(message, type, duration) : toast inline 5s auto-dismiss
+ *  - updateKpisFromStats(stats) : met a jour les KPIs selon stats object
+ *  - triggerRowHighlight(tr, mode) : flash animation sur <tr> (success ou reject)
+ *
+ * Ces fonctions sont surchargeable page par page si besoin.
+ */
+(function () {
+    'use strict';
+
+    // =========================================================================
+    // iiConfirm — Promise-based BS5 modal confirmation
+    // =========================================================================
+    window.iiConfirm = window.iiConfirm || function (options) {
+        return new Promise((resolve) => {
+            const opts = Object.assign({
+                title: 'Confirmer',
+                message: 'Voulez-vous continuer ?',
+                confirmLabel: 'Confirmer',
+                cancelLabel: 'Annuler',
+                danger: false,
+            }, options || {});
+
+            let modal = document.getElementById('ii-common-confirm-modal');
+            if (!modal) {
+                modal = document.createElement('div');
+                modal.id = 'ii-common-confirm-modal';
+                modal.className = 'modal fade';
+                modal.tabIndex = -1;
+                modal.innerHTML = `
+                    <div class="modal-dialog modal-dialog-centered modal-sm">
+                        <div class="modal-content" style="border:none; border-radius:14px; overflow:hidden;">
+                            <div class="modal-header" style="background:linear-gradient(135deg,#0453cb 0%,#3b7ddb 100%); color:#fff; border:none; padding:16px 20px;">
+                                <h5 class="modal-title" style="font-size:1rem; font-weight:700;" data-role="title"></h5>
+                                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                            </div>
+                            <div class="modal-body" style="padding:20px; font-size:.9rem; color:#334155;" data-role="message"></div>
+                            <div class="modal-footer" style="border:none; padding:14px 20px;">
+                                <button type="button" class="btn btn-light" data-bs-dismiss="modal" data-role="cancel"></button>
+                                <button type="button" class="btn btn-primary" data-role="confirm" style="font-weight:600;"></button>
+                            </div>
+                        </div>
+                    </div>
+                `;
+                document.body.appendChild(modal);
+            }
+
+            modal.querySelector('[data-role="title"]').textContent = opts.title;
+            modal.querySelector('[data-role="message"]').textContent = opts.message;
+            const cancelBtn = modal.querySelector('[data-role="cancel"]');
+            const confirmBtn = modal.querySelector('[data-role="confirm"]');
+            cancelBtn.textContent = opts.cancelLabel;
+            confirmBtn.textContent = opts.confirmLabel;
+            confirmBtn.className = 'btn ' + (opts.danger ? 'btn-danger' : 'btn-primary');
+            confirmBtn.style.fontWeight = '600';
+
+            const bsModal = bootstrap.Modal.getOrCreateInstance(modal);
+            let decided = false;
+
+            const onConfirm = () => { decided = true; bsModal.hide(); resolve(true); };
+            const onHidden = () => { if (!decided) resolve(false); cleanup(); };
+            const cleanup = () => {
+                confirmBtn.removeEventListener('click', onConfirm);
+                modal.removeEventListener('hidden.bs.modal', onHidden);
+            };
+
+            confirmBtn.addEventListener('click', onConfirm, { once: true });
+            modal.addEventListener('hidden.bs.modal', onHidden, { once: true });
+            bsModal.show();
+        });
+    };
+
+    // =========================================================================
+    // showToast — toast inline 5s auto-dismiss, 4 types
+    // =========================================================================
+    window.showToast = window.showToast || function (message, type, duration) {
+        type = type || 'info';
+        duration = duration || 5000;
+
+        let container = document.getElementById('ii-common-toast-container');
+        if (!container) {
+            container = document.createElement('div');
+            container.id = 'ii-common-toast-container';
+            container.style.cssText = 'position:fixed; top:1rem; right:1rem; z-index:10050; display:flex; flex-direction:column; gap:.5rem;';
+            document.body.appendChild(container);
+        }
+
+        const colors = {
+            success: { bg: '#10b981', border: '#059669', icon: 'fa-check-circle' },
+            info:    { bg: '#0453cb', border: '#033a8e', icon: 'fa-info-circle' },
+            warning: { bg: '#f59e0b', border: '#d97706', icon: 'fa-exclamation-triangle' },
+            error:   { bg: '#dc2626', border: '#991b1b', icon: 'fa-times-circle' },
+        };
+        const c = colors[type] || colors.info;
+
+        const toast = document.createElement('div');
+        toast.style.cssText = `
+            background:${c.bg}; color:#fff; border-left:4px solid ${c.border};
+            padding:.85rem 1.1rem; border-radius:10px; box-shadow:0 10px 30px rgba(0,0,0,.15);
+            display:flex; align-items:center; gap:.6rem; font-size:.88rem; font-weight:500;
+            max-width:380px; animation:iiToastSlideIn .25s ease-out;
+        `;
+        toast.innerHTML = `<i class="fas ${c.icon}" style="font-size:1.05rem;"></i><span style="flex:1;">${message}</span><button type="button" style="background:transparent; border:none; color:rgba(255,255,255,.85); cursor:pointer; padding:0 .2rem; font-size:1rem;"><i class="fas fa-times"></i></button>`;
+
+        const closeBtn = toast.querySelector('button');
+        const dismiss = () => {
+            toast.style.animation = 'iiToastSlideOut .25s ease-in forwards';
+            setTimeout(() => toast.remove(), 250);
+        };
+        closeBtn.addEventListener('click', dismiss);
+        container.appendChild(toast);
+        setTimeout(dismiss, duration);
+
+        // Style animations once
+        if (!document.getElementById('ii-common-toast-style')) {
+            const st = document.createElement('style');
+            st.id = 'ii-common-toast-style';
+            st.textContent = `
+                @keyframes iiToastSlideIn { from { transform:translateX(120%); opacity:0; } to { transform:translateX(0); opacity:1; } }
+                @keyframes iiToastSlideOut { from { transform:translateX(0); opacity:1; } to { transform:translateX(120%); opacity:0; } }
+            `;
+            document.head.appendChild(st);
+        }
+    };
+
+    // =========================================================================
+    // updateKpisFromStats — met a jour les KPIs via attribut data-kpi="<key>"
+    // =========================================================================
+    window.updateKpisFromStats = window.updateKpisFromStats || function (stats) {
+        if (!stats || typeof stats !== 'object') return;
+        Object.entries(stats).forEach(([key, value]) => {
+            const el = document.querySelector(`[data-kpi="${key}"] [data-kpi-value]`);
+            if (el) el.textContent = value;
+        });
+    };
+
+    // =========================================================================
+    // triggerRowHighlight — flash animation sur td de la row
+    // =========================================================================
+    window.triggerRowHighlight = window.triggerRowHighlight || function (tr, mode) {
+        if (!tr) return;
+        mode = mode || 'success';
+        const cells = tr.querySelectorAll('td');
+        cells.forEach((td) => {
+            td.classList.remove('ii-flash-success', 'ii-flash-reject');
+            void td.offsetWidth;
+            td.classList.add(mode === 'reject' ? 'ii-flash-reject' : 'ii-flash-success');
+            setTimeout(() => td.classList.remove('ii-flash-success', 'ii-flash-reject'), 1600);
+        });
+    };
+
+    // Styles globaux pour triggerRowHighlight
+    if (!document.getElementById('ii-common-flash-style')) {
+        const st = document.createElement('style');
+        st.id = 'ii-common-flash-style';
+        st.textContent = `
+            @keyframes iiFlashSuccess { 0% { background-color: rgba(16,185,129,0); } 40% { background-color: rgba(16,185,129,.35); } 100% { background-color: rgba(16,185,129,0); } }
+            @keyframes iiFlashReject { 0% { background-color: rgba(220,38,38,0); } 40% { background-color: rgba(220,38,38,.35); } 100% { background-color: rgba(220,38,38,0); } }
+            .ii-flash-success { animation: iiFlashSuccess 1.6s ease-out; }
+            .ii-flash-reject { animation: iiFlashReject 1.6s ease-out; }
+        `;
+        document.head.appendChild(st);
+    }
+})();

--- a/public/js/inscriptions/sous-reserve.js
+++ b/public/js/inscriptions/sous-reserve.js
@@ -1,0 +1,332 @@
+/**
+ * sous-reserve.js — gestion de la page inscriptions/sous-reserve.
+ * Depend de : common.js (iiConfirm, showToast, updateKpisFromStats).
+ */
+(function () {
+    'use strict';
+
+    const ROUTES = window.KLASSCI_SOUSRESERVE_ROUTES || {};
+    const resultsEl = document.getElementById('isr-results');
+    const cardEl = document.getElementById('isr-results-card');
+    const totalEl = document.getElementById('isr-total');
+    const searchInput = document.getElementById('isr-search');
+    const anneeSelect = document.getElementById('isr-annee');
+    const conditionSelect = document.getElementById('isr-condition');
+    const perPageSelect = document.getElementById('isr-per-page');
+    const resetBtn = document.getElementById('isr-reset');
+    const bulkBar = document.getElementById('isr-bulk-bar');
+    const bulkCount = document.getElementById('isr-bulk-count');
+
+    let searchTimer = null;
+    let currentFilters = readFiltersFromUrl();
+
+    // =========================================================================
+    // URL & filter management
+    // =========================================================================
+    function readFiltersFromUrl() {
+        const params = new URLSearchParams(window.location.search);
+        return {
+            search: params.get('search') || '',
+            annee_id: params.get('annee_id') || '',
+            condition: params.get('condition') || '',
+            has_payment: params.get('has_payment') || '',
+            sort: params.get('sort') || 'created_at',
+            dir: params.get('dir') || 'desc',
+            per_page: params.get('per_page') || '25',
+            page: params.get('page') || '1',
+        };
+    }
+
+    function buildUrl(filters) {
+        const params = new URLSearchParams();
+        Object.entries(filters).forEach(([k, v]) => {
+            if (v !== '' && v !== null && v !== undefined) params.set(k, v);
+        });
+        return ROUTES.index + (params.toString() ? '?' + params.toString() : '');
+    }
+
+    function updateUrl() {
+        const url = buildUrl(currentFilters);
+        window.history.pushState({}, '', url);
+    }
+
+    function fetchResults(opts) {
+        opts = opts || {};
+        if (!opts.keepPage) currentFilters.page = '1';
+        updateUrl();
+
+        if (cardEl) cardEl.style.opacity = '0.6';
+
+        const url = buildUrl(currentFilters);
+        fetch(url, {
+            headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
+        })
+            .then((r) => r.json())
+            .then((data) => {
+                if (data.html && resultsEl) resultsEl.innerHTML = data.html;
+                if (data.stats) {
+                    window.updateKpisFromStats(data.stats);
+                    if (totalEl && typeof data.stats.total !== 'undefined') totalEl.textContent = data.stats.total;
+                }
+                clearSelection();
+            })
+            .catch((err) => {
+                console.error('isr fetchResults error', err);
+                window.showToast('Erreur lors du rechargement', 'error');
+            })
+            .finally(() => {
+                if (cardEl) cardEl.style.opacity = '1';
+            });
+    }
+
+    // =========================================================================
+    // Filter events
+    // =========================================================================
+    if (searchInput) {
+        searchInput.addEventListener('input', () => {
+            clearTimeout(searchTimer);
+            searchTimer = setTimeout(() => {
+                currentFilters.search = searchInput.value.trim();
+                fetchResults();
+            }, 400);
+        });
+    }
+
+    [anneeSelect, conditionSelect].forEach((sel) => {
+        if (!sel) return;
+        sel.addEventListener('change', () => {
+            if (sel === anneeSelect) currentFilters.annee_id = sel.value;
+            if (sel === conditionSelect) currentFilters.condition = sel.value;
+            fetchResults();
+        });
+    });
+
+    if (perPageSelect) {
+        perPageSelect.addEventListener('change', () => {
+            currentFilters.per_page = perPageSelect.value;
+            fetchResults();
+        });
+    }
+
+    if (resetBtn) {
+        resetBtn.addEventListener('click', () => {
+            currentFilters = { sort: 'created_at', dir: 'desc', per_page: '25', page: '1' };
+            if (searchInput) searchInput.value = '';
+            if (anneeSelect) anneeSelect.value = '';
+            if (conditionSelect) conditionSelect.value = '';
+            document.querySelectorAll('.ii-kpi').forEach((k) => k.classList.remove('is-active'));
+            const totalKpi = document.querySelector('.ii-kpi[data-kpi="total"]');
+            if (totalKpi) totalKpi.classList.add('is-active');
+            fetchResults();
+        });
+    }
+
+    // =========================================================================
+    // KPIs cliquables (filter par statut paiement)
+    // =========================================================================
+    document.querySelectorAll('.ii-kpi[data-filter-payment]').forEach((kpi) => {
+        kpi.addEventListener('click', () => {
+            const target = kpi.dataset.filterPayment || '';
+            if (currentFilters.has_payment === target) {
+                currentFilters.has_payment = '';
+                document.querySelectorAll('.ii-kpi').forEach((k) => k.classList.remove('is-active'));
+                const totalKpi = document.querySelector('.ii-kpi[data-kpi="total"]');
+                if (totalKpi) totalKpi.classList.add('is-active');
+            } else {
+                currentFilters.has_payment = target;
+                document.querySelectorAll('.ii-kpi').forEach((k) => k.classList.remove('is-active'));
+                kpi.classList.add('is-active');
+            }
+            fetchResults();
+        });
+    });
+
+    // =========================================================================
+    // Sort columns (delegation)
+    // =========================================================================
+    document.addEventListener('click', (e) => {
+        const th = e.target.closest('#isr-results .is-sortable');
+        if (!th) return;
+        const sortCol = th.dataset.sort;
+        const nextDir = th.dataset.nextDir || 'asc';
+        currentFilters.sort = sortCol;
+        currentFilters.dir = nextDir;
+        fetchResults();
+    });
+
+    // =========================================================================
+    // Row click navigation
+    // =========================================================================
+    document.addEventListener('click', (e) => {
+        const row = e.target.closest('#isr-results tr[data-href]');
+        if (!row) return;
+        if (e.target.closest('[data-no-row-click], a, button, input')) return;
+        window.location.href = row.dataset.href;
+    });
+
+    // =========================================================================
+    // Pagination (AJAX)
+    // =========================================================================
+    document.addEventListener('click', (e) => {
+        const link = e.target.closest('#isr-results .pagination a');
+        if (!link) return;
+        e.preventDefault();
+        try {
+            const url = new URL(link.href, window.location.origin);
+            const page = url.searchParams.get('page') || '1';
+            currentFilters.page = page;
+            fetchResults({ keepPage: true });
+        } catch (_) {
+            window.location.href = link.href;
+        }
+    });
+
+    // =========================================================================
+    // Checkboxes / bulk
+    // =========================================================================
+    document.addEventListener('change', (e) => {
+        if (e.target.id === 'isr-select-all') {
+            document.querySelectorAll('.isr-row-checkbox').forEach((cb) => (cb.checked = e.target.checked));
+            updateBulkBar();
+        } else if (e.target.classList.contains('isr-row-checkbox')) {
+            const all = document.querySelectorAll('.isr-row-checkbox');
+            const checked = document.querySelectorAll('.isr-row-checkbox:checked');
+            const selectAll = document.getElementById('isr-select-all');
+            if (selectAll) selectAll.checked = all.length > 0 && checked.length === all.length;
+            updateBulkBar();
+        }
+    });
+
+    function updateBulkBar() {
+        const count = document.querySelectorAll('.isr-row-checkbox:checked').length;
+        if (count > 0) {
+            bulkBar.classList.add('is-visible');
+            bulkCount.textContent = count;
+        } else {
+            bulkBar.classList.remove('is-visible');
+        }
+    }
+
+    function getSelectedIds() {
+        return Array.from(document.querySelectorAll('.isr-row-checkbox:checked')).map((cb) => cb.value);
+    }
+
+    function clearSelection() {
+        document.querySelectorAll('.isr-row-checkbox').forEach((cb) => (cb.checked = false));
+        const sa = document.getElementById('isr-select-all');
+        if (sa) sa.checked = false;
+        updateBulkBar();
+    }
+    window.isrClearSelection = clearSelection;
+
+    // =========================================================================
+    // Actions
+    // =========================================================================
+    window.isrLeverReserve = async function (id, label) {
+        const ok = await window.iiConfirm({
+            title: 'Lever la réserve',
+            message: `Confirmer la levée de réserve pour ${label} ? L'inscription sera marquée comme confirmée.`,
+            confirmLabel: 'Lever la réserve',
+        });
+        if (!ok) return;
+
+        const res = await fetch(ROUTES.leverReservesBulk, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': ROUTES.csrf,
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({ inscription_ids: [id] }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (res.ok && data.success) {
+            window.showToast(data.message || 'Réserve levée avec succès', 'success');
+            fetchResults({ keepPage: true });
+        } else {
+            window.showToast(data.message || 'Erreur lors de la levée de réserve', 'error');
+        }
+    };
+
+    window.isrAnnuler = async function (id, label) {
+        const ok = await window.iiConfirm({
+            title: "Annuler l'inscription",
+            message: `Confirmer l'annulation de l'inscription de ${label} ? Cette action est irréversible.`,
+            confirmLabel: 'Annuler',
+            cancelLabel: 'Retour',
+            danger: true,
+        });
+        if (!ok) return;
+
+        // Use legacy annuler endpoint via form POST with _method=PUT
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = `/esbtp/inscriptions/${id}/annuler`;
+        form.style.display = 'none';
+        form.innerHTML = `
+            <input type="hidden" name="_token" value="${ROUTES.csrf}">
+            <input type="hidden" name="_method" value="PUT">
+            <input type="hidden" name="motif_annulation" value="Condition de réserve non remplie">
+        `;
+        document.body.appendChild(form);
+        form.submit();
+    };
+
+    window.isrBulkLever = async function () {
+        const ids = getSelectedIds();
+        if (ids.length === 0) return;
+        const ok = await window.iiConfirm({
+            title: 'Lever les réserves',
+            message: `Lever la réserve pour ${ids.length} inscription(s) ? Les documents afficheront "Est régulièrement inscrit(e)" sans mention sous réserve.`,
+            confirmLabel: `Lever ${ids.length} réserve(s)`,
+        });
+        if (!ok) return;
+
+        const res = await fetch(ROUTES.leverReservesBulk, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': ROUTES.csrf,
+                'X-Requested-With': 'XMLHttpRequest',
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({ inscription_ids: ids }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (res.ok && data.success) {
+            window.showToast(data.message || `${data.count} réserve(s) levée(s)`, 'success');
+            fetchResults({ keepPage: true });
+        } else {
+            window.showToast(data.message || 'Erreur lors du bulk', 'error');
+        }
+    };
+
+    window.isrBulkExporter = function () {
+        const ids = getSelectedIds();
+        if (ids.length === 0) return;
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = ROUTES.bulkExport;
+        form.style.display = 'none';
+        form.innerHTML = `<input type="hidden" name="_token" value="${ROUTES.csrf}">`;
+        ids.forEach((id) => {
+            const inp = document.createElement('input');
+            inp.type = 'hidden';
+            inp.name = 'inscription_ids[]';
+            inp.value = id;
+            form.appendChild(inp);
+        });
+        document.body.appendChild(form);
+        form.submit();
+        form.remove();
+    };
+
+    // =========================================================================
+    // Browser back/forward
+    // =========================================================================
+    window.addEventListener('popstate', () => {
+        currentFilters = readFiltersFromUrl();
+        fetchResults({ keepPage: true });
+    });
+})();

--- a/resources/views/components/workflow-step-badge.blade.php
+++ b/resources/views/components/workflow-step-badge.blade.php
@@ -1,0 +1,4 @@
+<span class="ii-wfbadge ii-wfbadge--{{ $key }}">
+    <i class="fas {{ $icon }}"></i>
+    <span>{{ $label }}</span>
+</span>

--- a/resources/views/esbtp/inscriptions/administration.blade.php
+++ b/resources/views/esbtp/inscriptions/administration.blade.php
@@ -4,6 +4,7 @@
 
 @section('styles')
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
+<link rel="stylesheet" href="{{ asset('css/inscriptions-common.css') }}">
 <style>
     .kpi-card {
         border-radius: var(--radius-medium);
@@ -278,250 +279,198 @@
 
 @section('content')
 <div class="dashboard-acasi">
-    <div class="main-content" style="padding: 1.5rem; max-width: 100%; overflow-x: hidden;">
-        <!-- Header moderne -->
-        <div class="dashboard-header">
-            <div class="header-left">
-                <h1><i class="fas fa-user-check me-2"></i>Administration des Inscriptions</h1>
-                <p class="header-subtitle">Gestion et validation des inscriptions en attente</p>
+    <div class="main-content" style="padding: 1.25rem; max-width: 100%;">
+
+        {{-- ================================================================
+             HERO
+             ================================================================ --}}
+        <div class="ii-hero">
+            <div class="ii-hero-top">
+                <div class="ii-hero-left">
+                    <div class="ii-hero-icon">
+                        <i class="fas fa-user-check"></i>
+                    </div>
+                    <div>
+                        <h1>Administration des Inscriptions</h1>
+                        <p>Validation des inscriptions en attente · gestion des paiements et du workflow</p>
+                        <span class="ii-hero-chip">
+                            <i class="fas fa-calendar-alt"></i>
+                            @if($anneeEnCours)
+                                {{ $anneeEnCours->name }}
+                            @else
+                                Aucune année courante
+                            @endif
+                        </span>
+                    </div>
+                </div>
+                <div class="ii-hero-actions">
+                    <a href="{{ route('esbtp.inscriptions.index') }}" class="ii-btn ii-btn--glass">
+                        <i class="fas fa-arrow-left"></i> Retour aux inscriptions
+                    </a>
+                    <a href="{{ route('esbtp.inscriptions.create') }}" class="ii-btn ii-btn--white">
+                        <i class="fas fa-plus"></i> Nouvelle inscription
+                    </a>
+                </div>
             </div>
-            <div class="header-actions">
-                <input type="search" class="search-bar" placeholder="Rechercher une inscription..." value="{{ request('search') }}">
-                <span class="badge rounded-pill bg-light text-dark me-2">
-                    <i class="fas fa-calendar me-1"></i>
-                    {{ $anneeEnCours->name ?? 'Année non définie' }}
-                </span>
-                <span class="text-muted me-2">{{ \Carbon\Carbon::now()->isoFormat('dddd D MMMM YYYY') }}</span>
+
+            {{-- 6 KPIs cliquables (filter par workflow_step / has_payment) --}}
+            <div class="ii-kpis">
+                <button type="button" class="ii-kpi {{ !request('workflow_step') && !request('has_payment') ? 'is-active' : '' }}" data-kpi="total_en_attente" data-filter-type="clear">
+                    <div class="ii-kpi-icon"><i class="fas fa-clock"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['total_en_attente'] }}</div>
+                        <div class="ii-kpi-label">Total</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ request('has_payment') === 'yes' ? 'is-active' : '' }}" data-kpi="avec_paiement" data-filter-type="has_payment" data-filter-value="yes">
+                    <div class="ii-kpi-icon"><i class="fas fa-money-bill-wave"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['avec_paiement'] }}</div>
+                        <div class="ii-kpi-label">Avec paiement</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ request('has_payment') === 'no' ? 'is-active' : '' }}" data-kpi="sans_paiement" data-filter-type="has_payment" data-filter-value="no">
+                    <div class="ii-kpi-icon"><i class="fas fa-exclamation-triangle"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['sans_paiement'] }}</div>
+                        <div class="ii-kpi-label">Sans paiement</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ request('workflow_step') === 'prospect' ? 'is-active' : '' }}" data-kpi="prospects" data-filter-type="workflow_step" data-filter-value="prospect">
+                    <div class="ii-kpi-icon"><i class="fas fa-user-plus"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['prospects'] }}</div>
+                        <div class="ii-kpi-label">Prospects</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ request('workflow_step') === 'documents_complets' ? 'is-active' : '' }}" data-kpi="documents_complets" data-filter-type="workflow_step" data-filter-value="documents_complets">
+                    <div class="ii-kpi-icon"><i class="fas fa-folder-open"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['documents_complets'] }}</div>
+                        <div class="ii-kpi-label">Documents</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ request('workflow_step') === 'en_validation' ? 'is-active' : '' }}" data-kpi="en_validation" data-filter-type="workflow_step" data-filter-value="en_validation">
+                    <div class="ii-kpi-icon"><i class="fas fa-hourglass-half"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['en_validation'] }}</div>
+                        <div class="ii-kpi-label">En validation</div>
+                    </div>
+                </button>
             </div>
         </div>
 
-        <div class="card-moderne mb-lg">
-            <div class="p-lg">
-                <div class="section-title mb-md">
-                    <i class="fas fa-calendar-alt me-2"></i>Année Académique Active
-                </div>
-                <div style="display: flex; gap: var(--space-md); align-items: end;">
-                    <div style="flex: 1; max-width: 300px;">
-                        <label for="annee_academique" style="display: block; margin-bottom: var(--space-sm); font-weight: 600; font-size: var(--text-small); text-transform: uppercase; letter-spacing: 0.5px; color: var(--text-secondary);">Année Académique Courante</label>
-                        <select name="annee_academique" id="annee_academique" class="year-selector" style="width: 100%; background-color: #f8f9fa; cursor: not-allowed;" disabled>
-                            <option value="{{ $anneeEnCours->id ?? '' }}" selected>
-                                {{ $anneeEnCours->name ?? 'Aucune année définie' }} (Année en cours)
-                            </option>
-                        </select>
-                    </div>
-                    <button type="button" class="btn-acasi secondary" onclick="showYearChangeInfo()" title="Comment changer d'année ?">
-                        <i class="fas fa-info-circle"></i>Changer d'année
-                    </button>
-                </div>
-                <div class="mt-3">
-                    <small class="text-muted">
-                        <i class="fas fa-info-circle me-1"></i>
-                        Les inscriptions affichées correspondent à l'année académique courante.
-                        @if($inscriptions->isEmpty())
-                            <strong class="text-warning">Aucune inscription trouvée pour cette année.</strong>
-                        @endif
-                    </small>
-                </div>
-                @if($inscriptions->isEmpty())
-                    <div class="mt-3">
-                        <div class="alert alert-warning d-flex align-items-center" role="alert">
-                            <i class="fas fa-exclamation-triangle me-2"></i>
-                            <div>
-                                <strong>Aucune inscription pour l'année {{ $anneeEnCours->name ?? 'courante' }}</strong><br>
-                                <small>Il y a {{ \App\Models\ESBTPInscription::count() }} inscriptions au total dans la base, mais aucune pour l'année académique active.
-                                Utilisez le bouton "Changer d'année" pour consulter les inscriptions d'autres années.</small>
-                            </div>
-                        </div>
-                    </div>
-                @endif
+        {{-- ================================================================
+             TOOLBAR
+             ================================================================ --}}
+        <div class="ii-toolbar">
+            <div class="ii-search">
+                <i class="fas fa-search"></i>
+                <input type="search" id="ia-search" placeholder="Matricule, nom, prénom..." value="{{ $search }}">
             </div>
+            <select id="ia-filiere" class="ii-select" aria-label="Filière">
+                <option value="">Toutes les filières</option>
+                @foreach($filieres as $fil)
+                    <option value="{{ $fil->id }}" {{ request('filiere') == $fil->id ? 'selected' : '' }}>
+                        {{ $fil->name ?? $fil->nom }}
+                    </option>
+                @endforeach
+            </select>
+            <select id="ia-niveau" class="ii-select" aria-label="Niveau">
+                <option value="">Tous les niveaux</option>
+                @foreach($niveaux as $niv)
+                    <option value="{{ $niv->id }}" {{ request('niveau') == $niv->id ? 'selected' : '' }}>
+                        {{ $niv->name ?? $niv->libelle ?? $niv->nom }}
+                    </option>
+                @endforeach
+            </select>
+            <select id="ia-annee" class="ii-select" aria-label="Année">
+                <option value="">Année courante</option>
+                @foreach($annees as $annee)
+                    <option value="{{ $annee->id }}" {{ request('annee') == $annee->id ? 'selected' : '' }}>
+                        {{ $annee->name }}@if($annee->is_current) (Courante)@endif
+                    </option>
+                @endforeach
+            </select>
+            <button type="button" class="ii-btn ii-btn--ghost" id="ia-reset">
+                <i class="fas fa-rotate-left"></i> Réinitialiser
+            </button>
         </div>
 
-        <div class="p-lg">
-            <!-- Statistiques -->
-            <div class="row g-3 mb-4">
-                <div class="col-lg-3 col-md-6 col-12">
-                    <div class="card-moderne kpi-card">
-                        <div class="d-flex justify-content-between align-items-start">
-                            <div>
-                                <div class="text-muted small text-uppercase">Total en attente</div>
-                                <div class="h4 mb-1">{{ $stats['total_en_attente'] }}</div>
-                                <div class="small text-muted">Toutes les demandes</div>
-                            </div>
-                            <div class="kpi-icon" style="background: rgba(245, 158, 11, 0.12); color: var(--warning);">
-                                <i class="fas fa-clock"></i>
-                            </div>
-                        </div>
-                    </div>
+        {{-- ================================================================
+             RESULTS
+             ================================================================ --}}
+        <div class="ii-results-card" id="ia-results-card">
+            <div class="ii-results-header">
+                <div class="ii-results-count">
+                    <strong id="ia-total">{{ $inscriptions->total() }}</strong> inscription(s) en attente
                 </div>
-                <div class="col-lg-3 col-md-6 col-12">
-                    <div class="card-moderne kpi-card">
-                        <div class="d-flex justify-content-between align-items-start">
-                            <div>
-                                <div class="text-muted small text-uppercase">Avec paiement</div>
-                                <div class="h4 mb-1">{{ $stats['avec_paiement'] }}</div>
-                                <div class="small text-muted">Payés ou en attente</div>
-                            </div>
-                            <div class="kpi-icon" style="background: rgba(16, 185, 129, 0.12); color: var(--success);">
-                                <i class="fas fa-credit-card"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-lg-3 col-md-6 col-12">
-                    <div class="card-moderne kpi-card">
-                        <div class="d-flex justify-content-between align-items-start">
-                            <div>
-                                <div class="text-muted small text-uppercase">Sans paiement</div>
-                                <div class="h4 mb-1">{{ $stats['sans_paiement'] }}</div>
-                                <div class="small text-muted">Nécessitent un règlement</div>
-                            </div>
-                            <div class="kpi-icon" style="background: rgba(245, 158, 11, 0.12); color: var(--warning);">
-                                <i class="fas fa-exclamation-triangle"></i>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-lg-3 col-md-6 col-12">
-                    <div class="card-moderne kpi-card">
-                        <div class="d-flex justify-content-between align-items-start">
-                            <div>
-                                <div class="text-muted small text-uppercase">Prospects</div>
-                                <div class="h4 mb-1">{{ $stats['prospects'] }}</div>
-                                <div class="small text-muted">Étape initiale</div>
-                            </div>
-                            <div class="kpi-icon" style="background: rgba(6, 182, 212, 0.12); color: var(--accent-blue);">
-                                <i class="fas fa-user-plus"></i>
-                            </div>
-                        </div>
-                    </div>
+                <div class="ii-per-page">
+                    <span>Afficher</span>
+                    <select id="ia-per-page" aria-label="Lignes par page">
+                        @foreach([15, 25, 50, 100] as $opt)
+                            <option value="{{ $opt }}" {{ request('per_page', 25) == $opt ? 'selected' : '' }}>{{ $opt }}</option>
+                        @endforeach
+                    </select>
+                    <span>par page</span>
                 </div>
             </div>
-
-            <!-- Filtres de recherche -->
-            <div class="card-moderne mb-4">
-                <div class="p-lg">
-                    <div class="section-title mb-md">
-                        <i class="fas fa-filter"></i>Filtrer les inscriptions en attente
-                    </div>
-                    <form method="GET" action="{{ route('esbtp.inscriptions.administration') }}" id="inscriptions-admin-filter-form">
-                        <div class="row">
-                            <div class="col-md-3 mb-3">
-                                <label for="filter-search" class="form-label">
-                                    <i class="fas fa-search me-1"></i>Recherche par nom ou matricule
-                                </label>
-                                <input type="text" class="form-control" id="filter-search" name="search" value="{{ request('search') }}" placeholder="Tapez pour rechercher...">
-                            </div>
-                            <div class="col-md-2 mb-3">
-                                <label for="filiere" class="form-label">
-                                    <i class="fas fa-graduation-cap me-1"></i>Filière
-                                </label>
-                                <select class="form-select" id="filiere" name="filiere">
-                                    <option value="">Toutes les filières</option>
-                                    @foreach($filieres as $fil)
-                                        <option value="{{ $fil->id }}" {{ request('filiere') == $fil->id ? 'selected' : '' }}>
-                                            {{ $fil->name ?? $fil->nom }}
-                                        </option>
-                                    @endforeach
-                                </select>
-                            </div>
-                            <div class="col-md-2 mb-3">
-                                <label for="niveau" class="form-label">
-                                    <i class="fas fa-layer-group me-1"></i>Niveau d'études
-                                </label>
-                                <select class="form-select" id="niveau" name="niveau">
-                                    <option value="">Tous les niveaux</option>
-                                    @foreach($niveaux as $niv)
-                                        <option value="{{ $niv->id }}" {{ request('niveau') == $niv->id ? 'selected' : '' }}>
-                                            {{ $niv->name ?? $niv->libelle ?? $niv->nom }}
-                                        </option>
-                                    @endforeach
-                                </select>
-                            </div>
-                            <div class="col-md-2 mb-3">
-                                <label for="workflow_step" class="form-label">
-                                    <i class="fas fa-tasks me-1"></i>Étape du workflow
-                                </label>
-                                <select class="form-select" id="workflow_step" name="workflow_step">
-                                    <option value="">Toutes les étapes</option>
-                                    <option value="prospect" {{ request('workflow_step') == 'prospect' ? 'selected' : '' }}>Prospect</option>
-                                    <option value="documents_complets" {{ request('workflow_step') == 'documents_complets' ? 'selected' : '' }}>Documents complets</option>
-                                    <option value="en_validation" {{ request('workflow_step') == 'en_validation' ? 'selected' : '' }}>En validation</option>
-                                </select>
-                            </div>
-                            <div class="col-md-2 mb-3">
-                                <label for="has_payment" class="form-label">
-                                    <i class="fas fa-credit-card me-1"></i>Statut paiement
-                                </label>
-                                <select class="form-select" id="has_payment" name="has_payment">
-                                    <option value="">Tous</option>
-                                    <option value="yes" {{ request('has_payment') == 'yes' ? 'selected' : '' }}>Avec paiement</option>
-                                    <option value="no" {{ request('has_payment') == 'no' ? 'selected' : '' }}>Sans paiement</option>
-                                </select>
-                            </div>
-                            <div class="col-md-1 mb-3 d-flex align-items-end">
-                                <button type="submit" class="btn-acasi primary w-100">
-                                    <i class="fas fa-search"></i>Filtrer
-                                </button>
-                            </div>
-                        </div>
-                    </form>
-                </div>
-            </div>
-
-            <!-- Liste des inscriptions -->
-            <div class="card-moderne">
-                <div class="p-lg">
-                    <div class="section-title mb-md">
-                        <i class="fas fa-list"></i>Inscriptions en attente de validation ({{ $inscriptions->total() }})
-                    </div>
-                    <div id="inscriptions-admin-results">
-                        @include('esbtp.inscriptions.partials.administration-results', ['inscriptions' => $inscriptions])
-                    </div>
-                </div>
+            <div id="inscriptions-admin-results">
+                @include('esbtp.inscriptions.partials.administration-results', ['inscriptions' => $inscriptions])
             </div>
         </div>
     </div>
 </div>
 
 @can('access_admin')
-<div id="bulk-actions-bar" style="display: none; position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%);
-     background: linear-gradient(135deg, #0453cb 0%, #5e91de 100%); color: white; padding: 15px 30px;
-     border-radius: 50px; box-shadow: 0 10px 40px rgba(4, 83, 203, 0.4); z-index: 1050;
-     animation: slideUp 0.3s ease-out;">
-    <div style="display: flex; align-items: center; gap: 20px;">
-        <div style="display: flex; align-items: center; gap: 8px;">
-            <i class="fas fa-check-circle" style="font-size: 1.2rem;"></i>
-            <span id="selected-count" style="font-weight: 600; font-size: 1.1rem;">0</span>
-            <span style="opacity: 0.9;">inscription(s) sélectionnée(s)</span>
-        </div>
-        <div style="display: flex; gap: 10px;">
-            <button type="button" class="btn btn-light btn-sm" onclick="openBulkValidationModal()"
-                    style="padding: 8px 20px; border-radius: 25px; font-weight: 600; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
-                <i class="fas fa-check-double me-1"></i>Valider la sélection
-            </button>
-            <button type="button" class="btn btn-outline-light btn-sm" onclick="clearInscriptionSelection()"
-                    style="padding: 8px 20px; border-radius: 25px; font-weight: 600;">
-                <i class="fas fa-times me-1"></i>Annuler
-            </button>
+{{-- Bulk bar premium --}}
+<div class="ii-bulk-bar" id="bulk-actions-bar">
+    <div class="ii-bulk-count">
+        <i class="fas fa-check-circle"></i>
+        <span id="selected-count">0</span> sélectionnée(s)
+    </div>
+    <button type="button" class="ii-btn ii-btn--white" onclick="openBulkValidationModal()">
+        <i class="fas fa-check-double"></i> Valider
+    </button>
+    <button type="button" class="ii-btn ii-btn--glass" onclick="iaBulkAnnuler()">
+        <i class="fas fa-ban"></i> Annuler
+    </button>
+    <button type="button" class="ii-btn ii-btn--glass" onclick="iaBulkExporter()">
+        <i class="fas fa-file-export"></i> CSV
+    </button>
+    <button type="button" class="ii-btn ii-btn--glass" onclick="clearInscriptionSelection()" title="Fermer">
+        <i class="fas fa-times"></i>
+    </button>
+</div>
+@endcan
+
+{{-- Modal bulk annuler --}}
+<div class="modal fade" id="ia-modal-bulk-annuler" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content" style="border:none; border-radius:14px; overflow:hidden;">
+            <div class="modal-header" style="background:linear-gradient(135deg,#dc2626 0%,#b91c1c 100%); color:#fff; border:none;">
+                <h5 class="modal-title"><i class="fas fa-ban me-2"></i>Annuler les inscriptions</h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div class="alert alert-info mb-3" style="background:rgba(4,83,203,.06); border:1px solid rgba(4,83,203,.15); color:var(--ii-primary-d);">
+                    <i class="fas fa-info-circle me-2"></i>
+                    <strong id="ia-bulk-annuler-count">0</strong> inscription(s) vont être annulée(s). Cette action est irréversible.
+                </div>
+                <div class="mb-3">
+                    <label class="form-label fw-bold">Motif d'annulation <span class="text-danger">*</span></label>
+                    <textarea id="ia-bulk-annuler-motif" class="form-control" rows="3" minlength="3" maxlength="500" placeholder="Raison de l'annulation..." required></textarea>
+                </div>
+            </div>
+            <div class="modal-footer" style="border:none;">
+                <button type="button" class="btn btn-light" data-bs-dismiss="modal">Retour</button>
+                <button type="button" class="btn btn-danger" id="ia-bulk-annuler-submit" style="font-weight:600;">
+                    <i class="fas fa-ban me-1"></i>Confirmer l'annulation
+                </button>
+            </div>
         </div>
     </div>
 </div>
-
-<style>
-@keyframes slideUp {
-    from {
-        bottom: -100px;
-        opacity: 0;
-    }
-    to {
-        bottom: 20px;
-        opacity: 1;
-    }
-}
-</style>
-@endcan
-
 <div class="modal fade" id="bulkValidationModal" tabindex="-1" aria-labelledby="bulkValidationModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content klassci-payment-modal">
@@ -874,6 +823,15 @@
 @endsection
 
 @push('scripts')
+<script>
+    window.KLASSCI_ADMIN_ROUTES = {
+        administration: '{{ route('esbtp.inscriptions.administration') }}',
+        bulkAnnuler: '{{ route('esbtp.inscriptions.bulk-annuler') }}',
+        bulkExport: '{{ route('esbtp.inscriptions.bulk-export') }}',
+        csrf: '{{ csrf_token() }}',
+    };
+</script>
+<script src="{{ asset('js/inscriptions/common.js') }}"></script>
 <script>
     const ADMIN_REFRESH_CONTEXT = 'administration';
     const ADMIN_BASE_URL = "{{ route('esbtp.inscriptions.administration') }}";
@@ -1883,4 +1841,5 @@
         }
     });
 </script>
+<script src="{{ asset('js/inscriptions/administration.js') }}"></script>
 @endpush

--- a/resources/views/esbtp/inscriptions/partials/administration-ligne.blade.php
+++ b/resources/views/esbtp/inscriptions/partials/administration-ligne.blade.php
@@ -7,149 +7,131 @@
 
     $hasProbleme = session('inscriptions_problemes') && isset(session('inscriptions_problemes')[$inscription->id]);
     $problemeInfo = $hasProbleme ? session('inscriptions_problemes')[$inscription->id] : null;
-    $problemeClass = $hasProbleme ? ($problemeInfo['type'] === 'error' ? 'table-danger' : 'table-warning') : '';
+
+    $fullName = trim(($inscription->etudiant->nom ?? '') . ' ' . ($inscription->etudiant->prenoms ?? ''));
+    $initials = strtoupper(substr($inscription->etudiant->nom ?? '?', 0, 1));
+    $hue = crc32($fullName) % 360;
+    $photoUrl = $inscription->etudiant->photo_url ?? null;
 @endphp
-<tr class="{{ $problemeClass }}" data-inscription-id="{{ $inscription->id }}"
+<tr data-inscription-id="{{ $inscription->id }}"
+    data-href="{{ route('esbtp.inscriptions.show', $inscription->id) }}"
     data-has-payment="{{ $hasPayment ? 1 : 0 }}"
     data-payment-status="{{ $paymentStatus }}"
-    data-student-label="{{ ($inscription->etudiant->nom ?? '') . ' ' . ($inscription->etudiant->prenoms ?? '') }}"
+    data-student-label="{{ $fullName }}"
     data-matricule="{{ $inscription->etudiant->matricule ?? '' }}"
     data-classe-id="{{ $inscription->classe->id ?? '' }}"
     data-classe-label="{{ optional($inscription->classe)->nom ?? optional($inscription->classe)->name ?? '' }}">
     @can('access_admin')
-    <td>
+    <td data-no-row-click>
         @if($inscription->workflow_step !== 'etudiant_cree')
-        <input type="checkbox" class="form-check-input inscription-checkbox"
-               value="{{ $inscription->id }}"
-               data-inscription-id="{{ $inscription->id }}">
+            <input type="checkbox" class="form-check-input inscription-checkbox ia-row-checkbox"
+                   value="{{ $inscription->id }}"
+                   data-inscription-id="{{ $inscription->id }}"
+                   aria-label="Sélectionner cette inscription">
         @endif
     </td>
     @endcan
-    <td><strong>{{ $inscription->etudiant->matricule ?? 'N/A' }}</strong></td>
-    <td>{{ $inscription->etudiant->nom ?? '' }} {{ $inscription->etudiant->prenoms ?? '' }}</td>
-    <td>{{ optional($inscription->filiere)->nom ?? optional($inscription->filiere)->name ?? 'N/A' }}</td>
-    <td>{{ optional($inscription->niveau)->nom ?? optional($inscription->niveau)->name ?? 'N/A' }}</td>
-    <td>{{ optional($inscription->classe)->nom ?? optional($inscription->classe)->name ?? 'N/A' }}</td>
     <td>
-        @switch($inscription->workflow_step)
-            @case('prospect')
-                <span class="badge bg-secondary">Prospect</span>
-                @break
-            @case('documents_complets')
-                <span class="badge bg-info">Documents complets</span>
-                @break
-            @case('en_validation')
-                <span class="badge bg-warning">En validation</span>
-                @break
-            @case('etudiant_cree')
-                <span class="badge bg-success">Validée</span>
-                @break
-            @default
-                <span class="badge bg-light text-dark">{{ $inscription->workflow_step }}</span>
-        @endswitch
+        <div class="ii-student">
+            @if($photoUrl)
+                <img src="{{ $photoUrl }}" alt="" class="ii-student-photo">
+            @else
+                <div class="ii-student-photo" style="background:hsl({{ $hue }}, 60%, 55%);">{{ $initials }}</div>
+            @endif
+            <div>
+                <div class="ii-student-name">{{ $fullName }}</div>
+                <div class="ii-student-meta">{{ $inscription->etudiant->matricule ?? '—' }}</div>
+            </div>
+        </div>
+    </td>
+    <td>
+        <div>{{ optional($inscription->filiere)->name ?? optional($inscription->filiere)->nom ?? 'N/A' }}</div>
+        <div class="ii-student-meta">{{ optional($inscription->niveau)->name ?? optional($inscription->niveau)->nom ?? 'N/A' }}</div>
+    </td>
+    <td>{{ optional($inscription->classe)->name ?? optional($inscription->classe)->nom ?? '—' }}</td>
+    <td>
+        <x-workflow-step-badge :inscription="$inscription" />
     </td>
     <td>
         @if($validatedPayment)
-            <span class="badge bg-success">
-                <i class="fas fa-check me-1"></i>Payé
+            <span class="ii-paiement-chip ii-paiement-chip--paye">
+                <i class="fas fa-check"></i> Payé
             </span>
-            <small class="d-block text-muted mt-1">
-                {{ number_format($paymentAmount, 0, ',', ' ') }} F
-            </small>
+            <div class="ii-student-meta">{{ number_format($paymentAmount, 0, ',', ' ') }} F</div>
         @elseif($pendingPayment)
-            <span class="badge bg-warning text-dark">
-                <i class="fas fa-clock me-1"></i>En attente
+            <span class="ii-paiement-chip ii-paiement-chip--attente">
+                <i class="fas fa-clock"></i> En attente
             </span>
-            <small class="d-block text-muted mt-1">
-                {{ number_format($paymentAmount, 0, ',', ' ') }} F
-            </small>
+            <div class="ii-student-meta">{{ number_format($paymentAmount, 0, ',', ' ') }} F</div>
         @else
-            <span class="badge bg-danger">
-                <i class="fas fa-times me-1"></i>Non payé
+            <span class="ii-paiement-chip ii-paiement-chip--aucun">
+                <i class="fas fa-times"></i> Aucun
             </span>
         @endif
     </td>
-    <td>
+    <td>{{ optional($inscription->created_at)->format('d/m/Y') }}</td>
+    <td style="text-align:right;" data-no-row-click>
         @if($hasProbleme)
-            <div class="mb-2 d-flex flex-column gap-2">
-                <span class="badge {{ $problemeInfo['type'] === 'error' ? 'bg-danger' : 'bg-warning text-dark' }} d-inline-flex align-items-start"
-                      style="font-size: 0.75rem; white-space: normal; word-wrap: break-word; text-align: left; line-height: 1.3;">
-                    <i class="fas {{ $problemeInfo['type'] === 'error' ? 'fa-exclamation-circle' : 'fa-exclamation-triangle' }} me-1 mt-1" style="flex-shrink: 0;"></i>
-                    <span style="word-break: break-word;">{{ $problemeInfo['message'] }}</span>
+            <div class="mb-2 d-flex flex-column gap-1" style="align-items:flex-end;">
+                <span class="ii-paiement-chip {{ $problemeInfo['type'] === 'error' ? 'ii-paiement-chip--aucun' : 'ii-paiement-chip--attente' }}"
+                      style="white-space:normal; text-align:left; line-height:1.3; max-width:240px;">
+                    <i class="fas {{ $problemeInfo['type'] === 'error' ? 'fa-exclamation-circle' : 'fa-exclamation-triangle' }}"></i>
+                    <span>{{ $problemeInfo['message'] }}</span>
                 </span>
-
                 @php
                     $raison = $problemeInfo['message'];
                     $isPaiementNonValide = str_contains($raison, 'paiement') && str_contains($raison, 'validé');
                     $isClassePleine = str_contains($raison, 'Classe pleine') || str_contains($raison, 'classe pleine');
                     $isSansPaiement = str_contains($raison, 'Aucun paiement') || str_contains($raison, 'sans paiement');
                 @endphp
-
                 @if($isPaiementNonValide)
-                    <button type="button" class="btn btn-sm btn-outline-warning"
+                    <button type="button" class="ii-btn ii-btn--outline" style="font-size:.72rem; padding:.3rem .6rem;"
                             onclick="ouvrirModalValiderPaiement({{ $inscription->id }})">
-                        <i class="fas fa-check-circle me-1"></i>Valider paiement
+                        <i class="fas fa-check-circle"></i> Valider paiement
                     </button>
                 @elseif($isClassePleine)
-                    <div class="d-flex flex-wrap gap-2">
-                        <button type="button" class="btn btn-sm btn-outline-primary"
-                                onclick="ouvrirModalChangerClasse({{ $inscription->id }})">
-                            <i class="fas fa-exchange-alt me-1"></i>Changer classe
-                        </button>
-                        @if(auth()->user()->hasAnyPermission(['access_admin', 'can_manage_school']))
-                            <button type="button" class="btn btn-sm btn-outline-danger"
-                                    onclick="handleInscriptionValidation({{ $inscription->id }}, {{ $hasPayment ? 'true' : 'false' }}, true)">
-                                <i class="fas fa-bolt me-1"></i>Forcer validation
-                            </button>
-                        @endif
-                    </div>
+                    <button type="button" class="ii-btn ii-btn--outline" style="font-size:.72rem; padding:.3rem .6rem;"
+                            onclick="ouvrirModalChangerClasse({{ $inscription->id }})">
+                        <i class="fas fa-exchange-alt"></i> Changer classe
+                    </button>
                 @elseif($isSansPaiement)
-                    <button type="button" class="btn btn-sm btn-outline-primary"
+                    <button type="button" class="ii-btn ii-btn--outline" style="font-size:.72rem; padding:.3rem .6rem;"
                             onclick="openPaymentModal({{ $inscription->id }}, { autoValidate: true })">
-                        <i class="fas fa-wallet me-1"></i>Créer paiement
+                        <i class="fas fa-wallet"></i> Créer paiement
                     </button>
                 @endif
             </div>
         @endif
-        <div class="inscription-actions-wrapper" data-inscription-actions="{{ $inscription->id }}">
-            <div class="inscription-actions-buttons">
-                <a href="{{ route('esbtp.inscriptions.show', $inscription->id) }}"
-                   class="action-btn action-view" title="Voir le dossier">
-                    <i class="fas fa-folder-open"></i>
-                </a>
-
+        <div class="ii-actions inscription-actions-wrapper" data-inscription-actions="{{ $inscription->id }}" style="justify-content:flex-end;">
+            <div class="inscription-actions-buttons" style="display:inline-flex; gap:.35rem;">
                 @if($inscription->workflow_step !== 'etudiant_cree')
-                    <button type="button"
-                            class="action-btn action-validate validate-inscription-btn"
+                    <button type="button" class="ii-action-btn ii-action-btn--primary validate-inscription-btn"
                             data-inscription-id="{{ $inscription->id }}"
                             data-has-payment="{{ $hasPayment ? 1 : 0 }}"
                             title="Valider l'inscription">
                         <i class="fas fa-check-double"></i>
                     </button>
                 @endif
-
                 @if($pendingPayment)
-                    <button class="action-btn action-payment"
+                    <button class="ii-action-btn ii-action-btn--primary"
                             onclick="ouvrirModalValiderPaiement({{ $inscription->id }})"
                             title="Valider le paiement">
                         <i class="fas fa-check-circle"></i>
                     </button>
                 @elseif(!$hasPayment)
-                    <button class="action-btn action-payment"
+                    <button class="ii-action-btn ii-action-btn--primary"
                             onclick="openPaymentModal({{ $inscription->id }})"
                             title="Associer un paiement">
                         <i class="fas fa-wallet"></i>
                     </button>
                 @endif
-
-                <button class="action-btn action-cancel"
+                <button class="ii-action-btn ii-action-btn--danger"
                         onclick="openCancelModal({{ $inscription->id }})"
                         title="Annuler l'inscription">
                     <i class="fas fa-ban"></i>
                 </button>
-
             </div>
-            <div class="inscription-actions-spinner" aria-hidden="true">
+            <div class="inscription-actions-spinner" aria-hidden="true" style="display:none;">
                 <div class="spinner-border spinner-border-sm text-primary" role="status">
                     <span class="visually-hidden">Chargement...</span>
                 </div>

--- a/resources/views/esbtp/inscriptions/partials/administration-results.blade.php
+++ b/resources/views/esbtp/inscriptions/partials/administration-results.blade.php
@@ -1,21 +1,52 @@
-@if($inscriptions->count() > 0)
-    <div class="table-responsive">
-        <table class="table table-hover align-middle">
-            <thead class="bg-light">
+@php
+    $currentSort = request('sort', 'created_at');
+    $currentDir = request('dir', 'desc');
+    $sortLink = function ($column, $label) use ($currentSort, $currentDir) {
+        $nextDir = ($currentSort === $column && $currentDir === 'asc') ? 'desc' : 'asc';
+        $ariaSort = $currentSort !== $column ? 'none' : ($currentDir === 'asc' ? 'ascending' : 'descending');
+        $icon = 'fa-sort';
+        if ($currentSort === $column) {
+            $icon = $currentDir === 'asc' ? 'fa-sort-up' : 'fa-sort-down';
+        }
+        return [
+            'column' => $column,
+            'label' => $label,
+            'nextDir' => $nextDir,
+            'ariaSort' => $ariaSort,
+            'icon' => $icon,
+        ];
+    };
+@endphp
+
+@if($inscriptions->count() === 0)
+    <div class="ii-empty">
+        <div class="ii-empty-icon"><i class="fas fa-inbox"></i></div>
+        <h4>Aucune inscription en attente</h4>
+        <p>Aucune inscription ne correspond aux filtres appliqués.</p>
+    </div>
+@else
+    <div class="ii-table-wrap">
+        <table class="ii-table">
+            <thead>
                 <tr>
                     @can('access_admin')
-                    <th style="width: 40px;">
-                        <input type="checkbox" id="select-all-inscriptions" class="form-check-input">
+                    <th style="width:38px;">
+                        <input type="checkbox" id="select-all-inscriptions" class="form-check-input" aria-label="Tout sélectionner">
                     </th>
                     @endcan
-                    <th>Matricule</th>
-                    <th>Nom complet</th>
-                    <th>Filière</th>
-                    <th>Niveau</th>
+                    <th>Étudiant</th>
+                    <th>Filière · Niveau</th>
                     <th>Classe</th>
-                    <th>Étape</th>
+                    @php $s = $sortLink('workflow_step', 'Étape'); @endphp
+                    <th class="is-sortable" data-sort="{{ $s['column'] }}" data-next-dir="{{ $s['nextDir'] }}" aria-sort="{{ $s['ariaSort'] }}">
+                        {{ $s['label'] }} <i class="fas {{ $s['icon'] }} ii-sort-icon"></i>
+                    </th>
                     <th>Paiement</th>
-                    <th>Actions</th>
+                    @php $s = $sortLink('created_at', 'Date'); @endphp
+                    <th class="is-sortable" data-sort="{{ $s['column'] }}" data-next-dir="{{ $s['nextDir'] }}" aria-sort="{{ $s['ariaSort'] }}">
+                        {{ $s['label'] }} <i class="fas {{ $s['icon'] }} ii-sort-icon"></i>
+                    </th>
+                    <th style="width:130px; text-align:right;">Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -26,18 +57,9 @@
         </table>
     </div>
 
-    <div class="d-flex justify-content-center mt-4">
-        {{ $inscriptions->appends(request()->query())->links() }}
-    </div>
-@else
-    <div class="text-center py-5">
-        <div class="mb-3">
-            <i class="fas fa-inbox fa-3x text-muted"></i>
+    @if($inscriptions->hasPages())
+        <div class="ii-pagination">
+            {{ $inscriptions->links() }}
         </div>
-        <h4>Aucune inscription trouvée</h4>
-        <p class="text-muted">Aucune inscription en attente ne correspond aux filtres appliqués.</p>
-        <button type="button" class="btn-acasi primary" onclick="resetAdminFilters()">
-            <i class="fas fa-refresh"></i>Réinitialiser les filtres
-        </button>
-    </div>
+    @endif
 @endif

--- a/resources/views/esbtp/inscriptions/partials/sous-reserve-results.blade.php
+++ b/resources/views/esbtp/inscriptions/partials/sous-reserve-results.blade.php
@@ -1,0 +1,140 @@
+@php
+    $currentSort = request('sort', 'created_at');
+    $currentDir = request('dir', 'desc');
+    $sortLink = function($column, $label) use ($currentSort, $currentDir) {
+        $nextDir = ($currentSort === $column && $currentDir === 'asc') ? 'desc' : 'asc';
+        $ariaSort = $currentSort !== $column ? 'none' : ($currentDir === 'asc' ? 'ascending' : 'descending');
+        $icon = 'fa-sort';
+        if ($currentSort === $column) {
+            $icon = $currentDir === 'asc' ? 'fa-sort-up' : 'fa-sort-down';
+        }
+        return [
+            'column' => $column,
+            'label' => $label,
+            'nextDir' => $nextDir,
+            'ariaSort' => $ariaSort,
+            'icon' => $icon,
+        ];
+    };
+@endphp
+
+@if($inscriptions->isEmpty())
+    <div class="ii-empty">
+        <div class="ii-empty-icon"><i class="fas fa-check-double"></i></div>
+        <h4>Aucune inscription sous réserve</h4>
+        <p>Toutes les inscriptions pour les filtres choisis sont confirmées.</p>
+    </div>
+@else
+    <div class="ii-table-wrap">
+        <table class="ii-table">
+            <thead>
+                <tr>
+                    <th style="width:38px;">
+                        <input type="checkbox" id="isr-select-all" class="form-check-input" aria-label="Tout sélectionner">
+                    </th>
+                    <th>Étudiant</th>
+                    <th>Classe</th>
+                    <th>Année</th>
+                    @php $s = $sortLink('condition_reserve', 'Condition'); @endphp
+                    <th class="is-sortable" data-sort="{{ $s['column'] }}" data-next-dir="{{ $s['nextDir'] }}" aria-sort="{{ $s['ariaSort'] }}">
+                        {{ $s['label'] }} <i class="fas {{ $s['icon'] }} ii-sort-icon"></i>
+                    </th>
+                    <th>Paiement</th>
+                    @php $s = $sortLink('workflow_step', 'Workflow'); @endphp
+                    <th class="is-sortable" data-sort="{{ $s['column'] }}" data-next-dir="{{ $s['nextDir'] }}" aria-sort="{{ $s['ariaSort'] }}">
+                        {{ $s['label'] }} <i class="fas {{ $s['icon'] }} ii-sort-icon"></i>
+                    </th>
+                    @php $s = $sortLink('created_at', 'Date'); @endphp
+                    <th class="is-sortable" data-sort="{{ $s['column'] }}" data-next-dir="{{ $s['nextDir'] }}" aria-sort="{{ $s['ariaSort'] }}">
+                        {{ $s['label'] }} <i class="fas {{ $s['icon'] }} ii-sort-icon"></i>
+                    </th>
+                    <th style="width:130px; text-align:right;">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($inscriptions as $inscription)
+                    @php
+                        $paiementValide = $inscription->paiements->firstWhere('status', 'validé');
+                        $totalPaye = $inscription->paiements->where('status', 'validé')->sum('montant');
+                        $fullName = trim(($inscription->etudiant->nom ?? '') . ' ' . ($inscription->etudiant->prenoms ?? ''));
+                        $initials = strtoupper(substr($inscription->etudiant->nom ?? '?', 0, 1));
+                        $hue = crc32($fullName) % 360;
+                        $photoUrl = $inscription->etudiant->photo_url ?? null;
+                    @endphp
+                    <tr data-inscription-id="{{ $inscription->id }}"
+                        data-href="{{ route('esbtp.inscriptions.show', $inscription) }}"
+                        data-student-label="{{ $fullName }}">
+                        <td data-no-row-click>
+                            <input class="form-check-input isr-row-checkbox" type="checkbox" value="{{ $inscription->id }}" aria-label="Sélectionner cette inscription">
+                        </td>
+                        <td>
+                            <div class="ii-student">
+                                @if($photoUrl)
+                                    <img src="{{ $photoUrl }}" alt="" class="ii-student-photo">
+                                @else
+                                    <div class="ii-student-photo" style="background:hsl({{ $hue }}, 60%, 55%);">{{ $initials }}</div>
+                                @endif
+                                <div>
+                                    <div class="ii-student-name">{{ $fullName }}</div>
+                                    <div class="ii-student-meta">{{ $inscription->etudiant->matricule ?? '—' }}</div>
+                                </div>
+                            </div>
+                        </td>
+                        <td>
+                            <div>{{ $inscription->classe->name ?? '—' }}</div>
+                            @if($inscription->filiere)
+                                <div class="ii-student-meta">{{ $inscription->filiere->name }}</div>
+                            @endif
+                        </td>
+                        <td>
+                            <strong>{{ $inscription->anneeUniversitaire->name ?? '—' }}</strong>
+                            @if($anneeEnCours && $inscription->annee_universitaire_id == $anneeEnCours->id)
+                                <div class="ii-student-meta" style="color:var(--ii-success);"><i class="fas fa-check"></i> Courante</div>
+                            @endif
+                        </td>
+                        <td>
+                            <span class="isr-condition-badge">
+                                <i class="fas fa-clock"></i> {{ $inscription->condition_reserve ?? 'Non précisé' }}
+                            </span>
+                        </td>
+                        <td>
+                            @if($totalPaye > 0)
+                                <span class="ii-paiement-chip ii-paiement-chip--paye">
+                                    <i class="fas fa-check"></i> {{ number_format($totalPaye, 0, ',', ' ') }} F
+                                </span>
+                            @else
+                                <span class="ii-paiement-chip ii-paiement-chip--aucun">
+                                    <i class="fas fa-times"></i> Aucun
+                                </span>
+                            @endif
+                        </td>
+                        <td>
+                            <x-workflow-step-badge :inscription="$inscription" />
+                        </td>
+                        <td>{{ optional($inscription->created_at)->format('d/m/Y') }}</td>
+                        <td style="text-align:right;" data-no-row-click>
+                            <div class="ii-actions" style="justify-content:flex-end;">
+                                <button type="button" class="ii-action-btn ii-action-btn--primary"
+                                        onclick="isrLeverReserve({{ $inscription->id }}, '{{ addslashes($fullName) }}')"
+                                        title="Lever la réserve">
+                                    <i class="fas fa-check"></i>
+                                </button>
+                                <button type="button" class="ii-action-btn ii-action-btn--danger"
+                                        onclick="isrAnnuler({{ $inscription->id }}, '{{ addslashes($fullName) }}')"
+                                        title="Annuler l'inscription">
+                                    <i class="fas fa-ban"></i>
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    @if($inscriptions->hasPages())
+        <div class="ii-pagination">
+            {{ $inscriptions->links() }}
+        </div>
+    @endif
+@endif

--- a/resources/views/esbtp/inscriptions/sous-reserve.blade.php
+++ b/resources/views/esbtp/inscriptions/sous-reserve.blade.php
@@ -2,383 +2,156 @@
 
 @section('title', 'Inscriptions sous réserve')
 
-@section('styles')
-<link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
+@push('styles')
+<link rel="stylesheet" href="{{ asset('css/inscriptions-common.css') }}">
 <style>
-    .sr-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
-    .sr-stat-card {
-        background: #fff; border-radius: 12px; padding: 20px 24px;
-        box-shadow: 0 1px 3px rgba(0,0,0,.08); position: relative; overflow: hidden;
-        transition: transform .2s, box-shadow .2s;
+    .isr-hero-icon { background: rgba(255, 255, 255, 0.14); }
+    .isr-condition-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.3rem;
+        padding: 0.25rem 0.6rem;
+        border-radius: 6px;
+        font-size: 0.72rem;
+        font-weight: 600;
+        background: rgba(245, 158, 11, 0.1);
+        color: #92400e;
     }
-    .sr-stat-card:hover { transform: translateY(-2px); box-shadow: 0 4px 12px rgba(0,0,0,.12); }
-    .sr-stat-card::before { content:''; position:absolute; top:0; left:0; right:0; height:4px; }
-    .sr-stat-card.primary::before { background: linear-gradient(90deg, #0453cb, #5e91de); }
-    .sr-stat-card.success::before { background: linear-gradient(90deg, #059669, #10b981); }
-    .sr-stat-card.danger::before { background: linear-gradient(90deg, #dc2626, #ef4444); }
-    .sr-stat-top { display: flex; justify-content: space-between; align-items: flex-start; }
-    .sr-stat-icon {
-        width: 44px; height: 44px; border-radius: 10px; display: flex;
-        align-items: center; justify-content: center; font-size: 1.1rem; color: #fff;
-    }
-    .sr-stat-value { font-size: 1.8rem; font-weight: 700; color: #1e293b; line-height: 1; margin-top: 12px; }
-    .sr-stat-label { font-size: .78rem; color: #64748b; text-transform: uppercase; letter-spacing: .5px; margin-top: 4px; }
-
-    .sr-filter-card {
-        background: #fff; border-radius: 12px; padding: 20px 24px;
-        box-shadow: 0 1px 3px rgba(0,0,0,.08); margin-bottom: 1.5rem;
-    }
-    .sr-filter-title { font-size: .9rem; font-weight: 700; color: #1e293b; margin-bottom: 14px; display: flex; align-items: center; gap: 8px; }
-    .sr-filter-title i { color: #0453cb; }
-
-    .sr-table-card {
-        background: #fff; border-radius: 12px; overflow: hidden;
-        box-shadow: 0 1px 3px rgba(0,0,0,.08);
-    }
-    .sr-table-header {
-        padding: 16px 24px; display: flex; justify-content: space-between;
-        align-items: center; border-bottom: 1px solid #e2e8f0; flex-wrap: wrap; gap: 10px;
-    }
-    .sr-table thead th {
-        background: linear-gradient(135deg, #0453cb, #1b64d4); color: #fff;
-        font-size: .78rem; font-weight: 600; text-transform: uppercase; letter-spacing: .4px;
-        padding: 12px 16px; white-space: nowrap; border: none;
-    }
-    .sr-table tbody td { padding: 12px 16px; font-size: .85rem; color: #334155; vertical-align: middle; border-bottom: 1px solid #f1f5f9; }
-    .sr-table tbody tr:hover { background: rgba(4,83,203,.03); cursor: pointer; }
-    .sr-table tbody tr:last-child td { border-bottom: none; }
-
-    .sr-badge {
-        display: inline-flex; align-items: center; gap: 5px;
-        padding: 4px 10px; border-radius: 6px; font-size: .75rem; font-weight: 600;
-    }
-    .sr-badge.reserve { background: rgba(245,158,11,.1); color: #92400e; border: 1px solid rgba(245,158,11,.3); }
-    .sr-badge.paye { background: rgba(16,185,129,.1); color: #065f46; }
-    .sr-badge.non-paye { background: rgba(239,68,68,.1); color: #991b1b; }
-    .sr-badge.workflow { background: rgba(59,130,246,.1); color: #1e40af; }
-
-    .sr-btn { display: inline-flex; align-items: center; gap: 5px; padding: 6px 12px; border-radius: 6px; font-size: .8rem; font-weight: 600; border: none; cursor: pointer; transition: all .2s; }
-    .sr-btn.confirm { background: linear-gradient(135deg, #059669, #10b981); color: #fff; }
-    .sr-btn.confirm:hover { transform: translateY(-1px); box-shadow: 0 3px 8px rgba(16,185,129,.35); }
-    .sr-btn.cancel { background: transparent; color: #dc2626; border: 1px solid #fecaca; }
-    .sr-btn.cancel:hover { background: #fef2f2; }
-
-    .sr-bulk-bar {
-        padding: 12px 24px; display: flex; align-items: center; gap: 12px;
-        background: linear-gradient(135deg, #f0f9ff, #e0f2fe); border-bottom: 1px solid #bae6fd;
-    }
-    .sr-bulk-count { font-size: .82rem; color: #0369a1; font-weight: 600; }
-
-    .sr-empty {
-        text-align: center; padding: 60px 20px;
-    }
-    .sr-empty-icon {
-        width: 80px; height: 80px; border-radius: 50%; margin: 0 auto 16px;
-        background: linear-gradient(135deg, #d1fae5, #a7f3d0);
-        display: flex; align-items: center; justify-content: center;
-    }
-    .sr-empty-icon i { font-size: 2rem; color: #059669; }
-    .sr-empty h4 { color: #1e293b; font-size: 1.1rem; margin-bottom: 6px; }
-    .sr-empty p { color: #64748b; font-size: .88rem; }
-
-    .sr-student-name { font-weight: 600; color: #1e293b; }
-    .sr-student-name small { font-weight: 400; color: #64748b; display: block; margin-top: 2px; }
 </style>
-@endsection
+@endpush
 
 @section('content')
 <div class="dashboard-acasi">
-    <div class="main-content">
+    <div class="main-content" style="padding: 1.25rem; max-width: 100%;">
 
-        {{-- Header --}}
-        <div class="dashboard-header">
-            <div class="header-left">
-                <h1><i class="fas fa-clipboard-check me-2"></i>Inscriptions sous réserve</h1>
-                <p class="header-subtitle">Gérer les inscriptions conditionnelles en attente de confirmation</p>
-            </div>
-            <div class="header-actions">
-                <a href="{{ route('esbtp.inscriptions.index') }}" class="btn-acasi secondary">
-                    <i class="fas fa-arrow-left me-1"></i> Retour aux inscriptions
-                </a>
-            </div>
-        </div>
-
-        {{-- Stat cards --}}
-        <div class="sr-stats">
-            <div class="sr-stat-card primary">
-                <div class="sr-stat-top">
-                    <div>
-                        <div class="sr-stat-value">{{ $stats['total'] }}</div>
-                        <div class="sr-stat-label">Total sous réserve</div>
-                    </div>
-                    <div class="sr-stat-icon" style="background: linear-gradient(135deg, #0453cb, #5e91de);">
+        {{-- ======================= HERO ======================= --}}
+        <div class="ii-hero" data-kpis-wrapper>
+            <div class="ii-hero-top">
+                <div class="ii-hero-left">
+                    <div class="ii-hero-icon">
                         <i class="fas fa-clipboard-check"></i>
                     </div>
-                </div>
-            </div>
-            <div class="sr-stat-card success">
-                <div class="sr-stat-top">
                     <div>
-                        <div class="sr-stat-value">{{ $stats['avec_paiement'] }}</div>
-                        <div class="sr-stat-label">Avec paiement</div>
-                    </div>
-                    <div class="sr-stat-icon" style="background: linear-gradient(135deg, #059669, #10b981);">
-                        <i class="fas fa-money-bill-wave"></i>
-                    </div>
-                </div>
-            </div>
-            <div class="sr-stat-card danger">
-                <div class="sr-stat-top">
-                    <div>
-                        <div class="sr-stat-value">{{ $stats['sans_paiement'] }}</div>
-                        <div class="sr-stat-label">Sans paiement</div>
-                    </div>
-                    <div class="sr-stat-icon" style="background: linear-gradient(135deg, #dc2626, #ef4444);">
-                        <i class="fas fa-exclamation-circle"></i>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        {{-- Alerts --}}
-        @if(session('success'))
-            <div class="alert alert-success alert-dismissible fade show"><i class="fas fa-check-circle me-2"></i>{{ session('success') }}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>
-        @endif
-        @if(session('warning'))
-            <div class="alert alert-warning alert-dismissible fade show"><i class="fas fa-exclamation-triangle me-2"></i><strong>Attention :</strong> {{ session('warning') }}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>
-        @endif
-        @if(session('error'))
-            <div class="alert alert-danger alert-dismissible fade show"><i class="fas fa-exclamation-circle me-2"></i>{{ session('error') }}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>
-        @endif
-
-        {{-- Filtres --}}
-        <div class="sr-filter-card">
-            <div class="sr-filter-title"><i class="fas fa-filter"></i> Filtrer les inscriptions</div>
-            <form method="GET" action="{{ route('esbtp.inscriptions.sous-reserve') }}">
-                <div class="row g-3 align-items-end">
-                    <div class="col-md-4">
-                        <label class="form-label" style="font-size:.82rem; font-weight:600; color:#334155;">
-                            <i class="fas fa-search me-1"></i> Recherche
-                        </label>
-                        <input type="text" class="form-control" name="search" value="{{ $search ?? '' }}" placeholder="Nom, prénom ou matricule...">
-                    </div>
-                    <div class="col-md-3">
-                        <label class="form-label" style="font-size:.82rem; font-weight:600; color:#334155;">
-                            <i class="fas fa-calendar-alt me-1"></i> Année universitaire
-                        </label>
-                        <select name="annee_id" class="form-select">
-                            <option value="">Toutes les années</option>
-                            @foreach($annees as $annee)
-                                <option value="{{ $annee->id }}" {{ ($anneeFilterId ?? '') == $annee->id ? 'selected' : '' }}>
-                                    {{ $annee->name }}@if($annee->is_current) (Courante)@endif
-                                </option>
-                            @endforeach
-                        </select>
-                    </div>
-                    <div class="col-md-3">
-                        <label class="form-label" style="font-size:.82rem; font-weight:600; color:#334155;">
-                            <i class="fas fa-graduation-cap me-1"></i> Condition
-                        </label>
-                        <select name="condition" class="form-select">
-                            <option value="">Toutes</option>
-                            <option value="BACCALAURÉAT" {{ request('condition') === 'BACCALAURÉAT' ? 'selected' : '' }}>BACCALAURÉAT</option>
-                            <option value="BTS" {{ request('condition') === 'BTS' ? 'selected' : '' }}>BTS</option>
-                        </select>
-                    </div>
-                    <div class="col-md-2">
-                        <button type="submit" class="btn-acasi primary w-100">
-                            <i class="fas fa-search me-1"></i> Filtrer
-                        </button>
-                    </div>
-                </div>
-            </form>
-        </div>
-
-        @if($inscriptions->isEmpty())
-            <div class="sr-table-card">
-                <div class="sr-empty">
-                    <div class="sr-empty-icon"><i class="fas fa-check-double"></i></div>
-                    <h4>Aucune inscription sous réserve</h4>
-                    <p>Toutes les inscriptions pour cette période sont confirmées.</p>
-                </div>
-            </div>
-        @else
-            <form method="POST" action="{{ route('esbtp.inscriptions.lever-reserves-bulk') }}" id="bulkForm">
-                @csrf
-                <div class="sr-table-card">
-                    {{-- Bulk bar --}}
-                    <div class="sr-bulk-bar">
-                        <div class="form-check mb-0">
-                            <input class="form-check-input" type="checkbox" id="selectAll">
-                            <label class="form-check-label fw-bold" for="selectAll" style="font-size:.82rem; color:#0369a1;">
-                                Tout sélectionner
-                            </label>
-                        </div>
-                        <button type="button" class="sr-btn confirm" id="bulkConfirmBtn" disabled onclick="confirmBulkLever()">
-                            <i class="fas fa-check-double"></i> Lever les réserves
-                        </button>
-                        <span class="sr-bulk-count" id="selectedCount">0 sélectionné(s)</span>
-                        <span style="margin-left:auto; font-size:.82rem; color:#64748b;">
-                            <strong>{{ $inscriptions->count() }}</strong> résultat(s)
+                        <h1>Inscriptions sous réserve</h1>
+                        <p>Inscriptions conditionnelles en attente de confirmation du document manquant</p>
+                        <span class="ii-hero-chip">
+                            <i class="fas fa-calendar-alt"></i>
+                            @if(!empty($anneeFilterId) && ($selectedAnnee = $annees->firstWhere('id', $anneeFilterId)))
+                                {{ $selectedAnnee->name }}
+                            @else
+                                Toutes les années
+                            @endif
                         </span>
                     </div>
-
-                    {{-- Table --}}
-                    <div class="table-responsive">
-                        <table class="table sr-table mb-0">
-                            <thead>
-                                <tr>
-                                    <th style="width:40px;"></th>
-                                    <th>Étudiant</th>
-                                    <th>Classe</th>
-                                    <th>Année</th>
-                                    <th>Condition</th>
-                                    <th>Paiement</th>
-                                    <th>Workflow</th>
-                                    <th style="width:150px;">Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach($inscriptions as $inscription)
-                                <tr data-href="{{ route('esbtp.inscriptions.show', $inscription) }}">
-                                    <td>
-                                        <input class="form-check-input row-checkbox" type="checkbox" name="inscription_ids[]" value="{{ $inscription->id }}">
-                                    </td>
-                                    <td>
-                                        <div class="sr-student-name">
-                                            {{ $inscription->etudiant->nom ?? '—' }} {{ $inscription->etudiant->prenoms ?? '' }}
-                                            <small>{{ $inscription->etudiant->matricule ?? '' }}</small>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        {{ $inscription->classe->name ?? '—' }}
-                                        @if($inscription->filiere)
-                                            <br><small style="color:#64748b;">{{ $inscription->filiere->name }}</small>
-                                        @endif
-                                    </td>
-                                    <td>
-                                        <strong>{{ $inscription->anneeUniversitaire->name ?? '—' }}</strong>
-                                        @if($anneeEnCours && $inscription->annee_universitaire_id == $anneeEnCours->id)
-                                            <br><small style="color:#059669; font-weight:600;">Année courante</small>
-                                        @endif
-                                    </td>
-                                    <td>
-                                        <span class="sr-badge reserve">
-                                            <i class="fas fa-clock"></i> {{ $inscription->condition_reserve ?? 'Non précisé' }}
-                                        </span>
-                                    </td>
-                                    <td>
-                                        @php $totalPaye = $inscription->paiements->where('status', 'validé')->sum('montant'); @endphp
-                                        @if($totalPaye > 0)
-                                            <span class="sr-badge paye"><i class="fas fa-check-circle"></i> {{ number_format($totalPaye, 0, ',', ' ') }} F</span>
-                                        @else
-                                            <span class="sr-badge non-paye"><i class="fas fa-times-circle"></i> Aucun</span>
-                                        @endif
-                                    </td>
-                                    <td>
-                                        <span class="sr-badge workflow"><i class="fas fa-tasks"></i> {{ $inscription->workflow_step_label }}</span>
-                                    </td>
-                                    <td>
-                                        <div class="d-flex gap-1">
-                                            <form method="POST" action="{{ route('esbtp.inscriptions.lever-reserve', $inscription) }}"
-                                                  onsubmit="return confirm('Confirmer la levée de réserve pour {{ addslashes(($inscription->etudiant->nom ?? '') . ' ' . ($inscription->etudiant->prenoms ?? '')) }} ?')">
-                                                @csrf
-                                                <button type="submit" class="sr-btn confirm" title="Lever la réserve">
-                                                    <i class="fas fa-check"></i> Confirmer
-                                                </button>
-                                            </form>
-                                            <form method="POST" action="{{ route('esbtp.inscriptions.annuler', $inscription) }}"
-                                                  onsubmit="return confirm('Annuler cette inscription ? Cette action est irréversible.')">
-                                                @csrf @method('PUT')
-                                                <input type="hidden" name="motif_annulation" value="Condition de réserve non remplie">
-                                                <button type="submit" class="sr-btn cancel" title="Annuler l'inscription">
-                                                    <i class="fas fa-times"></i>
-                                                </button>
-                                            </form>
-                                        </div>
-                                    </td>
-                                </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    </div>
                 </div>
-            </form>
-        @endif
-
-    </div>
-</div>
-
-{{-- Modal confirmation bulk --}}
-<div class="modal fade" id="bulkConfirmModal" tabindex="-1">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content" style="border:none; border-radius:14px; overflow:hidden;">
-            <div class="modal-header" style="background:linear-gradient(135deg, #059669, #10b981); color:#fff; border:none; padding:20px 24px;">
-                <h5 class="modal-title"><i class="fas fa-check-double me-2"></i> Confirmation</h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                <div class="ii-hero-actions">
+                    <a href="{{ route('esbtp.inscriptions.index') }}" class="ii-btn ii-btn--glass">
+                        <i class="fas fa-arrow-left"></i> Retour
+                    </a>
+                </div>
             </div>
-            <div class="modal-body" style="padding:24px;">
-                <p>Vous allez lever la réserve pour <strong id="bulkCountText">0</strong> inscription(s).</p>
-                <p style="color:#64748b; font-size:.88rem;">Les documents afficheront désormais "Est régulièrement inscrit(e)" sans la mention sous réserve.</p>
-            </div>
-            <div class="modal-footer" style="border:none; padding:16px 24px;">
-                <button type="button" class="btn btn-light" data-bs-dismiss="modal">Annuler</button>
-                <button type="button" class="sr-btn confirm" id="bulkConfirmSubmit" style="padding:8px 20px;">
-                    <i class="fas fa-check-double"></i> Confirmer la levée
+
+            {{-- KPIs cliquables (filtre paiement) --}}
+            <div class="ii-kpis">
+                <button type="button" class="ii-kpi {{ $hasPayment === '' ? 'is-active' : '' }}" data-kpi="total" data-filter-payment="">
+                    <div class="ii-kpi-icon"><i class="fas fa-list"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['total'] }}</div>
+                        <div class="ii-kpi-label">Total</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ $hasPayment === 'yes' ? 'is-active' : '' }}" data-kpi="avec_paiement" data-filter-payment="yes">
+                    <div class="ii-kpi-icon"><i class="fas fa-money-bill-wave"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['avec_paiement'] }}</div>
+                        <div class="ii-kpi-label">Avec paiement</div>
+                    </div>
+                </button>
+                <button type="button" class="ii-kpi {{ $hasPayment === 'no' ? 'is-active' : '' }}" data-kpi="sans_paiement" data-filter-payment="no">
+                    <div class="ii-kpi-icon"><i class="fas fa-exclamation-circle"></i></div>
+                    <div class="ii-kpi-content">
+                        <div class="ii-kpi-value" data-kpi-value>{{ $stats['sans_paiement'] }}</div>
+                        <div class="ii-kpi-label">Sans paiement</div>
+                    </div>
                 </button>
             </div>
         </div>
+
+        {{-- ======================= TOOLBAR ======================= --}}
+        <div class="ii-toolbar">
+            <div class="ii-search">
+                <i class="fas fa-search"></i>
+                <input type="search" id="isr-search" placeholder="Nom, prénom ou matricule..." value="{{ $search }}">
+            </div>
+            <select id="isr-annee" class="ii-select" aria-label="Année universitaire">
+                <option value="">Toutes les années</option>
+                @foreach($annees as $annee)
+                    <option value="{{ $annee->id }}" {{ ($anneeFilterId ?? '') == $annee->id ? 'selected' : '' }}>
+                        {{ $annee->name }}@if($annee->is_current) (Courante)@endif
+                    </option>
+                @endforeach
+            </select>
+            <select id="isr-condition" class="ii-select" aria-label="Condition">
+                <option value="">Toutes conditions</option>
+                <option value="BACCALAURÉAT" {{ $condition === 'BACCALAURÉAT' ? 'selected' : '' }}>BACCALAURÉAT</option>
+                <option value="BTS" {{ $condition === 'BTS' ? 'selected' : '' }}>BTS</option>
+            </select>
+            <button type="button" class="ii-btn ii-btn--ghost" id="isr-reset">
+                <i class="fas fa-rotate-left"></i> Réinitialiser
+            </button>
+        </div>
+
+        {{-- ======================= RESULTS ======================= --}}
+        <div class="ii-results-card" id="isr-results-card">
+            <div class="ii-results-header">
+                <div class="ii-results-count">
+                    <strong id="isr-total">{{ $inscriptions->total() }}</strong> inscription(s) sous réserve
+                </div>
+                <div class="ii-per-page">
+                    <span>Afficher</span>
+                    <select id="isr-per-page" aria-label="Lignes par page">
+                        @foreach([15, 25, 50, 100] as $opt)
+                            <option value="{{ $opt }}" {{ request('per_page', 25) == $opt ? 'selected' : '' }}>{{ $opt }}</option>
+                        @endforeach
+                    </select>
+                    <span>par page</span>
+                </div>
+            </div>
+            <div id="isr-results">
+                @include('esbtp.inscriptions.partials.sous-reserve-results', ['inscriptions' => $inscriptions, 'anneeEnCours' => $anneeEnCours])
+            </div>
+        </div>
     </div>
 </div>
+
+{{-- Bulk bar --}}
+<div class="ii-bulk-bar" id="isr-bulk-bar">
+    <div class="ii-bulk-count">
+        <i class="fas fa-check-circle me-1"></i>
+        <span id="isr-bulk-count">0</span> sélectionnée(s)
+    </div>
+    <button type="button" class="ii-btn ii-btn--white" onclick="isrBulkLever()">
+        <i class="fas fa-check-double"></i> Lever réserves
+    </button>
+    <button type="button" class="ii-btn ii-btn--glass" onclick="isrBulkExporter()">
+        <i class="fas fa-file-export"></i> Exporter CSV
+    </button>
+    <button type="button" class="ii-btn ii-btn--glass" onclick="isrClearSelection()" title="Fermer">
+        <i class="fas fa-times"></i>
+    </button>
+</div>
+
 @endsection
 
 @push('scripts')
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    const selectAll = document.getElementById('selectAll');
-    const checkboxes = document.querySelectorAll('.row-checkbox');
-    const bulkBtn = document.getElementById('bulkConfirmBtn');
-    const selectedCount = document.getElementById('selectedCount');
-
-    function updateCount() {
-        const checked = document.querySelectorAll('.row-checkbox:checked').length;
-        selectedCount.textContent = checked + ' sélectionné(s)';
-        bulkBtn.disabled = checked === 0;
-    }
-
-    if (selectAll) {
-        selectAll.addEventListener('change', function() {
-            checkboxes.forEach(cb => cb.checked = this.checked);
-            updateCount();
-        });
-    }
-
-    checkboxes.forEach(cb => {
-        cb.addEventListener('change', function() {
-            if (!this.checked) selectAll.checked = false;
-            if (document.querySelectorAll('.row-checkbox:checked').length === checkboxes.length) selectAll.checked = true;
-            updateCount();
-        });
-    });
-
-    // Clickable rows — navigate to inscription detail
-    document.querySelectorAll('.sr-table tbody tr[data-href]').forEach(row => {
-        row.addEventListener('click', function(e) {
-            if (e.target.closest('input, button, a, form')) return;
-            window.location.href = this.dataset.href;
-        });
-    });
-});
-
-function confirmBulkLever() {
-    const checked = document.querySelectorAll('.row-checkbox:checked').length;
-    document.getElementById('bulkCountText').textContent = checked;
-    const modal = new bootstrap.Modal(document.getElementById('bulkConfirmModal'));
-    modal.show();
-    document.getElementById('bulkConfirmSubmit').onclick = function() {
-        modal.hide();
-        document.getElementById('bulkForm').submit();
+    window.KLASSCI_SOUSRESERVE_ROUTES = {
+        index: '{{ route('esbtp.inscriptions.sous-reserve') }}',
+        leverReservesBulk: '{{ route('esbtp.inscriptions.lever-reserves-bulk') }}',
+        bulkExport: '{{ route('esbtp.inscriptions.bulk-export') }}',
+        csrf: '{{ csrf_token() }}',
     };
-}
 </script>
+<script src="{{ asset('js/inscriptions/common.js') }}"></script>
+<script src="{{ asset('js/inscriptions/sous-reserve.js') }}"></script>
 @endpush


### PR DESCRIPTION
## Résumé

Suite du redesign inscriptions après PR #217 (index). Aligne `administration.blade.php` et `sous-reserve.blade.php` sur le même design system premium avec namespace `ii-*` partagé.

Closes #218

## Infrastructure partagée (nouveaux fichiers)

- **`public/css/inscriptions-common.css`** — tokens `--ii-*`, `.ii-hero`, `.ii-kpi` cliquable, `.ii-toolbar`, `.ii-table`, `.ii-badge--*`, `.ii-wfbadge--*`, `.ii-bulk-bar`, responsive mobile-first
- **`public/js/inscriptions/common.js`** — `iiConfirm()` Promise-based, `showToast()` 5s auto-dismiss, `updateKpisFromStats()`, `triggerRowHighlight()`
- **`app/View/Components/WorkflowStepBadge.php`** — badge workflow (prospect / documents_complets / en_validation / etudiant_cree)

## Controller

- `administration()` : sort whitelist (`created_at`, `updated_at`, `workflow_step`, `status`), per_page whitelist (15/25/50/100), stats dans réponse AJAX, cast `(string) $search` pour contrer `ConvertEmptyStringsToNull`
- `sousReserveIndex()` : pagination ajoutée, sort whitelist, per_page, filtre `has_payment`, AJAX JSON response avec stats, partial dédié `sous-reserve-results`
- `leverReservesBulk()` : branche AJAX retournant JSON `{success, count, processed_ids}`

## Page administration

| Avant | Maintenant |
|-------|------------|
| Header basique + 4 KPIs statiques | Hero gradient + **6 KPIs cliquables** (Total / Avec paiement / Sans paiement / Prospects / Documents / En validation) |
| Carte \"Année Académique Active\" en dur | Chip année dans le hero |
| Form filtre avec submit button | Toolbar compacte : search debounce 400ms + 3 selects + reset |
| Table basique | Table sort-enabled (`workflow_step`, `created_at`) + aria-sort, row cliquable (JS delegation) |
| Avatars initiales plates | Photos étudiants HSL fallback (pattern PR1) |
| Bulk bar pill basique | Bulk bar premium monochrome : Valider / **Annuler (avec motif)** / **CSV** / Close |

**Modals legacy conservés** (bulkValidation, paymentModal, modalValiderPaiement, modalChangerClasse, cancelInscriptionModal) — fonctionnels, juste repensés visuellement via CSS.

**JS externalisé** (`public/js/inscriptions/administration.js`) gère filter/KPI/sort/pagination/bulk sans toucher aux handlers legacy. Override `updateInscriptionSelectionCount` pour bulk bar via `classList.is-visible`.

## Page sous-reserve

| Avant | Maintenant |
|-------|------------|
| Namespace `sr-*` multicouleurs (vert, rouge) | Namespace `ii-*` monochrome bleu |
| Stats statiques 3 cards | Hero + **3 KPIs cliquables** (filter `has_payment`) |
| Filter form avec submit | Toolbar : search debounce + année + condition + reset |
| Pas de pagination | Pagination + per_page selector |
| Pas de sort | Sort sur `condition_reserve` / `workflow_step` / `created_at` |
| Confirm bulk via modal custom + native `confirm()` pour unit | Toutes confirmations via `iiConfirm()` Promise-based |
| Bulk = seulement Lever réserves | Bulk bar premium : Lever / CSV / Close |

## Décisions user (héritées du plan-and-confirm FULL session 2026-04-17)

- Q1a : KPIs cliquables
- Q2 : Row clickable via JS delegation
- Q3a : Sort columns + aria-sort
- Q4 : Partials unifiés
- Q5b : Blade component (WorkflowStepBadge)
- Q6 : Modals globaux (iiConfirm)
- Q7 : Bulk bar complète
- Q8 : **PR2 = administration + sous-reserve** (réalisé)
- Q9a : Pagination numérotée + per_page

## Tests à faire après merge sur `presentation`

### Administration
- [ ] `/esbtp/inscriptions-administration` charge avec hero + 6 KPIs + toolbar + empty state si aucune
- [ ] Cliquer KPI \"Prospects\" → filtre `workflow_step=prospect` + reclick = reset
- [ ] Cliquer KPI \"Avec paiement\" → filtre `has_payment=yes`, clear workflow_step
- [ ] Search debounce 400ms puis AJAX refresh
- [ ] Selects filière/niveau/année changent sans reload
- [ ] Reset → vide tout, KPI Total actif
- [ ] Per_page 15/25/50/100 change la pagination
- [ ] Pagination AJAX (pas de reload complet)
- [ ] Click row → navigue vers show
- [ ] Click bouton action (wallet/ban/check) → ouvre modal, pas de navigate
- [ ] Bulk : sélectionner 2+, bulk bar apparaît
- [ ] Bulk Valider → modal bulk avec résumé, ignore non-éligibles
- [ ] Bulk Annuler → modal motif (3+ chars required), AJAX, refresh rows
- [ ] Bulk CSV → télécharge fichier horodaté UTF-8 BOM
- [ ] Problème chip + bouton action rapide (créer paiement / valider / changer classe)

### Sous-réserve
- [ ] `/esbtp/inscriptions/sous-reserve` charge avec hero + 3 KPIs
- [ ] KPI Avec paiement actif → filtre, reclick reset
- [ ] Search, année, condition → AJAX refresh
- [ ] Sort condition / workflow / date
- [ ] Row click → show
- [ ] Action Lever réserve (inline) → `iiConfirm()` modal → AJAX → toast
- [ ] Action Annuler → `iiConfirm()` danger → form POST `_method=PUT`
- [ ] Bulk Lever réserves → confirm → AJAX → refresh
- [ ] Bulk CSV → téléchargement

### Cross-page
- [ ] Navigate entre PR1 (index) et PR2 (admin/sous-reserve) → style cohérent
- [ ] Responsive mobile : hero reflow, KPIs wrap, toolbar column

## Risques

- Aucun changement sur les routes (juste AJAX branches ajoutées)
- Les IDs legacy (`#select-all-inscriptions`, `.inscription-checkbox`, `#bulk-actions-bar`) préservés → compat avec les handlers inline existants
- `administration.js` chargé APRÈS le bloc script legacy pour override correct de `updateInscriptionSelectionCount`
- Les modals legacy (payment, validation, changerClasse) non touchés → comportement identique
- Pas de breaking change sur le controller (fallbacks redirect conservés)