### PR TITLE
chore(public): foundation layout layouts.landing pour pages publiques

### DIFF
--- a/public/css/landing.css
+++ b/public/css/landing.css
@@ -1,0 +1,1056 @@
+/* ────────────────────────────────────
+   KLASSCI — Editorial Landing (chrome)
+   Inspired by zed.dev : warm, serif headings,
+   monospace accents, grain, generous space.
+
+   This file holds the SHARED chrome used by
+   every public marketing/docs page (nav,
+   footer, base typography, buttons, reveal
+   observer states, theme toggle, mobile nav,
+   body overlays).
+
+   Page-specific styles (hero, features, faq,
+   pricing, modals, etc.) stay in their own
+   Blade files via @push('styles').
+──────────────────────────────────── */
+
+:root {
+    --bg: #f6f4f0;
+    --bg-alt: #edeae4;
+    --bg-card: #fff;
+    --text: #1a1a1a;
+    --text-secondary: #3a3d43;
+    --text-muted: #8a8a8a;
+    --accent: #0453cb;
+    --accent-hover: #0340a0;
+    --accent-light: rgba(4,83,203,0.08);
+    --border: #dadde2;
+    --border-strong: #c5c9d0;
+    --radius: 4px;
+    --max-w: 1120px;
+    --nav-bg: rgba(246,244,240,0.85);
+    --footer-bg: var(--accent);
+    --footer-text: #fff;
+    --footer-link: rgba(255,255,255,0.7);
+    --footer-border: rgba(255,255,255,0.15);
+    --dot-color: rgba(0,0,0,0.06);
+    --duration-fast: 100ms;
+    --duration-normal: 200ms;
+    --duration-slow: 300ms;
+    --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+html.dark {
+    --bg: #1a1d23;
+    --bg-alt: #21252b;
+    --bg-card: #282c34;
+    --text: #dce0e5;
+    --text-secondary: #9da3ae;
+    --text-muted: #6b7280;
+    --accent: #4b8af0;
+    --accent-hover: #6da3f7;
+    --accent-light: rgba(75,138,240,0.12);
+    --border: #363b44;
+    --border-strong: #4b5263;
+    --nav-bg: rgba(26,29,35,0.85);
+    --footer-bg: #111318;
+    --footer-text: #dce0e5;
+    --footer-link: rgba(220,224,229,0.6);
+    --footer-border: rgba(255,255,255,0.08);
+    --dot-color: rgba(255,255,255,0.04);
+    color-scheme: dark;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html { scroll-behavior: smooth; overflow-x: hidden; }
+
+body {
+    font-family: 'IBM Plex Sans', system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.5;
+    letter-spacing: -0.025em;
+    overflow-x: hidden;
+    -webkit-font-smoothing: antialiased;
+    position: relative;
+    transition: background var(--duration-slow), color var(--duration-slow);
+}
+
+/* Noise texture overlay */
+body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    pointer-events: none;
+    opacity: 0.35;
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.06'/%3E%3C/svg%3E");
+    background-repeat: repeat;
+    background-size: 256px 256px;
+}
+
+/* Dot grid background */
+body::after {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background-image: radial-gradient(circle, var(--dot-color) 1px, transparent 1px);
+    background-size: 20px 20px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+a { text-decoration: none; color: var(--accent); transition: color 0.2s; }
+a:hover { color: var(--accent-hover); }
+
+img { max-width: 100%; display: block; }
+
+.container {
+    max-width: var(--max-w);
+    margin: 0 auto;
+    padding: 0 clamp(1.25rem, 5vw, 2.5rem);
+}
+
+.container--narrow {
+    max-width: 860px;
+}
+
+/* ─── Typography ─── */
+h1, h2, h3 {
+    font-family: 'IBM Plex Serif', Georgia, serif;
+    font-weight: 300;
+    color: var(--accent);
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+}
+
+.mono {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.85rem;
+    letter-spacing: -0.01em;
+}
+
+/* Skip link for keyboard users */
+.skip-link {
+    position: absolute;
+    left: -9999px;
+    top: 0;
+    padding: 0.6rem 1rem;
+    background: var(--accent);
+    color: #fff;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.85rem;
+    z-index: 10000;
+    border-radius: 0 0 var(--radius) 0;
+}
+.skip-link:focus {
+    left: 0;
+    color: #fff;
+}
+
+/* ═══════════════════════
+   NAV
+═══════════════════════ */
+.nav {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    z-index: 100;
+    height: 57px;
+    display: flex;
+    align-items: center;
+    background: var(--nav-bg);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border-bottom: 1px solid var(--border);
+    transition: background var(--duration-slow), border-color var(--duration-slow);
+}
+
+.nav-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.nav-logo {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    color: var(--text);
+}
+
+.nav-logo img { height: 28px; }
+
+.nav-logo span {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-weight: 700;
+    font-size: 1.05rem;
+    letter-spacing: -0.02em;
+}
+
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    list-style: none;
+}
+
+.nav-links a, .nav-links button {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+    padding: 0.4rem 0.75rem;
+    border-radius: var(--radius);
+    transition: all var(--duration-normal);
+    letter-spacing: -0.02em;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.nav-links a:hover, .nav-links button:hover {
+    color: var(--text);
+    background: var(--accent-light);
+}
+
+.nav-links a.is-active {
+    color: var(--accent);
+    background: var(--accent-light);
+}
+
+.nav-cta {
+    background: var(--accent) !important;
+    color: #fff !important;
+    padding: 0.4rem 1rem !important;
+    border-radius: var(--radius) !important;
+}
+
+.nav-cta:hover {
+    background: var(--accent-hover) !important;
+    color: #fff !important;
+}
+
+.nav-hamburger {
+    background: none; border: none;
+    cursor: pointer; padding: 0.5rem;
+}
+
+.nav-hamburger span {
+    display: block; width: 20px; height: 2px;
+    background: var(--text); margin: 4px 0;
+    border-radius: 1px;
+    transition: all 0.2s;
+}
+
+.mobile-nav {
+    display: none;
+    position: fixed; inset: 0;
+    background: var(--bg);
+    z-index: 99;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+}
+
+.mobile-nav.open { display: flex; }
+.mobile-nav a {
+    font-family: 'IBM Plex Serif', serif;
+    font-size: 1.75rem;
+    color: var(--text);
+}
+
+.mobile-nav-cta {
+    background: var(--accent) !important;
+    color: #fff !important;
+    padding: 0.6rem 2rem !important;
+    border-radius: var(--radius) !important;
+    font-family: 'IBM Plex Sans', sans-serif !important;
+    font-size: 1rem !important;
+    font-weight: 600 !important;
+    margin-top: 0.5rem;
+}
+
+.nav-mobile-actions {
+    display: none;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.theme-toggle-mini {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-card);
+    cursor: pointer;
+    color: var(--text-secondary);
+    transition: all var(--duration-normal);
+    padding: 0;
+}
+
+.theme-toggle-mini:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.theme-toggle-mini svg { width: 16px; height: 16px; }
+
+.theme-toggle-mini .sun-icon { display: none; }
+.theme-toggle-mini .moon-icon { display: block; }
+html.dark .theme-toggle-mini .sun-icon { display: block; }
+html.dark .theme-toggle-mini .moon-icon { display: none; }
+
+@media (max-width: 768px) {
+    .nav-links { display: none; }
+    .nav-mobile-actions { display: flex; }
+}
+
+/* Theme switch flash animation */
+@keyframes themeFlash {
+    0% { opacity: 1; }
+    40% { opacity: 0.7; }
+    100% { opacity: 1; }
+}
+
+html.theme-switching body {
+    animation: themeFlash 0.8s var(--ease-out);
+}
+
+/* ═══════════════════════
+   THEME TOGGLE (full)
+═══════════════════════ */
+.theme-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    height: 34px;
+    padding: 0 0.75rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius);
+    background: var(--bg-card);
+    cursor: pointer;
+    color: var(--text);
+    transition: all var(--duration-normal) var(--ease-out);
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.78rem;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    position: relative;
+    width: 100px;
+}
+
+.theme-toggle:hover {
+    border-color: var(--accent);
+    background: var(--accent-light);
+    color: var(--accent);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(4,83,203,0.12);
+}
+
+.theme-toggle svg {
+    width: 15px;
+    height: 15px;
+    flex-shrink: 0;
+}
+
+.theme-toggle .sun-group,
+.theme-toggle .moon-group {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    white-space: nowrap;
+    transition: opacity 0.6s var(--ease-out), transform 0.6s var(--ease-out);
+}
+
+.theme-toggle .sun-group { opacity: 0; transform: translateX(-50%) translateY(8px); pointer-events: none; }
+.theme-toggle .moon-group { opacity: 1; transform: translateX(-50%) translateY(0); }
+html.dark .theme-toggle .sun-group { opacity: 1; transform: translateX(-50%) translateY(0); pointer-events: auto; }
+html.dark .theme-toggle .moon-group { opacity: 0; transform: translateX(-50%) translateY(-8px); pointer-events: none; }
+
+/* ═══════════════════════
+   BUTTONS
+═══════════════════════ */
+.btn-primary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--accent);
+    color: #fff;
+    padding: 0.6rem 1.4rem;
+    border-radius: var(--radius);
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid var(--accent);
+    cursor: pointer;
+    transition: all var(--duration-normal) var(--ease-out);
+    letter-spacing: -0.02em;
+    position: relative;
+}
+
+.btn-primary:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(4,83,203,0.25);
+}
+
+.btn-outline {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(255,255,255,0.5);
+    color: var(--text);
+    padding: 0.6rem 1.4rem;
+    border-radius: var(--radius);
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid var(--border);
+    cursor: pointer;
+    transition: all var(--duration-normal) var(--ease-out);
+    letter-spacing: -0.02em;
+}
+
+html.dark .btn-outline { background: rgba(255,255,255,0.05); }
+
+.btn-outline:hover {
+    border-color: var(--border-strong);
+    color: var(--text);
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+}
+
+/* ═══════════════════════
+   FOOTER
+═══════════════════════ */
+.footer {
+    padding: 3rem 0 2rem;
+    background: var(--footer-bg);
+    color: var(--footer-text);
+    border-top: none;
+    transition: background var(--duration-slow);
+}
+
+.footer-grid {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr 1fr;
+    gap: 3rem;
+    margin-bottom: 3rem;
+}
+
+.footer-brand p {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.82rem;
+    color: var(--footer-link);
+    line-height: 1.6;
+    margin-top: 1rem;
+    max-width: 260px;
+}
+
+.footer .nav-logo span { color: var(--footer-text) !important; }
+
+.footer-col h4 {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--footer-text);
+    margin-bottom: 1rem;
+    font-weight: 600;
+}
+
+.footer-col ul {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.footer-col a {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.82rem;
+    color: var(--footer-link);
+    transition: color var(--duration-normal);
+}
+
+.footer-col a:hover { color: var(--footer-text); }
+
+.footer-bottom {
+    border-top: 1px solid var(--footer-border);
+    padding-top: 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.footer-bottom p {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.75rem;
+    color: var(--footer-link);
+}
+
+.footer-social {
+    display: flex;
+    gap: 1rem;
+}
+
+.footer-social a {
+    color: var(--footer-link);
+    font-size: 0.9rem;
+    transition: color var(--duration-normal);
+}
+
+.footer-social a:hover { color: var(--footer-text); }
+
+@media (max-width: 768px) {
+    .footer-grid { grid-template-columns: 1fr 1fr; gap: 2rem; }
+}
+@media (max-width: 480px) {
+    .footer-grid { grid-template-columns: 1fr; }
+}
+
+/* ─── Scroll reveal ─── */
+.reveal {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.7s var(--ease-out), transform 0.7s var(--ease-out);
+}
+.reveal.visible {
+    opacity: 1;
+    transform: none;
+}
+.reveal-d1 { transition-delay: 80ms; }
+.reveal-d2 { transition-delay: 160ms; }
+.reveal-d3 { transition-delay: 240ms; }
+
+.reveal-left {
+    opacity: 0;
+    transform: translateX(-40px);
+    transition: opacity 0.8s var(--ease-out), transform 0.8s var(--ease-out);
+}
+.reveal-right {
+    opacity: 0;
+    transform: translateX(40px);
+    transition: opacity 0.8s var(--ease-out), transform 0.8s var(--ease-out);
+}
+.reveal-left.visible, .reveal-right.visible {
+    opacity: 1;
+    transform: none;
+}
+
+.reveal-scale {
+    opacity: 0;
+    transform: scale(0.92);
+    transition: opacity 0.9s var(--ease-out), transform 0.9s var(--ease-out);
+}
+.reveal-scale.visible {
+    opacity: 1;
+    transform: none;
+}
+
+/* Disable transitions briefly during theme switch */
+.no-transitions,
+.no-transitions *,
+.no-transitions *::before,
+.no-transitions *::after {
+    transition-duration: 0s !important;
+}
+
+/* Reduced-motion fallback for chrome-level animations */
+@media (prefers-reduced-motion: reduce) {
+    .reveal, .reveal-left, .reveal-right, .reveal-scale {
+        opacity: 1 !important;
+        transform: none !important;
+    }
+}
+
+/* ═══════════════════════
+   PAGE HERO (shared by docs/changelog/api)
+   Compact hero used by content pages.
+═══════════════════════ */
+.page-hero {
+    padding: 8rem 0 3rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.page-hero-eyebrow {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.78rem;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin-bottom: 1rem;
+}
+
+.page-hero h1 {
+    font-size: clamp(2rem, 5vw, 2.85rem);
+    font-style: normal;
+    margin-bottom: 1rem;
+    line-height: 1.15;
+}
+
+.page-hero p {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: clamp(1rem, 1.6vw, 1.1rem);
+    color: var(--text-secondary);
+    max-width: 640px;
+    line-height: 1.65;
+}
+
+.page-hero-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem;
+    margin-top: 1.5rem;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    align-items: center;
+}
+
+.page-hero-meta .dot {
+    width: 4px;
+    height: 4px;
+    background: var(--text-muted);
+    border-radius: 50%;
+    display: inline-block;
+}
+
+@media (max-width: 768px) {
+    .page-hero { padding: 6.5rem 0 2.5rem; }
+}
+
+/* ═══════════════════════
+   PAGE LAYOUT WITH SIDEBAR (docs/changelog/api)
+═══════════════════════ */
+.page-with-sidebar {
+    padding: 3rem 0 5rem;
+}
+
+.page-with-sidebar-inner {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    gap: 4rem;
+    align-items: start;
+}
+
+.page-sidebar {
+    position: sticky;
+    top: 80px;
+    align-self: start;
+    max-height: calc(100vh - 100px);
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.page-sidebar h4 {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    margin-bottom: 0.75rem;
+    margin-top: 1.5rem;
+    font-weight: 600;
+}
+
+.page-sidebar h4:first-child { margin-top: 0; }
+
+.page-sidebar ul {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    margin-bottom: 0.5rem;
+}
+
+.page-sidebar a {
+    display: block;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.84rem;
+    color: var(--text-secondary);
+    padding: 0.35rem 0.6rem;
+    border-radius: var(--radius);
+    transition: all var(--duration-normal);
+    border-left: 2px solid transparent;
+    margin-left: -0.6rem;
+}
+
+.page-sidebar a:hover {
+    color: var(--accent);
+    background: var(--accent-light);
+}
+
+.page-sidebar a.is-active {
+    color: var(--accent);
+    border-left-color: var(--accent);
+    font-weight: 600;
+}
+
+.page-content {
+    min-width: 0; /* avoids overflow with pre/code */
+}
+
+/* Prose styling for markdown content */
+.prose {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 1rem;
+    color: var(--text-secondary);
+    line-height: 1.7;
+    max-width: 720px;
+}
+
+.prose h2 {
+    font-family: 'IBM Plex Serif', Georgia, serif;
+    font-size: clamp(1.5rem, 3vw, 1.85rem);
+    font-style: normal;
+    font-weight: 400;
+    margin: 2.75rem 0 1rem;
+    color: var(--accent);
+    line-height: 1.25;
+    letter-spacing: -0.015em;
+}
+
+.prose h2:first-child { margin-top: 0; }
+
+.prose h3 {
+    font-family: 'IBM Plex Serif', Georgia, serif;
+    font-size: 1.3rem;
+    font-style: normal;
+    font-weight: 400;
+    margin: 2rem 0 0.75rem;
+    color: var(--text);
+    letter-spacing: -0.01em;
+}
+
+.prose h4 {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 1.5rem 0 0.5rem;
+    color: var(--text);
+}
+
+.prose p {
+    margin-bottom: 1rem;
+}
+
+.prose a {
+    color: var(--accent);
+    border-bottom: 1px solid rgba(4,83,203,0.25);
+    transition: border-color var(--duration-normal);
+}
+html.dark .prose a { border-bottom-color: rgba(75,138,240,0.35); }
+.prose a:hover { border-bottom-color: var(--accent); }
+
+.prose strong {
+    color: var(--text);
+    font-weight: 600;
+}
+
+.prose ul, .prose ol {
+    margin: 1rem 0 1.25rem;
+    padding-left: 1.5rem;
+}
+
+.prose ul li, .prose ol li {
+    margin-bottom: 0.5rem;
+}
+
+.prose ul li::marker { color: var(--accent); }
+
+.prose code {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.86em;
+    background: var(--bg-alt);
+    color: var(--text);
+    padding: 1px 6px;
+    border-radius: 3px;
+    border: 1px solid var(--border);
+}
+
+.prose pre {
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1rem 1.25rem;
+    overflow-x: auto;
+    margin: 1.25rem 0;
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.84rem;
+    line-height: 1.55;
+    color: var(--text);
+}
+
+.prose pre code {
+    background: transparent;
+    border: none;
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+}
+
+.prose blockquote {
+    border-left: 3px solid var(--accent);
+    padding: 0.5rem 0 0.5rem 1.25rem;
+    margin: 1.5rem 0;
+    color: var(--text-secondary);
+    font-style: italic;
+    background: var(--accent-light);
+    border-radius: 0 var(--radius) var(--radius) 0;
+}
+
+.prose img {
+    border-radius: var(--radius);
+    border: 1px solid var(--border);
+    margin: 1.5rem 0;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.05);
+}
+
+.prose hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 2.5rem 0;
+}
+
+.prose table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.25rem 0;
+    font-size: 0.9rem;
+}
+
+.prose table th, .prose table td {
+    text-align: left;
+    padding: 0.6rem 0.85rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.prose table th {
+    font-weight: 600;
+    color: var(--text);
+    background: var(--bg-alt);
+    border-bottom: 1px solid var(--border-strong);
+}
+
+.prose table tr:hover td {
+    background: var(--accent-light);
+}
+
+@media (max-width: 1024px) {
+    .page-with-sidebar-inner { grid-template-columns: 1fr; gap: 2rem; }
+    .page-sidebar {
+        position: static;
+        max-height: none;
+        overflow: visible;
+        padding-right: 0;
+        padding-bottom: 1.5rem;
+        border-bottom: 1px solid var(--border);
+        margin-bottom: 0.5rem;
+    }
+}
+
+/* ═══════════════════════
+   CONTENT CARDS / GRID (used by docs index, api index)
+═══════════════════════ */
+.card-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    background: var(--bg-card);
+}
+
+.card-grid > .card-tile {
+    padding: 1.75rem 1.85rem;
+    border-right: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    transition: background var(--duration-normal);
+}
+
+.card-grid > .card-tile:nth-child(3n) { border-right: none; }
+.card-grid > .card-tile:nth-last-child(-n+3):not(.is-disabled ~ *) { border-bottom: none; }
+
+.card-grid > .card-tile:hover {
+    background: var(--accent-light);
+}
+
+.card-grid > .card-tile.is-disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
+.card-grid > .card-tile.is-disabled:hover {
+    background: transparent;
+}
+
+.card-tile-eyebrow {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.7rem;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 0.25rem;
+}
+
+.card-tile h3 {
+    font-family: 'IBM Plex Serif', Georgia, serif;
+    font-size: 1.1rem;
+    font-weight: 400;
+    font-style: normal;
+    color: var(--text);
+    letter-spacing: -0.01em;
+    margin-bottom: 0.25rem;
+}
+
+.card-tile p {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.88rem;
+    color: var(--text-secondary);
+    line-height: 1.55;
+    flex: 1;
+}
+
+.card-tile-foot {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.6rem;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.78rem;
+    color: var(--accent);
+    font-weight: 500;
+}
+
+.card-tile.is-disabled .card-tile-foot {
+    color: var(--text-muted);
+}
+
+@media (max-width: 768px) {
+    .card-grid { grid-template-columns: 1fr; }
+    .card-grid > .card-tile {
+        border-right: none !important;
+        border-bottom: 1px solid var(--border) !important;
+    }
+    .card-grid > .card-tile:last-child { border-bottom: none !important; }
+}
+
+/* ═══════════════════════
+   CALLOUTS (info/note/warning) inside prose
+═══════════════════════ */
+.callout {
+    border-left: 3px solid var(--accent);
+    background: var(--accent-light);
+    padding: 1rem 1.25rem;
+    border-radius: 0 var(--radius) var(--radius) 0;
+    margin: 1.5rem 0;
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.92rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+}
+
+.callout--warning {
+    border-left-color: #d97706;
+    background: rgba(217,119,6,0.08);
+}
+html.dark .callout--warning {
+    background: rgba(251,191,36,0.1);
+    border-left-color: #fbbf24;
+}
+
+.callout--note {
+    border-left-color: var(--text-muted);
+    background: var(--bg-alt);
+}
+
+.callout strong { color: var(--text); }
+
+/* ═══════════════════════
+   PREV / NEXT navigation between articles
+═══════════════════════ */
+.prev-next {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border);
+}
+
+.prev-next a {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    transition: all var(--duration-normal) var(--ease-out);
+    background: var(--bg-card);
+}
+
+.prev-next a:hover {
+    border-color: var(--accent);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 16px rgba(4,83,203,0.08);
+}
+
+.prev-next-label {
+    font-family: 'IBM Plex Mono', monospace;
+    font-size: 0.7rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.prev-next-title {
+    font-family: 'IBM Plex Sans', sans-serif;
+    font-size: 0.95rem;
+    color: var(--text);
+    font-weight: 500;
+}
+
+.prev-next a.is-next {
+    text-align: right;
+    align-items: flex-end;
+}
+
+@media (max-width: 640px) {
+    .prev-next { grid-template-columns: 1fr; }
+    .prev-next a.is-next { text-align: left; align-items: flex-start; }
+}
+
+/* Print: collapse decorative overlays for clean print */
+@media print {
+    body::before, body::after { display: none; }
+    .nav, .footer, .page-sidebar { display: none; }
+    .page-content { max-width: 100% !important; }
+}

--- a/public/js/landing.js
+++ b/public/js/landing.js
@@ -1,0 +1,98 @@
+/* KLASSCI — Editorial Landing (chrome JS)
+ * Theme toggle (persisted), mobile nav, scroll
+ * reveal observer, smooth anchor scroll. Page-
+ * specific JS lives in each Blade via @push.
+ */
+(function () {
+    'use strict';
+
+    var html = document.documentElement;
+
+    /* Theme : init from localStorage (also done inline in <head> to prevent FOUC) */
+    var saved = localStorage.getItem('klassci-theme');
+    if (saved === 'dark') {
+        html.classList.add('dark');
+        html.classList.remove('light');
+    } else {
+        html.classList.add('light');
+        html.classList.remove('dark');
+    }
+
+    function toggleTheme() {
+        html.classList.toggle('dark');
+        html.classList.toggle('light');
+        html.classList.add('theme-switching');
+        localStorage.setItem(
+            'klassci-theme',
+            html.classList.contains('dark') ? 'dark' : 'light'
+        );
+        setTimeout(function () {
+            html.classList.remove('theme-switching');
+        }, 850);
+    }
+
+    var themeBtn = document.getElementById('themeToggle');
+    var themeBtnMobile = document.getElementById('themeToggleMobile');
+    if (themeBtn) themeBtn.addEventListener('click', toggleTheme);
+    if (themeBtnMobile) themeBtnMobile.addEventListener('click', toggleTheme);
+
+    /* Mobile nav */
+    var hamburger = document.getElementById('hamburger');
+    var mobileNav = document.getElementById('mobileNav');
+    if (hamburger && mobileNav) {
+        hamburger.addEventListener('click', function () {
+            mobileNav.classList.toggle('open');
+        });
+        window.closeMobile = function () {
+            mobileNav.classList.remove('open');
+        };
+    }
+
+    /* Scroll reveal — supports .reveal, .reveal-left, .reveal-right, .reveal-scale */
+    var reveals = document.querySelectorAll('.reveal, .reveal-left, .reveal-right, .reveal-scale');
+    if ('IntersectionObserver' in window && reveals.length) {
+        var obs = new IntersectionObserver(
+            function (entries) {
+                entries.forEach(function (e) {
+                    if (e.isIntersecting) {
+                        e.target.classList.add('visible');
+                        obs.unobserve(e.target);
+                    }
+                });
+            },
+            { threshold: 0.1, rootMargin: '0px 0px -40px 0px' }
+        );
+        reveals.forEach(function (el) { obs.observe(el); });
+    } else {
+        /* No IO support → just show everything */
+        reveals.forEach(function (el) { el.classList.add('visible'); });
+    }
+
+    /* Smooth anchor scroll (offsets for fixed nav) */
+    document.querySelectorAll('a[href^="#"]').forEach(function (a) {
+        a.addEventListener('click', function (e) {
+            var h = this.getAttribute('href');
+            if (h === '#' || h.length < 2) return;
+            var target = document.querySelector(h);
+            if (target) {
+                e.preventDefault();
+                window.scrollTo({
+                    top: target.getBoundingClientRect().top + window.pageYOffset - 70,
+                    behavior: 'smooth'
+                });
+            }
+        });
+    });
+
+    /* Mark active sidebar entry based on hash + path */
+    var path = window.location.pathname.replace(/\/$/, '') || '/';
+    document.querySelectorAll('.page-sidebar a, .nav-links a').forEach(function (a) {
+        try {
+            var url = new URL(a.href, window.location.origin);
+            var aPath = url.pathname.replace(/\/$/, '') || '/';
+            if (aPath === path && (!url.hash || url.hash === window.location.hash)) {
+                a.classList.add('is-active');
+            }
+        } catch (err) { /* ignore malformed URLs */ }
+    });
+})();

--- a/resources/views/layouts/landing.blade.php
+++ b/resources/views/layouts/landing.blade.php
@@ -1,0 +1,178 @@
+{{-- KLASSCI — Editorial public layout
+     Used by: /docs, /docs/{slug}, /api-reference, /changelog
+     (and progressively /, once welcome.blade.php is refactored).
+
+     Yields:
+       - title         : page <title>
+       - description   : meta description
+     Sections (all optional):
+       - meta          : extra meta tags (canonical override, OG image, hreflang, JSON-LD)
+       - body_class    : extra class on <body>
+       - content       : main page content
+     Stacks:
+       - styles        : page-specific CSS pushed after landing.css
+       - scripts       : page-specific JS pushed after landing.js
+--}}
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>@yield('title', 'KLASSCI') — Gestion scolaire, repensée.</title>
+    <meta name="description" content="@yield('description', 'KLASSCI digitalise la gestion de votre établissement scolaire. Notes, emplois du temps, paiements, bulletins — un seul outil, zéro paperasse.')">
+
+    <meta name="keywords" content="gestion scolaire, logiciel école, KLASSCI, notes, bulletins, emploi du temps, paiements, présences, SaaS éducation, Côte d'Ivoire, Afrique">
+    <meta name="author" content="African Digital Consulting">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="{{ url()->current() }}">
+
+    {{-- Open Graph --}}
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ url()->current() }}">
+    <meta property="og:title" content="@yield('title', 'KLASSCI') — Gestion scolaire, repensée.">
+    <meta property="og:description" content="@yield('description', 'KLASSCI digitalise la gestion de votre établissement.')">
+    <meta property="og:image" content="@yield('og_image', asset('images/landing/hero_section.png'))">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:locale" content="fr_FR">
+    <meta property="og:site_name" content="KLASSCI">
+
+    {{-- Twitter --}}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="@yield('title', 'KLASSCI')">
+    <meta name="twitter:description" content="@yield('description', 'KLASSCI digitalise la gestion de votre établissement.')">
+    <meta name="twitter:image" content="@yield('og_image', asset('images/landing/hero_section.png'))">
+
+    @yield('meta')
+
+    {{-- Favicon --}}
+    <link rel="icon" href="{{ asset('images/LOGO-KLASSCI-PNG.png') }}" type="image/png">
+    <link rel="apple-touch-icon" href="{{ asset('images/LOGO-KLASSCI-PNG.png') }}">
+    <meta name="theme-color" content="#0453cb">
+
+    {{-- Fonts --}}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@300;400;500&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+    {{-- Shared chrome (cacheable) --}}
+    <link rel="stylesheet" href="{{ asset('css/landing.css') }}?v={{ config('app.asset_version', '1') }}">
+
+    @stack('styles')
+
+    {{-- Prevent FOUC on theme --}}
+    <script>
+        (function () {
+            var t = localStorage.getItem('klassci-theme');
+            var h = document.documentElement;
+            if (t === 'dark') { h.classList.add('dark'); h.classList.remove('light'); }
+            else { h.classList.add('light'); h.classList.remove('dark'); }
+        })();
+    </script>
+</head>
+<body class="@yield('body_class')">
+
+<a href="#main-content" class="skip-link">Aller au contenu principal</a>
+
+{{-- NAV --}}
+<nav class="nav" aria-label="Navigation principale">
+    <div class="container nav-inner">
+        <a href="{{ route('welcome') }}" class="nav-logo" aria-label="Accueil KLASSCI">
+            <img src="{{ asset('images/LOGO-KLASSCI-PNG.png') }}" alt="KLASSCI">
+            <span>KLASSCI</span>
+        </a>
+        <ul class="nav-links">
+            <li><a href="{{ route('welcome') }}#fonctionnalites">Fonctionnalités</a></li>
+            <li><a href="{{ route('welcome') }}#tarifs">Tarifs</a></li>
+            <li><a href="{{ Route::has('docs.index') ? route('docs.index') : '#' }}">Documentation</a></li>
+            <li><a href="{{ Route::has('changelog') ? route('changelog') : '#' }}">Changelog</a></li>
+            <li><a href="{{ route('login') }}" class="nav-cta">Se connecter</a></li>
+            <li>
+                <button class="theme-toggle" id="themeToggle" aria-label="Changer le thème">
+                    <span class="moon-group">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                        <span>Sombre</span>
+                    </span>
+                    <span class="sun-group">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+                        <span>Clair</span>
+                    </span>
+                </button>
+            </li>
+        </ul>
+        <div class="nav-mobile-actions">
+            <button class="theme-toggle-mini" id="themeToggleMobile" aria-label="Changer le thème">
+                <svg class="moon-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+                <svg class="sun-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+            </button>
+            <button class="nav-hamburger" id="hamburger" aria-label="Menu" aria-controls="mobileNav" aria-expanded="false">
+                <span></span><span></span><span></span>
+            </button>
+        </div>
+    </div>
+</nav>
+
+<div class="mobile-nav" id="mobileNav">
+    <a href="{{ route('welcome') }}#fonctionnalites" onclick="closeMobile()">Fonctionnalités</a>
+    <a href="{{ route('welcome') }}#tarifs" onclick="closeMobile()">Tarifs</a>
+    <a href="{{ Route::has('docs.index') ? route('docs.index') : '#' }}" onclick="closeMobile()">Documentation</a>
+    <a href="{{ Route::has('changelog') ? route('changelog') : '#' }}" onclick="closeMobile()">Changelog</a>
+    <a href="{{ route('welcome') }}#contact" onclick="closeMobile()">Contact</a>
+    <a href="{{ route('login') }}" class="mobile-nav-cta" onclick="closeMobile()">Se connecter</a>
+</div>
+
+<main id="main-content">
+    @yield('content')
+</main>
+
+{{-- FOOTER --}}
+<footer class="footer">
+    <div class="container">
+        <div class="footer-grid">
+            <div class="footer-brand">
+                <a href="{{ route('welcome') }}" class="nav-logo" aria-label="Accueil KLASSCI">
+                    <img src="{{ asset('images/LOGO-KLASSCI-PNG.png') }}" alt="KLASSCI" style="height:24px">
+                    <span style="font-weight:700;font-size:0.95rem;color:var(--footer-text)">KLASSCI</span>
+                </a>
+                <p>Plateforme de gestion scolaire conçue pour les établissements d'enseignement supérieur en Afrique.</p>
+            </div>
+            <div class="footer-col">
+                <h4>Produit</h4>
+                <ul>
+                    <li><a href="{{ route('welcome') }}#fonctionnalites">Fonctionnalités</a></li>
+                    <li><a href="{{ route('welcome') }}#tarifs">Tarifs</a></li>
+                    <li><a href="{{ route('login') }}">Connexion</a></li>
+                </ul>
+            </div>
+            <div class="footer-col">
+                <h4>Ressources</h4>
+                <ul>
+                    <li><a href="{{ Route::has('docs.index') ? route('docs.index') : '#' }}">Documentation</a></li>
+                    <li><a href="{{ Route::has('api-reference') ? route('api-reference') : '#' }}">API Reference</a></li>
+                    <li><a href="{{ Route::has('changelog') ? route('changelog') : '#' }}">Changelog</a></li>
+                </ul>
+            </div>
+            <div class="footer-col">
+                <h4>Contact</h4>
+                <ul>
+                    <li><a href="mailto:contact@klassci.com">contact@klassci.com</a></li>
+                    <li><a href="{{ route('welcome') }}#contact">Demander une démo</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; {{ date('Y') }} KLASSCI — African Digital Consulting</p>
+            <div class="footer-social">
+                <a href="#" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a>
+                <a href="#" aria-label="LinkedIn"><i class="fab fa-linkedin-in"></i></a>
+                <a href="#" aria-label="X"><i class="fab fa-x-twitter"></i></a>
+            </div>
+        </div>
+    </div>
+</footer>
+
+<script src="{{ asset('js/landing.js') }}?v={{ config('app.asset_version', '1') }}" defer></script>
+@stack('scripts')
+</body>
+</html>


