### PR TITLE
chore(attendances): simplify PR #258 + #260 post-review

### DIFF
--- a/app/Http/Controllers/ESBTPAttendanceController.php
+++ b/app/Http/Controllers/ESBTPAttendanceController.php
@@ -1833,7 +1833,10 @@ class ESBTPAttendanceController extends Controller
     public function loadManualTab(Request $request, ManualAttendanceHoursService $service)
     {
         $globalEnabled = (bool) \App\Helpers\SettingsHelper::get('attendance_manual_hours_global_enabled', false);
-        $isGlobal = $globalEnabled && ($request->input('mode') === 'global' || $request->input('matiere_id') === null);
+        $isGlobal = $globalEnabled && (
+            $request->input('mode') === ManualAttendanceHoursService::MODE_GLOBAL
+            || $request->input('matiere_id') === null
+        );
 
         $request->validate([
             'classe_id' => 'required|exists:esbtp_classes,id',
@@ -1955,15 +1958,10 @@ class ESBTPAttendanceController extends Controller
             ], 422);
         }
 
-        $globalEnabled = (bool) \App\Helpers\SettingsHelper::get('attendance_manual_hours_global_enabled', false);
+        // La FormRequest `StoreManualAttendanceHoursRequest` a déjà garanti
+        // que `matiere_id` est présent quand le flag est OFF — pas de double-check
+        // nécessaire ici, la défense est côté validation.
         $matiereId = $request->filled('matiere_id') ? (int) $request->matiere_id : null;
