### PR TITLE
feat(emploi-temps): PR3 polish grille (legende chips + kebab seance + modal preview PDF + settings couleur)

### DIFF
--- a/app/Http/Controllers/ESBTPEmploiTempsController.php
+++ b/app/Http/Controllers/ESBTPEmploiTempsController.php
@@ -1675,7 +1675,8 @@ class ESBTPEmploiTempsController extends Controller
     }
 
     /**
-     * Prévisualise l'emploi du temps avant génération PDF
+     * Prévisualise l'emploi du temps en affichant le PDF réel inline
+     * (même rendu que le téléchargement, ouvert dans le viewer natif du navigateur).
      */
     public function previewEmploiTemps($id)
     {
@@ -1688,206 +1689,22 @@ class ESBTPEmploiTempsController extends Controller
                 'annee',
             ])->findOrFail($id);
 
-            // Récupérer la configuration PDF
-            $config = $this->getPDFConfig();
-            $settings = $config; // Utiliser la même structure que les bulletins
+            // Générer le vrai PDF (même pipeline que le téléchargement)
+            $pdfService = app(ESBTPPDFService::class);
+            $pdf = $pdfService->genererEmploiTempsPDF($emploiTemps);
 
-            // Préparer le logo en base64
-            $logoBase64 = $this->prepareLogoBase64($config['school_logo']);
+            $filename = 'apercu_emploi_temps_'.($emploiTemps->classe->name ?? 'classe').'_'.now()->format('Y-m-d').'.pdf';
 
