### PR TITLE
fix(attendances): matières par filière+niveau, tri alphabétique des étudiants & filtres de classe

### DIFF
--- a/app/Http/Controllers/ESBTPAttendanceController.php
+++ b/app/Http/Controllers/ESBTPAttendanceController.php
@@ -10,6 +10,7 @@ use App\Models\ESBTPEtudiant;
 use App\Models\ESBTPSeanceCours;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPMatiere;
+use App\Models\ESBTPMatiereFilierNiveau;
 use App\Models\ESBTPAcademicYear;
 use App\Models\ESBTPTeacherAttendance;
 use App\Http\Requests\Attendance\StoreManualAttendanceHoursRequest;
@@ -1784,10 +1785,10 @@ class ESBTPAttendanceController extends Controller
     }
 
     /**
-     * Récupère les matières d'une classe via planifications académiques (filière + niveau).
-     * Fallback : pivot esbtp_classe_matiere si aucune planification n'existe (classes BTS legacy).
-     * C'est la source canonique utilisée par ClassPlanningService pour la cohérence
-     * planning / emploi-temps / notes / saisie manuelle.
+     * Récupère les matières liées à la combinaison (filière + niveau) de la classe.
+     * Source canonique : table esbtp_matiere_filiere_niveau (modèle ESBTPMatiereFilierNiveau),
+     * utilisée par ESBTPPlanningConfigController, ESBTPMatiereController, TroncCommunService.
+     * Fallback : pivot esbtp_classe_matiere (classes BTS legacy attachées directement).
      */
     private function getMatieresClasse(ESBTPClasse $classe): \Illuminate\Support\Collection
     {
@@ -1795,17 +1796,15 @@ class ESBTPAttendanceController extends Controller
             return collect();
         }
 
-        $matieres = ESBTPPlanificationAcademique::query()
-            ->where('filiere_id', $classe->filiere_id)
-            ->where('niveau_etude_id', $classe->niveau_etude_id)
-            ->whereNotNull('matiere_id')
-            ->with('matiere:id,name')
-            ->get()
-            ->pluck('matiere')
-            ->filter()
-            ->unique('id')
-            ->sortBy('name')
-            ->values();
+        $matiereIds = ESBTPMatiereFilierNiveau::matiereIdsForCombo(
+            $classe->filiere_id,
+            $classe->niveau_etude_id
+        );
+
+        $matieres = ESBTPMatiere::whereIn('id', $matiereIds)
+            ->where('is_active', true)
+            ->orderBy('name')
+            ->get(['id', 'name']);
 
         if ($matieres->isEmpty()) {
             // Fallback classes BTS historiques attachées directement via pivot

--- a/app/Http/Controllers/ESBTPAttendanceController.php
+++ b/app/Http/Controllers/ESBTPAttendanceController.php
@@ -425,8 +425,14 @@ class ESBTPAttendanceController extends Controller
      */
     public function create(Request $request)
     {
-        // Récupérer les classes pour le filtre
-        $classes = ESBTPClasse::all();
+        // Récupérer les classes pour le filtre (avec filière + niveau pour filtrage côté client)
+        $classes = ESBTPClasse::with('filiere:id,name', 'niveau:id,name')
+            ->orderBy('name')
+            ->get(['id', 'name', 'filiere_id', 'niveau_etude_id']);
+
+        // Listes pour les filtres (filière + niveau) du selecteur de classe
+        $filieres = \App\Models\ESBTPFiliere::active()->orderBy('name')->get(['id', 'name']);
+        $niveauxEtudes = \App\Models\ESBTPNiveauEtude::active()->orderBy('name')->get(['id', 'name']);
 
         // Initialiser les variables
         $seances = collect();
@@ -513,6 +519,8 @@ class ESBTPAttendanceController extends Controller
                                   ->where('status', 'active')
                                   ->where('classe_id', $classe->id);
                             })
+                            ->orderBy('esbtp_etudiants.nom')
+                            ->orderBy('esbtp_etudiants.prenoms')
                             ->get();
                         $debug['nombre_etudiants'] = $etudiants->count();
                         $debug['etudiants_ids'] = $etudiants->pluck('id')->toArray();
