### PR TITLE
fix(lmd): align résultats class list with notes (ignore classe.annee_universitaire_id)

### DIFF
--- a/app/Http/Controllers/ESBTPLMDResultatController.php
+++ b/app/Http/Controllers/ESBTPLMDResultatController.php
@@ -22,7 +22,6 @@ class ESBTPLMDResultatController extends Controller
 
         $classes = ESBTPClasse::where('systeme_academique', 'LMD')
             ->where('is_active', true)
-            ->when($anneeId, fn($q, $id) => $q->where('annee_universitaire_id', $id))
             ->withCount([
                 'inscriptions as total_etudiants' => fn($q) => $q
                     ->where('status', 'active')


### PR DESCRIPTION
Résultats affichait moins de classes que Notes car il filtrait les classes
par esbtp_classes.annee_universitaire_id, colonne non pertinente pour le
filtrage métier. On se fie uniquement à annee_universitaire_id côté
inscription (déjà appliqué dans le withCount) et côté bulletin. Les deux
pages listent désormais le même ensemble de classes LMD actives.

https://claude.ai/code/session_01WFV3kqePBQdDnM2Ce75waJ