### PR TITLE
feat(chatbot): workflow_step + places sur tools + contexte conversationnel

### DIFF
--- a/app/Services/Chatbot/ClaudeAgentService.php
+++ b/app/Services/Chatbot/ClaudeAgentService.php
@@ -41,9 +41,12 @@ class ClaudeAgentService
     protected int $contextWindow = 10;
     protected int $maxToolRounds = 3;
 
-    public function __construct(ChatbotSetupGuideService $setupGuide)
+    protected ConversationContextProvider $contextProvider;
+
+    public function __construct(ChatbotSetupGuideService $setupGuide, ConversationContextProvider $contextProvider)
     {
         $this->registerTools($setupGuide);
+        $this->contextProvider = $contextProvider;
     }
 
     protected function registerTools(ChatbotSetupGuideService $setupGuide): void
@@ -98,7 +101,7 @@ class ClaudeAgentService
             return $this->fallbackResponse();
         }
 
-        $systemPrompt = $this->buildSystemInstruction($user, $preferences, $clientContext);
+        $systemPrompt = $this->buildSystemInstruction($user, $preferences, $clientContext, $conversation);
         $history = $this->buildHistory($conversation);
         $toolDefinitions = $this->buildToolDefinitions($user);
 
@@ -150,6 +153,10 @@ class ClaudeAgentService
                 // Capturer les métadonnées d'affichage
                 if ($tool && !isset($result['error'])) {
                     $allToolCalls[] = ['tool' => $toolName, 'args' => $toolArgs, 'result_count' => $result['count'] ?? null];
+
+                    // Enregistrer un résumé minimal dans le contexte conversationnel
+                    // pour permettre les questions de suivi ("et dans la classe d'à côté ?").
+                    $this->contextProvider->updateFromToolResult($conversation, $toolName, $toolArgs, $result);
 
                     $resultDisplayType = $result['display_type'] ?? 'text';
 
@@ -278,8 +285,12 @@ class ClaudeAgentService
     /**
      * Construire l'instruction système.
      */
-    protected function buildSystemInstruction($user, ?ChatbotUserPreference $preferences, ?array $clientContext): string
-    {
+    protected function buildSystemInstruction(
+        $user,
+        ?ChatbotUserPreference $preferences,
+        ?array $clientContext,
+        ?ChatbotConversation $conversation = null,
+    ): string {
         $domainContext = $this->getDomainContext();
         $userName = $preferences?->preferred_name ?? $user->name ?? 'utilisateur';
         $roleName = $user->roles?->first()?->name ?? 'utilisateur';
@@ -313,13 +324,24 @@ class ClaudeAgentService
             $notesUtilisateur = "\nNotes personnelles de l'utilisateur : {$preferences->notes}";
         }
 
+        // Contexte conversationnel : résumé minimal du dernier tool result, pour les questions de suivi.
+        // Haiku doit UTILISER les IDs exacts listés ici (cf. règle 3b) si l'utilisateur fait référence à un élément précédent.
+        $previousContext = '';
+        if ($conversation) {
+            $summary = $this->contextProvider->summaryBlock($conversation);
+            if ($summary) {
+                $previousContext = "\nContexte du dernier résultat d'outil (pour les questions de suivi) : {$summary}\n"
+                    . "→ Si l'utilisateur fait référence implicitement à ces résultats (\"et pour l'autre classe ?\", \"et dans la 2e année ?\"), utilise ces IDs/noms exacts. Sinon, fais un nouvel appel d'outil.";
+            }
+        }
+
         return <<<PROMPT
 Tu es l'assistant IA de KLASSCI, un système de gestion d'établissement scolaire professionnel (BTS, Licence) en Côte d'Ivoire.
 
 {$domainContext}
 
 L'utilisateur s'appelle {$userName} et a le rôle "{$roleName}".
-{$styleInstructions}{$pageContext}{$notesUtilisateur}
+{$styleInstructions}{$pageContext}{$notesUtilisateur}{$previousContext}
 
 WORKFLOW EMPLOI DU TEMPS :
 - La page "Emplois du temps" (index) liste tous les emplois du temps + raccourci pour créer rapidement + bouton "Modifier rapidement" (multi-sélection)

--- a/app/Services/Chatbot/ClaudeAgentService.php
+++ b/app/Services/Chatbot/ClaudeAgentService.php
@@ -154,8 +154,6 @@ class ClaudeAgentService
                 if ($tool && !isset($result['error'])) {
                     $allToolCalls[] = ['tool' => $toolName, 'args' => $toolArgs, 'result_count' => $result['count'] ?? null];
 
-                    // Enregistrer un résumé minimal dans le contexte conversationnel
-                    // pour permettre les questions de suivi ("et dans la classe d'à côté ?").
                     $this->contextProvider->updateFromToolResult($conversation, $toolName, $toolArgs, $result);
 
                     $resultDisplayType = $result['display_type'] ?? 'text';

--- a/app/Services/Chatbot/ConversationContextProvider.php
+++ b/app/Services/Chatbot/ConversationContextProvider.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Services\Chatbot;
+
+use App\Models\ChatbotConversation;
+
+/**
+ * Gère un résumé minimal du dernier résultat d'outil pour permettre à Claude
+ * de résoudre des questions de suivi contextuelles ("et dans la classe d'à côté ?",
+ * "et pour la 2e année ?") sans gonfler les tokens en réinjectant tous les résultats.
+ *
+ * Format du summary stocké dans conversation->context['last_result_summary'] :
+ *   {
+ *     "tool":    "search_classes",                       // nom de l'outil appelé
+ *     "filters": {"filiere":"BTP","has_places":true},    // filtres utiles (scalaires uniquement)
+ *     "count":   5,                                       // nombre de résultats retournés
+ *     "total":   12,                                      // total sans limit (si dispo)
+ *     "ids":     [3, 7, 12, 18, 25],                     // max 5 IDs (stabilise les follow-ups)
+ *     "names":   ["BTP L1", "BTP L2", …],                // max 5 noms (lecture humaine)
+ *     "at":      "2026-04-25T10:22:03+00:00"
+ *   }
+ *
+ * Aucune donnée PII brute (pas de matricule, email, téléphone).
+ */
+class ConversationContextProvider
+{
+    /** Limite stricte sur le nombre d'IDs/noms conservés dans le summary. */
+    public const MAX_SAMPLE = 5;
+
+    /** Clé sous laquelle le summary est stocké dans conversation->context. */
+    public const CONTEXT_KEY = 'last_result_summary';
+
+    /**
+     * Renvoyer un bloc texte court à injecter dans le system prompt, ou null si pas de contexte.
+     */
+    public function summaryBlock(ChatbotConversation $conversation): ?string
+    {
+        $context = $conversation->context ?? [];
+        $summary = $context[self::CONTEXT_KEY] ?? null;
+        if (!is_array($summary) || empty($summary['tool'])) {
+            return null;
+        }
+
+        $parts = [];
+        $parts[] = 'tool=' . $summary['tool'];
+        if (!empty($summary['filters']) && is_array($summary['filters'])) {
+            $filters = [];
+            foreach ($summary['filters'] as $k => $v) {
+                $filters[] = $k . '=' . (is_bool($v) ? ($v ? 'true' : 'false') : (string) $v);
+            }
+            if ($filters) {
+                $parts[] = 'filters={' . implode(', ', $filters) . '}';
+            }
+        }
+        if (isset($summary['count'])) {
+            $parts[] = 'count=' . $summary['count'];
+        }
+        if (!empty($summary['ids']) && is_array($summary['ids'])) {
+            $parts[] = 'ids=[' . implode(',', $summary['ids']) . ']';
+        }
+        if (!empty($summary['names']) && is_array($summary['names'])) {
+            $parts[] = 'names=[' . implode(', ', array_map(fn ($n) => '"' . $n . '"', $summary['names'])) . ']';
+        }
+
+        return implode(' | ', $parts);
+    }
+
+    /**
+     * Mettre à jour le contexte avec un résumé du dernier tool result.
+     * Sauvegarde uniquement si des résultats sont présents.
+     */
+    public function updateFromToolResult(
+        ChatbotConversation $conversation,
+        string $toolName,
+        array $args,
+        array $result,
+    ): void {
+        // Ne pas polluer le contexte avec des errors ou 0 résultats
+        if (isset($result['error']) || empty($result['results'])) {
+            return;
+        }
+
+        $sample = array_slice($result['results'], 0, self::MAX_SAMPLE);
+        $ids = [];
+        $names = [];
+        foreach ($sample as $row) {
+            if (isset($row['id']) && is_numeric($row['id'])) {
+                $ids[] = (int) $row['id'];
+            }
+            $name = $row['nom'] ?? $row['etudiant'] ?? $row['name'] ?? null;
+            if (is_string($name) && $name !== '' && $name !== 'N/A') {
+                $names[] = mb_substr($name, 0, 60, 'UTF-8');
+            }
+        }
+
+        $summary = [
+            'tool' => $toolName,
+            'filters' => $this->sanitizeFilters($args),
+            'count' => $result['count'] ?? count($result['results'] ?? []),
+            'ids' => $ids,
+            'names' => $names,
+            'at' => now()->toIso8601String(),
+        ];
+
+        if (isset($result['total'])) {
+            $summary['total'] = (int) $result['total'];
+        }
+
+        $context = $conversation->context ?? [];
+        if (!is_array($context)) {
+            $context = [];
+        }
+        $context[self::CONTEXT_KEY] = $summary;
+        $conversation->context = $context;
+        $conversation->save();
+    }
+
+    /**
+     * Garder uniquement les filtres scalaires (string/int/bool) pour éviter d'y mettre des
+     * objets ou des payloads volumineux qui exploseraient la taille du summary.
+     */
+    protected function sanitizeFilters(array $args): array
+    {
+        $filtered = [];
+        foreach ($args as $k => $v) {
+            if (is_scalar($v) && $v !== '' && $v !== null) {
+                $filtered[$k] = is_string($v) ? mb_substr($v, 0, 80, 'UTF-8') : $v;
+            }
+        }
+        return $filtered;
+    }
+}

--- a/app/Services/Chatbot/ConversationContextProvider.php
+++ b/app/Services/Chatbot/ConversationContextProvider.php
@@ -75,7 +75,6 @@ class ConversationContextProvider
         array $args,
         array $result,
     ): void {
-        // Ne pas polluer le contexte avec des errors ou 0 résultats
         if (isset($result['error']) || empty($result['results'])) {
             return;
         }
@@ -107,9 +106,6 @@ class ConversationContextProvider
         }
 
         $context = $conversation->context ?? [];
-        if (!is_array($context)) {
-            $context = [];
-        }
         $context[self::CONTEXT_KEY] = $summary;
         $conversation->context = $context;
         $conversation->save();

--- a/app/Services/Chatbot/Tools/SearchClassesTool.php
+++ b/app/Services/Chatbot/Tools/SearchClassesTool.php
@@ -14,7 +14,7 @@ class SearchClassesTool extends ChatbotTool
 
     public function description(): string
     {
-        return 'Rechercher des classes. Retourne nom, code, filière, niveau, effectif, statut actif/inactif.';
+        return 'Rechercher des classes. Retourne nom, code, filière, niveau, places totales/occupées/disponibles et statut places (disponible/limité/presque_complet/complet).';
     }
 
     public function parameters(): array
@@ -34,9 +34,17 @@ class SearchClassesTool extends ChatbotTool
                     'type' => 'string',
                     'description' => 'Niveau d\'études',
                 ],
+                'systeme' => [
+                    'type' => 'string',
+                    'description' => 'Système académique : "BTS" ou "LMD"',
+                ],
                 'active_only' => [
                     'type' => 'boolean',
                     'description' => 'Si true, retourne uniquement les classes actives (défaut: true)',
+                ],
+                'has_places' => [
+                    'type' => 'boolean',
+                    'description' => 'Si true, retourne uniquement les classes avec au moins une place disponible',
                 ],
                 'limit' => [
                     'type' => 'integer',
@@ -48,9 +56,7 @@ class SearchClassesTool extends ChatbotTool
 
     public function execute(array $args, $user): array
     {
-        $query = ESBTPClasse::query()
-            ->with(['filiere', 'niveau'])
-            ->withCount('inscriptions');
+        $query = ESBTPClasse::query()->with(['filiere', 'niveau']);
 
         if (!empty($args['name'])) {
             $search = $args['name'];
@@ -74,6 +80,10 @@ class SearchClassesTool extends ChatbotTool
             });
         }
 
+        if (!empty($args['systeme'])) {
+            $query->where('systeme_academique', strtoupper($args['systeme']));
+        }
+
         $activeOnly = $args['active_only'] ?? true;
         if ($activeOnly) {
             $query->where('is_active', true);
@@ -81,19 +91,41 @@ class SearchClassesTool extends ChatbotTool
 
         $limit = min(max((int) ($args['limit'] ?? 15), 1), 50);
         $total = (clone $query)->count();
-        $results = $query->orderBy('name')->limit($limit)->get();
+        // Charger un peu plus large pour pouvoir filtrer has_places en PHP (l'accessor places_disponibles n'est pas queryable en SQL)
+        $fetchLimit = !empty($args['has_places']) ? min($total, max($limit * 3, 50)) : $limit;
+        $results = $query->orderBy('name')->limit($fetchLimit)->get();
+
+        if (!empty($args['has_places'])) {
+            $results = $results->filter(fn ($c) => ($c->places_disponibles ?? 0) > 0)->take($limit)->values();
+        }
 
         $classes = $results->map(function ($c) {
+            $placesTotales = (int) ($c->places_totales ?? 0);
+            $placesDisponibles = (int) ($c->places_disponibles ?? 0);
+            $placesOccupees = max(0, $placesTotales - $placesDisponibles);
+            $ratio = $placesTotales > 0 ? $placesDisponibles / $placesTotales : 0;
+
+            $statut = match (true) {
+                $placesDisponibles <= 0 => 'complet',
+                $ratio < 0.10 => 'presque_complet',
+                $ratio < 0.30 => 'limite',
+                default => 'disponible',
+            };
+
             return [
                 'id' => $c->id,
                 'nom' => $c->name,
                 'code' => $c->code ?? 'N/A',
                 'filiere' => $c->filiere?->name ?? 'N/A',
                 'niveau' => $c->niveau?->name ?? 'N/A',
-                'effectif' => $c->inscriptions_count ?? 0,
+                'systeme' => $c->systeme_academique ?? 'N/A',
+                'places_totales' => $placesTotales,
+                'places_occupees' => $placesOccupees,
+                'places_disponibles' => $placesDisponibles,
+                'statut_places' => $statut,
                 'active' => $c->is_active ? 'Oui' : 'Non',
             ];
-        })->toArray();
+        })->values()->toArray();
 
         return [
             'results' => $classes,

--- a/app/Services/Chatbot/Tools/SearchClassesTool.php
+++ b/app/Services/Chatbot/Tools/SearchClassesTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPClasse;
 use Illuminate\Support\Facades\Route;
 
@@ -56,7 +57,16 @@ class SearchClassesTool extends ChatbotTool
 
     public function execute(array $args, $user): array
     {
-        $query = ESBTPClasse::query()->with(['filiere', 'niveau']);
+        // Single lookup (not per-class) — sinon l'accessor places_disponibles exploserait en N+1.
+        $anneeCouranteId = ESBTPAnneeUniversitaire::where('is_current', true)->value('id');
+
+        $query = ESBTPClasse::query()
+            ->with(['filiere', 'niveau'])
+            ->withCount(['inscriptions as effectif_reel' => function ($q) use ($anneeCouranteId) {
+                $q->where('status', 'active')
+                  ->where('workflow_step', 'etudiant_cree')
+                  ->when($anneeCouranteId, fn ($qq) => $qq->where('annee_universitaire_id', $anneeCouranteId));
+            }]);
 
         if (!empty($args['name'])) {
             $search = $args['name'];
@@ -90,19 +100,26 @@ class SearchClassesTool extends ChatbotTool
         }
 
         $limit = min(max((int) ($args['limit'] ?? 15), 1), 50);
-        $total = (clone $query)->count();
-        // Charger un peu plus large pour pouvoir filtrer has_places en PHP (l'accessor places_disponibles n'est pas queryable en SQL)
-        $fetchLimit = !empty($args['has_places']) ? min($total, max($limit * 3, 50)) : $limit;
-        $results = $query->orderBy('name')->limit($fetchLimit)->get();
 
+        // has_places en SQL : places_totales > effectif_reel (via l'alias du withCount).
         if (!empty($args['has_places'])) {
-            $results = $results->filter(fn ($c) => ($c->places_disponibles ?? 0) > 0)->take($limit)->values();
+            $query->whereRaw('COALESCE(places_totales, 0) > (
+                select count(*) from esbtp_inscriptions
+                where esbtp_inscriptions.classe_id = esbtp_classes.id
+                  and esbtp_inscriptions.status = ?
+                  and esbtp_inscriptions.workflow_step = ?
+                  ' . ($anneeCouranteId ? 'and esbtp_inscriptions.annee_universitaire_id = ?' : '') . '
+            )', $anneeCouranteId ? ['active', 'etudiant_cree', $anneeCouranteId] : ['active', 'etudiant_cree']);
         }
+
+        $total = (clone $query)->count();
+        $results = $query->orderBy('name')->limit($limit)->get();
 
         $classes = $results->map(function ($c) {
             $placesTotales = (int) ($c->places_totales ?? 0);
-            $placesDisponibles = (int) ($c->places_disponibles ?? 0);
-            $placesOccupees = max(0, $placesTotales - $placesDisponibles);
+            $effectifReel = (int) ($c->effectif_reel ?? 0);
+            $placesDisponibles = max(0, $placesTotales - $effectifReel);
+            $placesOccupees = $effectifReel;
             $ratio = $placesTotales > 0 ? $placesDisponibles / $placesTotales : 0;
 
             $statut = match (true) {
@@ -125,7 +142,7 @@ class SearchClassesTool extends ChatbotTool
                 'statut_places' => $statut,
                 'active' => $c->is_active ? 'Oui' : 'Non',
             ];
-        })->values()->toArray();
+        })->toArray();
 
         return [
             'results' => $classes,

--- a/app/Services/Chatbot/Tools/SearchStudentsTool.php
+++ b/app/Services/Chatbot/Tools/SearchStudentsTool.php
@@ -80,8 +80,6 @@ class SearchStudentsTool extends ChatbotTool
             });
         }
 
