### PR TITLE
fix(attendances): 2 bugs post-feature saisie globale

### DIFF
--- a/resources/views/esbtp/attendances/create.blade.php
+++ b/resources/views/esbtp/attendances/create.blade.php
@@ -204,14 +204,14 @@
                             <button type="button"
                                     class="att-tab"
                                     :class="{ 'att-tab--active': activeTab === 'seances' }"
-                                    @click="activeTab = 'seances'"
+                                    @click="activeTab = 'seances'; $dispatch('attendance:tab-changed', { tab: 'seances' })"
                                     role="tab">
                                 <i class="fas fa-calendar-check"></i>Saisie par séance
                             </button>
                             <button type="button"
                                     class="att-tab"
                                     :class="{ 'att-tab--active': activeTab === 'manual' }"
-                                    @click="activeTab = 'manual'"
+                                    @click="activeTab = 'manual'; $dispatch('attendance:tab-changed', { tab: 'manual' })"
                                     role="tab">
                                 <i class="fas fa-list-check"></i>Saisie manuelle (heures)
                             </button>
@@ -383,18 +383,22 @@
                             </div>
                     </div>
 
-                    {{-- Alertes contextuelles (Alpine-réactives) — en dehors des onglets pour être visibles même sans classe --}}
+                    {{-- Alertes contextuelles (Alpine-réactives) — en dehors des onglets pour être visibles même sans classe.
+                         `activeTab` est synchronisé via l'event `attendance:tab-changed` dispatché par les boutons d'onglets —
+                         on ne peut pas lire l'`activeTab` du composant manualHoursTab directement car il est dans un autre x-data scope. --}}
                     <div x-data="{
                             hasClasse: {{ (isset($classeSelectionnee) && $classeSelectionnee) ? 'true' : 'false' }},
                             hasSeance: {{ request()->filled('seance_id') ? 'true' : 'false' }},
-                            hasStudents: {{ (isset($etudiants) && $etudiants->count() > 0) ? 'true' : 'false' }}
+                            hasStudents: {{ (isset($etudiants) && $etudiants->count() > 0) ? 'true' : 'false' }},
+                            activeTab: 'seances'
                          }"
                          @attendance:classe-changed.window="hasClasse = !!$event.detail.classeId; hasSeance = false; hasStudents = false;"
-                         @attendance:seance-loaded.window="hasSeance = true; hasStudents = ($event.detail.nbEtudiants ?? 0) > 0;">
-                        <div class="alert alert-warning" x-show="hasClasse && hasSeance && !hasStudents" x-cloak>
+                         @attendance:seance-loaded.window="hasSeance = true; hasStudents = ($event.detail.nbEtudiants ?? 0) > 0;"
+                         @attendance:tab-changed.window="activeTab = $event.detail.tab">
+                        <div class="alert alert-warning" x-show="hasClasse && hasSeance && !hasStudents && activeTab === 'seances'" x-cloak>
                             <i class="fas fa-triangle-exclamation me-2"></i>Aucun étudiant n'est inscrit dans cette classe pour l'année en cours.
                         </div>
-                        <div class="alert alert-info" x-show="hasClasse && !hasSeance" x-cloak>
+                        <div class="alert alert-info" x-show="hasClasse && !hasSeance && activeTab === 'seances'" x-cloak>
                             <i class="fas fa-info-circle me-2"></i>Veuillez sélectionner une séance pour voir les étudiants et marquer les présences.
                         </div>
                         <div class="alert alert-info" x-show="!hasClasse" x-cloak>

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -3902,6 +3902,7 @@
     {{-- ── Année en cours : bloc FLAT (toujours visible) ── --}}
     @if($presAnneeCourante)
     @php
+        $hasManualHoursCur = false;
         if ($presInscCourante) {
             $anneePresId    = $presAnneeCourante->id;
             $attRowCur = \App\Models\ESBTPAttendance::finalOnly()
@@ -3915,6 +3916,15 @@
             $absCur    = (int)($attRowCur->nb_absences ?? 0);
             $justCur   = (int)($attRowCur->nb_absences_just ?? 0);
             $tauxCur   = $totalCur > 0 ? round(($presCur + $retardCur) / $totalCur * 100, 1) : null;
+
+            // Précharger la présence de saisie manuelle pour cette année :
+            // ça évite d'afficher le message "Aucune séance enregistrée"
+            // alors que la card manual-hours juste en-dessous contient des
+            // données — la séparation visuelle paraissait incohérente.
+            $hasManualHoursCur = \App\Models\ESBTPAttendanceManualHours::query()
+                ->where('etudiant_id', $etudiant->id)
+                ->where('annee_universitaire_id', $anneePresId)
+                ->exists();
         }
     @endphp
     <div class="fin-hero" style="margin-bottom:16px;">
@@ -3945,11 +3955,15 @@
 
         @if(!$presInscCourante)
             {{-- Pas d'inscription courante — message déjà affiché dans le hero badge ci-dessus --}}
-        @elseif(($totalCur ?? 0) === 0)
+        @elseif(($totalCur ?? 0) === 0 && !$hasManualHoursCur)
             <div style="text-align:center; padding:28px 16px; color:var(--k-muted);">
                 <i class="fas fa-calendar-times" style="font-size:2rem; opacity:.25; display:block; margin-bottom:12px;"></i>
                 <p style="font-size:.84rem; margin:0; font-weight:500;">Aucune séance de présence enregistrée pour cette année.</p>
             </div>
+        @elseif(($totalCur ?? 0) === 0 && $hasManualHoursCur)
+            {{-- Des heures manuelles existent — pas d'empty state, la card
+                 presences-manual-hours s'affichera naturellement en-dessous
+                 et portera la donnée. --}}
         @else
             @php
                 $presConstatClassCur = ($tauxCur ?? 0) >= 80 ? 'good' : (($tauxCur ?? 0) >= 60 ? 'warning' : 'bad');


### PR DESCRIPTION
## Summary

Fix 2 bugs rapportés après merge de #258/260/261 en production.

## Bugs fixés

### 1. Tab Présences etudiants.show — empty state incohérent
**Avant** : dark hero affiche "Aucune séance enregistrée" + grosse zone vide, puis card manuel-hours en-dessous. Visuellement séparé et contradictoire (la donnée EST là).
**Maintenant** : précharge `\$hasManualHoursCur`. Quand heures manuelles existent → skip empty state. Le hero reste compact (juste le badge année), la card manuel enchaîne naturellement.

### 2. /esbtp/attendances/create — alertes séance persistantes sur onglet manuel
**Avant** : message "Veuillez sélectionner une séance" visible même sur l'onglet Saisie manuelle (heures).
**Maintenant** : les boutons d'onglet dispatchent `attendance:tab-changed`. Le bloc d'alertes écoute cet event et filtre selon `activeTab === 'seances'`. L'alerte "pas de classe" reste globale (pertinente aux 2 onglets).

## Bug 3 (non-bug) — toggle "Mode global" absent

Le toggle "Mode global (sans matière)" apparaît uniquement quand le flag tenant `attendance_manual_hours_global_enabled` est ON. **Activation côté serveur** (SSH sur le tenant concerné, ex: `~/public_html/presentation`) :

\`\`\`bash
php artisan tinker --execute="\App\Helpers\SettingsHelper::setOrCreate('attendance_manual_hours_global_enabled', '1', 'attendance', 'boolean'); \Illuminate\Support\Facades\Cache::forget('setting_attendance_manual_hours_global_enabled'); echo 'OK';"
\`\`\`

Ou SQL direct :
\`\`\`sql
INSERT INTO settings (\`key\`, value, \`group\`, type, is_active, created_at, updated_at)
VALUES ('attendance_manual_hours_global_enabled', '1', 'attendance', 'boolean', 1, NOW(), NOW())
ON DUPLICATE KEY UPDATE value = '1', is_active = 1, updated_at = NOW();
\`\`\`

Puis `php artisan cache:clear`.

Le flag reste **OFF par défaut** (validé au plan) pour que les tenants tests (yakro, abidjan, islg-rostan, hetec) ne voient pas la feature tant que pas demandée.

## Test plan

- [ ] Fiche étudiant avec saisie manuelle S1 mais aucune séance → plus de "Aucune séance enregistrée" au-dessus, enchaînement naturel
- [ ] /esbtp/attendances/create onglet "Saisie manuelle" → pas d'alerte "Veuillez sélectionner une séance"
- [ ] Basculer vers "Saisie par séance" → l'alerte réapparaît
- [ ] Activer le flag via tinker → recharger la page → toggle "Mode global" visible