### PR TITLE
feat(emploi-temps): PR1 foundation redesign premium show (hero + dead buttons + modal + setting)

### DIFF
--- a/.claude/rules/premium-redesign.md
+++ b/.claude/rules/premium-redesign.md
@@ -15,11 +15,33 @@ Cette rule s'active quand on redesign une page Blade (vue) avec du CSS premium.
 --dark:       #0f172a     /* Texte principal */
 --text:       #1e293b     /* Texte body */
 --muted:      #64748b     /* Labels, hints */
---success:    #10b981     /* Statuts positifs uniquement */
 --surface:    #f8fafc     /* Fond léger */
 ```
 
-**INTERDIT** : purple `#7c3aed`, amber `#f59e0b` (sauf warnings fonctionnels), rouge `#ef4444`, multicolore, AI slop (dark mode, gradient orbs, bento grids, glassmorphism, animated counters), `--esbtp-green` (variable morte).
+### Couleurs sémantiques autorisées (exception à la règle monochrome)
+
+Les couleurs sémantiques **success/warning/danger** sont autorisées **quand elles portent du sens fonctionnel** — ne JAMAIS les utiliser comme simple décoration ou pour différencier des catégories neutres.
+
+```css
+--success: #10b981    /* Succès : paiement validé, action réussie, statut OK */
+--warning: #f59e0b    /* Alerte : paiement en attente, délai approchant, à surveiller */
+--danger:  #dc2626    /* Danger : suppression, erreur critique, paiement rejeté, delete confirm */
+```
+
+**Exemples d'usage correct (sens fonctionnel) :**
+- Badge "Payé" → vert success, "En attente" → orange warning, "Annulé" → rouge danger
+- Bouton "Supprimer" / "Archiver" → `btn-danger` (a11y + convention universelle)
+- Alert "Paiement échoué" → alert-danger, "Paiement imminent" → alert-warning
+- Modal header destructif ("Annuler inscription") → gradient rouge
+
+**Exemples d'usage INCORRECT (décoration, différenciation neutre) :**
+- Badges Types de séances CM/TD/TP → multicolore (bleu/vert/orange) → **FAUX** — utiliser monochrome tonal (opacity + icône + border-style)
+- KPIs dashboard "Total étudiants" → couleur différente par KPI → **FAUX** — tous en bleu
+- Boutons d'action secondaires colorés → **FAUX** — ghost/outline bleu
+
+**Principe** : si la couleur porte une information sémantique que l'œil doit capter en <1 seconde (statut, niveau d'alerte, action destructive), elle est autorisée. Sinon, monochrome bleu.
+
+**INTERDIT** : purple `#7c3aed`, multicolore décoratif, AI slop (dark mode, gradient orbs, bento grids, glassmorphism, animated counters), `--esbtp-green` (variable morte), couleurs arbitraires pour différencier des catégories neutres.
 
 ## Modèle de référence : Planning Général (`planning-header`)
 

--- a/app/Http/Controllers/ESBTPEmploiTempsController.php
+++ b/app/Http/Controllers/ESBTPEmploiTempsController.php
@@ -820,6 +820,9 @@ class ESBTPEmploiTempsController extends Controller
         // Grouper les séances par jour
         $seancesParJour = $emploi_temp->getSeancesParJour();
 
+        // Setting configurable : afficher le dimanche ou non (default false)
+        $showSunday = (bool) \App\Models\ESBTPSystemSetting::getValue('emploi_temps.show_sunday', false);
+
         // Noms des jours pour l'affichage
         $joursNoms = [
             1 => 'Lundi',
@@ -829,6 +832,9 @@ class ESBTPEmploiTempsController extends Controller
             5 => 'Vendredi',
             6 => 'Samedi',
         ];
+        if ($showSunday) {
+            $joursNoms[7] = 'Dimanche';
+        }
 
         // Générer dynamiquement les créneaux horaires (pas de 15 minutes pour couvrir 08:30, 09:15, etc.)
         $timeSlots = $this->generateTimeSlots($seances);
@@ -856,12 +862,33 @@ class ESBTPEmploiTempsController extends Controller
             );
         }
 
+        // KPIs pour le hero premium
+        $totalSeances = $emploi_temp->seances->count();
+        $totalHeuresPlanifiees = $planificationData['heures_totales'] ?? 0;
+        $heuresRestantes = $planificationData['heures_restantes'] ?? 0;
+        $pourcentageRestant = $totalHeuresPlanifiees > 0
+            ? round(($heuresRestantes / $totalHeuresPlanifiees) * 100)
+            : 0;
+        $enseignantsIds = $emploi_temp->seances
+            ->pluck('teacher_id')
+            ->filter()
+            ->unique()
+            ->count();
+
+        $heroKpis = [
+            'total_seances' => $totalSeances,
+            'heures_planifiees' => $totalHeuresPlanifiees,
+            'pourcentage_restant' => $pourcentageRestant,
+            'enseignants' => $enseignantsIds,
+        ];
+
         // Renommer la variable pour la vue
         $emploiTemps = $emploi_temp;
 
         return view('esbtp.emploi-temps.show', compact(
             'emploiTemps', 'seances', 'seancesParJour',
-            'joursNoms', 'matiereStats', 'timeSlots', 'days', 'planificationData'
+            'joursNoms', 'matiereStats', 'timeSlots', 'days', 'planificationData',
+            'heroKpis', 'showSunday'
         ));
     }
 