-
-        if ($matiereId === null && !$globalEnabled) {
-            return response()->json([
-                'success' => false,
-                'message' => 'La saisie globale (sans matière) n\'est pas activée pour ce tenant.',
-            ], 422);
-        }
 
         $count = $service->upsertBatch(
             $entries,

--- a/app/Services/ESBTP/ManualAttendanceHoursService.php
+++ b/app/Services/ESBTP/ManualAttendanceHoursService.php
@@ -10,6 +10,9 @@ class ManualAttendanceHoursService
 {
     public const PERIODES = ['semestre1', 'semestre2', 'annuel'];
 
+    /** Valeur du paramètre `mode` attendue côté `loadManualTab` pour la saisie globale (sans matière). */
+    public const MODE_GLOBAL = 'global';
+
     public function getForEtudiant(int $etudiantId, int $anneeId, string $periode): Collection
     {
         return ESBTPAttendanceManualHours::forEtudiant($etudiantId)

--- a/app/Services/ESBTP/ManualHoursResolver.php
+++ b/app/Services/ESBTP/ManualHoursResolver.php
@@ -19,7 +19,24 @@ use App\Support\Attendance\ManualHoursSnapshot;
  */
 class ManualHoursResolver
 {
+    /**
+     * Cache in-process pour éviter de re-requêter les mêmes
+     * (étudiant, année, période) lors d'une même requête HTTP.
+     * BulletinService appelle à la fois `calculerDetailAbsences` et
+     * `calculerAbsencesParMatiere` pour chaque étudiant lors de la
+     * génération d'un bulletin de classe — sans ce cache on doublerait
+     * les queries.
+     */
+    private array $cache = [];
+
     public function snapshot(int $etudiantId, int $anneeId, string $periode): ManualHoursSnapshot
+    {
+        $key = "{$etudiantId}:{$anneeId}:{$periode}";
+
+        return $this->cache[$key] ??= $this->build($etudiantId, $anneeId, $periode);
+    }
+
+    private function build(int $etudiantId, int $anneeId, string $periode): ManualHoursSnapshot
     {
         $rows = ESBTPAttendanceManualHours::query()
             ->where('etudiant_id', $etudiantId)

--- a/app/Support/Attendance/HoursFormatter.php
+++ b/app/Support/Attendance/HoursFormatter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Support\Attendance;
+
+/**
+ * Formatage des heures (décimales) pour l'affichage.
+ *
+ * KLASSCI stocke les heures d'absence/présence en `decimal(6,2)` (voir
+ * `esbtp_attendance_manual_hours`), mais pour l'affichage on veut :
+ *
+ *   - 4.00 → "4"
+ *   - 4.50 → "4.5"
+ *   - 4.25 → "4.25"
+ *
+ * Autrement dit : trailing-zero stripping après arrondi à 2 décimales.
+ * Le pattern `rtrim(rtrim(number_format(...), '0'), '.')` était dupliqué
+ * dans 3+ sites (les 2 partials manual-hours, ESBTPPDFService) — centralisé ici.
+ *
+ * Le séparateur décimal est paramétrable car `ESBTPPDFService` utilise
+ * la virgule (convention française du bulletin) alors que les grilles de
+ * saisie web utilisent le point (input type=number).
+ */
+final class HoursFormatter
+{
+    public static function format(float $hours, string $decimalSeparator = '.'): string
+    {
+        return rtrim(rtrim(number_format($hours, 2, $decimalSeparator, ''), '0'), $decimalSeparator);
+    }
+}

--- a/app/Support/Attendance/ManualHoursSnapshot.php
+++ b/app/Support/Attendance/ManualHoursSnapshot.php
@@ -57,15 +57,4 @@ final class ManualHoursSnapshot
     {
         return $this->perMatiere->keys()->all();
     }
-
-    /**
-     * Source effective pour une matière donnée selon la règle de priorité.
-     * Ne retourne JAMAIS la ligne globale ici — la ventilation par matière
-     * depuis une ligne globale ne serait qu'une moyenne artificielle. La
-     * ligne globale se consomme explicitement via `$snapshot->global`.
-     */
-    public function effectiveForMatiere(int $matiereId): ?ESBTPAttendanceManualHours
-    {
-        return $this->forMatiere($matiereId);
-    }
 }

--- a/resources/views/esbtp/attendances/partials/manual-hours-tab.blade.php
+++ b/resources/views/esbtp/attendances/partials/manual-hours-tab.blade.php
@@ -1,7 +1,7 @@
 @php
     $volumeHoraireTotal = $volumeHoraireTotal ?? 0;
     $isGlobal = $isGlobal ?? false;
-    $fmtHours = fn ($h) => rtrim(rtrim(number_format((float) $h, 2, '.', ''), '0'), '.');
+    $fmtHours = fn ($h) => \App\Support\Attendance\HoursFormatter::format((float) $h);
 @endphp
 <div class="amh-panel" data-classe-id="{{ $classe->id }}" data-matiere-id="{{ $isGlobal ? '' : $matiere->id }}" data-periode="{{ $periode }}" data-annee-id="{{ $anneeUniversitaire->id }}" data-volume-total="{{ $volumeHoraireTotal }}" data-mode="{{ $isGlobal ? 'global' : 'per-matiere' }}">
     <div class="amh-header">

--- a/resources/views/esbtp/etudiants/partials/presences-manual-hours.blade.php
+++ b/resources/views/esbtp/etudiants/partials/presences-manual-hours.blade.php
@@ -23,7 +23,7 @@
     $mhPerMatiere = $mhRows->filter(fn ($r) => $r->matiere_id !== null);
     $mhGlobalRows = $mhRows->filter(fn ($r) => $r->matiere_id === null);
 
-    $fmtHours = fn ($h) => rtrim(rtrim(number_format((float) $h, 2, '.', ''), '0'), '.');
+    $fmtHours = fn ($h) => \App\Support\Attendance\HoursFormatter::format((float) $h);
 
     $periodeLabel = fn ($p) => ucfirst(str_replace('semestre', 'Semestre ', $p));
 @endphp

--- a/tests/Unit/Services/ESBTP/ManualHoursResolverTest.php
+++ b/tests/Unit/Services/ESBTP/ManualHoursResolverTest.php
@@ -76,7 +76,7 @@ class ManualHoursResolverTest extends TestCase
         $this->assertSame([$matiere->id], $snapshot->matiereIdsWithManual());
     }
 
-    public function test_effective_for_matiere_never_falls_back_to_global(): void
+    public function test_per_matiere_collection_never_contains_global(): void
     {
         $etudiant = ESBTPEtudiant::factory()->create();
         $annee = ESBTPAnneeUniversitaire::factory()->create();
@@ -94,7 +94,9 @@ class ManualHoursResolverTest extends TestCase
 
         $snapshot = $this->resolver->snapshot($etudiant->id, $annee->id, 'semestre1');
 
-        $this->assertNull($snapshot->effectiveForMatiere($matiere->id));
+        $this->assertNull($snapshot->forMatiere($matiere->id));
+        $this->assertFalse($snapshot->hasMatiere($matiere->id));
+        $this->assertTrue($snapshot->perMatiere->isEmpty());
         $this->assertNotNull($snapshot->global);
     }
 }


### PR DESCRIPTION
## Summary

Applique les findings des 3 agents `/simplify` (code-reuse, quality, efficiency) sur les 2 PRs mergées.

## What

- **`HoursFormatter` util** : extraction de `rtrim(rtrim(number_format($h, 2, '.', ''), '0'), '.')` dupliqué dans 3+ sites → `App\Support\Attendance\HoursFormatter::format()`. Utilisé dans les 2 partials manual-hours.
- **`ManualHoursResolver` cache in-process** : `BulletinService` appelle `snapshot()` 2× par étudiant (via `calculerDetailAbsences` + `calculerAbsencesParMatiere`) — sans cache, bulletin classe = 2× N queries sur `manual_hours`. Gain estimé ~50% sur cette table lors d'un bulletin de classe.
- **`MODE_GLOBAL` constant** : stringly-typed `'global'` → `ManualAttendanceHoursService::MODE_GLOBAL`.
- **Drop defensive double-check** : la vérif `if ($matiereId === null && !$globalEnabled)` dans `storeManualHours` était redondante — la `FormRequest` valide déjà.
- **Remove dead `effectiveForMatiere()`** : simple délégation vers `forMatiere()`. Test adapté pour asserter directement l'invariant.

## Test plan

- [ ] Partial `presences-manual-hours.blade.php` continue de formater `4.00` → `4`, `4.5` → `4.5`, `4.25` → `4.25`
- [ ] Bulletin classe → 2× moins de queries sur `manual_hours` (vérifier via Debugbar/Telescope)
- [ ] Saisie manuelle `/esbtp/attendances/create` toggle global → fonctionne identiquement

## Not applied (higher cost, defer)

- Dedup `collectSessionAbsences` entre `calculerDetailAbsences` et `calculerAbsencesParMatiere` (refactor ~50 lignes, séparer en PR dédiée)
- Déplacer la query inline du partial vers `EtudiantDossierService` (requiert modif controller)
- Unifier `matchQuery` / resolver via scope Eloquent `scopeForSlot` (nice-to-have)