### PR TITLE
fix(classes): reset collection keys + align PDF @page with bulletin pattern

### DIFF
--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -1552,7 +1552,8 @@ class ESBTPClasseController extends Controller
                 return $inscription->etudiant;
             })
             ->filter()
-            ->sortBy(["nom", "prenoms"]);
+            ->sortBy(["nom", "prenoms"])
+            ->values();
 
         // Récupérer les paramètres de l'établissement
         $etablissement = [
@@ -1601,7 +1602,8 @@ class ESBTPClasseController extends Controller
                 return $inscription->etudiant;
             })
             ->filter()
-            ->sortBy(["nom", "prenoms"]);
+            ->sortBy(["nom", "prenoms"])
+            ->values();
 
         // Récupérer les paramètres de l'établissement
         $etablissement = [
@@ -1659,7 +1661,8 @@ class ESBTPClasseController extends Controller
                 return $inscription->etudiant;
             })
             ->filter()
-            ->sortBy(["nom", "prenoms"]);
+            ->sortBy(["nom", "prenoms"])
+            ->values();
 
         // Récupérer les paramètres de l'établissement
         $etablissement = [
@@ -1891,9 +1894,9 @@ class ESBTPClasseController extends Controller
                 "total_classes" => $classes->count(),
             ]);
 
-            // Générer le PDF
-            // Taille/orientation via setPaper() (plus fiable que `size` dans @page côté DomPDF) ;
-            // les marges restent pilotées par @page dans le template (SettingsHelper).
+            // Générer le PDF — setPaper() + `size`/`margin` dans @page du template
+            // (pattern strictement identique à bulletins/pdf-configurable, seul
+            // combo vérifié rendant des marges visibles en prod sur cet hébergeur).
             $pdf = PDF::loadView("esbtp.classes.export-pdf", [
                 "classes" => $classes,
                 "anneeCourante" => $anneeCourante,

--- a/resources/views/esbtp/classes/export-pdf.blade.php
+++ b/resources/views/esbtp/classes/export-pdf.blade.php
@@ -4,14 +4,6 @@
     $hdrText = $pdfCfg['header_text_color'] ?? '#ffffff';
     $primary = $pdfCfg['primary_color']     ?? '#0453cb';
 
-    // Marges configurables (mm) — cf. SettingsHelper::getPdfSettings()
-    // Plancher minimum forcé à 10mm : certains tenants ont des valeurs trop basses
-    // qui font paraître le PDF sans marges.
-    $mTop    = max(10, (int) ($pdfCfg['margin_top']    ?? 15));
-    $mBottom = max(10, (int) ($pdfCfg['margin_bottom'] ?? 15));
-    $mLeft   = max(10, (int) ($pdfCfg['margin_left']   ?? 15));
-    $mRight  = max(10, (int) ($pdfCfg['margin_right']  ?? 15));
-
     // Fusion : settings passés par le controller (nom, adresse, …) pour l'établissement,
     // couleurs depuis les settings PDF globaux.
     $etablissement = [
@@ -55,14 +47,11 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
-        /* Pattern éprouvé dans l'app (etudiants/paiements/bulletins) :
-           `size` + `margin` dans @page, doublé par setPaper() côté controller. */
+        /* Pattern strictement identique à bulletins/pdf-configurable.blade.php:342
+           — seule combinaison vérifiée visible en prod dans ce projet. */
         @page {
-            margin-top: {{ $mTop }}mm;
-            margin-right: {{ $mRight }}mm;
-            margin-bottom: {{ $mBottom }}mm;
-            margin-left: {{ $mLeft }}mm;
             size: A4 landscape;
+            margin: 15mm 12mm;
         }
 
         body {


### PR DESCRIPTION
## Summary

Deux fix indépendants approuvés dans la même session de plan :

### 1. Numérotation alphabétique séquentielle sur `liste-complete` (web + PDF + Excel)

**Symptôme** : sur la page `/esbtp/classes/{id}/liste-complete` et dans le PDF associé, les étudiants étaient bien triés alphabétiquement (AGBEVO → AKAFFOU → AKISSI → …) mais les numéros de ligne affichés ne suivaient pas (37, 30, 11, 2, 12, …).

**Cause** : dans `ESBTPClasseController`, les 3 méthodes `listeComplete` / `listeCompletePDF` / `listeCompleteExcel` terminaient leur pipeline par `->sortBy(["nom", "prenoms"])` **sans `->values()`**. Comme `map()->filter()->sortBy()` préservent les clés d'origine, `@foreach($etudiants as $index => $etudiant)` lisait des clés non séquentielles au lieu de 0, 1, 2, …

**Fix** : ajout de `->values()` après chaque `sortBy` (3 endroits : lignes 1556, 1606, 1665) — idiome déjà utilisé ailleurs dans le même contrôleur (lignes 1265, 1444, 1497).

### 2. Marges PDF `classes.index` (5ᵉ tentative, la bonne)

**Symptôme** : après 4 PRs, le PDF sortait toujours sans marges visibles.

**Cause racine identifiée** : les variantes testées (`@page { margin: … }` seul, longhand `margin-top/right/bottom/left`, valeurs dynamiques depuis `SettingsHelper`) produisent toutes un rendu sans marges dans DomPDF sur cet hébergeur cPanel. Le **seul pattern vérifié visible en prod** dans ce projet est celui de `bulletins/pdf-configurable.blade.php:342` :

```css
@page {
    size: A4 landscape;
    margin: 15mm 12mm;
}
```

- `size:` en premier
- **shorthand** 2 valeurs
- **valeurs en dur** (plus de `SettingsHelper::getPdfSettings()` pour ce PDF — l'indirection était la source du silent fail)

`->setPaper('a4', 'landscape')` côté contrôleur est conservé (ceinture + bretelles, comme dans les autres exports qui marchent).

## Test plan
- [ ] `/esbtp/classes/{id}/liste-complete` (web) : les numéros affichent 1, 2, 3, … dans l'ordre alphabétique.
- [ ] Télécharger le PDF liste complète : même ordre + même numérotation.
- [ ] Télécharger l'Excel : idem.
- [ ] `/esbtp/classes` → Export PDF : le PDF a maintenant ~15 mm de marge haut/bas et ~12 mm gauche/droite, en A4 paysage.

https://claude.ai/code/session_01XjhWvPz1hmrpuKGno9Dmpw