--- a/database/migrations/2026_04_17_185400_add_emploi_temps_show_sunday_setting.php
+++ b/database/migrations/2026_04_17_185400_add_emploi_temps_show_sunday_setting.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $exists = DB::table('esbtp_system_settings')
+            ->where('key', 'emploi_temps.show_sunday')
+            ->exists();
+
+        if (! $exists) {
+            DB::table('esbtp_system_settings')->insert([
+                'key' => 'emploi_temps.show_sunday',
+                'value' => '0',
+                'type' => 'boolean',
+                'description' => "Afficher la colonne 'Dimanche' dans la grille horaire et les vues emploi du temps. Masquee par defaut.",
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        DB::table('esbtp_system_settings')
+            ->where('key', 'emploi_temps.show_sunday')
+            ->delete();
+    }
+};

--- a/resources/views/components/emploi-temps/liste-seances.blade.php
+++ b/resources/views/components/emploi-temps/liste-seances.blade.php
@@ -1,5 +1,119 @@
 @props(['seances' => collect(), 'emploiTemps'])
 
+@once
+<style>
+    .els-table thead th {
+        background: #f8fafc;
+        color: #64748b;
+        font-size: .72rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: .4px;
+        padding: .7rem .9rem;
+        border-bottom: 1px solid #e2e8f0;
+        white-space: nowrap;
+    }
+    .els-table tbody td {
+        padding: .8rem .9rem;
+        border-bottom: 1px solid #f1f5f9;
+        font-size: .86rem;
+        color: #1e293b;
+        vertical-align: middle;
+    }
+    .els-table tbody tr:hover { background: rgba(4,83,203,.025); }
+    .els-type-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: .3rem;
+        padding: .28rem .6rem;
+        border-radius: 8px;
+        font-size: .7rem;
+        font-weight: 600;
+        letter-spacing: .3px;
+    }
+    .els-type-badge--course {
+        background: rgba(4,83,203,.1);
+        color: #033a8e;
+    }
+    .els-type-badge--homework {
+        background: rgba(59,125,219,.12);
+        color: #0453cb;
+        border: 1px dashed rgba(4,83,203,.35);
+    }
+    .els-type-badge--break {
+        background: rgba(94,145,222,.15);
+        color: #0453cb;
+        opacity: .75;
+    }
+    .els-type-badge--lunch {
+        background: rgba(148,163,184,.18);
+        color: #475569;
+    }
+    .els-matiere-icon {
+        width: 30px; height: 30px;
+        border-radius: 8px;
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: #fff;
+        font-size: .75rem;
+        flex-shrink: 0;
+    }
+    .els-status-active {
+        display: inline-flex;
+        align-items: center;
+        gap: .3rem;
+        padding: .25rem .55rem;
+        border-radius: 7px;
+        font-size: .7rem;
+        font-weight: 600;
+        background: rgba(16,185,129,.1);
+        color: #065f46;
+    }
+    .els-status-inactive {
+        display: inline-flex;
+        align-items: center;
+        gap: .3rem;
+        padding: .25rem .55rem;
+        border-radius: 7px;
+        font-size: .7rem;
+        font-weight: 600;
+        background: rgba(148,163,184,.15);
+        color: #475569;
+    }
+    .els-repartition {
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        padding: 1rem 1.25rem;
+        margin-top: 1rem;
+    }
+    .els-repartition-item {
+        text-align: center;
+        padding: .5rem;
+    }
+    .els-repartition-value {
+        font-size: 1.6rem;
+        font-weight: 700;
+        color: #0453cb;
+        line-height: 1;
+    }
+    .els-repartition-label {
+        font-size: .72rem;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: .4px;
+        margin-top: .35rem;
+    }
+    .els-repartition-pct {
+        font-size: .7rem;
+        color: #94a3b8;
+        margin-top: .15rem;
+    }
+</style>
+@endonce
+
 <div class="main-card mb-4">
     <div class="main-card-header">
         <div class="main-card-title">
@@ -11,28 +125,28 @@
     <div class="main-card-body">
         @if($seances && $seances->count() > 0)
             <div class="table-responsive">
-                <table class="table table-striped table-hover mb-0">
-                    <thead class="table-dark">
+                <table class="table els-table mb-0">
+                    <thead>
                         <tr>
-                            <th width="8%">#</th>
-                            <th width="20%">Matière</th>
+                            <th width="6%">#</th>
+                            <th width="22%">Matière</th>
                             <th width="18%">Enseignant</th>
                             <th width="10%">Type</th>
-                            <th width="12%">Jour</th>
+                            <th width="10%">Jour</th>
                             <th width="12%">Heure</th>
-                            <th width="8%">Durée</th>
-                            <th width="7%">Statut</th>
-                            <th width="5%">Actions</th>
+                            <th width="7%">Durée</th>
+                            <th width="8%">Statut</th>
+                            <th width="7%" class="text-end">Actions</th>
                         </tr>
                     </thead>
                     <tbody>
                         @foreach($seances->sortBy([['jour', 'asc'], ['heure_debut', 'asc']]) as $index => $seance)
                         <tr>
-                            <td class="text-center fw-bold">{{ $index + 1 }}</td>
+                            <td class="text-center fw-bold text-muted">{{ $index + 1 }}</td>
                             <td>
-                                <div class="d-flex align-items-center">
-                                    <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-2" style="width: 25px; height: 25px; flex-shrink: 0;">
-                                        <i class="fas fa-book" style="font-size: 10px;"></i>
+                                <div class="d-flex align-items-center gap-2">
+                                    <div class="els-matiere-icon">
+                                        <i class="fas fa-book"></i>
                                     </div>
                                     <strong>{{ $seance->matiere->name ?? 'Non définie' }}</strong>
                                 </div>
@@ -51,22 +165,16 @@
                             </td>
                             <td>
                                 @php
-                                    $typeColors = [
-                                        'course' => 'primary',
-                                        'homework' => 'success', 
-                                        'break' => 'warning',
-                                        'lunch' => 'info'
-                                    ];
                                     $typeLabels = [
                                         'course' => 'COURS',
-                                        'homework' => 'DEVOIR', 
+                                        'homework' => 'DEVOIR',
                                         'break' => 'RÉCRÉATION',
                                         'lunch' => 'PAUSE'
                                     ];
