### PR TITLE
fix(attendances): fix Blade @json parse error on create view

### DIFF
--- a/resources/views/esbtp/attendances/create.blade.php
+++ b/resources/views/esbtp/attendances/create.blade.php
@@ -86,9 +86,19 @@
 
                     <!-- Sélection de la classe et de la séance -->
                     <div class="mb-4">
+                        @php
+                            $classesForJs = ($classes ?? collect())->map(function ($c) {
+                                return [
+                                    'id' => $c->id,
+                                    'name' => $c->name,
+                                    'filiere_id' => $c->filiere_id,
+                                    'niveau_etude_id' => $c->niveau_etude_id,
+                                ];
+                            })->values();
+                        @endphp
                         <form id="selectionForm" method="GET" action="{{ route('esbtp.attendances.create') }}" class="row g-3">
                             <div class="col-md-4"
-                                 data-classes='@json(($classes ?? collect())->map(fn ($c) => ["id" => $c->id, "name" => $c->name, "filiere_id" => $c->filiere_id, "niveau_etude_id" => $c->niveau_etude_id])->values())'
+                                 data-classes='@json($classesForJs)'
                                  x-data="classeFilter({
                                      classes: JSON.parse($el.dataset.classes || '[]'),
                                      initialClasseId: {{ (int) request('classe_id', 0) }}


### PR DESCRIPTION
## Contexte

Erreur en prod sur `/esbtp/attendances/create` après le merge de #247 :

> Le caractère `'['` non fermé ne correspond pas à `')'`
> (Vue : `resources/views/esbtp/attendances/create.blade.php`)

## Cause

Le parser d'arguments de la directive Blade `@json(...)` compte mal les parenthèses quand l'expression contient une arrow function `fn ($c) => [...]` avec un tableau littéral imbriqué. Le compilateur coupe l'argument avant la fin, laissant le `[` non fermé dans le PHP généré → erreur de parse à la compilation.

Présent dans le code livré par #247 :

```blade
data-classes='@json(($classes ?? collect())->map(fn ($c) => ["id" => $c->id, ...])->values())'
```

## Fix

Extraction du `->map()` dans un bloc `@php` avant l'appel à `@json` :

```blade
@php
    $classesForJs = ($classes ?? collect())->map(function ($c) {
        return [
            'id' => $c->id,
            'name' => $c->name,
            'filiere_id' => $c->filiere_id,
            'niveau_etude_id' => $c->niveau_etude_id,
        ];
    })->values();
@endphp
...
data-classes='@json($classesForJs)'
```

Même comportement à l'exécution, compilation Blade robuste.

## Test plan

- [ ] Déployer sur `esbtp-abidjan`
- [ ] `php artisan view:clear` pour purger les vues compilées
- [ ] Charger `/esbtp/attendances/create` → la page doit s'afficher sans erreur 500
- [ ] Vérifier que les filtres de classe (filière / niveau / recherche) fonctionnent toujours
- [ ] Vérifier que le compteur "X / Y classe(s) affichée(s)" s'affiche correctement

## Pas de migration, pas de changement de modèle.