### PR TITLE
fix(classes-pdf): align @page pattern with working exports + floor margins to 10mm

### DIFF
--- a/resources/views/esbtp/classes/export-pdf.blade.php
+++ b/resources/views/esbtp/classes/export-pdf.blade.php
@@ -5,10 +5,12 @@
     $primary = $pdfCfg['primary_color']     ?? '#0453cb';
 
     // Marges configurables (mm) — cf. SettingsHelper::getPdfSettings()
-    $mTop    = $pdfCfg['margin_top']    ?? 15;
-    $mBottom = $pdfCfg['margin_bottom'] ?? 15;
-    $mLeft   = $pdfCfg['margin_left']   ?? 12;
-    $mRight  = $pdfCfg['margin_right']  ?? 12;
+    // Plancher minimum forcé à 10mm : certains tenants ont des valeurs trop basses
+    // qui font paraître le PDF sans marges.
+    $mTop    = max(10, (int) ($pdfCfg['margin_top']    ?? 15));
+    $mBottom = max(10, (int) ($pdfCfg['margin_bottom'] ?? 15));
+    $mLeft   = max(10, (int) ($pdfCfg['margin_left']   ?? 15));
+    $mRight  = max(10, (int) ($pdfCfg['margin_right']  ?? 15));
 
     // Fusion : settings passés par le controller (nom, adresse, …) pour l'établissement,
     // couleurs depuis les settings PDF globaux.
@@ -53,8 +55,14 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
+        /* Pattern éprouvé dans l'app (etudiants/paiements/bulletins) :
+           `size` + `margin` dans @page, doublé par setPaper() côté controller. */
         @page {
-            margin: {{ $mTop }}mm {{ $mRight }}mm {{ $mBottom }}mm {{ $mLeft }}mm;
+            margin-top: {{ $mTop }}mm;
+            margin-right: {{ $mRight }}mm;
+            margin-bottom: {{ $mBottom }}mm;
+            margin-left: {{ $mLeft }}mm;
+            size: A4 landscape;
         }
 
         body {


### PR DESCRIPTION
## Diagnostic

Après la PR #253, les marges n'apparaissaient toujours pas. Deux causes identifiées :

### 1. Mauvais pattern `@page`
J'avais simplifié le `@page` à `{ margin: … }` seul (size via `setPaper()` uniquement). Mais **tous les autres exports PDF qui fonctionnent dans l'app** utilisent le pattern combiné :
```css
@page {
    margin: …;
    size: A4 landscape;
}
```
PLUS `->setPaper('a4', 'landscape')` côté contrôleur. Références : `etudiants/export-pdf.blade.php:223`, `paiements/export-pdf.blade.php:151`, `bulletins/pdf-configurable.blade.php:342`, `notes/saisie-rapide-pdf.blade.php:379`, `liste-complete-pdf.blade.php:253`.

Retour au pattern éprouvé, avec propriétés `margin-top/right/bottom/left` en longhand pour éviter tout souci de parsing du shorthand.

### 2. Plancher de 10 mm
Les marges viennent de `SettingsHelper::getPdfSettings()` (clés `pdf_margin_*`). Certains tenants les ont configurées très basses (2–5 mm) ce qui donne un rendu quasi sans marges. Plancher forcé à **10 mm** dans la vue — les valeurs tenant > 10 mm restent respectées.

## Bonus diagnostic — cache compilé
`.github/workflows/deploycPanel.yml:30` exclut `storage/framework/views/**` du FTP. Mais Laravel (`BladeCompiler::isExpired()`) recompile si `filemtime(source) > filemtime(compilé)` — donc la modification du .blade.php suffit à invalider le cache.

## Test plan
- [ ] Exporter le PDF depuis `/esbtp/classes`.
- [ ] Vérifier qu'il y a au minimum ~10 mm de marge sur les 4 côtés (défaut 15 mm sauf override tenant).
- [ ] Vérifier que le PDF est bien en A4 paysage.
- [ ] Aucun élément ne doit être coupé par la marge.

https://claude.ai/code/session_01XjhWvPz1hmrpuKGno9Dmpw