-                                    $typeColor = $typeColors[$seance->type] ?? 'primary';
-                                    $typeLabel = $typeLabels[$seance->type] ?? 'COURS';
+                                    $typeKey = $seance->type ?? 'course';
+                                    $typeLabel = $typeLabels[$typeKey] ?? 'COURS';
                                 @endphp
-                                <span class="badge bg-{{ $typeColor }}">
+                                <span class="els-type-badge els-type-badge--{{ $typeKey }}">
                                     {{ $typeLabel }}
                                 </span>
                             </td>
@@ -99,30 +207,35 @@
                                     $fin = \Carbon\Carbon::parse($seance->heure_fin);
                                     $duree = $debut->diffInHours($fin);
                                 @endphp
-                                <span class="badge bg-secondary">{{ $duree }}h</span>
+                                <small class="text-muted">{{ $duree }}h</small>
                             </td>
                             <td class="text-center">
                                 @if($seance->is_active ?? true)
-                                    <span class="badge bg-success">
+                                    <span class="els-status-active">
                                         <i class="fas fa-check"></i> Actif
                                     </span>
                                 @else
-                                    <span class="badge bg-warning">
+                                    <span class="els-status-inactive">
                                         <i class="fas fa-pause"></i> Inactif
                                     </span>
                                 @endif
                             </td>
                             <td class="text-center">
-                                <div class="btn-group btn-group-sm">
-                                    <button type="button" class="btn btn-sm btn-outline-primary" 
-                                            data-bs-toggle="tooltip" title="Modifier">
+                                <div class="btn-group btn-group-sm" role="group" aria-label="Actions séance">
+                                    @can('edit_timetables')
+                                    <a href="{{ route('esbtp.seances-cours.edit', $seance->id) }}"
+                                       class="btn btn-sm btn-outline-primary"
+                                       data-bs-toggle="tooltip" title="Modifier">
                                         <i class="fas fa-edit"></i>
-                                    </button>
-                                    <button type="button" class="btn btn-sm btn-outline-danger" 
+                                    </a>
+                                    @endcan
+                                    @can('delete_timetables')
+                                    <button type="button" class="btn btn-sm btn-outline-danger"
                                             data-bs-toggle="tooltip" title="Supprimer"
-                                            onclick="if(confirm('Êtes-vous sûr de vouloir supprimer cette séance ?')) { /* Action supprimer */ }">
+                                            onclick="window.etsDeleteSeance({{ $seance->id }}, @js($seance->matiere->name ?? 'Séance'))">
                                         <i class="fas fa-trash"></i>
                                     </button>
+                                    @endcan
                                 </div>
                             </td>
                         </tr>
@@ -132,12 +245,12 @@
             </div>
             
             <!-- Résumé par type de séance -->
-            <div class="mt-3 p-3 bg-light rounded">
-                <h6 class="mb-2">
-                    <i class="fas fa-chart-bar text-primary me-1"></i>
+            <div class="els-repartition">
+                <h6 class="mb-3" style="color: #0453cb; font-size: .88rem; font-weight: 700;">
+                    <i class="fas fa-chart-bar me-1"></i>
                     Répartition par type de séance
                 </h6>
-                <div class="row">
+                <div class="row g-2">
                     @php
                         $repartition = [
                             'course' => $seances->where('type', 'course')->count(),
@@ -146,32 +259,21 @@
                             'lunch' => $seances->where('type', 'lunch')->count(),
                         ];
                         $total = $seances->count();
-                        
-                        $typeColors = [
-                            'course' => 'primary',
-                            'homework' => 'success', 
-                            'break' => 'warning',
-                            'lunch' => 'info'
-                        ];
                         $typeLabels = [
                             'course' => 'COURS',
-                            'homework' => 'DEVOIRS', 
+                            'homework' => 'DEVOIRS',
                             'break' => 'RÉCRÉATIONS',
                             'lunch' => 'PAUSES'
                         ];
                     @endphp
-                    
+
                     @foreach($repartition as $type => $count)
                         @if($count > 0)
-                        <div class="col-md-3 col-6 mb-2">
-                            <div class="text-center">
-                                <div class="h4 mb-1 text-{{ $typeColors[$type] }}">
-                                    {{ $count }}
-                                </div>
-                                <small class="text-muted">
-                                    {{ $typeLabels[$type] }}
-                                    <br>({{ $total > 0 ? round(($count / $total) * 100, 1) : 0 }}%)
-                                </small>
+                        <div class="col-md-3 col-6">
+                            <div class="els-repartition-item">
+                                <div class="els-repartition-value">{{ $count }}</div>
+                                <div class="els-repartition-label">{{ $typeLabels[$type] }}</div>
+                                <div class="els-repartition-pct">{{ $total > 0 ? round(($count / $total) * 100, 1) : 0 }}%</div>
                             </div>
                         </div>
                         @endif
@@ -179,18 +281,18 @@
                 </div>
             </div>
         @else
-            <div class="alert alert-info mb-0">
-                <div class="d-flex align-items-center">
-                    <i class="fas fa-calendar-plus fa-2x me-3 text-primary"></i>
-                    <div>
-                        <h6><strong>Aucune séance programmée</strong></h6>
-                        <p class="mb-2">Cet emploi du temps ne contient aucune séance.</p>
-                        <a href="{{ route('esbtp.seances-cours.create', ['emploi_temps_id' => $emploiTemps->id]) }}"
-                           class="btn btn-primary btn-sm">
-                            <i class="fas fa-plus me-1"></i>Ajouter la première séance
-                        </a>
-                    </div>
+            <div class="text-center py-4" style="border: 1px dashed #cbd5e1; border-radius: 12px; background: #f8fafc;">
+                <div style="width:64px; height:64px; margin:0 auto 1rem; border-radius:50%; background:linear-gradient(135deg, rgba(4,83,203,.08), rgba(59,125,219,.12)); display:flex; align-items:center; justify-content:center;">
+                    <i class="fas fa-calendar-plus" style="color:#0453cb; font-size:1.5rem;"></i>
                 </div>
