### PR TITLE
fix(emploi-temps): dropdown kebab deborde a droite sur show page

### DIFF
--- a/resources/views/esbtp/emploi-temps/show.blade.php
+++ b/resources/views/esbtp/emploi-temps/show.blade.php
@@ -18,7 +18,7 @@
         padding: 1.75rem 2rem 1.25rem;
         color: #fff;
         margin-bottom: 1.25rem;
-        overflow: hidden;
+        /* Pas d'overflow:hidden — le dropdown du menu kebab doit pouvoir s'etendre */
     }
     .ets-hero::before {
         content: '';
@@ -26,6 +26,15 @@
         inset: 0;
         background: radial-gradient(circle at 80% 20%, rgba(255,255,255,.12), transparent 60%);
         pointer-events: none;
+        border-radius: inherit;
+    }
+    /* Safety: dropdown du kebab toujours au-dessus + aligne sur le droit */
+    .ets-hero-actions .dropdown-menu {
+        z-index: 1060;
+    }
+    .ets-hero-actions .dropdown-menu-end[data-bs-popper] {
+        right: 0;
+        left: auto;
     }
 
     .ets-hero-top {
@@ -680,8 +689,13 @@
                     <a href="{{ route('esbtp.emploi-temps.index') }}" class="ets-btn ets-btn--glass">
                         <i class="fas fa-arrow-left"></i> Retour
                     </a>
+                    @can('create_timetable')
+                    <a href="{{ route('esbtp.seances-cours.create', ['emploi_temps_id' => $emploiTemps->id]) }}" class="ets-btn ets-btn--white">
+                        <i class="fas fa-plus"></i> Séance
+                    </a>
+                    @endcan
                     <div class="dropdown">
-                        <button type="button" class="ets-btn ets-btn--glass" data-bs-toggle="dropdown" aria-expanded="false" aria-label="Actions">
+                        <button type="button" class="ets-btn ets-btn--glass" data-bs-toggle="dropdown" data-bs-auto-close="true" aria-expanded="false" aria-label="Actions">
                             <i class="fas fa-ellipsis-v"></i>
                         </button>
                         <ul class="dropdown-menu dropdown-menu-end ets-dropdown-menu">
@@ -712,11 +726,6 @@
                             @endcan
                         </ul>
                     </div>
-                    @can('create_timetable')
-                    <a href="{{ route('esbtp.seances-cours.create', ['emploi_temps_id' => $emploiTemps->id]) }}" class="ets-btn ets-btn--white">
-                        <i class="fas fa-plus"></i> Séance
-                    </a>
-                    @endcan
                 </div>
             </div>
 


### PR DESCRIPTION
## Probleme

Le menu kebab dans le hero de /esbtp/emploi-temps/{id} debordait du viewport a droite. Items Previsualiser PDF / Telecharger PDF / Modifier l'emploi etaient coupes.

## Cause

1. Kebab au MILIEU des actions (entre Retour et + Seance) -> dropdown-menu-end alignait sur un point milieu, pas sur le bord droit reel de la row
2. overflow:hidden sur .ets-hero clippait le dropdown

## Fix

- Reorder : kebab en DERNIERE position (apres + Seance)
- Retirer overflow:hidden sur .ets-hero + border-radius:inherit sur ::before
- Safety CSS : z-index 1060 + right:0;left:auto force dropdown-menu-end