### PR TITLE
fix(paiements): replace blocking confirm() with iiConfirm modal + rate-limit validation

### DIFF
--- a/resources/views/esbtp/paiements/index.blade.php
+++ b/resources/views/esbtp/paiements/index.blade.php
@@ -741,6 +741,7 @@
 @endsection
 
 @push('scripts')
+<script src="{{ asset('js/inscriptions/common.js') }}"></script>
 <style>
 .avatar-circle {
     width: 40px;
@@ -1573,7 +1574,7 @@ function showYearChangeInfo() {
          */
         debugLog('🎯 Installation du handler de validation avec capture phase...');
 
-        document.addEventListener('click', function(e) {
+        document.addEventListener('click', async function(e) {
             // Vérifier si le clic est sur un bouton de validation ou un de ses enfants
             let btn = e.target.closest('.valider-paiement-btn');
 
@@ -1599,7 +1600,16 @@ function showYearChangeInfo() {
                     return false;
                 }
 
-                if (!confirm('Êtes-vous sûr de vouloir valider ce paiement ?')) {
+                const confirmed = typeof window.iiConfirm === 'function'
+                    ? await window.iiConfirm({
+                        title: 'Valider le paiement',
+                        message: 'Valider ce paiement ? Le montant sera comptabilisé immédiatement.',
+                        confirmLabel: 'Valider',
+                        cancelLabel: 'Annuler',
+                    })
+                    : window.confirm('Valider ce paiement ?');
+
+                if (!confirmed) {
                     debugLog('⏸️ Validation annulée par l\'utilisateur');
                     return false;
                 }
@@ -1674,7 +1684,7 @@ function clearAllFilters() {
     $form.submit();
 }
 
-function bulkValider() {
+async function bulkValider() {
     const selectedIds = getSelectedPaiementIds();
 
     if (selectedIds.length === 0) {
@@ -1682,7 +1692,16 @@ function bulkValider() {
         return;
     }
 
-    if (!confirm(`Êtes-vous sûr de vouloir valider ${selectedIds.length} paiement(s) ?`)) {
+    const confirmed = typeof window.iiConfirm === 'function'
+        ? await window.iiConfirm({
+            title: 'Valider la sélection',
+            message: `Valider ${selectedIds.length} paiement${selectedIds.length > 1 ? 's' : ''} ? Les montants seront comptabilisés immédiatement.`,
+            confirmLabel: `Valider (${selectedIds.length})`,
+            cancelLabel: 'Annuler',
+        })
+        : window.confirm(`Êtes-vous sûr de vouloir valider ${selectedIds.length} paiement(s) ?`);
+
+    if (!confirmed) {
         return;
     }
 

--- a/resources/views/esbtp/paiements/show.blade.php
+++ b/resources/views/esbtp/paiements/show.blade.php
@@ -342,18 +342,31 @@
                 <a href="{{ route('esbtp.paiements.edit', $paiement->id) }}" class="ps-btn warning">
                     <i class="fas fa-edit"></i> Modifier
                 </a>
-                <form action="{{ route('esbtp.paiements.destroy', $paiement->id) }}" method="POST" style="margin:0"
-                      onsubmit="return confirm('Supprimer définitivement ce paiement ?')">
+                <form id="ps-form-delete-{{ $paiement->id }}" action="{{ route('esbtp.paiements.destroy', $paiement->id) }}" method="POST" style="margin:0">
                     @csrf @method('DELETE')
-                    <button type="submit" class="ps-btn danger"><i class="fas fa-trash"></i></button>
+                    <button type="button"
+                            class="ps-btn danger"
+                            data-ii-confirm-form="ps-form-delete-{{ $paiement->id }}"
+                            data-ii-confirm-title="Supprimer le paiement"
+                            data-ii-confirm-message="Supprimer définitivement ce paiement ? Cette action est irréversible."
+                            data-ii-confirm-label="Supprimer"
+                            data-ii-confirm-danger="1">
+                        <i class="fas fa-trash"></i>
+                    </button>
                 </form>
                 @endcan
 
                 @if($paiement->status === 'en_attente')
-                <form action="{{ route('esbtp.paiements.valider', $paiement->id) }}" method="POST" style="margin:0"
-                      onsubmit="return confirm('Valider ce paiement ?')">
+                <form id="ps-form-valider-{{ $paiement->id }}" action="{{ route('esbtp.paiements.valider', $paiement->id) }}" method="POST" style="margin:0">
                     @csrf
-                    <button type="submit" class="ps-btn success"><i class="fas fa-check"></i> Valider</button>
+                    <button type="button"
+                            class="ps-btn success"
+                            data-ii-confirm-form="ps-form-valider-{{ $paiement->id }}"
+                            data-ii-confirm-title="Valider le paiement"
+                            data-ii-confirm-message="Valider ce paiement ? Le montant sera comptabilisé immédiatement."
+                            data-ii-confirm-label="Valider le paiement">
+                        <i class="fas fa-check"></i> Valider
+                    </button>
                 </form>
                 <button type="button" class="ps-btn danger" data-bs-toggle="modal" data-bs-target="#modalRejeter">
                     <i class="fas fa-times"></i> Rejeter
@@ -605,12 +618,39 @@
 @endsection
 
 @push('scripts')
+<script src="{{ asset('js/inscriptions/common.js') }}"></script>
 <script>
 // Copy receipt number on click
 document.querySelectorAll('.ps-receipt').forEach(el => {
     el.addEventListener('click', function() {
         const hint = this.querySelector('.ps-copy-hint');
         if (hint) { hint.textContent = 'Copié !'; setTimeout(() => hint.textContent = 'Copier', 2000); }
+    });
+});
+
+// Intercept [data-ii-confirm-form] buttons — show iiConfirm modal, then submit
+// the referenced form programmatically. Replaces native confirm() dialogs
+// which don't always render in modern Chrome and lack KLASSCI styling.
+document.querySelectorAll('[data-ii-confirm-form]').forEach(btn => {
+    btn.addEventListener('click', async function (e) {
+        e.preventDefault();
+        const formId = this.getAttribute('data-ii-confirm-form');
+        const form = document.getElementById(formId);
+        if (!form || typeof window.iiConfirm !== 'function') {
+            return;
+        }
+
+        const confirmed = await window.iiConfirm({
+            title: this.getAttribute('data-ii-confirm-title') || 'Confirmer',
+            message: this.getAttribute('data-ii-confirm-message') || 'Voulez-vous continuer ?',
+            confirmLabel: this.getAttribute('data-ii-confirm-label') || 'Confirmer',
+            cancelLabel: this.getAttribute('data-ii-confirm-cancel') || 'Annuler',
+            danger: this.getAttribute('data-ii-confirm-danger') === '1',
+        });
+
+        if (confirmed) {
+            form.submit();
+        }
     });
 });
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -823,16 +823,16 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             // Routes pour les reliquats
             Route::post('/reliquats/pay', [App\Http\Controllers\ESBTPPaiementController::class, 'payReliquat'])->name('reliquats.pay');
 
-            // Routes pour validation des paiements
-            Route::post('/paiements/{paiement}/valider', [App\Http\Controllers\ESBTPPaiementController::class, 'valider'])->name('paiements.valider');
-            Route::post('/paiements/{paiement}/rejeter', [App\Http\Controllers\ESBTPPaiementController::class, 'rejeter'])->name('paiements.rejeter');
+            // Routes pour validation des paiements (throttled — money movement)
+            Route::post('/paiements/{paiement}/valider', [App\Http\Controllers\ESBTPPaiementController::class, 'valider'])->name('paiements.valider')->middleware('throttle:60,1');
+            Route::post('/paiements/{paiement}/rejeter', [App\Http\Controllers\ESBTPPaiementController::class, 'rejeter'])->name('paiements.rejeter')->middleware('throttle:60,1');
 
             // Route pour validation rapide depuis modal (inscriptions.index)
-            Route::post('/paiements/{paiement}/valider-rapide', [App\Http\Controllers\ESBTPPaiementController::class, 'validerRapide'])->name('paiements.valider-rapide');
+            Route::post('/paiements/{paiement}/valider-rapide', [App\Http\Controllers\ESBTPPaiementController::class, 'validerRapide'])->name('paiements.valider-rapide')->middleware('throttle:60,1');
 
-            // Routes pour validation/rejet groupés
-            Route::post('/paiements/bulk-valider', [App\Http\Controllers\ESBTPPaiementController::class, 'bulkValider'])->name('paiements.bulk-valider');
-            Route::post('/paiements/bulk-rejeter', [App\Http\Controllers\ESBTPPaiementController::class, 'bulkRejeter'])->name('paiements.bulk-rejeter');
+            // Routes pour validation/rejet groupés (plus strict — opère sur N lignes à la fois)
+            Route::post('/paiements/bulk-valider', [App\Http\Controllers\ESBTPPaiementController::class, 'bulkValider'])->name('paiements.bulk-valider')->middleware('throttle:10,1');
+            Route::post('/paiements/bulk-rejeter', [App\Http\Controllers\ESBTPPaiementController::class, 'bulkRejeter'])->name('paiements.bulk-rejeter')->middleware('throttle:10,1');
 
             // Routes ESBTP Bulletins
             Route::prefix('bulletins')->name('bulletins.')->group(function () {


### PR DESCRIPTION
## Summary

Bug reported by user : le dialog de confirmation ne s'affiche plus quand on clique Valider sur un paiement (paiements.index + paiements.show). Le fix remplace les 4 sites \`window.confirm()\` par \`iiConfirm\` (modal BS5 premium déjà dans \`public/js/inscriptions/common.js\`, utilisé par inscriptions.index + emploi-temps.show).

## Fix

- **paiements.index:1603** (single valider row AJAX) → \`await iiConfirm({title, message, confirmLabel})\` + fallback \`window.confirm\` défensif
- **paiements.index:1685** (bulk valider AJAX) → idem avec count dynamique
- **paiements.show:346** (destroy form natif) → bouton \`type=button\` + data-attributes interceptés par handler délégué, \`form.submit()\` si confirmé
- **paiements.show:354** (valider form natif) → idem, message explicite \"Le montant sera comptabilisé immédiatement\"
- **common.js chargé** dans les 2 vues (jusque-là limité aux inscriptions)

## Rate-limiting (critic BLOCK fix)

Money movement sans throttle = risque d'abus. Ajout middleware \`throttle\` sur les 5 routes de validation/rejet :
- \`paiements.valider\` / \`rejeter\` / \`valider-rapide\` → \`throttle:60,1\` (60 actions/min, permissif pour comptable en fin de trimestre)
- \`bulk-valider\` / \`bulk-rejeter\` → \`throttle:10,1\` (chaque call traite N paiements)

## Type

fix

## Test plan

- [ ] Login caissier OU comptable sur tenant avec paiements en_attente
- [ ] paiements.index : cliquer bouton \"Valider\" sur une ligne → iiConfirm bleu KLASSCI apparaît → Confirmer → row flash vert + refresh AJAX
- [ ] paiements.index : sélectionner 2+ lignes → bouton bulk valider → iiConfirm avec count → Confirmer → rows refresh staggered
- [ ] paiements.show : bouton \"Valider\" → iiConfirm → Confirmer → submit natif → redirect avec flash
- [ ] paiements.show : bouton \"Supprimer\" (superAdmin) → iiConfirm danger → Confirmer → delete
- [ ] Annuler le modal → rien ne se passe (AJAX pas fired)
- [ ] Régression rejet : bulk rejet + single rejet modals toujours fonctionnels (non touchés)

## Closes

Closes bug reporté en session 2026-04-22 — payment validation dialog not showing.