### PR TITLE
fix(attendances): skip fin-hero dark + toggle settings UI

### DIFF
--- a/app/Http/Controllers/ESBTP/ESBTPSettingsController.php
+++ b/app/Http/Controllers/ESBTP/ESBTPSettingsController.php
@@ -153,6 +153,22 @@ class ESBTPSettingsController extends Controller
                 );
             }
 
+            // Assiduité / saisie manuelle d'heures — toggle tenant
+            Setting::firstOrCreate(
+                ['key' => 'attendance_manual_hours_global_enabled'],
+                [
+                    'value' => '0',
+                    'type' => 'boolean',
+                    'group' => 'attendance',
+                    'category' => 'bulletin',
+                    'description' => "Active le mode global (sans matière) pour la saisie manuelle d'heures sur /esbtp/attendances/create",
+                    'is_required' => false,
+                    'default_value' => '0',
+                    'validation_rules' => null,
+                    'sort_order' => 155,
+                ]
+            );
+
             // Créer les settings tronc commun si inexistants
             $troncCommunDefaults = [
                 'tronc_commun_enabled' => ['value' => '0', 'description' => 'Activer le tronc commun'],
@@ -192,6 +208,7 @@ class ESBTPSettingsController extends Controller
                 'bulletin_auto_calculate_mention', 'bulletin_show_felicitation', 'bulletin_show_encouragement',
                 'certificat_show_classe', 'certificat_show_niveau', 'certificat_show_filiere',
                 'bulletin_conduite_enabled', 'bulletin_show_absences_par_matiere',
+                'attendance_manual_hours_global_enabled',
             ], array_keys($troncCommunDefaults)))->get();
 
             foreach ($allCheckboxSettings as $setting) {

--- a/resources/views/esbtp/etudiants/show.blade.php
+++ b/resources/views/esbtp/etudiants/show.blade.php
@@ -1929,6 +1929,25 @@
     background: #fff;
     margin-top: 1rem;
 }
