### PR TITLE
fix(attendances): use canonical matiere-filiere-niveau relation for manual entry subjects

### DIFF
--- a/app/Http/Controllers/ESBTPAttendanceController.php
+++ b/app/Http/Controllers/ESBTPAttendanceController.php
@@ -10,6 +10,7 @@ use App\Models\ESBTPEtudiant;
 use App\Models\ESBTPSeanceCours;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPMatiere;
+use App\Models\ESBTPMatiereFilierNiveau;
 use App\Models\ESBTPAcademicYear;
 use App\Models\ESBTPTeacherAttendance;
 use App\Http\Requests\Attendance\StoreManualAttendanceHoursRequest;
@@ -1784,10 +1785,10 @@ class ESBTPAttendanceController extends Controller
     }
 
     /**
-     * Récupère les matières d'une classe via planifications académiques (filière + niveau).
-     * Fallback : pivot esbtp_classe_matiere si aucune planification n'existe (classes BTS legacy).
-     * C'est la source canonique utilisée par ClassPlanningService pour la cohérence
-     * planning / emploi-temps / notes / saisie manuelle.
+     * Récupère les matières liées à la combinaison (filière + niveau) de la classe.
+     * Source canonique : table esbtp_matiere_filiere_niveau (modèle ESBTPMatiereFilierNiveau),
+     * utilisée par ESBTPPlanningConfigController, ESBTPMatiereController, TroncCommunService.
+     * Fallback : pivot esbtp_classe_matiere (classes BTS legacy attachées directement).
      */
     private function getMatieresClasse(ESBTPClasse $classe): \Illuminate\Support\Collection
     {
@@ -1795,17 +1796,15 @@ class ESBTPAttendanceController extends Controller
             return collect();
         }
 
-        $matieres = ESBTPPlanificationAcademique::query()
-            ->where('filiere_id', $classe->filiere_id)
-            ->where('niveau_etude_id', $classe->niveau_etude_id)
-            ->whereNotNull('matiere_id')
-            ->with('matiere:id,name')
-            ->get()
-            ->pluck('matiere')
-            ->filter()
-            ->unique('id')
-            ->sortBy('name')
-            ->values();
+        $matiereIds = ESBTPMatiereFilierNiveau::matiereIdsForCombo(
+            $classe->filiere_id,
+            $classe->niveau_etude_id
+        );
+
+        $matieres = ESBTPMatiere::whereIn('id', $matiereIds)
+            ->where('is_active', true)
+            ->orderBy('name')
+            ->get(['id', 'name']);
 
         if ($matieres->isEmpty()) {
             // Fallback classes BTS historiques attachées directement via pivot


### PR DESCRIPTION
The manual entry tab on attendances.create was loading subjects via
esbtp_planifications_academiques with a fallback to the legacy
esbtp_classe_matiere pivot (direct class-to-subject link). This showed
wrong subjects for tenants where the planning table was empty for the
(filiere, niveau) combo, since the fallback returned class-direct
subjects instead of the expected filiere+niveau subjects.

Switch getMatieresClasse() to use ESBTPMatiereFilierNiveau (table
esbtp_matiere_filiere_niveau) as primary source — the same canonical
relation already used by ESBTPPlanningConfigController,
ESBTPMatiereController and TroncCommunService. The BTS-legacy pivot
remains as last-resort fallback only.

Fixes both the initial server-rendered dropdown (create() -> view) and
the AJAX refresh on class change (loadSeances endpoint).