### PR TITLE
feat(emploi-temps): PR2 layout + tabs (Infos / Planification / Liste seances)

### DIFF
--- a/resources/views/components/emploi-temps/info-stats-section.blade.php
+++ b/resources/views/components/emploi-temps/info-stats-section.blade.php
@@ -1,96 +1,291 @@
 @props(['emploiTemps', 'matiereStats' => []])
 
-<div class="row mb-4">
-    <!-- Section: Informations -->
-    <div class="col-lg-6">
-        <div class="main-card h-100">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-info-circle"></i>
-                    Informations
+@once
+<style>
+    .eis-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 1rem;
+    }
+    .eis-card {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        padding: 1.1rem 1.25rem;
+        box-shadow: 0 1px 3px rgba(15,23,42,.04);
+    }
+    .eis-card-title {
+        display: flex;
+        align-items: center;
+        gap: .55rem;
+        font-size: .82rem;
+        font-weight: 700;
+        color: #0f172a;
+        text-transform: uppercase;
+        letter-spacing: .4px;
+        margin-bottom: .85rem;
+    }
+    .eis-card-title i {
+        width: 26px;
+        height: 26px;
+        border-radius: 7px;
+        background: rgba(4,83,203,.1);
+        color: #0453cb;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: .72rem;
+    }
+
+    /* Info rows */
+    .eis-row {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        padding: .5rem 0;
+        border-bottom: 1px solid #f1f5f9;
+        font-size: .85rem;
+        gap: 1rem;
+    }
+    .eis-row:last-child { border-bottom: none; }
+    .eis-row-label {
+        color: #64748b;
+        font-weight: 500;
+    }
+    .eis-row-value {
+        color: #1e293b;
+        font-weight: 600;
+        text-align: right;
+        min-width: 0;
+        word-break: break-word;
+    }
+    .eis-row-value .badge { font-weight: 600; }
+
+    /* Stats (types) */
+    .eis-types {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+        gap: .55rem;
+    }
+    .eis-type {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        padding: .6rem .5rem;
+        border-radius: 10px;
+        background: #f8fafc;
+        border: 1px solid #e2e8f0;
+        transition: all .15s ease;
+    }
+    .eis-type:hover {
+        border-color: #0453cb;
+        background: #fff;
+    }
+    .eis-type-icon {
+        width: 30px;
+        height: 30px;
+        border-radius: 7px;
+        background: rgba(4,83,203,.1);
+        color: #0453cb;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: .78rem;
+        margin-bottom: .35rem;
+    }
+    .eis-type-value {
+        font-size: 1.1rem;
+        font-weight: 700;
+        color: #0f172a;
+        line-height: 1;
+    }
+    .eis-type-label {
+        font-size: .68rem;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: .3px;
+        margin-top: .3rem;
+    }
+
+    /* Matieres count list */
+    .eis-matieres-list {
+        max-height: 220px;
+        overflow-y: auto;
+        padding-right: .25rem;
+    }
+    .eis-matieres-list::-webkit-scrollbar { width: 4px; }
+    .eis-matieres-list::-webkit-scrollbar-thumb {
+        background: #cbd5e1;
+        border-radius: 2px;
+    }
+    .eis-matiere-row {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: .4rem 0;
+        font-size: .82rem;
+        border-bottom: 1px solid #f8fafc;
+    }
+    .eis-matiere-row:last-child { border-bottom: none; }
+    .eis-matiere-row-name { color: #1e293b; }
+    .eis-matiere-row-count {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 28px;
+        padding: .2rem .5rem;
+        background: rgba(4,83,203,.08);
+        color: #0453cb;
+        border-radius: 99px;
+        font-size: .75rem;
+        font-weight: 700;
+    }
+
+    /* Totals row */
+    .eis-totals {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: .75rem;
+        margin-top: .85rem;
+        padding-top: .85rem;
+        border-top: 1px solid #e2e8f0;
+    }
+    .eis-total {
+        text-align: center;
+        padding: .5rem;
+        background: rgba(4,83,203,.04);
+        border-radius: 8px;
+    }
+    .eis-total-value {
+        font-size: 1.3rem;
+        font-weight: 700;
+        color: #0453cb;
+        line-height: 1;
+    }
+    .eis-total-label {
+        font-size: .7rem;
+        color: #64748b;
+        text-transform: uppercase;
+        letter-spacing: .3px;
+        margin-top: .3rem;
+    }
+</style>
+@endonce
+
+@php
+    $seances = is_object($emploiTemps) && is_object($emploiTemps->seances) ? $emploiTemps->seances : collect();
+    $countTypes = [
+        'course' => $seances->where('type', 'course')->count(),
+        'homework' => $seances->where('type', 'homework')->count(),
+        'break' => $seances->where('type', 'break')->count(),
+        'lunch' => $seances->where('type', 'lunch')->count(),
+    ];
+    $typeLabels = [
+        'course' => 'Cours',
+        'homework' => 'Devoirs',
+        'break' => 'Récréations',
+        'lunch' => 'Pauses',
+    ];
+    $typeIcons = [
+        'course' => 'fa-chalkboard',
+        'homework' => 'fa-pencil-alt',
+        'break' => 'fa-coffee',
+        'lunch' => 'fa-utensils',
+    ];
+    $totalSeances = $seances->count();
+    $activesCount = $seances->where('is_active', 1)->count();
+    $statut = ($emploiTemps->is_active ?? false) ? 'Actif' : 'Inactif';
+    $periode = match($emploiTemps->semestre ?? null) {
+        'Semestre 1' => 'Semestre 1',
+        'Semestre 2' => 'Semestre 2',
+        default => 'Année complète',
+    };
+@endphp
+
+<div class="eis-grid">
+    {{-- Card 1 : Informations détaillées --}}
+    <div class="eis-card">
+        <div class="eis-card-title"><i class="fas fa-info-circle"></i> Détails emploi du temps</div>
+
+        <div class="eis-row">
+            <span class="eis-row-label">Période</span>
+            <span class="eis-row-value">{{ $periode }}</span>
+        </div>
+        @if($emploiTemps->date_debut && $emploiTemps->date_fin)
+        <div class="eis-row">
+            <span class="eis-row-label">Dates</span>
+            <span class="eis-row-value">
+                {{ \Carbon\Carbon::parse($emploiTemps->date_debut)->format('d/m/Y') }}
+                →
+                {{ \Carbon\Carbon::parse($emploiTemps->date_fin)->format('d/m/Y') }}
+            </span>
+        </div>
+        @endif
+        <div class="eis-row">
+            <span class="eis-row-label">Statut</span>
+            <span class="eis-row-value">
+                @if($emploiTemps->is_active ?? false)
+                    <span class="els-status-active"><i class="fas fa-check"></i> Actif</span>
+                @else
+                    <span class="els-status-inactive"><i class="fas fa-pause"></i> Inactif</span>
+                @endif
+                @if($emploiTemps->is_current ?? false)
+                    <span class="ms-1 badge" style="background:rgba(4,83,203,.12); color:#0453cb;">Courant</span>
+                @endif
+            </span>
+        </div>
+        @if($emploiTemps->created_at)
+        <div class="eis-row">
+            <span class="eis-row-label">Créé le</span>
+            <span class="eis-row-value">{{ $emploiTemps->created_at->format('d/m/Y') }}</span>
+        </div>
+        @endif
+        @if($emploiTemps->updated_at)
+        <div class="eis-row">
+            <span class="eis-row-label">Dernière modif.</span>
+            <span class="eis-row-value">{{ $emploiTemps->updated_at->diffForHumans() }}</span>
+        </div>
+        @endif
+    </div>
+
+    {{-- Card 2 : Stats types séances --}}
+    <div class="eis-card">
+        <div class="eis-card-title"><i class="fas fa-layer-group"></i> Types de séances</div>
+
+        <div class="eis-types">
+            @foreach($countTypes as $type => $count)
+                <div class="eis-type">
+                    <div class="eis-type-icon"><i class="fas {{ $typeIcons[$type] }}"></i></div>
+                    <div class="eis-type-value">{{ $count }}</div>
+                    <div class="eis-type-label">{{ $typeLabels[$type] }}</div>
                 </div>
-                <div class="main-card-subtitle">Détails de l'emploi du temps</div>
+            @endforeach
+        </div>
+
+        <div class="eis-totals">
+            <div class="eis-total">
+                <div class="eis-total-value">{{ $totalSeances }}</div>
+                <div class="eis-total-label">Total séances</div>
             </div>
-            <div class="main-card-body">
-                <div class="info-list">
-                    <p class="mb-2"><strong>Classe :</strong> {{ is_object($emploiTemps) && is_object($emploiTemps->classe) ? $emploiTemps->classe->name : 'Non définie' }}</p>
-                    <p class="mb-2"><strong>Filière :</strong> {{ is_object($emploiTemps) && is_object($emploiTemps->classe) && is_object($emploiTemps->classe->filiere) ? $emploiTemps->classe->filiere->name : 'Non définie' }}</p>
-                    <p class="mb-2"><strong>Niveau :</strong> {{ is_object($emploiTemps) && is_object($emploiTemps->classe) && is_object($emploiTemps->classe->niveau) ? $emploiTemps->classe->niveau->name : 'Non défini' }}</p>
-                    <p class="mb-2"><strong>Année universitaire :</strong> {{ is_object($emploiTemps) && is_object($emploiTemps->annee) ? $emploiTemps->annee->name : 'Non définie' }}</p>
-                    <p class="mb-2">
-                        <strong>Période :</strong>
-                        @if(isset($emploiTemps->semestre) && $emploiTemps->semestre == 'Semestre 1')
-                            Semestre 1
-                        @elseif(isset($emploiTemps->semestre) && $emploiTemps->semestre == 'Semestre 2')
-                            Semestre 2
-                        @else
-                            Année complète
-                        @endif
-                    </p>
-                    <p class="mb-2">
-                        <strong>Statut :</strong>
-                        @if(isset($emploiTemps->is_active) && $emploiTemps->is_active)
-                            <span class="badge bg-success">Actif</span>
-                        @else
-                            <span class="badge bg-secondary">Inactif</span>
-                        @endif
-                        @if(isset($emploiTemps->is_current) && $emploiTemps->is_current)
-                            <span class="badge bg-info ms-1">Courant</span>
-                        @endif
-                    </p>
-                </div>
+            <div class="eis-total">
+                <div class="eis-total-value">{{ $activesCount }}</div>
+                <div class="eis-total-label">Séances actives</div>
             </div>
         </div>
     </div>
 
-    <!-- Section: Statistiques -->
-    <div class="col-lg-6">
-        <div class="main-card h-100">
-            <div class="main-card-header">
-                <div class="main-card-title">
-                    <i class="fas fa-chart-pie"></i>
-                    Statistiques
+    {{-- Card 3 : Séances par matière (if any) --}}
+    @if(!empty($matiereStats))
+    <div class="eis-card">
+        <div class="eis-card-title"><i class="fas fa-book"></i> Séances par matière</div>
+        <div class="eis-matieres-list">
+            @foreach($matiereStats as $matiere => $count)
+                <div class="eis-matiere-row">
+                    <span class="eis-matiere-row-name">{{ $matiere }}</span>
+                    <span class="eis-matiere-row-count">{{ $count }}</span>
                 </div>
-                <div class="main-card-subtitle">Répartition des séances</div>
-            </div>
-            <div class="main-card-body">
-                <div class="stats-grid">
-                    <div class="stat-item mb-3">
-                        <h6>Types de séances</h6>
-                        <div class="d-flex flex-wrap gap-2">
-                            <span class="badge bg-primary">{{ is_object($emploiTemps) && is_object($emploiTemps->seances) ? $emploiTemps->seances->where('type', 'course')->count() : '0' }} cours</span>
-                            <span class="badge bg-success">{{ is_object($emploiTemps) && is_object($emploiTemps->seances) ? $emploiTemps->seances->where('type', 'homework')->count() : '0' }} devoirs</span>
-                            <span class="badge bg-warning">{{ is_object($emploiTemps) && is_object($emploiTemps->seances) ? $emploiTemps->seances->where('type', 'break')->count() : '0' }} récréations</span>
-                            <span class="badge bg-info">{{ is_object($emploiTemps) && is_object($emploiTemps->seances) ? $emploiTemps->seances->where('type', 'lunch')->count() : '0' }} pauses</span>
-                        </div>
-                    </div>
-                    <div class="stat-item mb-3">
-                        <h6>Séances par matière</h6>
-                        <div style="max-height: 120px; overflow-y: auto;">
-                            @if(isset($matiereStats) && is_array($matiereStats))
-                                @foreach($matiereStats as $matiere => $count)
-                                    <div class="d-flex justify-content-between mb-1">
-                                        <span>{{ $matiere }}</span>
-                                        <span class="badge bg-light text-dark">{{ $count }}</span>
-                                    </div>
-                                @endforeach
-                            @else
-                                <small class="text-muted">Aucune donnée disponible</small>
-                            @endif
-                        </div>
-                    </div>
-                    <div class="stat-item">
-                        <div class="d-flex justify-content-between">
-                            <span>Total séances :</span>
-                            <strong>{{ is_object($emploiTemps) && is_object($emploiTemps->seances) ? $emploiTemps->seances->count() : '0' }}</strong>
-                        </div>
-                        <div class="d-flex justify-content-between">
-                            <span>Séances actives :</span>
-                            <strong>{{ is_object($emploiTemps) && is_object($emploiTemps->seances) ? $emploiTemps->seances->where('is_active', 1)->count() : '0' }}</strong>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            @endforeach
         </div>
     </div>
+    @endif
 </div>

--- a/resources/views/components/emploi-temps/liste-seances.blade.php
+++ b/resources/views/components/emploi-temps/liste-seances.blade.php
@@ -111,18 +111,30 @@
         color: #94a3b8;
         margin-top: .15rem;
     }