-            // Grouper les séances par jour
-            $seancesParJour = $emploiTemps->getSeancesParJour();
-
-            // Récupérer les heures de début et de fin pour l'affichage
-            $heuresDebut = [];
-            $heuresFin = [];
-            for ($heure = 8; $heure < 18; $heure++) {
-                $heuresDebut[] = sprintf('%02d:00', $heure);
-                $heuresFin[] = sprintf('%02d:00', $heure + 1);
-            }
-
-            // Noms des jours pour l'affichage
-            $joursNoms = [
-                1 => 'Lundi',
-                2 => 'Mardi',
-                3 => 'Mercredi',
-                4 => 'Jeudi',
-                5 => 'Vendredi',
-                6 => 'Samedi',
-            ];
-
-            // Créer les variables $timeSlots et $days pour la vue
-            $timeSlots = $heuresDebut;
-            $days = array_keys($joursNoms);
-
-            // Calcul des statistiques par matière
-            $matiereStats = [];
-            foreach ($emploiTemps->seances as $seance) {
-                $matiereName = $seance->matiere ? $seance->matiere->name : 'Non définie';
-                if (! isset($matiereStats[$matiereName])) {
-                    $matiereStats[$matiereName] = 0;
-                }
-                $matiereStats[$matiereName]++;
-            }
-            $matiereStats = collect($matiereStats)->sortDesc();
-
-            $totalSeances = $emploiTemps->seances->count();
-            $totalMinutes = $emploiTemps->seances->reduce(function ($carry, $seance) {
-                $start = $seance->heure_debut instanceof Carbon
-                    ? $seance->heure_debut->copy()
-                    : ($seance->heure_debut ? Carbon::parse($seance->heure_debut) : null);
-                $end = $seance->heure_fin instanceof Carbon
-                    ? $seance->heure_fin->copy()
-                    : ($seance->heure_fin ? Carbon::parse($seance->heure_fin) : null);
-
-                if ($start && $end) {
-                    if ($end->lessThanOrEqualTo($start)) {
-                        $end = $end->addDay();
-                    }
-
-                    return $carry + $start->diffInMinutes($end);
-                }
-
-                return $carry;
-            }, 0);
-            $totalHours = $totalMinutes > 0 ? $totalMinutes / 60 : 0;
-            $totalHoursFormatted = $totalHours > 0
-                ? rtrim(rtrim(number_format($totalHours, 1, ',', ' '), '0'), ',').' h'
-                : '0 h';
-
-            $uniqueMatieres = $matiereStats->count();
-            $uniqueTeachers = $emploiTemps->seances
-                ->map(function ($seance) {
-                    if ($seance->teacher_id) {
-                        return 'teacher_'.$seance->teacher_id;
-                    }
-                    if (! empty($seance->enseignant)) {
-                        return 'name_'.$seance->enseignant;
-                    }
-
-                    return null;
-                })
-                ->filter()
-                ->unique()
-                ->count();
-
-            $daysCovered = $emploiTemps->seances->pluck('jour')->filter()->unique()->count();
-
-            $sessionTypeLabels = [
-                ESBTPSeanceCours::TYPE_COURSE => 'Cours',
-                ESBTPSeanceCours::TYPE_HOMEWORK => 'Devoir',
-                ESBTPSeanceCours::TYPE_BREAK => 'Récréation',
-                ESBTPSeanceCours::TYPE_LUNCH => 'Pause déjeuner',
-            ];
-
-            $sessionTypeColors = [
-                ESBTPSeanceCours::TYPE_COURSE => ['bg' => '#0453cb', 'text' => '#ffffff'],
-                ESBTPSeanceCours::TYPE_HOMEWORK => ['bg' => '#3ba54f', 'text' => '#ffffff'],
-                ESBTPSeanceCours::TYPE_BREAK => ['bg' => '#f59e0b', 'text' => '#1f2937'],
-                ESBTPSeanceCours::TYPE_LUNCH => ['bg' => '#0ea5e9', 'text' => '#ffffff'],
-                'default' => ['bg' => '#5e91de', 'text' => '#ffffff'],
-            ];
-
-            $sessionTypeSwatches = [];
-            foreach ($emploiTemps->seances as $seance) {
-                $type = $seance->type ?? ESBTPSeanceCours::TYPE_COURSE;
-                if (! isset($sessionTypeSwatches[$type])) {
-                    $background = $seance->color ?: ($sessionTypeColors[$type]['bg'] ?? $sessionTypeColors['default']['bg']);
-                    $sessionTypeSwatches[$type] = [
-                        'bg' => $background,
-                        'text' => $this->calculateTextColor($background, $sessionTypeColors[$type]['text'] ?? '#ffffff'),
-                    ];
-                }
-            }
-            foreach ($sessionTypeLabels as $type => $label) {
-                if (! isset($sessionTypeSwatches[$type])) {
-                    $sessionTypeSwatches[$type] = $sessionTypeColors[$type] ?? $sessionTypeColors['default'];
-                }
-            }
-
-            $sessionTypeStats = $emploiTemps->seances
-                ->groupBy(function ($seance) {
-                    return $seance->type ?? ESBTPSeanceCours::TYPE_COURSE;
-                })
-                ->map
-                ->count()
-                ->toArray();
-
-            $summaryStats = [
-                [
-                    'label' => 'Séances programmées',
-                    'value' => $totalSeances,
-                    'icon' => 'fa-calendar-check',
-                    'description' => 'Total des séances de la semaine',
-                ],
-                [
-                    'label' => 'Volume horaire',
-                    'value' => $totalHoursFormatted,
-                    'icon' => 'fa-hourglass-half',
-                    'description' => 'Durée cumulée des séances',
-                ],
-                [
-                    'label' => 'Matières couvertes',
-                    'value' => $uniqueMatieres,
-                    'icon' => 'fa-book-open',
-                    'description' => 'Nombre de matières différentes',
-                ],
-                [
-                    'label' => 'Intervenants mobilisés',
-                    'value' => $uniqueTeachers,
-                    'icon' => 'fa-user-tie',
-                    'description' => 'Nombre d’enseignants uniques',
-                ],
-            ];
-
-            $periodeAffichage = null;
-            if ($emploiTemps->date_debut && $emploiTemps->date_fin) {
-                $periodeAffichage = Carbon::parse($emploiTemps->date_debut)->locale('fr')->isoFormat('LL')
-                    .' → '
-                    .Carbon::parse($emploiTemps->date_fin)->locale('fr')->isoFormat('LL');
-            } elseif ($emploiTemps->annee && $emploiTemps->annee->name) {
-                $periodeAffichage = $emploiTemps->annee->name;
-            } elseif (! empty($emploiTemps->semestre)) {
-                $periodeAffichage = 'Semestre '.$emploiTemps->semestre;
-            }
-
-            $etablissementInfo = [
-                'nom' => $config['school_name'],
-                'adresse' => $config['school_address'],
-                'telephone' => $config['school_phone'],
-                'email' => $config['school_email'],
-                'ville' => $config['school_city'],
-                'pays' => $config['school_country'],
-                'type' => $config['school_type'],
-            ];
-
-            return view('esbtp.emploi-temps.preview-pdf', [
-                'emploiTemps' => $emploiTemps,
-                'seances' => $emploiTemps->seances,
-                'seancesParJour' => $seancesParJour,
-                'heuresDebut' => $heuresDebut,
-                'heuresFin' => $heuresFin,
-                'joursNoms' => $joursNoms,
-                'timeSlots' => $timeSlots,
-                'days' => $days,
-                'matiereStats' => $matiereStats,
-                'logoBase64' => $logoBase64,
-                'settings' => $settings,
-                'summaryStats' => $summaryStats,
-                'sessionTypeStats' => $sessionTypeStats,
-                'sessionTypeLabels' => $sessionTypeLabels,
-                'sessionTypeColors' => $sessionTypeColors,
-                'sessionTypeSwatches' => $sessionTypeSwatches,
-                'totalHoursFormatted' => $totalHoursFormatted,
-                'totalSeances' => $totalSeances,
-                'daysCovered' => $daysCovered,
-                'periodeAffichage' => $periodeAffichage,
-                'etablissement' => $etablissementInfo,
+            // Afficher inline dans le viewer PDF du navigateur (pas de téléchargement forcé)
+            return response($pdf, 200, [
+                'Content-Type' => 'application/pdf',
+                'Content-Disposition' => 'inline; filename="'.$filename.'"',
             ]);
-
         } catch (\Exception $e) {
             \Log::error('Erreur lors de la prévisualisation de l\'emploi du temps', [
                 'error' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
                 'emploi_temps_id' => $id,
             ]);
 

--- a/app/Http/Controllers/ESBTPSeanceCoursController.php
+++ b/app/Http/Controllers/ESBTPSeanceCoursController.php
@@ -953,7 +953,6 @@ class ESBTPSeanceCoursController extends Controller
                 'jour' => 'required|integer|min:1|max:7',
                 'heure_debut' => 'required|date_format:H:i',
                 'heure_fin' => 'required|date_format:H:i|after:heure_debut',
-                'color' => 'nullable|string',
                 'is_recurring' => 'boolean',
                 'recurrence_days' => 'nullable|array',
                 'recurrence_days.*' => 'integer|min:1|max:7',

--- a/resources/views/components/emploi-temps/grille-horaire.blade.php
+++ b/resources/views/components/emploi-temps/grille-horaire.blade.php
@@ -15,12 +15,22 @@
         ESBTPSeanceCours::TYPE_LUNCH => 'Pause déjeuner',
     ];
 
+    // Couleurs semantiques par type (rule premium-redesign : types de seances ont un sens fonctionnel
+    // que l'oeil doit capter en < 1s). Couleurs choisies pour bonne lisibilite ecran + contraste
+    // suffisant pour impression noir & blanc (tons moyens bien differencies en niveaux de gris).
     $sessionTypeColors = [
-        ESBTPSeanceCours::TYPE_COURSE => ['bg' => '#0453cb', 'text' => '#ffffff'],
-        ESBTPSeanceCours::TYPE_HOMEWORK => ['bg' => '#3ba54f', 'text' => '#ffffff'],
-        ESBTPSeanceCours::TYPE_BREAK => ['bg' => '#f59e0b', 'text' => '#1f2937'],
-        ESBTPSeanceCours::TYPE_LUNCH => ['bg' => '#0ea5e9', 'text' => '#ffffff'],
-        'default' => ['bg' => '#5e91de', 'text' => '#ffffff'],
+        ESBTPSeanceCours::TYPE_COURSE   => ['bg' => '#0453cb', 'text' => '#ffffff'], // Bleu KLASSCI (primary)
+        ESBTPSeanceCours::TYPE_HOMEWORK => ['bg' => '#10b981', 'text' => '#ffffff'], // Vert success
+        ESBTPSeanceCours::TYPE_BREAK    => ['bg' => '#f59e0b', 'text' => '#1f2937'], // Orange warning
+        ESBTPSeanceCours::TYPE_LUNCH    => ['bg' => '#0ea5e9', 'text' => '#ffffff'], // Cyan neutre
+        'default'                        => ['bg' => '#5e91de', 'text' => '#ffffff'],
+    ];
+
+    $sessionTypeIcons = [
+        ESBTPSeanceCours::TYPE_COURSE   => 'fa-chalkboard',
+        ESBTPSeanceCours::TYPE_HOMEWORK => 'fa-pencil-alt',
+        ESBTPSeanceCours::TYPE_BREAK    => 'fa-coffee',
+        ESBTPSeanceCours::TYPE_LUNCH    => 'fa-utensils',
     ];
 
     foreach ($seances as $seance) {
@@ -31,30 +41,126 @@
     }
 @endphp
 
-<div class="main-card mb-4">
-    <div class="main-card-header">
-        <div class="main-card-title">
+@push('styles')
+<style>
+    .egh-card {
+        background: #fff;
+        border: 1px solid #e2e8f0;
+        border-radius: 14px;
+        box-shadow: 0 1px 3px rgba(15,23,42,.04);
+        overflow: visible;
+        margin-bottom: 1rem;
+    }
+    .egh-header {
+        padding: 1rem 1.25rem;
+        border-bottom: 1px solid #e2e8f0;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 1rem;
+    }
+    .egh-header-title {
+        display: flex;
+        align-items: center;
+        gap: .55rem;
+        color: #0f172a;
+        font-weight: 700;
+        font-size: .92rem;
+    }
+    .egh-header-title i {
+        width: 28px;
+        height: 28px;
+        border-radius: 8px;
+        background: linear-gradient(135deg, #0453cb, #3b7ddb);
+        color: #fff;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        font-size: .75rem;
+    }
+    .egh-legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: .4rem;
+    }
+    .egh-legend-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: .35rem;
+        padding: .3rem .65rem;
+        background: #fff;
+        border: 1.5px solid #e2e8f0;
+        border-radius: 99px;
+        font-size: .72rem;
+        font-weight: 600;
+        color: #475569;
+        cursor: pointer;
+        transition: all .15s ease;
+        user-select: none;
+    }
+    .egh-legend-chip:hover {
+        border-color: #0453cb;
+        color: #0453cb;
+    }
+    .egh-legend-chip.is-active {
+        background: #f8fafc;
+        border-color: #cbd5e1;
+        color: #1e293b;
+    }
+    .egh-legend-chip.is-inactive {
+        opacity: 0.4;
+        text-decoration: line-through;
+        text-decoration-color: #94a3b8;
+        text-decoration-thickness: 1.5px;
+    }
+    .egh-legend-chip.is-inactive .egh-legend-dot {
+        filter: grayscale(1);
+    }
+    .egh-legend-chip i { font-size: .7rem; }
+    .egh-legend-dot {
+        display: inline-block;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+    .egh-body { padding: 1rem 1.25rem; }
+    .egh-body .timeline-grid {
+        overflow: visible !important;
+        max-height: none !important;
+    }
+</style>
+@endpush
+
+<div class="egh-card"
+     x-data="{ activeTypes: { course: true, homework: true, break: true, lunch: true } }"
+     x-effect="Object.entries(activeTypes).forEach(([type, isActive]) => {
+         $el.querySelectorAll('.timeline-session.type-' + type).forEach(el => {
+             el.style.display = isActive ? '' : 'none';
+         });
+     })">
+    <div class="egh-header">
+        <div class="egh-header-title">
             <i class="fas fa-calendar-week"></i>
             Grille horaire
         </div>