### PR DESCRIPTION
## Summary

PR **strictement additive** — préparation foundation pour les 3 PRs suivantes (Documentation, API Reference, Changelog).

Extrait le chrome partagé (CSS, JS, structure HTML) dans 3 nouveaux fichiers réutilisables. **Aucun fichier existant n'est modifié** (le landing welcome.blade.php reste self-contained pour cette PR).

## Ce qui est ajouté

### \`public/css/landing.css\` (~750 lignes)
Design system éditorial inspiré zed.dev :
- Variables CSS (\`:root\` + \`html.dark\`) palette + spacing + transitions
- Typographie IBM Plex Serif/Sans/Mono
- Body overlays : grain SVG + dot-grid
- \`prefers-reduced-motion\` honoré
- \`.container\`, \`.btn-primary\`, \`.btn-outline\`, \`.skip-link\`
- \`.nav\` complet + \`.mobile-nav\` + \`.theme-toggle\` + \`.theme-toggle-mini\`
- \`.footer\` avec dark-mode footer-bg
- \`.reveal*\` (left/right/scale + delays)
- \`.page-hero\`, \`.page-with-sidebar\`, \`.page-sidebar\`, \`.page-content\`
- \`.prose\` complet (h2/h3/h4/p/a/code/pre/blockquote/ul/ol/img/hr/table) pour rendu markdown
- \`.card-grid\` + \`.card-tile\` (avec variant \`.is-disabled\`)
- \`.callout\` (3 variants: default/warning/note)
- \`.prev-next\` (navigation précédent/suivant entre articles)
- \`@media print\` clean

### \`public/js/landing.js\` (~95 lignes)
Chrome JS isolé, propre, IIFE :
- Init thème depuis \`localStorage\` (anti-FOUC inline aussi)
- \`toggleTheme()\` avec animation \`theme-switching\`
- Mobile nav toggle + \`window.closeMobile\`
- \`IntersectionObserver\` pour \`.reveal*\` (fallback \`.visible\` si pas IO)
- Smooth anchor scroll (offset 70px nav fixe)
- Auto-active state pour sidebar/nav-links matching path/hash

### \`resources/views/layouts/landing.blade.php\` (~150 lignes)
Layout pivot \`@extends\`-able :
- \`@yield\` : title / description / og_image / body_class
- \`@section('meta')\` : extra meta tags (canonical override, hreflang, JSON-LD…)
- \`@stack('styles')\` / \`@stack('scripts')\` slots page-specific
- Skip link clavier (\`a11y\`)
- Nav avec \`Route::has()\` guards : footer/nav links pointent vers \`#\` tant que les routes docs/changelog/api-reference n'existent pas
- Liens vers fragments du landing (\`#fonctionnalites\`, \`#tarifs\`) via \`route('welcome')\`

## Pourquoi cette PR isolée

Le critic 4-axes (audit pre-commit) a posé un BLOCK architectural sur l'idée de copier-coller welcome.blade.php pour chaque nouvelle page (drift inévitable). Cette PR pose la foundation propre : les 3 PRs suivantes (\`/changelog\`, \`/docs\`, \`/api-reference\`) sont \`@extends('layouts.landing')\` et ne dupliquent rien.

## Risque

**Très bas** : aucun fichier existant modifié. Si un problème survient, il suffit de revert ce commit. Le landing actuel (\`welcome.blade.php\`) continue à fonctionner exactement comme avant — il est self-contained.

## Test plan

- [x] \`php artisan route:list\` ne plante pas
- [ ] Visite \`/\` (landing) sur \`presentation.klassci.com\` après merge → identique à avant (pas de regression)
- [ ] Visite \`/css/landing.css\` directement → 200, ne contient pas de variables manquantes
- [ ] Visite \`/js/landing.js\` directement → 200

## Suite

PR1 = \`/changelog\` (markdown CommonMark + cache 24h, curé Jan→Avr 2026)
PR2 = \`/docs\` (TOC + 3 articles markdown : getting-started, superadmin/onboarding, secretaire/inscriptions)
PR3 = \`/api-reference\` (uniquement \`/api/lms/*\`, bannière Beta, jamais \`/api/cli/*\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)