@@ -589,6 +597,8 @@ class ESBTPAttendanceController extends Controller
                               ->where('status', 'active')
                               ->where('classe_id', $classe->id);
                         })
+                        ->orderBy('esbtp_etudiants.nom')
+                        ->orderBy('esbtp_etudiants.prenoms')
                         ->get();
                     $debug['nombre_etudiants_classe'] = $etudiants->count();
 
@@ -627,6 +637,8 @@ class ESBTPAttendanceController extends Controller
 
         return view('esbtp.attendances.create', compact(
             'classes',
+            'filieres',
+            'niveauxEtudes',
             'seances',
             'etudiants',
             'dateSeance',
@@ -791,6 +803,8 @@ class ESBTPAttendanceController extends Controller
                       ->where('status', 'active')
                       ->where('classe_id', $classe->id);
                 })
+                ->orderBy('esbtp_etudiants.nom')
+                ->orderBy('esbtp_etudiants.prenoms')
                 ->get();
 
             if ($etudiants->isEmpty()) {
@@ -1840,8 +1854,8 @@ class ESBTPAttendanceController extends Controller
                         ->where('status', 'active')
                         ->where('classe_id', $classe->id);
                 })
-                ->orderBy('nom')
-                ->orderBy('prenoms')
+                ->orderBy('esbtp_etudiants.nom')
+                ->orderBy('esbtp_etudiants.prenoms')
                 ->get();
 
             $existing = $service->getForClasseMatiere(

--- a/resources/views/esbtp/attendances/create.blade.php
+++ b/resources/views/esbtp/attendances/create.blade.php
@@ -87,18 +87,53 @@
                     <!-- Sélection de la classe et de la séance -->
                     <div class="mb-4">
                         <form id="selectionForm" method="GET" action="{{ route('esbtp.attendances.create') }}" class="row g-3">
-                            <div class="col-md-4">
+                            <div class="col-md-4"
+                                 data-classes='@json(($classes ?? collect())->map(fn ($c) => ["id" => $c->id, "name" => $c->name, "filiere_id" => $c->filiere_id, "niveau_etude_id" => $c->niveau_etude_id])->values())'
+                                 x-data="classeFilter({
+                                     classes: JSON.parse($el.dataset.classes || '[]'),
+                                     initialClasseId: {{ (int) request('classe_id', 0) }}
+                                 })">
+                                <div class="row g-2 mb-2">
+                                    <div class="col-6">
+                                        <select x-model="filiereId" class="form-control form-control-sm" aria-label="Filtrer par filière">
+                                            <option value="">Toutes les filières</option>
+                                            @foreach($filieres ?? [] as $f)
+                                                <option value="{{ $f->id }}">{{ $f->name }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                    <div class="col-6">
+                                        <select x-model="niveauId" class="form-control form-control-sm" aria-label="Filtrer par niveau d'études">
+                                            <option value="">Tous les niveaux</option>
+                                            @foreach($niveauxEtudes ?? [] as $n)
+                                                <option value="{{ $n->id }}">{{ $n->name }}</option>
+                                            @endforeach
+                                        </select>
+                                    </div>
+                                </div>
+                                <input type="text"
+                                       x-model.debounce.150ms="search"
+                                       class="form-control form-control-sm mb-2"
+                                       placeholder="Rechercher une classe..."
+                                       aria-label="Rechercher une classe">
+
                                 <label for="classe_id" class="form-label">Classe</label>
-                                <select name="classe_id" id="classe_id" class="form-control" required>
+                                <select name="classe_id" id="classe_id" class="form-control" required x-model="selectedId">
                                     <option value="">Sélectionner une classe</option>
-                                    @foreach($classes as $classe)
-                                        <option value="{{ $classe->id }}" {{ request('classe_id') == $classe->id ? 'selected' : '' }}>
-                                            {{ $classe->name }}
-                                        </option>
-                                    @endforeach
+                                    <template x-for="c in filtered" :key="c.id">
+                                        <option :value="c.id" x-text="c.name"></option>
+                                    </template>
                                 </select>
-                                <small class="form-text text-muted">
-                                    <i class="fas fa-info-circle"></i> Sélectionnez d'abord une classe pour voir les séances disponibles.
+                                <small class="form-text text-muted d-flex justify-content-between align-items-center">
+                                    <span>
+                                        <i class="fas fa-info-circle"></i>
+                                        <span x-text="filtered.length"></span> / <span x-text="classes.length"></span> classe(s) affichée(s)
+                                    </span>
+                                    <a href="#" x-show="filiereId || niveauId || search"
+                                       @click.prevent="reset()"
+                                       class="text-decoration-none">
+                                        <i class="fas fa-rotate-left"></i> Réinitialiser
+                                    </a>
                                 </small>
                             </div>
 
@@ -217,7 +252,7 @@
                                                                 {{ $initials ?: '?' }}
                                                             @endif
                                                         </span>
-                                                        <span class="at-etu-name">{{ $etudiant->nom_complet }}</span>
+                                                        <span class="at-etu-name">{{ trim(mb_strtoupper($etudiant->nom ?? '', 'UTF-8').' '.($etudiant->prenoms ?? '')) }}</span>
                                                     </div>
                                                 </td>
                                                 <td>
@@ -1497,6 +1532,41 @@
 
         debugLog('✅ [ATTENDANCES] Event delegation configuré - ZERO RELOAD MODE');
     });