-        <div class="main-card-subtitle">Visualisation dynamique de la semaine en cours</div>
-    </div>
-    <div class="main-card-body">
-        <div class="mb-4">
-            <h6 class="mb-3"><i class="fas fa-palette me-2"></i>Légende des formats :</h6>
-            <div class="d-flex flex-wrap gap-3">
-                @foreach($sessionTypeLabels as $type => $label)
-                    @php
-                        $swatch = $sessionTypeColors[$type] ?? $sessionTypeColors['default'];
-                    @endphp
-                    <div class="legend-item d-inline-flex align-items-center gap-2 px-3 py-1 rounded-pill" style="background: rgba(15,23,42,0.05);">
-                        <span class="legend-color" style="display:inline-block;width:16px;height:16px;border-radius:50%;background: {{ $swatch['bg'] }};"></span>
-                        <small class="fw-semibold text-uppercase" style="letter-spacing: 0.05em;">{{ $label }}</small>
-                    </div>
-                @endforeach
-            </div>
+        <div class="egh-legend" role="group" aria-label="Filtrer les types de séance">
+            @foreach($sessionTypeLabels as $type => $label)
+                @php $typeColor = $sessionTypeColors[$type]['bg'] ?? '#5e91de'; @endphp
+                <button type="button"
+                        class="egh-legend-chip is-active"
+                        :class="{ 'is-active': activeTypes.{{ $type }}, 'is-inactive': !activeTypes.{{ $type }} }"
+                        @click="activeTypes.{{ $type }} = !activeTypes.{{ $type }}"
+                        :aria-pressed="activeTypes.{{ $type }}">
+                    <span class="egh-legend-dot" style="background: {{ $typeColor }};"></span>
+                    <i class="fas {{ $sessionTypeIcons[$type] ?? 'fa-circle' }}"></i>
+                    <span>{{ $label }}</span>
+                </button>
+            @endforeach
         </div>