+    .els-wrap {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        box-shadow: 0 1px 3px rgba(15,23,42,.04);
+        overflow: hidden;
+    }
 </style>
 @endonce
 
-<div class="main-card mb-4">
-    <div class="main-card-header">
-        <div class="main-card-title">
-            <i class="fas fa-list-ul"></i>
-            Liste des séances
+<div class="els-wrap">
+    <div style="padding: 1rem 1.25rem; border-bottom: 1px solid #e2e8f0; display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:.5rem;">
+        <div style="display:flex; align-items:center; gap:.55rem; font-weight:700; color:#0f172a; font-size:.9rem;">
+            <i class="fas fa-list-ul" style="color:#0453cb;"></i>
+            {{ $seances->count() }} séance(s) programmée(s)
         </div>
-        <div class="main-card-subtitle">{{ $seances->count() }} séance(s) programmée(s)</div>
+        @can('create_timetable')
+        <a href="{{ route('esbtp.seances-cours.create', ['emploi_temps_id' => $emploiTemps->id]) }}"
+           class="btn btn-sm btn-primary" style="border-radius:9px; font-weight:600; background:#0453cb; border-color:#0453cb;">
+            <i class="fas fa-plus me-1"></i>Ajouter
+        </a>
+        @endcan
     </div>
-    <div class="main-card-body">
+    <div style="padding: 0 1.25rem 1rem;">
         @if($seances && $seances->count() > 0)
             <div class="table-responsive">
                 <table class="table els-table mb-0">

