### PR TITLE
fix(classes-pdf): enforce margins via setPaper + @page (DomPDF reliable pattern)

### DIFF
--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -1892,13 +1892,15 @@ class ESBTPClasseController extends Controller
             ]);
 
             // Générer le PDF
+            // Taille/orientation via setPaper() (plus fiable que `size` dans @page côté DomPDF) ;
+            // les marges restent pilotées par @page dans le template (SettingsHelper).
             $pdf = PDF::loadView("esbtp.classes.export-pdf", [
                 "classes" => $classes,
                 "anneeCourante" => $anneeCourante,
                 "filters" => $filters,
                 "settings" => $settings,
                 "dateExport" => now(),
-            ]);
+            ])->setPaper("a4", "landscape");
 
             // Télécharger le PDF
             $filename = "classes_" . now()->format("Y-m-d_His") . ".pdf";

--- a/resources/views/esbtp/classes/export-pdf.blade.php
+++ b/resources/views/esbtp/classes/export-pdf.blade.php
@@ -54,7 +54,6 @@
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
         @page {
-            size: A4 landscape;
             margin: {{ $mTop }}mm {{ $mRight }}mm {{ $mBottom }}mm {{ $mLeft }}mm;
         }
 


### PR DESCRIPTION
## Summary
- Le PDF `classes.index` sortait sans aucune marge visible — le contenu touchait les 4 bords de la feuille.
- Cause : la combinaison `@page { size: A4 landscape; margin: … }` est mal gérée par DomPDF — quand `size` et `margin` cohabitent dans la même règle `@page`, les marges sont silencieusement ignorées.
- Fix appliqué selon le pattern documenté dans le skill `dompdf-expert` (§1 & §3) :
  - **Contrôleur** (`ESBTPClasseController::exportPdf`) : taille/orientation déplacées vers `->setPaper('a4', 'landscape')`.
  - **Vue** (`export-pdf.blade.php`) : `@page` ne contient plus que `margin:`, valeurs depuis `SettingsHelper::getPdfSettings()`.

## Test plan
- [ ] `php artisan view:clear` côté serveur après déploiement.
- [ ] Exporter le PDF depuis `/esbtp/classes` (bouton Export PDF).
- [ ] Vérifier les marges : ~20 mm haut/bas, ~15 mm gauche/droite (valeurs par défaut de `SettingsHelper`, ou valeurs tenant si customisées).
- [ ] Confirmer que l'orientation est bien **A4 paysage** et qu'aucun élément n'est coupé.

https://claude.ai/code/session_01XjhWvPz1hmrpuKGno9Dmpw