+
+/* Chip compact "Année en cours" rendu au-dessus de la card mh-card
+   quand on saute le fin-hero dark (étudiant avec heures manuelles mais
+   pas de séances). */
+.pres-year-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .5rem .9rem;
+    background: #eff6ff;
+    color: #1e40af;
+    border: 1px solid #bfdbfe;
+    border-radius: 999px;
+    font-size: .78rem;
+    font-weight: 600;
+    margin-bottom: .6rem;
+}
+.pres-year-chip i { color: #0453cb; }
+.pres-year-chip strong { color: #0c4a6e; font-weight: 700; }
 </style>
 @endsection
 
@@ -3926,7 +3945,25 @@
                 ->where('annee_universitaire_id', $anneePresId)
                 ->exists();
         }
+
+        // Skip totalement le dark hero quand l'étudiant n'a QUE des heures
+        // manuelles pour cette année (ni séances, ni absence d'inscription) —
+        // la section manuelle ci-dessous porte toute la donnée et un dark
+        // hero vide créait une bande inutile.
+        $skipFinHeroPresCur = $presInscCourante
+            && ($totalCur ?? 0) === 0
+            && $hasManualHoursCur;
     @endphp
+    @if($skipFinHeroPresCur)
+        {{-- Juste un chip compact "Année en cours · Classe", en bleu clair. --}}
+        <div class="pres-year-chip">
+            <i class="fas fa-calendar-check"></i>
+            Année en cours&nbsp;: <strong>{{ $presAnneeCourante->name }}</strong>
+            @if($presInscCourante->classe)
+                &middot; {{ $presInscCourante->classe->name }}
+            @endif
+        </div>
+    @else
     <div class="fin-hero" style="margin-bottom:16px;">
         @if($presInscCourante)
         <div class="fin-hero-year-badge">
@@ -3955,15 +3992,14 @@
 
         @if(!$presInscCourante)
             {{-- Pas d'inscription courante — message déjà affiché dans le hero badge ci-dessus --}}
-        @elseif(($totalCur ?? 0) === 0 && !$hasManualHoursCur)
+        @elseif(($totalCur ?? 0) === 0)
+            {{-- Cas "pas de séances, pas de manual" : empty state classique.
+                 Le cas "pas de séances MAIS manual existe" ne rentre pas ici :
+                 on a sauté le fin-hero entier via `$skipFinHeroPresCur`. --}}
             <div style="text-align:center; padding:28px 16px; color:var(--k-muted);">
                 <i class="fas fa-calendar-times" style="font-size:2rem; opacity:.25; display:block; margin-bottom:12px;"></i>
                 <p style="font-size:.84rem; margin:0; font-weight:500;">Aucune séance de présence enregistrée pour cette année.</p>
             </div>
-        @elseif(($totalCur ?? 0) === 0 && $hasManualHoursCur)
-            {{-- Des heures manuelles existent — pas d'empty state, la card
-                 presences-manual-hours s'affichera naturellement en-dessous
-                 et portera la donnée. --}}
         @else
             @php
                 $presConstatClassCur = ($tauxCur ?? 0) >= 80 ? 'good' : (($tauxCur ?? 0) >= 60 ? 'warning' : 'bad');
@@ -4052,6 +4088,7 @@
             </div>
         @endif
     </div>
+    @endif {{-- /!$skipFinHeroPresCur --}}
 
     {{-- Section "Saisie manuelle" année courante : extraite du hero dark
          vers une card claire (contraste WCAG correct). --}}

--- a/resources/views/esbtp/settings/index.blade.php
+++ b/resources/views/esbtp/settings/index.blade.php
@@ -1214,6 +1214,39 @@
                 </div>
             </div>
 
+            <!-- Section 6b: Assiduite / Saisie manuelle d'heures -->
+            <div class="settings-section">
+                <div class="section-header">
+                    <div class="section-icon"><i class="fas fa-list-check"></i></div>
+                    <div>
+                        <h3 class="section-title">Assiduite -- Saisie manuelle d'heures</h3>
+                        <p class="section-description">Sources et options pour la saisie manuelle des heures de presence/absence (page Marquer les presences)</p>
+                    </div>
+                </div>
+
+                <div class="bc-grid bc-grid-1">
+                    <div class="bc-card">
+                        <div class="bc-icon"><i class="fas fa-globe"></i></div>
+                        <div class="bc-body">
+                            <div class="bc-label">Mode global (saisie sans matiere)</div>
+                            <div class="bc-desc">
+                                Active l'option "Mode global" dans /esbtp/attendances/create onglet Saisie manuelle.
+                                Permet d'enregistrer des heures d'absence/presence pour un etudiant sans les rattacher
+                                a une matiere specifique (cas : signalement disciplinaire, dispense, retour maladie).
+                                La regle de priorite bulletin reste : <strong>par matiere &gt; global &gt; seances</strong>.
+                            </div>
+                        </div>
+                        <div class="bc-toggle">
+                            <label class="form-switch-modern">
+                                <input type="checkbox" name="attendance_manual_hours_global_enabled" value="1"
+                                       {{ \App\Helpers\SettingsHelper::get('attendance_manual_hours_global_enabled', '0') == '1' ? 'checked' : '' }}>
+                                <span class="slider"></span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- Section 7: Mentions et Seuils -->
             <div class="settings-section">
                 <div class="section-header">


### PR DESCRIPTION
## Summary

Répond à la question de l'user sur Image #17 : ma précédente correction ne suffisait pas — le dark hero restait affiché vide car je n'avais supprimé que le **message** à l'intérieur, pas le **conteneur**.

## What

### 1. Skip fin-hero dark quand seules les heures manuelles existent

- Précharge `\$skipFinHeroPresCur = \$presInscCourante && \$totalCur === 0 && \$hasManualHoursCur`
- Quand vrai → SAUTE totalement le `<div class="fin-hero">` (plus de bande dark vide ~180px)
- Affiche à la place un petit chip `.pres-year-chip` en bleu clair ("Année en cours : 2025-2026 · B3 COM")
- Flux visuel naturel : chip compact → card mh-card avec KPIs

### 2. Toggle settings UI (scope 1 flag)

- Ajout section "Assiduite — Saisie manuelle d'heures" dans `/esbtp/settings` tab Bulletin
- Toggle `attendance_manual_hours_global_enabled` → plus besoin de SSH+tinker
- Controller : `firstOrCreate` + ajout à `\$allCheckboxSettings`
- Cache auto-invalidé par le model `Setting` sur update

## Test plan

- [ ] Fiche étudiant avec heures manuelles mais aucune séance → plus de bande dark vide, juste un petit chip bleu clair au-dessus de la card mh
- [ ] Fiche étudiant avec séances → dark hero normal (stats + donut) inchangé
- [ ] `/esbtp/settings` tab Bulletin → section "Assiduite" visible, toggle activable
- [ ] Après toggle ON → /esbtp/attendances/create onglet "Saisie manuelle" affiche le toggle "Mode global"

## Quality Gate 4 axes

| Axe | Verdict | Detail |
|-----|---------|--------|
| Architecture | PASS | Pattern existant (firstOrCreate + \$allCheckboxSettings) réutilisé |
| Qualité vs Vitesse | PASS | 1 query de plus (`$hasManualHoursCur = exists()`) mais bornée à la fiche étudiant |
| Production-grade | PASS | Cache auto-invalidé, pas de breaking change |
| SOLID | PASS | Aucun changement d'interface, juste extension de la vue |