+
+    /* ═══════════════════════════════════════════════════════════
+       Filtre de classe : recherche texte + filtres filière / niveau
+       ═══════════════════════════════════════════════════════════ */
+    function classeFilter(config) {
+        return {
+            classes: Array.isArray(config.classes) ? config.classes : [],
+            filiereId: '',
+            niveauId: '',
+            search: '',
+            selectedId: String(config.initialClasseId || ''),
+            init() {
+                this.$watch('filtered', (list) => {
+                    if (!this.selectedId) return;
+                    const stillThere = list.some(c => String(c.id) === String(this.selectedId));
+                    if (!stillThere) this.selectedId = '';
+                });
+            },
+            get filtered() {
+                const term = this.search.trim().toLowerCase();
+                const f = this.filiereId ? parseInt(this.filiereId, 10) : null;
+                const n = this.niveauId ? parseInt(this.niveauId, 10) : null;
+                return this.classes.filter(c =>
+                    (!f || parseInt(c.filiere_id, 10) === f) &&
+                    (!n || parseInt(c.niveau_etude_id, 10) === n) &&
+                    (!term || (c.name || '').toLowerCase().includes(term))
+                );
+            },
+            reset() {
+                this.filiereId = '';
+                this.niveauId = '';
+                this.search = '';
+            }
+        };
+    }
 
     /* ═══════════════════════════════════════════════════════════
        Onglet Saisie manuelle des heures (Alpine component)

--- a/resources/views/esbtp/attendances/partials/manual-hours-tab.blade.php
+++ b/resources/views/esbtp/attendances/partials/manual-hours-tab.blade.php
@@ -88,7 +88,7 @@
                                 data-orig-notes="{{ $origNotes }}">
                                 <td class="amh-col-name">
                                     <div class="amh-etu">
-                                        <span class="amh-etu__name">{{ $etu->nom_complet ?? trim(($etu->nom ?? '').' '.($etu->prenoms ?? '')) }}</span>
+                                        <span class="amh-etu__name">{{ trim(mb_strtoupper($etu->nom ?? '', 'UTF-8').' '.($etu->prenoms ?? '')) }}</span>
                                         <span class="amh-state-chip amh-state-chip--saved" data-state-for="saved"
                                               title="Valeurs sauvegardées sur le bulletin">
                                             <i class="fas fa-check"></i>Enregistré

--- a/resources/views/esbtp/attendances/partials/student-list.blade.php
+++ b/resources/views/esbtp/attendances/partials/student-list.blade.php
@@ -18,7 +18,7 @@
                         {{ $initials ?: '?' }}
                     @endif
                 </span>
-                <span class="at-etu-name">{{ $etudiant->nom_complet }}</span>
+                <span class="at-etu-name">{{ trim(mb_strtoupper($etudiant->nom ?? '', 'UTF-8').' '.($etudiant->prenoms ?? '')) }}</span>
                 @if($attendance)
                     <span class="at-etu-badge at-etu-badge--edit" title="Modification d'une présence existante">
                         <i class="fas fa-edit"></i>Modifié


### PR DESCRIPTION
## Résumé

Trois corrections sur `/esbtp/attendances/create` :

### 1. Matières de la saisie manuelle (commit `469b3d6`)
Le dropdown "Matière" de la saisie manuelle (heures) affichait de mauvaises matières quand la table `esbtp_planifications_academiques` était vide pour la combinaison (filière, niveau) — le fallback tombait sur le pivot legacy `esbtp_classe_matiere` (liaison directe classe→matière), ce qui renvoyait des matières non pertinentes.

**Fix** : `getMatieresClasse()` utilise désormais la **relation canonique** `esbtp_matiere_filiere_niveau` (`ESBTPMatiereFilierNiveau::matiereIdsForCombo`) — la même source que `ESBTPPlanningConfigController`, `ESBTPMatiereController` et `TroncCommunService`. Le pivot legacy BTS reste en fallback ultime uniquement.

### 2. Tri alphabétique + affichage `NOM Prenoms` (commit `6ecc71d`)
La grille saisie manuelle montrait des étudiants dans un ordre qui ne paraissait pas alphabétique, et la saisie par séance n'avait aucun `orderBy` du tout.

- Ajout de `->orderBy('esbtp_etudiants.nom')->orderBy('esbtp_etudiants.prenoms')` sur les 3 requêtes étudiants qui n'en avaient pas (`create()` avec/sans `seance_id`, `loadStudents` AJAX).
- Qualification de l'`orderBy` existant dans `loadManualTab` (défense contre l'ambiguïté `hasManyThrough`).
- Format d'affichage dans les 3 vues `attendances` changé de `"Prenoms Nom"` (via `nom_complet`) vers `"NOM Prenoms"` (`mb_strtoupper` safe pour les accents) — pour que la liste lise visuellement alphabétique comme le SQL le trie. Convention scolaire française.
- ⚠️ L'accessor `getNomCompletAttribute()` du modèle n'est **pas** modifié (blast radius énorme sur bulletins, PDFs, dashboards).

### 3. Filtres sur le sélecteur de classe (commit `6ecc71d`)
Avec 96+ classes, le `<select>` natif devenait fastidieux.

Ajout d'un bloc Alpine `classeFilter` au-dessus du select :
- Sélecteur de **filière**
- Sélecteur de **niveau d'études**
- Champ de **recherche texte** (debounced 150ms)
- Compteur live "X / Y classe(s) affichée(s)" + lien "Réinitialiser"

Le `<select name="classe_id" id="classe_id">` est conservé (même id, même name, même `required`) — donc le handler jQuery existant et l'event `attendance:classe-changed` continuent de fonctionner sans modification. Aucune nouvelle dépendance (pas de Select2) — purement Alpine.js.

## Test plan

- [ ] Aller sur `/esbtp/attendances/create`
- [ ] Vérifier que les 3 filtres (filière, niveau, recherche) restreignent bien la liste des classes et que le compteur se met à jour
- [ ] Cliquer "Réinitialiser" → les 3 filtres reviennent à vide
- [ ] Sélectionner une classe → la grille saisie par séance doit montrer les étudiants **triés par nom puis prénoms**, affichés `"NOM Prenoms"`
- [ ] Onglet "Saisie manuelle (heures)" → le dropdown "Matière" liste les matières de la combinaison (filière, niveau) uniquement
- [ ] Charger la grille manuelle → étudiants triés alphabétiquement, affichage `"NOM Prenoms"`
- [ ] Vérifier sur un tenant BTS legacy (pas de `esbtp_matiere_filiere_niveau` alimenté) que le fallback pivot fonctionne — ou lancer `php artisan sync:matiere-filiere-niveau` si nécessaire

## Pas de migration, pas de changement de modèle, pas de nouvelle dépendance.