-        // Filtre workflow_step : défaut "etudiant_cree" (seulement les inscriptions validées)
-        // L'utilisateur peut passer "all" pour inclure brouillons/pré-inscriptions.
         $workflowStep = $args['workflow_step'] ?? 'etudiant_cree';
         if ($workflowStep !== 'all' && $workflowStep !== '') {
             $query->whereHas('inscriptions', function ($q) use ($workflowStep) {

--- a/app/Services/Chatbot/Tools/SearchStudentsTool.php
+++ b/app/Services/Chatbot/Tools/SearchStudentsTool.php
@@ -14,7 +14,7 @@ class SearchStudentsTool extends ChatbotTool
 
     public function description(): string
     {
-        return 'Rechercher des étudiants dans le système KLASSCI. Retourne nom, matricule, classe, statut.';
+        return 'Rechercher des étudiants dans le système KLASSCI. Par défaut limité aux inscriptions validées (workflow_step=etudiant_cree). Retourne nom, matricule, classe, statut.';
     }
 
     public function parameters(): array
@@ -37,6 +37,14 @@ class SearchStudentsTool extends ChatbotTool
                 'filiere' => [
                     'type' => 'string',
                     'description' => 'Nom de la filière (ex: "BTS Bâtiment", "Génie Civil")',
+                ],
+                'workflow_step' => [
+                    'type' => 'string',
+                    'description' => 'Filtre sur le workflow d\'inscription. Par défaut "etudiant_cree" (inscription validée, l\'étudiant est réellement inscrit). Utiliser "all" pour désactiver le filtre (inclure brouillons/pré-inscriptions).',
+                ],
+                'status' => [
+                    'type' => 'string',
+                    'description' => 'Statut de l\'inscription : "active", "inactive", "annule". Par défaut, pas de filtre.',
                 ],
                 'limit' => [
                     'type' => 'integer',
@@ -69,6 +77,22 @@ class SearchStudentsTool extends ChatbotTool
             $filiereName = $args['filiere'];
             $query->whereHas('inscriptions.classe.filiere', function ($q) use ($filiereName) {
                 $q->where('name', 'like', "%{$filiereName}%");
+            });
+        }
+
+        // Filtre workflow_step : défaut "etudiant_cree" (seulement les inscriptions validées)
+        // L'utilisateur peut passer "all" pour inclure brouillons/pré-inscriptions.
+        $workflowStep = $args['workflow_step'] ?? 'etudiant_cree';
+        if ($workflowStep !== 'all' && $workflowStep !== '') {
+            $query->whereHas('inscriptions', function ($q) use ($workflowStep) {
+                $q->where('workflow_step', $workflowStep);
+            });
+        }
+
+        if (!empty($args['status'])) {
+            $status = $args['status'];
+            $query->whereHas('inscriptions', function ($q) use ($status) {
+                $q->where('status', $status);
             });
         }
 

--- a/tests/Unit/Services/Chatbot/ConversationContextProviderTest.php
+++ b/tests/Unit/Services/Chatbot/ConversationContextProviderTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests\Unit\Services\Chatbot;
+
+use App\Models\ChatbotConversation;
+use App\Models\User;
+use App\Services\Chatbot\ConversationContextProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ConversationContextProviderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected ConversationContextProvider $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->provider = new ConversationContextProvider();
+    }
+
+    public function test_summary_block_returns_null_when_no_context(): void
+    {
+        $conversation = $this->makeConversation();
+
+        $this->assertNull($this->provider->summaryBlock($conversation));
+    }
+
+    public function test_update_ignores_empty_results(): void
+    {
+        $conversation = $this->makeConversation();
+
+        $this->provider->updateFromToolResult($conversation, 'search_classes', [], [
+            'results' => [],
+            'count' => 0,
+        ]);
+
+        $this->assertNull($this->provider->summaryBlock($conversation->fresh()));
+    }
+
+    public function test_update_ignores_error_results(): void
+    {
+        $conversation = $this->makeConversation();
+
+        $this->provider->updateFromToolResult($conversation, 'search_classes', [], [
+            'error' => 'Something broke',
+        ]);
+
+        $this->assertNull($this->provider->summaryBlock($conversation->fresh()));
+    }
+
+    public function test_update_stores_minimal_summary(): void
+    {
+        $conversation = $this->makeConversation();
+
+        $this->provider->updateFromToolResult($conversation, 'search_classes', [
+            'filiere' => 'BTP',
+            'has_places' => true,
+        ], [
+            'results' => [
+                ['id' => 1, 'nom' => 'BTP L1'],
+                ['id' => 2, 'nom' => 'BTP L2'],
+            ],
+            'count' => 2,
+            'total' => 5,
+        ]);
+
+        $summary = $this->provider->summaryBlock($conversation->fresh());
+
+        $this->assertStringContainsString('tool=search_classes', $summary);
+        $this->assertStringContainsString('filiere=BTP', $summary);
+        $this->assertStringContainsString('has_places=true', $summary);
+        $this->assertStringContainsString('count=2', $summary);
+        $this->assertStringContainsString('ids=[1,2]', $summary);
+        $this->assertStringContainsString('"BTP L1"', $summary);
+    }
+
+    public function test_update_caps_ids_at_max_sample(): void
+    {
+        $conversation = $this->makeConversation();
+
+        $results = [];
+        for ($i = 1; $i <= 10; $i++) {
+            $results[] = ['id' => $i, 'nom' => "Classe {$i}"];
+        }
+
+        $this->provider->updateFromToolResult($conversation, 'search_classes', [], [
+            'results' => $results,
+            'count' => 10,
+        ]);
+
+        $stored = $conversation->fresh()->context['last_result_summary'];
+
+        $this->assertCount(ConversationContextProvider::MAX_SAMPLE, $stored['ids']);
+        $this->assertCount(ConversationContextProvider::MAX_SAMPLE, $stored['names']);
+        $this->assertSame([1, 2, 3, 4, 5], $stored['ids']);
+    }
+
+    public function test_update_drops_non_scalar_filters(): void
+    {
+        $conversation = $this->makeConversation();
+
+        $this->provider->updateFromToolResult($conversation, 'search_students', [
+            'name' => 'Koné',
+            'payload' => ['deep' => 'object'],
+            'empty' => '',
+        ], [
+            'results' => [['id' => 42, 'etudiant' => 'Koné Aminata']],
+            'count' => 1,
+        ]);
+
+        $stored = $conversation->fresh()->context['last_result_summary'];
+
+        $this->assertArrayHasKey('name', $stored['filters']);
+        $this->assertArrayNotHasKey('payload', $stored['filters']);
+        $this->assertArrayNotHasKey('empty', $stored['filters']);
+    }
+
+    public function test_update_writes_under_context_key_without_clobbering_other_keys(): void
+    {
+        $conversation = $this->makeConversation([
+            'context' => ['some_other_flag' => true],
+        ]);
+
+        $this->provider->updateFromToolResult($conversation, 'search_classes', [], [
+            'results' => [['id' => 7, 'nom' => 'Test']],
+            'count' => 1,
+        ]);
+
+        $context = $conversation->fresh()->context;
+        $this->assertTrue($context['some_other_flag']);
+        $this->assertArrayHasKey('last_result_summary', $context);
+    }
+
+    protected function makeConversation(array $extra = []): ChatbotConversation
+    {
+        $user = User::factory()->create(['username' => 'ctx_' . Str::lower(Str::random(8))]);
+
+        return ChatbotConversation::create(array_merge([
+            'user_id' => $user->id,
+            'session_id' => (string) Str::uuid(),
+            'title' => 'Unit test',
+            'last_activity_at' => now(),
+            'is_active' => true,
+        ], $extra));
+    }
+}


### PR DESCRIPTION
## Summary

Extension du chatbot Claude Haiku 4.5 sur 3 axes, **sans créer de nouveaux tools** (évite la confusion de tool selection côté Haiku — cf. mémoire \`haiku-tool-use-patterns\`).

### 1. SearchStudentsTool

- Nouveau param \`workflow_step\` (défaut \`\"etudiant_cree\"\`, \`\"all\"\` pour désactiver). Évite les brouillons/pré-inscriptions non validées dans les résultats.
- Nouveau param \`status\` (filtre sur \`inscription.status\`).

### 2. SearchClassesTool

- Nouveaux params \`systeme\` (BTS/LMD) + \`has_places\` (bool, classes avec ≥ 1 place).
- Output enrichi : \`places_totales\`, \`places_occupees\`, \`places_disponibles\`, \`statut_places\` (\`disponible\` / \`limite\` / \`presque_complet\` / \`complet\`) — **mêmes seuils que le blocage d'inscription** (>30% / 10-30% / <10% / 0).

### 3. ConversationContextProvider (nouveau service)

Stocke un résumé minimal du dernier tool result dans \`conversation.context.last_result_summary\` :

\`\`\`json
{
  \"tool\": \"search_classes\",
  \"filters\": {\"filiere\":\"BTP\",\"has_places\":true},
  \"count\": 5,
  \"ids\": [3, 7, 12, 18, 25],
  \"names\": [\"BTP L1\", \"BTP L2\", ...],
  \"at\": \"2026-04-25T10:22:03+00:00\"
}
\`\`\`

- **PII-safe** : aucune donnée sensible (matricule, email, téléphone). Seulement ID + nom public + filtres scalaires.
- **Cap** : max 5 IDs/noms (constante \`MAX_SAMPLE\`).
- Exposé dans le system prompt via \`buildSystemInstruction()\` → Haiku peut résoudre les questions de suivi (\"et dans la classe d'à côté ?\", \"et pour la 2e année ?\") sans nouvelle recherche exhaustive.
- Injecté dans \`ClaudeAgentService\` via DI.

## Architecture (SOLID)

- \`ConversationContextProvider\` : service standalone, testable sans mock.
- DI Laravel auto-résout la dépendance du controller → pas de binding spécifique requis.
- Strict mode tool use (\`additionalProperties: false\`) déjà appliqué → rien à changer.
- Respect de la règle 3b system prompt (utiliser IDs exacts, pas position liste).

## Tests

7 tests unitaires sur \`ConversationContextProvider\` :
- ✅ null quand pas de contexte
- ✅ ignore résultats vides
- ✅ ignore erreurs
- ✅ écrit summary minimal correctement formaté
- ✅ cap à MAX_SAMPLE (5) même avec 10+ résultats
- ✅ drop des filtres non-scalaires (objets/arrays)
- ✅ préserve les autres clés de \`context\` (pas de clobber)

## Test plan

- [ ] Ouvrir le chatbot et demander \"liste les classes BTS avec au moins 10 places\" → doit retourner la table avec colonnes places + statut + filtres actifs.
- [ ] Enchaîner \"et la 2e année ?\" → Haiku doit utiliser le contexte précédent (filiere/niveau) et refaire une recherche ciblée.
- [ ] Demander \"combien d'étudiants dans cette classe\" sur une classe avec brouillons → vérifier que seuls les inscriptions \`workflow_step=etudiant_cree\` sont comptés par défaut.
- [ ] Checker en DB que \`chatbot_conversations.context\` ne contient aucune PII.