+                <h6 style="color:#1e293b; font-weight:600;">Aucune séance programmée</h6>
+                <p class="text-muted mb-3" style="font-size:.88rem;">Cet emploi du temps ne contient aucune séance.</p>
+                @can('create_timetable')
+                <a href="{{ route('esbtp.seances-cours.create', ['emploi_temps_id' => $emploiTemps->id]) }}"
+                   class="btn btn-primary btn-sm" style="border-radius:9px; font-weight:600;">
+                    <i class="fas fa-plus me-1"></i>Ajouter la première séance
+                </a>
+                @endcan
             </div>
         @endif
     </div>

--- a/resources/views/esbtp/emploi-temps/show.blade.php
+++ b/resources/views/esbtp/emploi-temps/show.blade.php
@@ -5,6 +5,302 @@
 @section('styles')
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 <style>
+    /* ═════════════════════════════════════════════════════════════════
+       Emploi du temps — show premium v1 (PR #221)
+       Namespace: ets-* (emploi-temps-show)
+       Pattern inspire de planning-header (ph-*)
+       ═════════════════════════════════════════════════════════════════ */
+
+    .ets-hero {
+        position: relative;
+        background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+        border-radius: 18px;
+        padding: 1.75rem 2rem 1.25rem;
+        color: #fff;
+        margin-bottom: 1.25rem;
+        overflow: hidden;
+    }
+    .ets-hero::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: radial-gradient(circle at 80% 20%, rgba(255,255,255,.12), transparent 60%);
+        pointer-events: none;
+    }
+
+    .ets-hero-top {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 1rem;
+        position: relative;
+        z-index: 2;
+    }
+    .ets-hero-left {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+        min-width: 0;
+    }
+    .ets-hero-icon {
+        width: 52px; height: 52px;
+        border-radius: 14px;
+        background: rgba(255,255,255,.14);
+        backdrop-filter: blur(8px);
+        border: 1px solid rgba(255,255,255,.2);
+        display: flex; align-items: center; justify-content: center;
+        font-size: 1.35rem; flex-shrink: 0; color: #fff;
+    }
+    .ets-hero-info { min-width: 0; }
+    .ets-hero-info h1 {
+        font-size: 1.4rem;
+        font-weight: 700;
+        color: #fff;
+        margin: 0;
+        letter-spacing: -.01em;
+    }
+    .ets-hero-info p {
+        margin: .15rem 0 0;
+        opacity: .78;
+        font-size: .85rem;
+    }
+    .ets-hero-chips {
+        display: flex;
+        gap: .4rem;
+        flex-wrap: wrap;
+        margin-top: .55rem;
+    }
+    .ets-hero-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: .3rem;
+        padding: .25rem .65rem;
+        background: rgba(255,255,255,.14);
+        border: 1px solid rgba(255,255,255,.2);
+        border-radius: 99px;
+        font-size: .72rem;
+        color: rgba(255,255,255,.92);
+        font-weight: 500;
+    }
+    .ets-hero-chip--success { background: rgba(16,185,129,.22); border-color: rgba(16,185,129,.35); color: #a7f3d0; }
+    .ets-hero-chip--muted   { background: rgba(148,163,184,.22); border-color: rgba(148,163,184,.3); color: #cbd5e1; }
+    .ets-hero-chip i { font-size: .65rem; }
+
+    .ets-hero-actions {
+        display: flex;
+        gap: .5rem;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        position: relative;
+        z-index: 3;
+    }
+    .ets-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: .4rem;
+        padding: .5rem 1rem;
+        border-radius: 10px;
+        font-size: .82rem;
+        font-weight: 600;
+        text-decoration: none;
+        transition: all .2s ease;
+        border: 1px solid transparent;
+        cursor: pointer;
+        white-space: nowrap;
+    }
+    .ets-btn--glass {
+        background: rgba(255,255,255,.15);
+        color: #fff;
+        border-color: rgba(255,255,255,.22);
+    }
+    .ets-btn--glass:hover { background: rgba(255,255,255,.25); color: #fff; }
+    .ets-btn--white {
+        background: #fff;
+        color: #0453cb;
+    }
+    .ets-btn--white:hover { background: #eef3ff; color: #033a8e; }
+
+    .ets-dropdown-menu {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 12px;
+        box-shadow: 0 12px 32px rgba(15,23,42,.15);
+        padding: .35rem;
+        min-width: 240px;
+        z-index: 1050;
+    }
+    .ets-dropdown-menu .dropdown-item {
+        color: #1e293b;
+        padding: .55rem .85rem;
+        border-radius: 8px;
+        font-size: .85rem;
+        display: flex;
+        align-items: center;
+        gap: .6rem;
+        transition: all .15s ease;
+    }
+    .ets-dropdown-menu .dropdown-item:hover { background: #f1f5f9; color: #0453cb; }
+    .ets-dropdown-menu .dropdown-item i { width: 16px; text-align: center; color: #0453cb; }
+    .ets-dropdown-menu .dropdown-item.text-danger i { color: #dc2626; }
+    .ets-dropdown-menu .dropdown-item.text-danger:hover { background: rgba(220,38,38,.06); color: #b91c1c; }
+    .ets-dropdown-divider {
+        height: 1px;
+        background: #e2e8f0;
+        margin: .3rem 0;
+    }
+
+    /* KPIs dans hero */
+    .ets-kpis {
+        display: flex;
+        gap: .65rem;
+        margin-top: 1.2rem;
+        flex-wrap: wrap;
+        position: relative;
+        z-index: 2;
+    }
+    .ets-kpi {
+        flex: 1;
+        min-width: 160px;
+        background: rgba(255,255,255,.1);
+        border: 1px solid rgba(255,255,255,.18);
+        border-radius: 12px;
+        padding: .75rem .9rem;
+        display: flex;
+        align-items: center;
+        gap: .75rem;
+    }
+    .ets-kpi-icon {
+        width: 36px; height: 36px;
+        border-radius: 9px;
+        background: rgba(255,255,255,.15);
+        display: flex; align-items: center; justify-content: center;
+        color: #fff;
+        font-size: .95rem;
+        flex-shrink: 0;
+    }
+    .ets-kpi-value {
+        font-size: 1.35rem;
+        font-weight: 700;
+        color: #fff;
+        line-height: 1;
+    }
+    .ets-kpi-label {
+        font-size: .72rem;
+        color: rgba(255,255,255,.72);
+        margin-top: .2rem;
+        text-transform: uppercase;
+        letter-spacing: .3px;
+    }
+
+    @media (max-width: 768px) {
+        .ets-hero { padding: 1.25rem 1.25rem 1rem; }
+        .ets-hero-info h1 { font-size: 1.15rem; }
+        .ets-hero-top { flex-direction: column; }
+        .ets-kpi { min-width: calc(50% - .35rem); }
+    }
+    @media (max-width: 480px) {
+        .ets-kpi { min-width: 100%; }
+    }
+
+    /* ═══════════════════════════════════════════════════════════
+       Modal config volumes — gradient bleu KLASSCI (pattern PR #220)
+       ═══════════════════════════════════════════════════════════ */
+    .ets-config-modal .modal-content {
+        border: none;
+        border-radius: 16px;
+        box-shadow: 0 24px 60px rgba(15,23,42,.25), 0 8px 20px rgba(4,83,203,.12);
+        overflow: hidden;
+    }
+    .ets-config-modal .modal-header {
+        background: linear-gradient(135deg, #0453cb 0%, #3b7ddb 100%);
+        color: #fff;
+        border-bottom: none;
+        padding: 1rem 1.5rem;
+    }
+    .ets-config-modal .modal-title {
+        font-weight: 700;
+        font-size: 1rem;
+        display: inline-flex;
+        align-items: center;
+        gap: .6rem;
+    }
+    .ets-config-modal .modal-title i {
+        width: 32px; height: 32px;
+        border-radius: 9px;
+        background: rgba(255,255,255,.16);
+        border: 1px solid rgba(255,255,255,.22);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: .88rem;
+        color: #fff;
+    }
+    .ets-config-modal .btn-close {
+        filter: invert(1) brightness(2);
+        opacity: .85;
+    }
+    .ets-config-modal .btn-close:hover { opacity: 1; }
+    .ets-config-modal .modal-body {
+        background: #fff;
+        padding: 1.5rem;
+    }
+    .ets-config-modal .modal-footer {
+        background: #f8fafc;
+        border-top: 1px solid #e2e8f0;
+        padding: 1rem 1.5rem;
+        gap: .5rem;
+    }
+    .ets-config-modal .modal-footer .btn {
+        border-radius: 10px;
+        font-weight: 600;
+        padding: .55rem 1.25rem;
+        font-size: .88rem;
+    }
+    .ets-config-modal .modal-footer .btn-light {
+        background: #fff;
+        color: #475569;
+        border: 1px solid #cbd5e1;
+    }
+    .ets-config-modal .modal-footer .btn-light:hover {
+        background: #f1f5f9;
+        border-color: #94a3b8;
+        color: #1e293b;
+    }
+    .ets-config-modal .modal-footer .btn-primary {
+        background: #0453cb;
+        border-color: #0453cb;
+        box-shadow: 0 2px 6px rgba(4,83,203,.2);
+    }
+    .ets-config-modal .modal-footer .btn-primary:hover {
+        background: #033a8e;
+        border-color: #033a8e;
+        transform: translateY(-1px);
+    }
+    .ets-config-modal .alert-info {
+        background: rgba(4,83,203,.06);
+        border: 1px solid rgba(4,83,203,.15);
+        color: #033a8e;
+        border-radius: 10px;
+        padding: .75rem 1rem;
+        font-size: .86rem;
+    }
+    .ets-config-modal .form-control,
+    .ets-config-modal .form-select {
+        border: 1.5px solid #e2e8f0;
+        border-radius: 9px;
+        font-size: .88rem;
+        transition: all .15s ease;
+    }
+    .ets-config-modal .form-control:focus,
+    .ets-config-modal .form-select:focus {
+        border-color: #0453cb;
+        box-shadow: 0 0 0 3px rgba(4,83,203,.1);
+        outline: none;
+    }
+
+    /* ═══════════════════════════════════════════════════════════ */
+
     .timetable-container {
         overflow-x: auto;
     }
@@ -331,39 +627,139 @@
 @section('content')
 <div class="dashboard-acasi">
     <div class="main-content">
-        <!-- Header Section -->
-        <div class="dashboard-header">
-            <div class="header-left">
-                <h1><i class="fas fa-calendar-alt me-2"></i>{{ $emploiTemps->titre ?? 'Emploi du Temps' }}</h1>
-                <p class="header-subtitle">
-                    Emploi du temps de {{ $emploiTemps->classe->name ?? 'Non défini' }}
-                    @if($emploiTemps->date_debut && $emploiTemps->date_fin)
-                        <br>
-                        <small class="text-muted">
-                            <i class="fas fa-calendar-day"></i> Du {{ \Carbon\Carbon::parse($emploiTemps->date_debut)->format('d/m/Y') }}
-                            au {{ \Carbon\Carbon::parse($emploiTemps->date_fin)->format('d/m/Y') }}
-                        </small>
-                    @endif
-                </p>
+
+        {{-- ═════════════════════════════════════════════════════════
+             HERO PREMIUM (ets-*)
+             ═════════════════════════════════════════════════════════ --}}
+        <div class="ets-hero">
+            <div class="ets-hero-top">
+                <div class="ets-hero-left">
+                    <div class="ets-hero-icon">
+                        <i class="fas fa-calendar-week"></i>
+                    </div>
+                    <div class="ets-hero-info">
+                        <h1>{{ $emploiTemps->titre ?: ('Emploi du temps — ' . ($emploiTemps->classe->name ?? 'Non défini')) }}</h1>
+                        <p>
+                            {{ $emploiTemps->classe->filiere->name ?? 'Filière' }} ·
+                            {{ $emploiTemps->classe->niveau->name ?? 'Niveau' }} ·
+                            {{ $emploiTemps->annee->name ?? 'Année' }}
+                        </p>
+                        <div class="ets-hero-chips">
+                            @if($emploiTemps->is_active ?? true)
+                                <span class="ets-hero-chip ets-hero-chip--success">
+                                    <i class="fas fa-circle"></i> Actif
+                                </span>
+                            @else
+                                <span class="ets-hero-chip ets-hero-chip--muted">
+                                    <i class="fas fa-circle"></i> Inactif
+                                </span>
+                            @endif
+                            @if($emploiTemps->is_current ?? false)
+                                <span class="ets-hero-chip">
+                                    <i class="fas fa-star"></i> Courant
+                                </span>
+                            @endif
+                            @if(isset($emploiTemps->semestre) && in_array($emploiTemps->semestre, ['Semestre 1', 'Semestre 2'], true))
+                                <span class="ets-hero-chip">
+                                    <i class="fas fa-calendar"></i> {{ $emploiTemps->semestre }}
+                                </span>
+                            @endif
+                            @if($emploiTemps->date_debut && $emploiTemps->date_fin)
+                                <span class="ets-hero-chip">
+                                    <i class="fas fa-calendar-day"></i>
+                                    {{ \Carbon\Carbon::parse($emploiTemps->date_debut)->format('d/m') }}
+                                    →
+                                    {{ \Carbon\Carbon::parse($emploiTemps->date_fin)->format('d/m/Y') }}
+                                </span>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+
+                <div class="ets-hero-actions">
+                    <a href="{{ route('esbtp.emploi-temps.index') }}" class="ets-btn ets-btn--glass">
+                        <i class="fas fa-arrow-left"></i> Retour
+                    </a>
+                    <div class="dropdown">
+                        <button type="button" class="ets-btn ets-btn--glass" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Actions">
+                            <i class="fas fa-ellipsis-v"></i>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end ets-dropdown-menu">
+                            <li>
+                                <a class="dropdown-item" href="{{ route('esbtp.emploi-temps.preview', ['emploi_temp' => $emploiTemps->id]) }}" target="_blank">
+                                    <i class="fas fa-eye"></i> Prévisualiser PDF
+                                </a>
+                            </li>
+                            <li>
+                                <a class="dropdown-item" href="{{ route('esbtp.emploi-temps.export-pdf', ['emploi_temp' => $emploiTemps->id]) }}" target="_blank">
+                                    <i class="fas fa-file-pdf"></i> Télécharger PDF
+                                </a>
+                            </li>
+                            <li><div class="ets-dropdown-divider"></div></li>
+                            @can('edit_timetables')
+                            <li>
+                                <a class="dropdown-item" href="{{ route('esbtp.emploi-temps.edit', ['emploi_temp' => $emploiTemps->id]) }}">
+                                    <i class="fas fa-edit"></i> Modifier l'emploi
+                                </a>
+                            </li>
+                            @endcan
+                            @can('delete_timetables')
+                            <li>
+                                <button type="button" class="dropdown-item text-danger" onclick="etsDeleteEmploi()">
+                                    <i class="fas fa-trash"></i> Supprimer l'emploi
+                                </button>
+                            </li>
+                            @endcan
+                        </ul>
+                    </div>
+                    @can('create_timetable')
+                    <a href="{{ route('esbtp.seances-cours.create', ['emploi_temps_id' => $emploiTemps->id]) }}" class="ets-btn ets-btn--white">
+                        <i class="fas fa-plus"></i> Séance
+                    </a>
+                    @endcan
+                </div>
             </div>
-            <div class="header-actions">
-                <a href="{{ route('esbtp.emploi-temps.index') }}" class="btn-acasi secondary">
-                    <i class="fas fa-arrow-left"></i>Retour à la liste
-                </a>
-                <a href="{{ route('esbtp.emploi-temps.preview', ['emploi_temp' => $emploiTemps->id]) }}" class="btn-acasi info" target="_blank">
-                    <i class="fas fa-eye"></i>Prévisualiser PDF
-                </a>
-                <a href="{{ route('esbtp.emploi-temps.export-pdf', ['emploi_temp' => $emploiTemps->id]) }}" class="btn-acasi danger" target="_blank">
-                    <i class="fas fa-file-pdf"></i>Générer PDF
-                </a>
-                <a href="{{ route('esbtp.emploi-temps.edit', ['emploi_temp' => $emploiTemps->id]) }}" class="btn-acasi warning">
-                    <i class="fas fa-edit"></i>Modifier
-                </a>
-                <a href="{{ route('esbtp.seances-cours.create', ['emploi_temps_id' => $emploiTemps->id]) }}" class="btn-acasi primary">
-                    <i class="fas fa-plus"></i>Ajouter une séance
-                </a>
+
+            {{-- KPIs --}}
+            <div class="ets-kpis">
+                <div class="ets-kpi">
+                    <div class="ets-kpi-icon"><i class="fas fa-clock"></i></div>
+                    <div>
+                        <div class="ets-kpi-value">{{ $heroKpis['total_seances'] }}</div>
+                        <div class="ets-kpi-label">Séances programmées</div>
+                    </div>
+                </div>
+                <div class="ets-kpi">
+                    <div class="ets-kpi-icon"><i class="fas fa-hourglass-half"></i></div>
+                    <div>
+                        <div class="ets-kpi-value">{{ number_format($heroKpis['heures_planifiees'], 0) }}h</div>
+                        <div class="ets-kpi-label">Heures planifiées</div>
+                    </div>
+                </div>
+                <div class="ets-kpi">
+                    <div class="ets-kpi-icon"><i class="fas fa-chart-line"></i></div>
+                    <div>
+                        <div class="ets-kpi-value">{{ $heroKpis['pourcentage_restant'] }}%</div>
+                        <div class="ets-kpi-label">Volume restant</div>
+                    </div>
+                </div>
+                <div class="ets-kpi">
+                    <div class="ets-kpi-icon"><i class="fas fa-chalkboard-teacher"></i></div>
+                    <div>
+                        <div class="ets-kpi-value">{{ $heroKpis['enseignants'] }}</div>
+                        <div class="ets-kpi-label">Enseignants</div>
+                    </div>
+                </div>
             </div>
         </div>
+
+        {{-- Form cache suppression emploi (declenche via kebab menu) --}}
+        @can('delete_timetables')
+        <form id="ets-delete-emploi-form" method="POST" action="{{ route('esbtp.emploi-temps.destroy', ['emploi_temp' => $emploiTemps->id]) }}" style="display:none;">
+            @csrf
+            @method('DELETE')
+        </form>
+        @endcan
 
         @if (session('success'))
             <div class="alert alert-success border-start border-success border-4 mb-4">
@@ -448,39 +844,40 @@
 </div>
 
 <!-- Modal de Configuration des Volumes Horaires -->
-<div class="modal fade" id="volumeConfigModal" tabindex="-1" aria-labelledby="volumeConfigModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
+<div class="modal fade ets-config-modal" id="volumeConfigModal" tabindex="-1" aria-labelledby="volumeConfigModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-centered">
         <div class="modal-content">
-            <div class="modal-header bg-primary text-white">
+            <div class="modal-header">
                 <h5 class="modal-title" id="volumeConfigModalLabel">
-                    <i class="fas fa-cog me-2"></i>
-                    Configuration des Volumes Horaires
+                    <i class="fas fa-cog"></i>
+                    <span>Configuration des volumes horaires</span>
                 </h5>
-                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
             </div>
             <div class="modal-body">
-                <div class="config-header mb-4">
-                    <h6 class="mb-1">Combinaison sélectionnée</h6>
-                    <p class="text-muted mb-0" id="config-combination-name">{{ $emploiTemps->classe->filiere->name ?? 'Filière' }} - {{ $emploiTemps->classe->niveau->name ?? 'Niveau' }}</p>
+                <div class="alert alert-info mb-3">
+                    <i class="fas fa-info-circle me-2"></i>
+                    <strong>Combinaison :</strong>
+                    <span id="config-combination-name">{{ $emploiTemps->classe->filiere->name ?? 'Filière' }} · {{ $emploiTemps->classe->niveau->name ?? 'Niveau' }}</span>
                 </div>
-                
+
                 <form id="volume-config-form">
                     <input type="hidden" id="config-filiere-id" name="filiere_id" value="{{ $emploiTemps->classe->filiere_id ?? '' }}">
                     <input type="hidden" id="config-niveau-id" name="niveau_id" value="{{ $emploiTemps->classe->niveau_etude_id ?? '' }}">
                     <input type="hidden" id="config-annee-id" name="annee_id" value="{{ $emploiTemps->annee->id ?? '' }}">
-                    
+
                     <div class="config-loading text-center py-4" id="config-loading" style="display: none;">
                         <i class="fas fa-spinner fa-spin fa-2x mb-3"></i>
-                        <p>Chargement des matières...</p>
+                        <p class="text-muted">Chargement des matières...</p>
                     </div>
-                    
+
                     <div id="matieres-container">
                         <!-- Les matières seront chargées ici via AJAX -->
                     </div>
                 </form>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                <button type="button" class="btn btn-light" data-bs-dismiss="modal">
                     <i class="fas fa-times me-1"></i>Annuler
                 </button>
                 <button type="button" class="btn btn-primary" id="save-volume-config">
@@ -493,7 +890,47 @@
 @endsection
 
 @section('scripts')
+<script src="{{ asset('js/inscriptions/common.js') }}"></script>
 <script>
+    // ═════════════════════════════════════════════════════════════════
+    // Emploi-temps show — actions premium (delete emploi, delete seance)
+    // ═════════════════════════════════════════════════════════════════
+
+    window.etsDeleteEmploi = async function () {
+        const ok = await window.iiConfirm({
+            title: "Supprimer l'emploi du temps",
+            message: "Cette action supprimera l'emploi du temps et toutes ses séances. Les données ne pourront pas être récupérées. Confirmer ?",
+            confirmLabel: 'Supprimer',
+            cancelLabel: 'Annuler',
+            danger: true,
+        });
+        if (!ok) return;
+        const form = document.getElementById('ets-delete-emploi-form');
+        if (form) form.submit();
+    };
+
+    window.etsDeleteSeance = async function (seanceId, matiereName) {
+        const ok = await window.iiConfirm({
+            title: "Supprimer la séance",
+            message: `Confirmer la suppression de la séance « ${matiereName || 'Séance'} » ? Cette action est irréversible.`,
+            confirmLabel: 'Supprimer',
+            cancelLabel: 'Annuler',
+            danger: true,
+        });
+        if (!ok) return;
+
+        const form = document.createElement('form');
+        form.method = 'POST';
+        form.action = `/esbtp/seances-cours/${seanceId}`;
+        form.style.display = 'none';
+        form.innerHTML = `
+            <input type="hidden" name="_token" value="{{ csrf_token() }}">
+            <input type="hidden" name="_method" value="DELETE">
+        `;
+        document.body.appendChild(form);
+        form.submit();
+    };
+
     // Variables globales pour le modal de configuration
     let currentFiliereId = null;
     let currentNiveauId = null;


### PR DESCRIPTION
## Résumé

Premier lot du redesign `/esbtp/emploi-temps/{id}` validé via /plan-and-confirm FULL (critic + codebase + docs + web search). Split en 3 PRs incrémentales, single-column layout, grille engine préservée.

Closes #221

## Ce qui change (côté utilisateur)

### 1. Hero premium

| Avant | Maintenant |
|-------|------------|
| Header basique avec 5 boutons plats | Hero gradient bleu KLASSCI avec icône glass 52×52 |
| Titre puis sous-titre séparé en dates | Titre + sous-titre + chips contextuels (Actif/Courant/Semestre/dates) |
| Aucun KPI visible | 4 KPIs dans hero : Séances / Heures planifiées / % restant / Enseignants |
| Preview PDF + Generate PDF + Modifier côte à côte | 1 bouton `+ Séance` + menu kebab regroupant PDF/Modifier/Supprimer |

### 2. Fix boutons morts (liste-seances)

Avant : boutons Modifier et Supprimer dans la table `liste-seances.blade.php:117-125` ne fonctionnaient PAS en production :
- Modifier : pas de `href`, pas de route
- Supprimer : `confirm()` natif avec commentaire stub `/* Action supprimer */`

Maintenant :
- Modifier → `route('seances-cours.edit', $seance)` + garde permission `edit_timetables`
- Supprimer → `iiConfirm()` modal premium (Promise-based) + form POST `seances-cours.destroy` + garde permission `delete_timetables`
- Même pattern pour suppression de l'emploi du temps via kebab menu

### 3. Modal volumeConfigModal redesign

Alignement sur le pattern PR #220 (modals inscriptions admin) :
- Header gradient bleu KLASSCI (plus `bg-primary` flat)
- Icône titre en badge glass 32×32 avec glass effect
- Form inputs border 1.5px, focus ring bleu
- Buttons btn-primary solide bleu, btn-light blanc cadre

### 4. Setting configurable `emploi_temps.show_sunday`

- Nouvelle entrée dans `esbtp_system_settings` (key=emploi_temps.show_sunday, type=boolean, default false)
- Controller lit la valeur et ajoute dimanche dans `joursNoms` si true
- Pas de hardcode : respect de la rule `feedback_always_configurable_settings`
- Peut être activé via l'interface Settings tenant si un établissement a des cours le dimanche

### 5. Monochrome cleanup (liste-seances)

Selon la rule `premium-redesign.md` (mise à jour dans ce PR pour clarifier les couleurs sémantiques autorisées) :
- Header table `thead.table-dark` (noir) → fond `#f8fafc` avec typographie bleue
- Badges types (CM/TD/TP/PAUSE) : multicolore → monochrome bleu tonal avec opacity/border/dashed
- Badge statut Actif : conserve vert `success` (**sens fonctionnel autorisé**)
- Badge statut Inactif : gris neutre
- Icône matière : gradient bleu KLASSCI
- Répartition par type : cards monochrome bleues
- Empty state : card premium avec icône gradient bleu

## Rule `.claude/rules/premium-redesign.md` mise à jour

Ajout d'une section "Couleurs sémantiques autorisées" clarifiant que success/warning/danger sont OK **quand elles portent un sens fonctionnel** (statut, action destructive, alerte) mais PAS comme décoration ou différenciation de catégories neutres.

Feedback user 2026-04-17 : "certains warning danger meritent d'avoir leur couleurs aussi juste le tout doit avoir les couleurs KLASSCI tout simplement".

## Non scope (reporté aux PRs suivantes)

- **PR2 (layout + tabs)** : structure single-col avec tabs Alpine `Infos | Planification | Liste` sous la grille, barres de progression monochrome par matière, URL hash sync, event delegation
- **PR3 (grille polish)** : auto-hide dimanche selon setting + légende chips filtrantes + kebab séance persistent desktop / tap-to-reveal mobile + empty cell affordance + monochrome tonal complet
- **Epic séparée** : détection conflits enseignants / dupliquer séance / export Excel / print CSS optimisé

## Décisions validées par agents

| Agent | Décision clé |
|-------|--------------|
| **Critic** | PROCEED WITH CHANGES. Single-col obligatoire (pas 2-col — tablet 1024px). Garder Liste séances (use case is_active). Persistent kebab + tap-to-reveal. Split 3 PRs. Préserver grid engine (604 lignes). |
| **Codebase** | planning-header (ph-*) existe mais trop spécifique (routes hardcodées) → copier le pattern en ets-*. `common.js` iiConfirm réutilisable. Settings pattern simple. |
| **Docs** | Alpine x-show (pas x-if). BS5 dropdowns click+hover natif. ARIA role=grid. Event delegation. |
| **Web UX** | NN/g + Google Calendar + Apple HIG : tap-to-reveal touch, monochrome tonal > multicolore, warn (pas block) sur conflits. |

## Tests à faire après merge

- [ ] `/esbtp/emploi-temps/{id}` charge avec hero premium + 4 KPIs
- [ ] Chips dans hero reflètent statut (Actif/Courant/Semestre/dates)
- [ ] Bouton `+ Séance` → route seances-cours.create
- [ ] Menu kebab ouvre dropdown avec 4 items
- [ ] Preview PDF + Download PDF fonctionnent
- [ ] Modifier EDT → route edit
- [ ] Supprimer EDT → iiConfirm modal premium, si OK suppression
- [ ] Dans liste séances, bouton Modifier → route edit séance
- [ ] Dans liste séances, bouton Supprimer → iiConfirm, si OK suppression séance
- [ ] Modal Config volumes (si planif non configurée) affiche avec gradient bleu
- [ ] Badge Actif (vert) et Inactif (gris) visibles
- [ ] Badges types séances en monochrome bleu (plus de multicolore)
- [ ] Header table blanc (plus noir)

## Risques

- Grid engine non touché (604 lignes de calculs server-side) → zéro régression sur la timetable
- Dead buttons fixés : action destructive maintenant fonctionnelle (iiConfirm garde l'utilisateur)
- Setting show_sunday default false → pas de changement comportement actuel pour tenants existants
- Rule premium-redesign mise à jour → applicable rétroactivement aux prochains designs