-
+    </div>
+    <div class="egh-body">
         @include('esbtp.emploi-temps.partials.timetable-grid', [
             'seances' => $seances,
             'timeSlots' => $timeSlots,

--- a/resources/views/esbtp/emploi-temps/partials/timetable-grid.blade.php
+++ b/resources/views/esbtp/emploi-temps/partials/timetable-grid.blade.php
@@ -298,11 +298,9 @@
             .timeline-grid {
                 border: 1px solid #dbeafe;
                 border-radius: 18px;
-                overflow: hidden;
                 box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
                 background: #ffffff;
-                max-height: 100vh;
-                overflow-y: auto;
+                /* overflow visible assure par .egh-body parent pour laisser respirer les dropdowns */
             }
             .timeline-grid .timeline-header {
                 display: contents;
@@ -402,31 +400,101 @@
                 margin-left: 8px;
                 opacity: 0.6;
             }
-            .timeline-grid .timeline-session-actions {
-                opacity: 0;
-                transition: opacity 0.2s ease;
+            /* Kebab menu sur seance card — persistent desktop / tap-to-reveal touch */
+            .timeline-grid .timeline-session-kebab {
+                position: absolute;
+                top: 6px;
+                right: 6px;
+                width: 26px;
+                height: 26px;
+                border-radius: 7px;
+                background: rgba(255,255,255,0.18);
+                color: #fff;
+                border: 1px solid rgba(255,255,255,0.22);
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                cursor: pointer;
+                font-size: 0.72rem;
+                opacity: 0.6;
+                transition: opacity 0.15s ease, background 0.15s ease;
+                padding: 0;
+                backdrop-filter: blur(6px);
             }
-            .timeline-grid .timeline-session:hover .timeline-session-actions {
+            .timeline-grid .timeline-session:hover .timeline-session-kebab {
                 opacity: 1;
             }
+            .timeline-grid .timeline-session-kebab:hover,
+            .timeline-grid .timeline-session-kebab:focus {
+                background: rgba(255,255,255,0.3);
+                opacity: 1;
+                outline: none;
+            }
+            /* Touch devices : kebab toujours visible (pas de hover possible) */
+            @media (hover: none) {
+                .timeline-grid .timeline-session-kebab { opacity: 1; }
+            }
+
+            .timeline-grid .timeline-session-dropdown {
+                background: #fff;
+                border: 1px solid #e2e8f0;
+                border-radius: 10px;
+                box-shadow: 0 12px 28px rgba(15,23,42,0.18);
+                padding: .3rem;
+                min-width: 180px;
+                z-index: 20;
+            }
+            .timeline-grid .timeline-session-dropdown .dropdown-item {
+                color: #1e293b;
+                padding: .45rem .7rem;
+                border-radius: 7px;
+                font-size: .82rem;
+                display: flex;
+                align-items: center;
+                gap: .5rem;
+            }
+            .timeline-grid .timeline-session-dropdown .dropdown-item:hover {
+                background: #f1f5f9;
+                color: #0453cb;
+            }
+            .timeline-grid .timeline-session-dropdown .dropdown-item i {
+                width: 16px;
+                text-align: center;
+                color: #0453cb;
+            }
+            .timeline-grid .timeline-session-dropdown .dropdown-item.text-danger i { color: #dc2626; }
+            .timeline-grid .timeline-session-dropdown .dropdown-item.text-danger:hover { background: rgba(220,38,38,.06); color: #b91c1c; }
+
+            /* Empty cell "+" : discret par defaut, emphase au hover */
             .timeline-grid .timeline-slot-add {
                 width: 26px;
                 height: 26px;
                 border-radius: 50%;
-                border: 2px dashed #3b82f6;
-                color: #1d4ed8;
-                background: #ffffff;
+                border: 1.5px dashed #cbd5e1;
+                color: #94a3b8;
+                background: rgba(255,255,255,0.4);
                 display: flex;
                 align-items: center;
                 justify-content: center;
-                font-size: 0.75rem;
-                box-shadow: 0 4px 12px rgba(59, 130, 246, 0.25);
-                transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+                font-size: 0.7rem;
+                opacity: 0.45;
+                transition: all 0.2s ease;
+                text-decoration: none;
+            }
+            .timeline-grid .timeline-day-background:hover ~ .timeline-slot-add,
+            .timeline-grid .timeline-slot-add:hover {
+                opacity: 1;
+                border-color: #0453cb;
+                background: #fff;
+                color: #0453cb;
+                box-shadow: 0 4px 12px rgba(4, 83, 203, 0.2);
             }
             .timeline-grid .timeline-slot-add:hover {
-                background: #1d4ed8;
-                color: #ffffff;
-                transform: translate(-50%, -50%) scale(1.05);
+                transform: translate(-50%, -50%) scale(1.1);
+            }
+            /* Touch : toujours visible */
+            @media (hover: none) {
+                .timeline-grid .timeline-slot-add { opacity: 0.7; }
             }
         </style>
     @endonce
@@ -482,7 +550,9 @@
 
             @foreach($timelineSessions[$daySlug] ?? [] as $session)
                 <div class="timeline-session type-{{ $session['type'] }}"
-                     style="grid-column: {{ $columnIndex }}; grid-row: {{ $session['gridRowStart'] }} / {{ $session['gridRowEnd'] }}; background: {{ $session['background'] }}; color: {{ $session['textColor'] }}; justify-self: center; width: 95%; transform: translateY(12px);">
+                     data-seance-id="{{ $session['id'] }}"
+                     data-seance-matiere="{{ $session['matiere'] }}"
+                     style="position: relative; grid-column: {{ $columnIndex }}; grid-row: {{ $session['gridRowStart'] }} / {{ $session['gridRowEnd'] }}; background: {{ $session['background'] }}; color: {{ $session['textColor'] }}; justify-self: center; width: 95%; transform: translateY(12px);">
                     <div class="timeline-session-type">{{ $session['typeLabel'] }}</div>
                     <div class="timeline-session-subject">{{ $session['matiere'] }}</div>
                     <div class="timeline-session-bottom">
@@ -501,19 +571,32 @@
                     @endif
 
                     @if($interactive)
-                        <div class="timeline-session-actions">
-                            <div class="btn-group btn-group-sm">
-                                <a href="{{ route('esbtp.seances-cours.edit', $session['id']) }}" class="btn btn-light btn-sm">
-                                    <i class="fas fa-edit"></i>
-                                </a>
-                                <form action="{{ route('esbtp.seances-cours.destroy', $session['id']) }}" method="POST" class="d-inline">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit" class="btn btn-light btn-sm" onclick="return confirm('Êtes-vous sûr de vouloir supprimer cette séance ?');">
-                                        <i class="fas fa-trash"></i>
+                        <div class="dropdown" style="position: absolute; top: 4px; right: 4px;">
+                            <button type="button"
+                                    class="timeline-session-kebab"
+                                    data-bs-toggle="dropdown"
+                                    aria-expanded="false"
+                                    aria-label="Actions séance {{ $session['matiere'] }}">
+                                <i class="fas fa-ellipsis-v"></i>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end timeline-session-dropdown">
+                                @can('edit_timetables')
+                                <li>
+                                    <a class="dropdown-item" href="{{ route('esbtp.seances-cours.edit', $session['id']) }}">
+                                        <i class="fas fa-edit"></i> Modifier
+                                    </a>
+                                </li>
+                                @endcan
+                                @can('delete_timetables')
+                                <li>
+                                    <button type="button"
+                                            class="dropdown-item text-danger"
+                                            onclick="window.etsDeleteSeance({{ $session['id'] }}, @js($session['matiere']))">
+                                        <i class="fas fa-trash"></i> Supprimer
                                     </button>
-                                </form>
-                            </div>
+                                </li>
+                                @endcan
+                            </ul>
                         </div>
                     @endif
                 </div>

--- a/resources/views/esbtp/emploi-temps/show.blade.php
+++ b/resources/views/esbtp/emploi-temps/show.blade.php
@@ -929,7 +929,7 @@
         <div class="ets-tabs-wrap"
              x-data="{
                 tab: (window.location.hash.replace('#','') || 'infos'),
-                switch(t) {
+                setTab(t) {
                     this.tab = t;
                     history.replaceState({}, '', '#' + t);
                 }
@@ -944,7 +944,7 @@
                         role="tab"
                         :aria-selected="tab === 'infos' ? 'true' : 'false'"
                         :class="{ 'is-active': tab === 'infos' }"
-                        @click="switch('infos')"
+                        @click="setTab('infos')"
                         id="ets-tab-infos">
                     <i class="fas fa-info-circle"></i> Informations
                 </button>
@@ -953,7 +953,7 @@
                         role="tab"
                         :aria-selected="tab === 'planif' ? 'true' : 'false'"
                         :class="{ 'is-active': tab === 'planif' }"
-                        @click="switch('planif')"
+                        @click="setTab('planif')"
                         id="ets-tab-planif">
                     <i class="fas fa-calendar-check"></i> Planification académique
                 </button>
@@ -962,7 +962,7 @@
                         role="tab"
                         :aria-selected="tab === 'liste' ? 'true' : 'false'"
                         :class="{ 'is-active': tab === 'liste' }"
-                        @click="switch('liste')"
+                        @click="setTab('liste')"
                         id="ets-tab-liste">
                     <i class="fas fa-list-ul"></i> Liste des séances
                     <span class="ets-tab-count">{{ $emploiTemps->seances->count() }}</span>

--- a/resources/views/esbtp/seances-cours/create.blade.php
+++ b/resources/views/esbtp/seances-cours/create.blade.php
@@ -276,14 +276,6 @@
                                 @enderror
                             </div>
 
-                            <div class="form-group">
-                                <label class="form-label">Couleur</label>
-                                <div class="color-picker-wrapper">
-                                    <input type="color" name="color" id="color" class="color-picker"
-                                        value="{{ old('color', $defaultColors['course']) }}">
-                                    <span class="color-label" id="colorLabel"></span>
-                                </div>
-                            </div>
                         </div>
 
                         <div class="form-options">
@@ -1002,11 +994,6 @@ document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('recurrenceDays').style.display = this.checked ? 'block' : 'none';
     });
 
-    // Handle color picker
-    document.getElementById('color').addEventListener('input', function(e) {
-        document.getElementById('colorLabel').textContent = e.target.value;
-    });
-
     // Écouter les changements d'horaires et de jour pour mettre à jour la grille
     const heureDebutInput = document.getElementById('heure_debut');
     const heureFinInput = document.getElementById('heure_fin');
@@ -1091,11 +1078,6 @@ function selectSessionType(type) {
         (type === 'course' || type === 'homework') ? 'block' : 'none';
     document.getElementById('homeworkFields').style.display =
         (type === 'homework') ? 'block' : 'none';
-
-    // Update color picker with default color
-    const selectedColor = seanceData.defaultColors[type];
-    document.getElementById('color').value = selectedColor;
-    document.getElementById('colorLabel').textContent = selectedColor;
 
     // Update required fields
     const teacherField = document.getElementById('teacher_id');

--- a/resources/views/esbtp/seances-cours/edit.blade.php
+++ b/resources/views/esbtp/seances-cours/edit.blade.php
@@ -217,17 +217,6 @@
                                 @enderror
                             </div>
 
-                            <div class="form-group">
-                                <label class="form-label">Couleur</label>
-                                <div class="color-picker-wrapper d-flex align-items-center gap-2">
-                                    <input type="color" name="color" id="color" class="color-picker @error('color') error @enderror"
-                                        value="{{ old('color', $seancesCour->color ?? ($defaultColors[$seancesCour->type] ?? '#2196F3')) }}">
-                                    <span class="color-label" id="colorLabel">{{ old('color', $seancesCour->color ?? ($defaultColors[$seancesCour->type] ?? '#2196F3')) }}</span>
-                                </div>
-                                @error('color')
-                                    <div class="form-error">{{ $message }}</div>
-                                @enderror
-                            </div>
                         </div>
 
                         <div class="form-options mt-3">
@@ -552,7 +541,6 @@
 <script>
 const currentTeacherId = "{{ old('teacher_id', $seancesCour->teacher_id) }}";
 const initialSessionType = "{{ old('type', $seancesCour->type) }}";
-const initialColor = "{{ old('color', $seancesCour->color ?? ($defaultColors[$seancesCour->type] ?? '#2196F3')) }}";
 const seanceDataElement = document.getElementById('seance-data');
 const seanceData = seanceDataElement
     ? {
@@ -601,22 +589,6 @@ document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('recurrenceDays').style.display = this.checked ? 'block' : 'none';
     });
 
-    // Handle color picker
-    document.getElementById('color').addEventListener('input', function(e) {
-        document.getElementById('colorLabel').textContent = e.target.value;
-    });
-
-    // Appliquer immédiatement la bonne couleur à l'affichage
-    const colorInput = document.getElementById('color');
-    const colorLabel = document.getElementById('colorLabel');
-    if (colorInput) {
-        colorInput.value = initialColor;
-        colorLabel.textContent = initialColor;
-        colorInput.addEventListener('change', (event) => {
-            colorLabel.textContent = event.target.value;
-        });
-    }
-
     // Écouter les changements d'horaires et de jour pour mettre à jour la grille
     const heureDebutInput = document.getElementById('heure_debut');
     const heureFinInput = document.getElementById('heure_fin');
@@ -655,7 +627,7 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     const initialType = originalSessionType;
-    selectSessionType(initialType, { skipColorUpdate: true, force: true });
+    selectSessionType(initialType, { force: true });
     updateHomeworkTimingInfo();
 
     // Pré-remplir les enseignants si une matière est déjà sélectionnée
@@ -671,7 +643,7 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 function selectSessionType(type, options = {}) {
-    const { skipColorUpdate = false, force = false } = options;
+    const { force = false } = options;
 
     if (!force && type !== originalSessionType) {
         showTypeChangeWarning(type);
@@ -695,16 +667,6 @@ function selectSessionType(type, options = {}) {
         (type === 'course' || type === 'homework') ? 'block' : 'none';
     document.getElementById('homeworkFields').style.display =
         (type === 'homework') ? 'block' : 'none';
-
-    // Update color picker with default color
-    const colorInput = document.getElementById('color');
-    const colorLabel = document.getElementById('colorLabel');
-    if (!skipColorUpdate && colorInput && defaultColors[type]) {
-        colorInput.value = defaultColors[type];
-    }
-    if (colorLabel && colorInput) {
-        colorLabel.textContent = colorInput.value;
-    }
 
     // Update required fields
     const teacherField = document.getElementById('teacher_id');


### PR DESCRIPTION
## Resume

Troisieme et derniere PR du redesign emploi-temps.show (suite #222 foundation + #225 tabs).

Closes #226

## Changements cote utilisateur

### 1. Legende chips filtrantes (monochrome + couleurs semantiques)

Remplace les 4 puces colorees statiques par des **chips cliquables** dans le header de la grille.
- Click = basculer visibilite du type de seance
- Chip actif : puce couleur + label
- Chip inactif : line-through + opacity 0.4 + dot grayscale
- Monochrome KLASSCI **mais** couleurs semantiques par type (regle premium-redesign : sens fonctionnel > decoration)

### 2. Kebab menu par seance

Bouton ⋮ sur chaque seance (top-right), persistent desktop / tap-to-reveal mobile (@media hover:none). Menu dropdown premium : Modifier / Supprimer (iiConfirm deja de PR1). Remplace les btn-group inline au hover.

### 3. Empty cell '+' affordance

Bouton '+' discret par defaut (opacity 0.45), emphase au hover (opacity 1 + scale + border bleu). Sur touch : opacity 0.7 permanent.

### 4. Bonus fixes dans cette PR

- **Tabs switch** : conflit mot-cle JS `switch` reserve (commit 4cd4b06a)
- **Preview PDF** : click 'Previsualiser' affiche maintenant le VRAI PDF inline (Browsershot stream) au lieu d'une page web (commit 50159084)
- **Create seance** : suppression color picker redondant avec la legende — couleur derivee du type (commit 8c2f9ffd)

## Rule premium-redesign clarifiee

Confirmation user 2026-04-17 : les couleurs semantiques sont autorisees quand elles portent un sens fonctionnel. Les 4 types de seances (cours/devoir/recreation/pause) sont fonctionnels — differenciation visuelle acceptable. Bleu KLASSCI garde la priorite pour le type 'course' (primary).

## Technique

- Alpine `x-effect` pour auto-sync DOM avec activeTypes state
- Namespace CSS `egh-*` (emploi-temps-grille-horaire)
- Grid engine `timetable-grid.blade.php` preserve (pas de changement structurel)
- Overflow visible sur .egh-body .timeline-grid pour dropdowns kebab

## Tests

- [ ] Click chip 'Cours' -> masque les seances type course
- [ ] Click a nouveau -> reaffiche
- [ ] Kebab seance : hover desktop fait apparaitre, toujours visible sur touch
- [ ] Kebab ouvre dropdown avec Modifier / Supprimer
- [ ] Preview PDF dans dropdown hero ouvre VRAI PDF dans nouvelle tab
- [ ] Page create seance n'a plus de color picker