--- a/resources/views/components/emploi-temps/planification-section.blade.php
+++ b/resources/views/components/emploi-temps/planification-section.blade.php
@@ -1,132 +1,297 @@
 @props(['planificationData' => null, 'emploiTemps'])
 
-@if(isset($planificationData) && !empty($planificationData))
-<div class="main-card mb-4">
-    <div class="main-card-header">
-        <div class="main-card-title">
+@once
+<style>
+    .epl-card {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        box-shadow: 0 1px 3px rgba(15,23,42,.04);
+        overflow: hidden;
+    }
+    .epl-header {
+        padding: 1rem 1.25rem;
+        border-bottom: 1px solid #e2e8f0;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: .5rem;
+    }
+    .epl-header-title {
+        display: flex;
+        align-items: center;
+        gap: .6rem;
+        color: #0f172a;
+        font-weight: 700;
+        font-size: .92rem;
+    }
+    .epl-header-title i {
+        width: 28px;
+        height: 28px;
+        border-radius: 8px;
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        color: #fff;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: .75rem;
+    }
+    .epl-header-summary {
+        display: flex;
+        gap: 1rem;
+        font-size: .82rem;
+    }
+    .epl-summary-item {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-end;
+    }
+    .epl-summary-value {
+        color: #0f172a;
+        font-weight: 700;
+        line-height: 1;
+        font-size: 1rem;
+    }
+    .epl-summary-label {
+        color: #64748b;
+        font-size: .72rem;
+        text-transform: uppercase;
+        letter-spacing: .3px;
+        margin-top: .15rem;
+    }
+    .epl-body {
+        padding: 1rem 1.25rem;
+    }
+
+    .epl-matiere {
+        padding: .85rem 0;
+        border-bottom: 1px solid #f1f5f9;
+    }
+    .epl-matiere:last-child { border-bottom: none; }
+    .epl-matiere-top {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: .75rem;
+        flex-wrap: wrap;
+        margin-bottom: .5rem;
+    }
+    .epl-matiere-name {
+        display: flex;
+        align-items: center;
+        gap: .55rem;
+        min-width: 0;
+        flex: 1;
+    }
+    .epl-matiere-icon {
+        width: 30px;
+        height: 30px;
+        border-radius: 8px;
+        background: rgba(4,83,203,.1);
+        color: #0453cb;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: .75rem;
+        flex-shrink: 0;
+    }
+    .epl-matiere-label {
+        font-weight: 600;
+        color: #1e293b;
+        font-size: .88rem;
+        line-height: 1.2;
+        word-break: break-word;
+    }
+    .epl-matiere-meta {
+        font-size: .75rem;
+        color: #64748b;
+        margin-top: .1rem;
+    }
+    .epl-matiere-teacher i { color: #94a3b8; }
+    .epl-matiere-numbers {
+        display: flex;
+        gap: .6rem;
+        align-items: baseline;
+        font-size: .78rem;
+        color: #64748b;
+        white-space: nowrap;
+    }
+    .epl-matiere-numbers strong {
+        color: #0f172a;
+        font-weight: 700;
+        font-size: .95rem;
+    }
+    .epl-matiere-pct {
+        color: #0453cb;
+        font-weight: 700;
+        font-size: .88rem;
+    }
+
+    .epl-progress {
+        width: 100%;
+        height: 8px;
+        background: #f1f5f9;
+        border-radius: 99px;
+        overflow: hidden;
+        position: relative;
+    }
+    .epl-progress-bar {
+        height: 100%;
+        background: linear-gradient(90deg, #0453cb, #3b7ddb);
+        border-radius: 99px;
+        transition: width .4s ease-out;
+    }
+    .epl-progress-bar--complete {
+        background: linear-gradient(90deg, #10b981, #34d399);
+    }
+
+    .epl-teachers-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: .3rem;
+        margin-top: .45rem;
+    }
+    .epl-teachers-chip {
+        font-size: .7rem;
+        padding: .2rem .55rem;
+        background: #f1f5f9;
+        color: #475569;
+        border-radius: 99px;
+        border: 1px solid #e2e8f0;
+    }
+
+    .epl-empty {
+        padding: 2rem 1rem;
+        text-align: center;
+    }
+    .epl-empty-icon {
+        width: 60px;
+        height: 60px;
+        margin: 0 auto .75rem;
+        border-radius: 50%;
+        background: linear-gradient(135deg, rgba(245,158,11,.1), rgba(245,158,11,.2));
+        color: #f59e0b;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.4rem;
+    }
+    .epl-empty h5 {
+        color: #1e293b;
+        font-size: 1rem;
+        margin: 0 0 .3rem;
+        font-weight: 600;
+    }
+    .epl-empty p {
+        color: #64748b;
+        font-size: .85rem;
+        margin-bottom: 1rem;
+    }
+    .epl-empty .btn-primary {
+        background: #0453cb;
+        border-color: #0453cb;
+        border-radius: 9px;
+        font-weight: 600;
+        padding: .5rem 1.1rem;
+        font-size: .85rem;
+    }
+    .epl-empty .btn-primary:hover {
+        background: #033a8e;
+        border-color: #033a8e;
+    }
+</style>
+@endonce
+
+<div class="epl-card">
+    <div class="epl-header">
+        <div class="epl-header-title">
             <i class="fas fa-calendar-check"></i>
-            Planification Académique
+            Suivi par matière
         </div>
-        <div class="main-card-subtitle">Suivi des heures planifiées pour cette classe</div>
-    </div>
-    <div class="main-card-body">
-        @if($planificationData['planifications_configurees'])
-            <div class="row">
-                <div class="col-lg-8">
-                    <div class="table-responsive">
-                        <table class="table table-sm table-hover mb-0">
-                            <thead class="bg-light text-dark">
-                                <tr>
-                                    <th width="35%">Matière</th>
-                                    <th width="25%">Enseignant</th>
-                                    <th width="15%" class="text-center">H. Total</th>
-                                    <th width="15%" class="text-center">H. Restantes</th>
-                                    <th width="10%" class="text-center">%</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                @foreach($planificationData['matieres_planifiees'] as $matiere)
-                                <tr>
-                                    <td>
-                                        <div class="d-flex align-items-center">
-                                            <div class="bg-primary text-white rounded-circle d-flex align-items-center justify-content-center me-2" style="width: 25px; height: 25px; flex-shrink: 0;">
-                                                <i class="fas fa-book" style="font-size: 10px;"></i>
-                                            </div>
-                                            <strong>{{ $matiere['matiere']->name }}</strong>
-                                        </div>
-                                    </td>
-                                    <td>
-                                        @php
-                                            $enseignantsDisponibles = $matiere['enseignants_selectables'] ?? collect();
-                                        @endphp
-                                        @if($matiere['enseignant_affiche'])
-                                            <small>
-                                                <i class="fas fa-user-tie text-secondary me-1"></i>
-                                                {{ $matiere['enseignant_affiche']->name }}
-                                            </small>
-                                        @else
-                                            <small class="text-muted">
-                                                <i class="fas fa-user-slash me-1"></i>Non assigné
-                                            </small>
-                                        @endif
-                                        @if($enseignantsDisponibles->count() > 0)
-                                            <div class="d-flex flex-wrap gap-1 mt-1">
-                                                @foreach($enseignantsDisponibles as $enseignant)
-                                                    @php
-                                                        $enseignantNom = optional($enseignant->user)->name ?? $enseignant->name ?? 'Enseignant';
-                                                    @endphp
-                                                    <span class="badge bg-light text-dark border">
-                                                        {{ $enseignantNom }}
-                                                    </span>
-                                                @endforeach
-                                            </div>
-                                        @endif
-                                    </td>
-                                    <td class="text-center">
-                                        <span class="badge bg-primary">{{ $matiere['volume_horaire_total_formatted'] ?? $matiere['volume_horaire_total'] . 'h' }}</span>
-                                    </td>
-                                    <td class="text-center">
-                                        <span class="badge bg-{{ $matiere['heures_restantes'] > 0 ? 'success' : 'warning' }}">
-                                            {{ $matiere['heures_restantes_formatted'] ?? $matiere['heures_restantes'] . 'h' }}
-                                        </span>
-                                    </td>
-                                    <td class="text-center">
-                                        <small><strong>{{ $matiere['pourcentage_utilise'] ?? 0 }}%</strong></small>
-                                    </td>
-                                </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    </div>
+
+        @if(isset($planificationData['planifications_configurees']) && $planificationData['planifications_configurees'])
+            <div class="epl-header-summary">
+                <div class="epl-summary-item">
+                    <div class="epl-summary-value">{{ $planificationData['heures_totales_formatted'] ?? ($planificationData['heures_totales'] ?? 0) . 'h' }}</div>
+                    <div class="epl-summary-label">Planifiées</div>
                 </div>
-                
-                <div class="col-lg-4">
-                    <div class="card bg-light border-0">
-                        <div class="card-body text-center">
-                            <h6 class="text-primary"><i class="fas fa-chart-pie me-2"></i>Résumé</h6>
-                            <div class="row">
-                                <div class="col-6">
-                                    <h4 class="text-primary mb-1">{{ $planificationData['heures_totales_formatted'] ?? $planificationData['heures_totales'] }}</h4>
-                                    <small>H. planifiées</small>
-                                </div>
-                                <div class="col-6">
-                                    <h4 class="text-success mb-1">{{ $planificationData['heures_restantes_formatted'] ?? $planificationData['heures_restantes'] }}</h4>
-                                    <small>H. restantes</small>
-                                </div>
-                            </div>
-                            <hr>
-                            <small class="text-muted">
-                                <i class="fas fa-graduation-cap me-1"></i>{{ $emploiTemps->classe->name }}<br>
-                                <i class="fas fa-calendar me-1"></i>{{ $emploiTemps->semestre ?? 'Année complète' }}
-                            </small>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        @else
-            <div class="alert alert-warning mb-0">
-                <div class="d-flex align-items-center">
-                    <i class="fas fa-exclamation-triangle fa-2x me-3"></i>
-                    <div>
-                        <h6><strong>Planification non configurée</strong></h6>
-                        <p class="mb-2">{{ $planificationData['message_configuration'] ?? 'Aucune planification académique configurée pour cette classe.' }}</p>
-                        <small class="text-muted">Vous devez d'abord définir les volumes horaires des matières pour cette classe.</small>
-                        @if($emploiTemps->classe && $emploiTemps->annee)
-                            <button type="button" class="btn btn-warning btn-sm" 
-                                    data-bs-toggle="modal" 
-                                    data-bs-target="#volumeConfigModal"
-                                    data-filiere-id="{{ $emploiTemps->classe->filiere_id }}"
-                                    data-niveau-id="{{ $emploiTemps->classe->niveau_etude_id }}"
-                                    data-annee-id="{{ $emploiTemps->annee->id }}"
-                                    data-combination-name="{{ $emploiTemps->classe->filiere->name ?? 'Filière' }} - {{ $emploiTemps->classe->niveau->name ?? 'Niveau' }}"
-                                    onclick="openVolumeConfigModal(this)">
-                                <i class="fas fa-cog me-1"></i>Configurer les volumes horaires
-                            </button>
-                        @endif
-                    </div>
+                <div class="epl-summary-item">
+                    <div class="epl-summary-value">{{ $planificationData['heures_restantes_formatted'] ?? ($planificationData['heures_restantes'] ?? 0) . 'h' }}</div>
+                    <div class="epl-summary-label">Restantes</div>
                 </div>
             </div>
         @endif
     </div>
+
+    <div class="epl-body">
+        @if(empty($planificationData) || empty($planificationData['planifications_configurees']))
+            <div class="epl-empty">
+                <div class="epl-empty-icon">
+                    <i class="fas fa-sliders-h"></i>
+                </div>
+                <h5>Planification non configurée</h5>
+                <p>{{ $planificationData['message_configuration'] ?? "Aucune planification académique n'est définie pour cette classe. Configurez d'abord les volumes horaires." }}</p>
+                @if($emploiTemps->classe && $emploiTemps->annee)
+                    <button type="button" class="btn btn-primary"
+                            data-bs-toggle="modal"
+                            data-bs-target="#volumeConfigModal"
+                            data-filiere-id="{{ $emploiTemps->classe->filiere_id }}"
+                            data-niveau-id="{{ $emploiTemps->classe->niveau_etude_id }}"
+                            data-annee-id="{{ $emploiTemps->annee->id }}"
+                            data-combination-name="{{ $emploiTemps->classe->filiere->name ?? 'Filière' }} · {{ $emploiTemps->classe->niveau->name ?? 'Niveau' }}"
+                            onclick="openVolumeConfigModal(this)">
+                        <i class="fas fa-cog me-1"></i>Configurer les volumes horaires
+                    </button>
+                @endif
+            </div>
+        @else
+            @foreach($planificationData['matieres_planifiees'] as $matiere)
+                @php
+                    $volumeTotal = (int) ($matiere['volume_horaire_total'] ?? 0);
+                    $heuresRestantes = (int) ($matiere['heures_restantes'] ?? 0);
+                    $pourcentageUtilise = (int) ($matiere['pourcentage_utilise'] ?? 0);
+                    $heuresUtilisees = max(0, $volumeTotal - $heuresRestantes);
+                    $isComplete = $pourcentageUtilise >= 100;
+                    $enseignantPrincipal = $matiere['enseignant_affiche'] ?? null;
+                    $enseignantsDispo = collect($matiere['enseignants_selectables'] ?? []);
+                @endphp
+                <div class="epl-matiere">
+                    <div class="epl-matiere-top">
+                        <div class="epl-matiere-name">
+                            <div class="epl-matiere-icon"><i class="fas fa-book"></i></div>
+                            <div>
+                                <div class="epl-matiere-label">{{ $matiere['matiere']->name }}</div>
+                                <div class="epl-matiere-meta epl-matiere-teacher">
+                                    @if($enseignantPrincipal)
+                                        <i class="fas fa-user-tie"></i> {{ $enseignantPrincipal->name }}
+                                    @else
+                                        <i class="fas fa-user-slash"></i> <span class="text-muted">Aucun enseignant assigné</span>
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
+                        <div class="epl-matiere-numbers">
+                            <span><strong>{{ $heuresUtilisees }}h</strong> / {{ $volumeTotal }}h</span>
+                            <span class="epl-matiere-pct">{{ $pourcentageUtilise }}%</span>
+                        </div>
+                    </div>
+
+                    <div class="epl-progress" role="progressbar" aria-valuenow="{{ $pourcentageUtilise }}" aria-valuemin="0" aria-valuemax="100" aria-label="Volume horaire utilisé pour {{ $matiere['matiere']->name }}">
+                        <div class="epl-progress-bar {{ $isComplete ? 'epl-progress-bar--complete' : '' }}"
+                             style="width: {{ min(100, max(0, $pourcentageUtilise)) }}%;"></div>
+                    </div>
+
+                    @if($enseignantsDispo->count() > 1)
+                        <div class="epl-teachers-chips" title="Enseignants pouvant intervenir sur cette matière">
+                            @foreach($enseignantsDispo as $ens)
+                                @php $nom = optional($ens->user)->name ?? $ens->name ?? 'Enseignant'; @endphp
+                                <span class="epl-teachers-chip">{{ $nom }}</span>
+                            @endforeach
+                        </div>
+                    @endif
+                </div>
+            @endforeach
+        @endif
+    </div>
 </div>
-@endif

--- a/resources/views/esbtp/emploi-temps/show.blade.php
+++ b/resources/views/esbtp/emploi-temps/show.blade.php
@@ -213,6 +213,92 @@
     }
 
     /* ═══════════════════════════════════════════════════════════
+       Tabs Infos / Planification / Liste seances (sous la grille)
+       ═══════════════════════════════════════════════════════════ */
+    .ets-tabs-wrap {
+        margin-top: 1.25rem;
+    }
+    [x-cloak] { display: none !important; }
+
+    .ets-tabs {
+        display: flex;
+        gap: .25rem;
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        padding: .4rem;
+        margin-bottom: 1rem;
+        overflow-x: auto;
+        scrollbar-width: none;
+        -ms-overflow-style: none;
+    }
+    .ets-tabs::-webkit-scrollbar { display: none; }
+
+    .ets-tab {
+        display: inline-flex;
+        align-items: center;
+        gap: .45rem;
+        padding: .6rem 1rem;
+        border: none;
+        background: transparent;
+        color: #64748b;
+        font-size: .85rem;
+        font-weight: 500;
+        border-radius: 10px;
+        white-space: nowrap;
+        cursor: pointer;
+        transition: all .18s ease;
+    }
+    .ets-tab:hover:not(.is-active) {
+        background: #f1f5f9;
+        color: #0453cb;
+    }
+    .ets-tab:focus-visible {
+        outline: 2px solid #0453cb;
+        outline-offset: 2px;
+    }
+    .ets-tab.is-active {
+        background: #0453cb;
+        color: #fff;
+        font-weight: 600;
+        box-shadow: 0 2px 8px rgba(4,83,203,.25);
+    }
+    .ets-tab i { font-size: .78rem; }
+
+    .ets-tab-count {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 22px;
+        height: 20px;
+        padding: 0 .4rem;
+        margin-left: .25rem;
+        background: rgba(100,116,139,.15);
+        color: #475569;
+        border-radius: 99px;
+        font-size: .7rem;
+        font-weight: 700;
+        line-height: 1;
+    }
+    .ets-tab.is-active .ets-tab-count {
+        background: rgba(255,255,255,.22);
+        color: #fff;
+    }
+
+    .ets-tab-panel {
+        animation: etsFadeIn .2s ease-out;
+    }
+    @keyframes etsFadeIn {
+        from { opacity: 0; transform: translateY(4px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+
+    @media (max-width: 768px) {
+        .ets-tab { padding: .5rem .75rem; font-size: .78rem; }
+        .ets-tab i { font-size: .72rem; }
+    }
+
+    /* ═══════════════════════════════════════════════════════════
        Modal config volumes — gradient bleu KLASSCI (pattern PR #220)
        ═══════════════════════════════════════════════════════════ */
     .ets-config-modal .modal-content {
@@ -791,11 +877,6 @@
                 </div>
             </div>
         @endif
-        <!-- Section: Planification Académique -->
-        <x-emploi-temps.planification-section 
-            :planificationData="$planificationData" 
-            :emploiTemps="$emploiTemps" />
-
         @if (session('warning'))
             <div class="alert alert-warning alert-dismissible fade show" role="alert">
                 <h5><i class="fas fa-exclamation-triangle me-2"></i>Attention</h5>
@@ -819,12 +900,6 @@
             </div>
         @endif
 
-        <!-- Section: Informations et Statistiques -->
-        <x-emploi-temps.info-stats-section 
-            :emploiTemps="$emploiTemps" 
-            :matiereStats="$matiereStats ?? []" />
-
-
         @php
             if (!isset($timeSlots) || !is_array($timeSlots) || empty($timeSlots)) {
                 $timeSlots = [];
@@ -838,17 +913,95 @@
             }
         @endphp
 
-        <!-- Section: Grille horaire (pleine largeur) -->
-        <x-emploi-temps.grille-horaire 
-            :seances="$emploiTemps->seances ?? collect()" 
+        {{-- ═══════════════════════════════════════════════════════════
+             GRILLE HORAIRE (focus principal, pleine largeur)
+             ═══════════════════════════════════════════════════════════ --}}
+        <x-emploi-temps.grille-horaire
+            :seances="$emploiTemps->seances ?? collect()"
             :emploiTemps="$emploiTemps"
             :timeSlots="$timeSlots"
             :days="$days" />
 
-        <!-- Section: Liste des séances (pleine largeur) -->
-        <x-emploi-temps.liste-seances 
-            :seances="$emploiTemps->seances ?? collect()" 
-            :emploiTemps="$emploiTemps" />
+        {{-- ═══════════════════════════════════════════════════════════
+             TABS : Infos / Planification / Liste séances
+             Alpine x-show + URL hash sync
+             ═══════════════════════════════════════════════════════════ --}}
+        <div class="ets-tabs-wrap"
+             x-data="{
+                tab: (window.location.hash.replace('#','') || 'infos'),
+                switch(t) {
+                    this.tab = t;
+                    history.replaceState({}, '', '#' + t);
+                }
+             }"
+             x-init="window.addEventListener('hashchange', () => { tab = window.location.hash.replace('#','') || 'infos'; })"
+             @keydown.arrow-left.prevent="$refs.tablist && (() => { const b = $refs.tablist.querySelectorAll('[role=tab]'); const i = [...b].findIndex(x => x.getAttribute('aria-selected') === 'true'); const prev = b[(i - 1 + b.length) % b.length]; prev.focus(); prev.click(); })()"
+             @keydown.arrow-right.prevent="$refs.tablist && (() => { const b = $refs.tablist.querySelectorAll('[role=tab]'); const i = [...b].findIndex(x => x.getAttribute('aria-selected') === 'true'); const next = b[(i + 1) % b.length]; next.focus(); next.click(); })()">
+
+            <div class="ets-tabs" role="tablist" x-ref="tablist" aria-label="Sections emploi du temps">
+                <button type="button"
+                        class="ets-tab"
+                        role="tab"
+                        :aria-selected="tab === 'infos' ? 'true' : 'false'"
+                        :class="{ 'is-active': tab === 'infos' }"
+                        @click="switch('infos')"
+                        id="ets-tab-infos">
+                    <i class="fas fa-info-circle"></i> Informations
+                </button>
+                <button type="button"
+                        class="ets-tab"
+                        role="tab"
+                        :aria-selected="tab === 'planif' ? 'true' : 'false'"
+                        :class="{ 'is-active': tab === 'planif' }"
+                        @click="switch('planif')"
+                        id="ets-tab-planif">
+                    <i class="fas fa-calendar-check"></i> Planification académique
+                </button>
+                <button type="button"
+                        class="ets-tab"
+                        role="tab"
+                        :aria-selected="tab === 'liste' ? 'true' : 'false'"
+                        :class="{ 'is-active': tab === 'liste' }"
+                        @click="switch('liste')"
+                        id="ets-tab-liste">
+                    <i class="fas fa-list-ul"></i> Liste des séances
+                    <span class="ets-tab-count">{{ $emploiTemps->seances->count() }}</span>
+                </button>
+            </div>
+
+            {{-- Tab: Infos (fusion infos + stats) --}}
+            <div class="ets-tab-panel"
+                 x-show="tab === 'infos'"
+                 x-cloak
+                 role="tabpanel"
+                 aria-labelledby="ets-tab-infos">
+                <x-emploi-temps.info-stats-section
+                    :emploiTemps="$emploiTemps"
+                    :matiereStats="$matiereStats ?? []" />
+            </div>
+
+            {{-- Tab: Planification (progress bars monochrome) --}}
+            <div class="ets-tab-panel"
+                 x-show="tab === 'planif'"
+                 x-cloak
+                 role="tabpanel"
+                 aria-labelledby="ets-tab-planif">
+                <x-emploi-temps.planification-section
+                    :planificationData="$planificationData"
+                    :emploiTemps="$emploiTemps" />
+            </div>
+
+            {{-- Tab: Liste séances --}}
+            <div class="ets-tab-panel"
+                 x-show="tab === 'liste'"
+                 x-cloak
+                 role="tabpanel"
+                 aria-labelledby="ets-tab-liste">
+                <x-emploi-temps.liste-seances
+                    :seances="$emploiTemps->seances ?? collect()"
+                    :emploiTemps="$emploiTemps" />
+            </div>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## Resume

Deuxieme lot du redesign /esbtp/emploi-temps/{id} (suite PR #222 foundation). Restructure la page en single-column avec tabs Alpine sous la grille horaire pour reduire la redondance et ameliorer la densite informationnelle.

Closes #223

## Changements cote utilisateur

### Structure avant / apres

Avant : 6 blocs empiles verticalement (hero, planif, info+stats 2-col, grille, liste) → user scrollait 5 ecrans pour la meme info repetee 3×.

Maintenant :
1. Hero premium (PR1 ✅)
2. Grille horaire pleine largeur (focus visuel principal)
3. **Tabs Alpine** sous la grille : Informations | Planification academique | Liste des seances (avec count badge)

### Tab Informations

Fusion des anciennes cards Informations + Statistiques en 3 cards grid :
- Details emploi du temps (Periode / Dates / Statut / Cree / Dernière modif)
- Types de seances (grid 4 icones bleues + totaux)
- Seances par matiere (liste avec count badge bleu)

Plus de redondance : classe/filiere/niveau deja affiches dans le hero.

### Tab Planification academique

Rewrite avec **barres de progression horizontales monochrome bleu** par matiere (pattern NN/g + Moodle valide par web search).

Format par matiere :
- Icone bleu + nom + enseignant principal
- 'X h / Y h'  +  '62%' (pourcentage bleu)
- Barre de progression gradient 0453cb → 3b7ddb
- Passe en vert 10b981 quand ≥ 100%
- Chips enseignants disponibles si plusieurs

Empty state premium : icone warning + message + bouton 'Configurer les volumes horaires' (ouvre modal PR1 en gradient bleu).

### Tab Liste seances

Migration de liste-seances.blade.php dans le tab (plus de duplication avec la grille). Wrapper premium els-wrap avec bordure et shadow, header simple avec count et bouton + Ajouter.

## Technique

- **Alpine x-data + x-show** (pas x-if — rule feedback_ajax_alpine_architecture)
- **URL hash sync** : #infos / #planif / #liste (bookmarkable)
- **Keyboard a11y** : ArrowLeft / ArrowRight entre tabs
- **ARIA** : role=tablist, role=tab, aria-selected, aria-labelledby
- **Namespace CSS** ets-* (tabs), eis-* (infos), epl-* (planification)
- **Grid engine preserve** (rule PR1 : 604 lignes timetable-grid non touchees)

## Non scope (PR3 suivant)

- Auto-hide dimanche quand setting false
- Legende chips filtrantes monochrome
- Kebab seance persistent desktop / tap-to-reveal mobile
- Empty cell '+' affordance
- Monochrome tonal complet (types CM/TD/TP en opacity + border)

## Tests apres merge

- [ ] URL /esbtp/emploi-temps/{id} charge avec tab Informations actif
- [ ] Clic tab Planification → bascule sans reload + URL #planif
- [ ] Bookmark URL avec #planif → ouvre directement tab Planif
- [ ] Clavier Tab pour focus, ArrowRight / ArrowLeft navigue entre tabs
- [ ] Barres de progression rendent proportionnel aux pourcentages
- [ ] Empty state planif affiche bouton Configurer volumes (si non configuree)
- [ ] Liste seances table avec count et bouton + Ajouter
- [ ] Pas de regression grille horaire
- [ ] Mobile : tabs scrollable horizontalement, responsive