### PR TITLE
feat(public): pages /docs avec TOC et 3 articles markdown

### DIFF
--- a/app/Http/Controllers/Public/DocsController.php
+++ b/app/Http/Controllers/Public/DocsController.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\Autolink\AutolinkExtension;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class DocsController extends Controller
+{
+    /**
+     * Render the /docs landing : sections grid (rôles, modules, getting-started).
+     */
+    public function index()
+    {
+        return response()
+            ->view('public.docs.index', [
+                'sections' => $this->groupedArticles(),
+            ])
+            ->withHeaders([
+                'Cache-Control' => 'public, max-age=3600',
+                'Expires' => gmdate('D, d M Y H:i:s', time() + 3600) . ' GMT',
+            ]);
+    }
+
+    /**
+     * Render an individual article at /docs/{slug}.
+     */
+    public function show(string $slug)
+    {
+        $articles = config('docs.articles', []);
+
+        if (! isset($articles[$slug]) || ! ($articles[$slug]['available'] ?? false)) {
+            throw new NotFoundHttpException("Article not found: {$slug}");
+        }
+
+        $article = $articles[$slug];
+        $payload = Cache::remember(
+            "public.docs.article.{$slug}.v1",
+            now()->addHours(24),
+            fn () => $this->buildArticlePayload($slug, $article)
+        );
+
+        [$prev, $next] = $this->neighbours($slug);
+
+        return response()
+            ->view('public.docs.show', [
+                'article' => $article,
+                'slug' => $slug,
+                'html' => $payload['html'],
+                'toc' => $payload['toc'],
+                'prev' => $prev,
+                'next' => $next,
+                'sidebar' => $this->groupedArticles(),
+            ])
+            ->withHeaders([
+                'Cache-Control' => 'public, max-age=3600',
+                'Expires' => gmdate('D, d M Y H:i:s', time() + 3600) . ' GMT',
+            ]);
+    }
+
+    /**
+     * Articles grouped by section, sorted by `order`. Both available and
+     * placeholder articles are returned (placeholders render greyed-out).
+     *
+     * @return array<string, array{title: string, description: string, articles: array<int, array<string, mixed>>}>
+     */
+    private function groupedArticles(): array
+    {
+        $sections = config('docs.sections', []);
+        $articles = config('docs.articles', []);
+
+        $grouped = [];
+        foreach ($sections as $key => $meta) {
+            $grouped[$key] = [
+                'title' => $meta['title'],
+                'description' => $meta['description'] ?? '',
+                'articles' => [],
+            ];
+        }
+
+        foreach ($articles as $slug => $article) {
+            $section = $article['section'] ?? null;
+            if ($section === null || ! isset($grouped[$section])) {
+                continue;
+            }
+            $grouped[$section]['articles'][] = ['slug' => $slug] + $article;
+        }
+
+        foreach ($grouped as $key => $_) {
+            usort(
+                $grouped[$key]['articles'],
+                fn ($a, $b) => ($a['order'] ?? 99) <=> ($b['order'] ?? 99)
+            );
+        }
+
+        return $grouped;
+    }
+
+    /**
+     * Find the previous and next AVAILABLE articles in `reading_order`.
+     *
+     * @return array{0: ?array<string, mixed>, 1: ?array<string, mixed>}
+     */
+    private function neighbours(string $slug): array
+    {
+        $order = config('docs.reading_order', []);
+        $articles = config('docs.articles', []);
+
+        $availableOrder = array_values(array_filter(
+            $order,
+            fn ($s) => isset($articles[$s]) && ($articles[$s]['available'] ?? false)
+        ));
+
+        $idx = array_search($slug, $availableOrder, true);
+        if ($idx === false) {
+            return [null, null];
+        }
+
+        $prevSlug = $idx > 0 ? $availableOrder[$idx - 1] : null;
+        $nextSlug = $idx < count($availableOrder) - 1 ? $availableOrder[$idx + 1] : null;
+
+        return [
+            $prevSlug ? ['slug' => $prevSlug] + $articles[$prevSlug] : null,
+            $nextSlug ? ['slug' => $nextSlug] + $articles[$nextSlug] : null,
+        ];
+    }
+
+    /**
+     * Convert a single article markdown file into HTML + extract h2/h3 TOC.
+     *
+     * @return array{html: string, toc: array<int, array{anchor: string, label: string, level: int}>}
+     */
+    private function buildArticlePayload(string $slug, array $article): array
+    {
+        $relative = $article['file'] ?? null;
+        if (! is_string($relative) || $relative === '') {
+            return ['html' => '', 'toc' => []];
+        }
+
+        $path = resource_path('docs/' . ltrim($relative, '/'));
+        if (! is_file($path)) {
+            Log::warning('Docs markdown missing', ['slug' => $slug, 'path' => $path]);
+            return ['html' => '<p>Cet article n\'est pas disponible pour le moment.</p>', 'toc' => []];
+        }
+
+        $markdown = (string) file_get_contents($path);
+
+        $environment = new Environment([
+            'html_input' => 'escape',
+            'allow_unsafe_links' => false,
+        ]);
+        $environment->addExtension(new CommonMarkCoreExtension());
+        $environment->addExtension(new AutolinkExtension());
+
+        $converter = new CommonMarkConverter([], $environment);
+        $html = (string) $converter->convert($markdown);
+
+        // Inject ids on h2/h3 + collect TOC entries.
+        $toc = [];
+        $html = preg_replace_callback(
+            '/<h(?<lvl>[23])>(?<title>[^<]+)<\/h\1>/u',
+            function (array $m) use (&$toc): string {
+                $slug = $this->slug($m['title']);
+                $toc[] = ['anchor' => $slug, 'label' => $m['title'], 'level' => (int) $m['lvl']];
+                return sprintf('<h%d id="%s">%s</h%d>', (int) $m['lvl'], $slug, e($m['title']), (int) $m['lvl']);
+            },
+            $html
+        ) ?? $html;
+
+        // Promote :::callout markers into proper callout divs.
+        // Markdown source can use :::callout / :::callout warning / :::callout note
+        // to wrap a paragraph in a callout-styled box.
+        $html = $this->convertCalloutSyntax($html);
+
+        return ['html' => $html, 'toc' => $toc];
+    }
+
+    /**
+     * Transform :::callout {variant?} ... ::: blocks into <div class="callout"></div>.
+     */
+    private function convertCalloutSyntax(string $html): string
+    {
+        return preg_replace_callback(
+            '/<p>:::callout(?:\s+(?<variant>warning|note))?<\/p>(?<body>.+?)<p>:::<\/p>/su',
+            function (array $m): string {
+                $cls = 'callout';
+                if (! empty($m['variant'])) {
+                    $cls .= ' callout--' . $m['variant'];
+                }
+                return sprintf('<div class="%s">%s</div>', $cls, $m['body']);
+            },
+            $html
+        ) ?? $html;
+    }
+
+    /**
+     * Slugify a heading label for use as an HTML id.
+     */
+    private function slug(string $value): string
+    {
+        $value = mb_strtolower($value, 'UTF-8');
+        $value = preg_replace('/[^\p{L}\p{N}\s-]+/u', '', $value) ?? '';
+        $value = preg_replace('/\s+/u', '-', trim($value)) ?? '';
+        return $value !== '' ? $value : 'section';
+    }
+}

--- a/config/docs.php
+++ b/config/docs.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ |--------------------------------------------------------------------------
+ | Documentation publique KLASSCI
+ |--------------------------------------------------------------------------
+ |
+ | Source-of-truth pour la table des matières publique de /docs.
+ | Chaque entrée pointe vers un fichier markdown dans resources/docs/.
+ | Le controller `Public\DocsController` expose ces articles à
+ | l'URL /docs/{slug}, en parsant le markdown via league/commonmark.
+ |
+ | Structure :
+ |   - sections : groupes principaux (Mise en route, Par rôle, Par module)
+ |   - articles : indexés par slug pour résolution O(1)
+ |   - chaque article : title, description, file (chemin relatif depuis
+ |     resources/docs/), section, hero_image (optionnel), available
+ |     (true = livré, false = placeholder grisé non cliquable)
+ |
+ */
+
+return [
+
+    'sections' => [
+        'getting-started' => [
+            'title' => 'Mise en route',
+            'description' => "Premiers pas avec KLASSCI : présentation, installation, comptes initiaux, premier déploiement.",
+        ],
+        'roles' => [
+            'title' => 'Par rôle',
+            'description' => "Guides dédiés à chaque profil utilisateur. Choisissez votre rôle pour voir les écrans qui vous concernent.",
+        ],
+        'modules' => [
+            'title' => 'Par module',
+            'description' => "Documentation fonctionnelle par grand domaine : académique, financier, présences, communication.",
+        ],
+    ],
+
+    'articles' => [
+
+        // ─── Getting started ───
+        'getting-started' => [
+            'title' => 'Bienvenue sur KLASSCI',
+            'description' => "Présentation de la plateforme, premiers pas, vocabulaire essentiel.",
+            'file' => 'getting-started.md',
+            'section' => 'getting-started',
+            'hero_image' => 'images/landing/hero_section.png',
+            'available' => true,
+            'order' => 1,
+        ],
+
+        // ─── Par rôle ───
+        'superadmin/onboarding' => [
+            'title' => 'Super-administrateur — installation initiale',
+            'description' => "Premier paramétrage : année universitaire, filières, niveaux, classes, frais, comptes du personnel.",
+            'file' => 'superadmin/onboarding.md',
+            'section' => 'roles',
+            'role_label' => 'Super-administrateur',
+            'available' => true,
+            'order' => 1,
+        ],
+        'secretaire/inscriptions' => [
+            'title' => 'Secrétaire — gérer les inscriptions',
+            'description' => "Pré-inscription, validation, paiement initial, ré-inscription et gestion des classes pleines.",
+            'file' => 'secretaire/inscriptions.md',
+            'section' => 'roles',
+            'role_label' => 'Secrétaire',
+            'available' => true,
+            'order' => 2,
+        ],
+        'enseignant/notes' => [
+            'title' => 'Enseignant — saisir les notes',
+            'description' => "Saisie en classe ou à distance, calcul automatique des moyennes, génération des bulletins.",
+            'file' => 'enseignant/notes.md',
+            'section' => 'roles',
+            'role_label' => 'Enseignant',
+            'available' => false,
+            'order' => 3,
+        ],
+        'comptable/relances' => [
+            'title' => 'Comptable — pilotage financier',
+            'description' => "Suivi des paiements, génération des relances, situations financières, exports comptables.",
+            'file' => 'comptable/relances.md',
+            'section' => 'roles',
+            'role_label' => 'Comptable',
+            'available' => false,
+            'order' => 4,
+        ],
+        'etudiant/bulletin' => [
+            'title' => 'Étudiant — accéder à ses notes et bulletins',
+            'description' => "Connexion étudiant, consultation des notes, téléchargement des bulletins, situation financière.",
+            'file' => 'etudiant/bulletin.md',
+            'section' => 'roles',
+            'role_label' => 'Étudiant',
+            'available' => false,
+            'order' => 5,
+        ],
+
+        // ─── Par module ───
+        'modules/lmd' => [
+            'title' => 'Système LMD',
+            'description' => "UE, ECUE, crédits ECTS, parcours, bulletins LMD conformes UEMOA, formules AQ/NAQ/APC.",
+            'file' => 'modules/lmd.md',
+            'section' => 'modules',
+            'available' => false,
+            'order' => 1,
+        ],
+        'modules/emploi-temps' => [
+            'title' => 'Emploi du temps',
+            'description' => "Planning général, séances de cours, émargement, vue par classe / par enseignant.",
+            'file' => 'modules/emploi-temps.md',
+            'section' => 'modules',
+            'available' => false,
+            'order' => 2,
+        ],
+        'modules/notes-bulletins' => [
+            'title' => 'Notes et bulletins',
+            'description' => "Évaluations, saisie, coefficients, moyennes, rangs, génération PDF, archivage.",
+            'file' => 'modules/notes-bulletins.md',
+            'section' => 'modules',
+            'available' => false,
+            'order' => 3,
+        ],
+        'modules/comptabilite' => [
+            'title' => 'Comptabilité',
+            'description' => "Frais, paiements, relances, dashboard financier, exports, intégration mobile money.",
+            'file' => 'modules/comptabilite.md',
+            'section' => 'modules',
+            'available' => false,
+            'order' => 4,
+        ],
+        'modules/presences' => [
+            'title' => 'Présences',
+            'description' => "Appel numérique, codes d'émargement, suivi par étudiant et par enseignant, rapports.",
+            'file' => 'modules/presences.md',
+            'section' => 'modules',
+            'available' => false,
+            'order' => 5,
+        ],
+        'modules/inscriptions' => [
+            'title' => 'Inscriptions et ré-inscriptions',
+            'description' => "Workflow complet, validation, paiement, blocage classes pleines, tronc commun, transferts.",
+            'file' => 'modules/inscriptions.md',
+            'section' => 'modules',
+            'available' => false,
+            'order' => 6,
+        ],
+    ],
+
+    /*
+     | Navigation prev/next : ordre canonique de lecture
+     | (utilisé par DocsController::neighbours).
+     */
+    'reading_order' => [
+        'getting-started',
+        'superadmin/onboarding',
+        'secretaire/inscriptions',
+        'enseignant/notes',
+        'comptable/relances',
+        'etudiant/bulletin',
+        'modules/lmd',
+        'modules/emploi-temps',
+        'modules/notes-bulletins',
+        'modules/comptabilite',
+        'modules/presences',
+        'modules/inscriptions',
+    ],
+
+];

--- a/resources/docs/getting-started.md
+++ b/resources/docs/getting-started.md
@@ -1,0 +1,90 @@
+## Qu'est-ce que KLASSCI
+
+KLASSCI est une plateforme de gestion scolaire conçue pour les **établissements d'enseignement supérieur en Afrique** : universités, grandes écoles, instituts BTS, licences professionnelles. Un seul outil pour remplacer les fichiers Excel, les cahiers de notes, les tableaux d'affichage et les bases Access vieillissantes.
+
+La plateforme couvre l'ensemble du cycle de vie d'un étudiant, de la pré-inscription à la délivrance du diplôme :
+
+- inscriptions et ré-inscriptions, avec workflow de validation et gestion des paiements
+- emploi du temps, séances de cours et émargement enseignant
+- présences étudiants, codes d'émargement, rapports d'assiduité
+- saisie des notes, calcul automatique des moyennes, génération des bulletins
+- comptabilité : frais, paiements, relances, dashboards financiers
+- système LMD complet (UE, ECUE, crédits ECTS, parcours) en parallèle du BTS classique
+- communication : annonces, messages, notifications
+
+Chaque établissement dispose de **sa propre base de données isolée**. Vos données ne sont jamais partagées avec d'autres écoles.
+
+## Pour qui
+
+KLASSCI est pensé pour les profils suivants :
+
+| Rôle | Ce qu'il fait dans KLASSCI |
+| --- | --- |
+| Super-administrateur | Paramétrage initial, gestion des comptes, configuration des frais, supervision globale |
+| Coordinateur | Pilotage pédagogique, planning général, charge par classe |
+| Secrétaire | Inscriptions, ré-inscriptions, dossiers étudiants, génération de documents |
+| Enseignant | Saisie des notes, émargement, consultation des classes, rapports |
+| Comptable | Suivi des paiements, relances, situations financières, exports comptables |
+| Caissier | Pré-inscription rapide, encaissement, génération de reçus |
+| Étudiant | Consultation des notes, bulletins, situation financière, emploi du temps |
+
+Les rôles disposent de permissions granulaires gérées via Spatie Permission. Un super-administrateur peut activer ou désactiver des **modules complets** (LMD, comptabilité, communication...) selon le plan de l'établissement.
+
+## Vocabulaire essentiel
+
+Quelques termes que vous croiserez souvent dans la plateforme et dans le reste de cette documentation :
+
+- **Filière** — la spécialité d'enseignement (ex. : Génie Civil, Bâtiment, Informatique de Gestion).
+- **Niveau d'étude** — l'année dans le cursus (BTS1, BTS2, L1, L2, L3, M1, M2). Un niveau appartient à un cycle (BTS, Licence, Master).
+- **Classe** — l'unité opérationnelle qui regroupe des étudiants pour une année universitaire donnée. Toujours liée à une filière + un niveau d'étude.
+- **Année universitaire** — la période académique (ex. : 2025-2026). Une seule est marquée comme « courante » à la fois.
+- **Inscription** — le lien entre un étudiant et une classe pour une année universitaire. Possède un `status` (active / annulée) et une `workflow_step` (pre_inscrit, etudiant_cree, etc.).
+- **Matière** — l'unité d'enseignement à laquelle on attache des notes. En LMD, une matière est une **ECUE** liée à une **UE** (Unité d'Enseignement) avec des crédits ECTS.
+- **Évaluation** — un type d'évaluation (devoir, partiel, examen final, projet) configuré pour une matière.
+- **Note** — la note d'un étudiant à une évaluation donnée.
+- **Bulletin** — la synthèse des résultats d'un étudiant pour une période (semestre ou année).
+- **Tronc commun** — un mode d'inscription en deux temps : tronc commun en S1, puis spécialisation en S2 (ou inversement selon la filière).
+
+## Premières étapes après création de votre compte
+
+Une fois votre établissement provisionné par l'équipe KLASSCI, vous recevez vos identifiants super-administrateur. Voici l'ordre recommandé :
+
+1. **Vérifiez l'année universitaire courante** dans `Paramètres → Configuration → Année universitaire`. Si elle n'est pas créée, créez-la et marquez-la `is_current = true`.
+2. **Configurez les filières** (`Académique → Filières`) puis les **niveaux d'étude** (`Académique → Niveaux`).
+3. **Créez les classes** pour l'année courante (`Académique → Classes`). Chaque classe est l'intersection d'une filière + un niveau pour une année donnée.
+4. **Définissez les matières** (`Académique → Matières`). Pour le LMD, créez d'abord les UE puis les ECUE rattachées.
+5. **Paramétrez les frais** (`Comptabilité → Frais → Configurer`). Définissez les catégories (inscription, scolarité, examens...) et les montants par filière + niveau.
+6. **Importez ou créez les comptes du personnel** (`Personnel`). Chaque membre reçoit ses identifiants par email. Le mot de passe est valable 6 mois et expire avec une alerte 1 mois avant.
+7. **Démarrez les inscriptions étudiants** (`Étudiants → Inscriptions → Nouvelle inscription`).
+
+Le guide [Super-administrateur — installation initiale](/docs/superadmin/onboarding) détaille chaque étape avec les écrans correspondants.
+
+## Connexion et environnements
+
+KLASSCI est accessible depuis n'importe quel navigateur moderne (Chrome, Firefox, Safari, Edge). Aucune installation locale, aucune extension à télécharger.
+
+Chaque établissement dispose d'une URL dédiée du type `https://votre-ecole.klassci.com`. Sur mobile, l'interface est entièrement responsive : les enseignants saisissent leurs notes depuis leur téléphone sans application native dédiée.
+
+:::callout
+**Bon à savoir.** Les sessions expirent au bout de 12 heures d'inactivité. Si vous perdez votre mot de passe, utilisez le lien « Mot de passe oublié » sur la page de connexion : un email de réinitialisation est envoyé sous 60 secondes.
+:::
+
+## Sécurité de vos données
+
+KLASSCI applique plusieurs niveaux de protection :
+
+- **Isolation par tenant** : chaque école a sa propre base MySQL, hébergée séparément.
+- **HTTPS obligatoire** : toutes les communications sont chiffrées (TLS 1.3 sur les domaines klassci.com).
+- **Permissions par rôle** : un comptable ne voit pas les notes, un enseignant ne voit pas la comptabilité.
+- **Audit IDOR** : protection systématique contre les accès directs non autorisés (`Policy` Laravel sur les ressources sensibles).
+- **Rate limiting** : les routes monétaires et d'authentification sont limitées pour bloquer les attaques en force brute.
+- **Sauvegardes** : sauvegardes automatiques quotidiennes, conservées 30 jours.
+
+## Prochaines étapes
+
+Selon votre rôle, continuez par l'un des guides suivants :
+
+- [Super-administrateur — installation initiale](/docs/superadmin/onboarding) si vous configurez votre établissement pour la première fois
+- [Secrétaire — gérer les inscriptions](/docs/secretaire/inscriptions) si vous gérez les dossiers étudiants au quotidien
+
+Les guides par module (LMD, emploi du temps, notes, comptabilité, présences) sont en cours de rédaction et seront publiés progressivement. Pour toute question ou demande de démo, écrivez à [contact@klassci.com](mailto:contact@klassci.com).

--- a/resources/docs/secretaire/inscriptions.md
+++ b/resources/docs/secretaire/inscriptions.md
@@ -1,0 +1,121 @@
+## Vue d'ensemble du workflow
+
+Une inscription dans KLASSCI suit un cycle en 4 étapes, modélisé par le champ `workflow_step` :
+
+1. **`pre_inscrit`** — l'étudiant a fourni ses informations mais le paiement initial n'a pas encore été validé. Aucune classe n'est encore attribuée.
+2. **`pre_inscrit_paye`** — le paiement initial est validé. L'étudiant attend l'attribution d'une classe par l'administration.
+3. **`affecte`** — la classe est attribuée. L'étudiant est en attente de validation finale.
+4. **`etudiant_cree`** — l'inscription est validée définitivement. L'étudiant est compté dans les effectifs et peut accéder à son espace.
+
+Cette séparation existe pour éviter qu'un étudiant qui a juste rempli un formulaire (sans payer) ne soit considéré comme inscrit dans les statistiques. Toutes les pages KPI filtrent par défaut sur `workflow_step = etudiant_cree`.
+
+:::callout
+**Règle d'or.** Tant que `workflow_step != etudiant_cree`, l'étudiant n'est PAS officiellement inscrit, même si son `status` vaut `active`. Les rapports d'effectifs, le calcul des places restantes et les tableaux de bord respectent cette règle.
+:::
+
+## Créer une nouvelle inscription
+
+### Cas général : étudiant qui paie immédiatement
+
+Allez dans `Étudiants → Inscriptions → Nouvelle inscription`. Le formulaire est divisé en sections logiques :
+
+1. **Informations étudiant** — nom, prénoms, date de naissance, sexe, nationalité, téléphone, email
+2. **Adresse et contact d'urgence**
+3. **Cursus antérieur** — diplôme obtenu, établissement d'origine, année
+4. **Affectation académique** — filière, niveau, classe (Select2 avec recherche)
+5. **Frais et paiement initial** — sélection des frais à acquitter, mode de paiement, montant
+
+Lorsque vous sélectionnez une classe, KLASSCI vérifie en temps réel les places disponibles via un appel AJAX vers `GET /esbtp/classes/{id}/available-places`. L'affichage utilise des seuils colorés :
+
+| Couleur | Seuil | Message |
+| --- | --- | --- |
+| Vert | > 30 % | « Places disponibles : X / Y » |
+| Orange | 10 % à 30 % | « Places limitées : X / Y » |
+| Orange foncé | < 10 % | « Presque complet : X / Y » |
+| Rouge | 0 | « Classe pleine » + bouton de soumission désactivé |
+
+Si la classe est pleine, le bouton « Valider l'inscription » est automatiquement grisé et un message d'erreur explicite apparaît au-dessus du formulaire. L'étudiant doit choisir une autre classe ou attendre une place.
+
+### Cas particulier : pré-inscription sans paiement immédiat
+
+Si l'étudiant n'a pas encore les fonds pour payer son inscription, vous pouvez l'enregistrer en **pré-inscription** depuis `Étudiants → Pré-inscriptions → Nouvelle pré-inscription`. Le formulaire est plus court (informations essentielles seulement, pas d'affectation de classe).
+
+Plus tard, quand l'étudiant paie, retrouvez sa pré-inscription dans la liste, cliquez sur « Compléter l'inscription » et finalisez le dossier. KLASSCI propose alors une **modale d'affectation** pour choisir la classe avec vérification des places.
+
+## Validation d'une inscription
+
+### Validation individuelle
+
+Sur la fiche d'inscription, cliquez sur le bouton « Valider l'inscription ». KLASSCI vérifie automatiquement :
+
+- qu'au moins un paiement existe sur cette inscription
+- que le paiement a un statut `valide` (pas `en_attente`)
+- qu'une classe est bien attribuée
+- que la classe a encore une place
+
+Si toutes les conditions sont réunies, l'inscription passe à `etudiant_cree`. L'étudiant reçoit son matricule (auto-généré selon la convention de l'établissement) et un email avec ses identifiants étudiant.
+
+:::callout warning
+**Pas de validation sans paiement.** KLASSCI bloque la validation si aucun paiement valide n'est associé. Cette règle s'applique aussi en validation en lot. Pour les cas exceptionnels, le super-administrateur peut forcer la validation depuis la console artisan.
+:::
+
+### Validation en lot
+
+Pour valider plusieurs inscriptions d'un coup (par exemple en début d'année scolaire), allez dans `Étudiants → Inscriptions`, cochez les inscriptions à valider, puis utilisez le bouton « Actions groupées → Valider la sélection ». KLASSCI traite chaque inscription dans une transaction séparée :
+
+- Les inscriptions avec paiement validé passent à `etudiant_cree`.
+- Les inscriptions avec paiement `en_attente` sont **ignorées** (pas validées) avec la raison « paiement_en_attente ».
+- Les inscriptions sans paiement sont **ignorées** avec la raison « sans_paiement ».
+- Les inscriptions sur une classe pleine sont **ignorées** avec la raison « classe_pleine ».
+
+Un toast récapitulatif affiche le nombre d'inscriptions validées et la liste des ignorées avec leurs raisons.
+
+## Ré-inscription d'un étudiant existant
+
+Pour un étudiant qui passe d'une année à l'autre, utilisez `Étudiants → Réinscriptions → Nouvelle réinscription`. Le formulaire est pré-rempli avec :
+
+- les informations personnelles de l'étudiant (modifiables)
+- l'historique de ses inscriptions précédentes
+- le **reliquat** éventuel de l'année précédente (somme due qui n'a pas été payée), automatiquement reportée sur la nouvelle année
+
+Choisissez la nouvelle classe (généralement le niveau supérieur dans la même filière) et finalisez le paiement initial. La règle métier impose que le **solde calculé** se base uniquement sur les `frais subscriptions` actives, sans fallback sur la configuration globale.
+
+Pour les filières en tronc commun, KLASSCI propose un workflow spécifique :
+
+1. À l'entrée, l'étudiant s'inscrit dans la classe `Tronc commun [Filière]`.
+2. À la fin du semestre commun, vous accédez à la fiche étudiant et utilisez « Spécialisation » pour le ré-inscrire dans une classe spécialisée. Une nouvelle inscription est créée, liée à la précédente par `inscription_origine_id`. La règle de contrainte unique a été assouplie pour permettre 2 inscriptions par année universitaire dans ce cas (`(etudiant_id, annee_universitaire_id, classe_id)`).
+3. Le bulletin annuel agrège automatiquement les notes du tronc commun (S1) et de la spécialisation (S2) avec la pondération configurée.
+
+## Annuler une inscription
+
+Sur la liste des inscriptions, sélectionnez les lignes à annuler et utilisez « Actions groupées → Annuler la sélection ». KLASSCI vous demande une **raison** (4 choix : abandon, exclusion, transfert, autre) et un commentaire libre.
+
+L'inscription passe en `status = annule` et `workflow_step = annule`. Les données sont conservées (pas de suppression physique) pour l'historique. Les notes et bulletins associés sont **soft-archivés** : ils restent en base mais n'apparaissent plus dans les listings courants. Vous pouvez les retrouver dans `Notes → Filtres avancés → Inclure les annulés`.
+
+Si l'étudiant avait payé, son paiement n'est PAS automatiquement remboursé : c'est une décision administrative. Le module comptabilité affiche les paiements rattachés à des inscriptions annulées dans une rubrique dédiée pour faciliter le traitement des remboursements.
+
+## Exporter et imprimer
+
+Depuis la liste des inscriptions, le bouton « Export » propose :
+
+- **CSV** — pour Excel ou Google Sheets, avec toutes les colonnes
+- **PDF liste** — un document avec en-tête établissement et toutes les inscriptions filtrées
+- **PDF détaillé** — un document par étudiant (utile pour archivage papier)
+
+Vous pouvez aussi générer le **dossier individuel** d'un étudiant depuis sa fiche : `Étudiants → [étudiant] → Documents → Dossier complet`. Le PDF inclut l'inscription, l'historique des paiements, les notes, le bulletin courant et les présences.
+
+## Erreurs fréquentes et résolution
+
+| Symptôme | Cause probable | Solution |
+| --- | --- | --- |
+| Le bouton « Valider » ne réagit pas | Aucun paiement validé | Validez d'abord le paiement dans `Comptabilité → Paiements` |
+| Toujours « En attente » après validation | `workflow_step != etudiant_cree` | Rafraîchir la page, ou vérifier que la validation a bien commit la transaction |
+| « Classe pleine » alors qu'il reste des places | Cache navigateur | Cliquer dans le sélecteur de classe (re-fetch AJAX) |
+| L'étudiant n'apparaît pas dans les effectifs | Filtre `workflow_step` actif | Vérifier que la validation est complète, ou enlever le filtre temporairement |
+| L'export PDF est vide | Filtre actif sans résultat | Vérifier les filtres actifs (statut, année, classe) |
+
+Pour toute autre question, contactez le service technique via [contact@klassci.com](mailto:contact@klassci.com).
+
+## Prochaine étape
+
+Une fois vos inscriptions sous contrôle, vous voudrez sans doute consulter le guide **Comptable** pour comprendre comment les paiements arrivent dans le module financier et comment générer les relances. Ce guide sera publié prochainement.

--- a/resources/docs/superadmin/onboarding.md
+++ b/resources/docs/superadmin/onboarding.md
@@ -1,0 +1,165 @@
+## Avant de commencer
+
+Ce guide s'adresse au **super-administrateur** d'un établissement qui vient d'être provisionné sur KLASSCI. Il décrit l'ordre dans lequel paramétrer la plateforme pour pouvoir démarrer les inscriptions de votre première année universitaire.
+
+Comptez environ **2 à 3 heures** pour un paramétrage complet, à condition d'avoir sous la main :
+
+- la liste de vos filières avec leurs niveaux d'étude,
+- la grille des frais de scolarité (ou au moins les frais d'inscription),
+- la liste de votre personnel administratif et enseignant avec leurs adresses email,
+- éventuellement les comptes parents si vous activez l'accès parental.
+
+:::callout
+**Pas de panique en cas d'oubli.** Tout est modifiable a posteriori. Vous pouvez très bien démarrer avec une seule filière et un seul frais, puis enrichir au fil des semaines.
+:::
+
+## Étape 1 : créer l'année universitaire courante
+
+L'année universitaire est la fondation de toute la plateforme : inscriptions, paiements, bulletins et résultats sont rattachés à une année donnée.
+
+Rendez-vous dans `Paramètres → Configuration → Année universitaire` et créez l'année courante en remplissant :
+
+- **Libellé** : `2025-2026` (ou la convention que vous utilisez en interne)
+- **Date de début** : 1er septembre par défaut
+- **Date de fin** : 31 juillet par défaut
+- **Année courante** : cochez `is_current = true`
+
+Une seule année peut être marquée comme courante à la fois. C'est elle qui apparaît par défaut dans tous les écrans de saisie.
+
+### À savoir sur les inscriptions et l'année
+
+Dans KLASSCI, **une classe n'est PAS attachée à une année universitaire** — c'est l'inscription qui l'est. Cela signifie qu'une même classe (ex. : `BTS Bâtiment 1ère année`) peut accueillir des étudiants de plusieurs années universitaires successives sans devoir être recréée.
+
+Concrètement, lorsque vous filtrez les étudiants par classe, ce qui les sépare entre 2024-2025 et 2025-2026, c'est la `annee_universitaire_id` de leur inscription, pas la classe elle-même.
+
+## Étape 2 : configurer les filières
+
+Allez dans `Académique → Filières → Nouvelle filière`. Pour chaque filière, renseignez :
+
+- **Nom** : `Génie Civil`, `Bâtiment`, `Informatique de Gestion`, etc.
+- **Code** : un code court unique (`GC`, `BAT`, `IG`)
+- **Système académique** : `BTS` ou `LMD`
+- **Tronc commun** : cochez si la filière commence par un semestre commun avant spécialisation
+
+Si votre établissement propose à la fois des BTS et des Licences/Masters, créez deux filières distinctes (`BTS Génie Civil` et `Licence Génie Civil`) — les bulletins et calculs de moyenne diffèrent profondément entre les deux systèmes.
+
+### Cas particulier : tronc commun
+
+Si vous activez le tronc commun sur une filière, vous devrez préciser :
+
+- combien de semestres en tronc commun (généralement 1)
+- les filières de spécialisation cibles (les filières « enfants » de ce tronc commun)
+
+Le module tronc commun déclenche un workflow d'inscription en deux temps : l'étudiant s'inscrit d'abord en tronc commun, puis en spécialisation à l'issue du semestre commun. Le bulletin de la classe d'origine est conservé et la moyenne annuelle agrège les notes du tronc commun et de la spécialisation.
+
+## Étape 3 : créer les niveaux d'étude
+
+Dans `Académique → Niveaux`, créez les niveaux que votre établissement propose. Quelques exemples :
+
+| Système | Niveau | Cycle |
+| --- | --- | --- |
+| BTS | BTS1 | Cycle court |
+| BTS | BTS2 | Cycle court |
+| LMD | L1 | Licence |
+| LMD | L2 | Licence |
+| LMD | L3 | Licence |
+| LMD | M1 | Master |
+| LMD | M2 | Master |
+
+Chaque niveau possède un **cycle** parent (BTS, Licence, Master, Doctorat) qui sert de filtre dans les rapports et les bulletins.
+
+## Étape 4 : créer les classes
+
+Une classe est l'intersection **filière × niveau d'étude** dans laquelle vos étudiants seront inscrits. Allez dans `Académique → Classes → Nouvelle classe` :
+
+- **Nom** : `BTS Bâtiment 1ère année`, `L2 Génie Civil`, etc.
+- **Filière** : sélectionner dans la liste créée à l'étape 2
+- **Niveau d'étude** : sélectionner dans la liste créée à l'étape 3
+- **Système académique** : déduit automatiquement de la filière (BTS ou LMD)
+- **Places totales** : la capacité maximale d'étudiants — sert au blocage automatique sur les inscriptions
+
+:::callout
+**Astuce.** Le seuil de blocage par défaut est 30 % de places restantes (vert), 10–30 % (orange), <10 % (orange foncé), 0 (rouge complet). Ces seuils sont configurables dans `Paramètres → Inscriptions → Capacité des classes`.
+:::
+
+## Étape 5 : configurer les matières
+
+### Pour les filières BTS
+
+Allez dans `Académique → Matières → Nouvelle matière`. Pour chaque matière, indiquez :
+
+- **Nom** : `Mathématiques appliquées`, `Topographie`, etc.
+- **Coefficient par défaut** : utilisé par les bulletins si la planification académique ne précise pas autrement
+
+Les matières BTS sont **rattachées aux classes** via les **planifications académiques**. Cette mécanique vous permet de définir des coefficients différents pour la même matière selon la filière et le niveau (par exemple, les Mathématiques peuvent avoir un coefficient 3 en Génie Civil et 4 en Topographie).
+
+Concrètement, allez dans `Planning Général → Configuration` et définissez les triplets `(filière, niveau, matière)` avec leur coefficient et volume horaire (CM / TD / TP).
+
+### Pour les filières LMD
+
+Le LMD utilise une hiérarchie en deux niveaux :
+
+1. **UE (Unité d'Enseignement)** — un regroupement thématique avec un nombre total de crédits ECTS (généralement entre 6 et 12).
+2. **ECUE** — les matières concrètes qui composent l'UE. Une ECUE peut appartenir à plusieurs UE avec des coefficients contextuels différents (relation many-to-many).
+
+Créez d'abord les UE (`Académique → LMD → UE → Nouvelle UE`) puis les ECUE (`Académique → LMD → ECUE → Nouvelle ECUE`). La modale ECUE inclut une jauge de validation des crédits qui empêche de dépasser le total alloué à l'UE.
+
+## Étape 6 : configurer les frais
+
+Le module comptabilité est central pour la trésorerie. Allez dans `Comptabilité → Frais → Configurer`.
+
+Définissez d'abord les **catégories de frais** (dans `Comptabilité → Frais → Catégories`) :
+
+- Frais d'inscription
+- Frais de scolarité
+- Frais d'examen
+- Frais de bibliothèque
+- Frais de polycopiés
+- Frais d'uniforme
+- etc.
+
+Chaque catégorie peut être obligatoire ou optionnelle. Les catégories obligatoires sont automatiquement attendues lors de l'inscription d'un étudiant.
+
+Ensuite, dans `Comptabilité → Frais → Configurer`, créez des **variants** : pour chaque combinaison `(filière, niveau, catégorie)`, définissez le montant attendu. Vous pouvez gérer cela en mode interactif via la commande artisan :
+
+```bash
+php artisan klassci:fees:configure
+```
+
+La commande vous guide pas à pas pour générer toutes les souscriptions sans doublon, archiver les inactifs et corriger les violations de contrainte unique.
+
+## Étape 7 : créer les comptes du personnel
+
+Allez dans `Personnel → Vue unifiée` et utilisez le bouton « + Nouveau personnel ». Choisissez le rôle (`coordinateur`, `enseignant`, `secrétaire`, `comptable`, `caissier`, `service technique`, `super-administrateur`).
+
+Pour chaque membre, KLASSCI génère automatiquement :
+
+- un **username** au format `prenom.nom` (déduplication automatique en cas de collision)
+- un **mot de passe initial** sécurisé (envoyé par email ou affiché dans une modale immédiate)
+- un **email** d'activation contenant le lien de première connexion
+
+À la première connexion, le membre est forcé à changer son mot de passe. Les mots de passe expirent au bout de 6 mois avec une alerte 1 mois avant.
+
+:::callout warning
+**Attention aux permissions enseignant.** Si vous activez les modules `notes_evaluations`, `presences` et `emploi_temps`, pensez à les attribuer également au rôle `enseignant`. Sinon, les enseignants verront une sidebar vide. Le toggle module ne suffit pas, il faut aussi la permission métier.
+:::
+
+## Étape 8 : valider la configuration et lancer
+
+Avant de communiquer l'URL aux étudiants, faites une dernière vérification :
+
+1. Connectez-vous avec le compte super-administrateur sur l'URL de votre établissement (`https://votre-ecole.klassci.com`).
+2. Vérifiez que la sidebar affiche bien tous les modules attendus.
+3. Créez un étudiant test (`Étudiants → Nouvel étudiant`) et inscrivez-le dans une classe.
+4. Vérifiez que la situation financière de cet étudiant test affiche les frais attendus.
+5. Connectez-vous avec un compte enseignant test et vérifiez que la saisie des notes fonctionne.
+
+Vous êtes prêt. Communiquez l'URL et les identifiants à votre équipe administrative et démarrez les inscriptions.
+
+## Que faire ensuite
+
+- Pour la gestion quotidienne des inscriptions, lisez le guide [Secrétaire — gérer les inscriptions](/docs/secretaire/inscriptions).
+- Pour comprendre les statuts d'inscription et le workflow de validation, le même guide les détaille.
+- Pour toute question, l'équipe support répond sous 24h ouvrées à [contact@klassci.com](mailto:contact@klassci.com).
+
+Bon démarrage avec KLASSCI.

--- a/resources/views/public/docs/index.blade.php
+++ b/resources/views/public/docs/index.blade.php
@@ -1,0 +1,215 @@
+@extends('layouts.landing')
+
+@section('title', 'Documentation')
+@section('description', 'Apprenez à utiliser KLASSCI : guides par rôle (super-administrateur, secrétaire, enseignant, comptable, étudiant) et par module (LMD, emploi du temps, notes, comptabilité, présences, inscriptions).')
+
+@push('styles')
+<style>
+    .docs-section { margin-bottom: 4rem; }
+    .docs-section:last-child { margin-bottom: 0; }
+
+    .docs-section-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 1rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.5rem;
+        padding-bottom: 1rem;
+        border-bottom: 1px solid var(--border);
+    }
+
+    .docs-section-header h2 {
+        font-family: 'IBM Plex Serif', Georgia, serif;
+        font-style: normal;
+        font-weight: 400;
+        font-size: 1.5rem;
+        color: var(--accent);
+        letter-spacing: -0.015em;
+    }
+
+    .docs-section-header p {
+        font-family: 'IBM Plex Sans', sans-serif;
+        font-size: 0.9rem;
+        color: var(--text-muted);
+        max-width: 540px;
+        text-align: right;
+        line-height: 1.55;
+    }
+
+    .docs-featured {
+        display: grid;
+        grid-template-columns: 1fr 1.2fr;
+        gap: 2.5rem;
+        align-items: center;
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 2.5rem;
+        margin-bottom: 4rem;
+        text-decoration: none;
+        color: inherit;
+        transition: all var(--duration-normal) var(--ease-out);
+    }
+
+    .docs-featured:hover {
+        border-color: var(--accent);
+        transform: translateY(-2px);
+        box-shadow: 0 8px 30px rgba(4,83,203,0.08);
+        color: inherit;
+    }
+
+    .docs-featured-eyebrow {
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.72rem;
+        color: var(--accent);
+        text-transform: uppercase;
+        letter-spacing: 0.12em;
+        margin-bottom: 0.75rem;
+    }
+
+    .docs-featured h3 {
+        font-family: 'IBM Plex Serif', Georgia, serif;
+        font-size: 1.65rem;
+        font-style: normal;
+        font-weight: 400;
+        color: var(--text);
+        margin-bottom: 0.75rem;
+        letter-spacing: -0.015em;
+    }
+
+    .docs-featured p {
+        font-family: 'IBM Plex Sans', sans-serif;
+        font-size: 0.95rem;
+        color: var(--text-secondary);
+        line-height: 1.65;
+        margin-bottom: 1rem;
+    }
+
+    .docs-featured-cta {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-family: 'IBM Plex Sans', sans-serif;
+        font-size: 0.9rem;
+        font-weight: 500;
+        color: var(--accent);
+    }
+
+    .docs-featured-image {
+        border-radius: var(--radius);
+        overflow: hidden;
+        border: 1px solid var(--border);
+        box-shadow: 0 4px 20px rgba(0,0,0,0.06);
+    }
+
+    .docs-featured-image img {
+        width: 100%;
+        display: block;
+    }
+
+    @media (max-width: 768px) {
+        .docs-featured { grid-template-columns: 1fr; padding: 1.75rem; }
+        .docs-section-header { flex-direction: column; }
+        .docs-section-header p { text-align: left; }
+    }
+
+    .docs-role-badge {
+        display: inline-block;
+        padding: 0.15rem 0.5rem;
+        background: var(--accent-light);
+        color: var(--accent);
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        border-radius: 3px;
+        margin-bottom: 0.5rem;
+        align-self: flex-start;
+    }
+</style>
+@endpush
+
+@section('content')
+
+<section class="page-hero">
+    <div class="container">
+        <div class="page-hero-eyebrow">Documentation</div>
+        <h1>Apprenez à utiliser KLASSCI</h1>
+        <p>
+            Guides pratiques pour chaque profil et chaque module. Pas de jargon technique inutile,
+            pas de captures floues : chaque article décrit un workflow réel sur la plateforme.
+        </p>
+    </div>
+</section>
+
+<section class="page-with-sidebar" style="padding-top:3rem">
+    <div class="container">
+
+        @php
+            $featured = $sections['getting-started']['articles'][0] ?? null;
+        @endphp
+
+        @if($featured && ($featured['available'] ?? false))
+            <a href="{{ route('docs.show', $featured['slug']) }}" class="docs-featured">
+                <div>
+                    <div class="docs-featured-eyebrow">À commencer ici</div>
+                    <h3>{{ $featured['title'] }}</h3>
+                    <p>{{ $featured['description'] }}</p>
+                    <span class="docs-featured-cta">
+                        Lire l'article
+                        <i class="fas fa-arrow-right" style="font-size:.7rem"></i>
+                    </span>
+                </div>
+                @if(!empty($featured['hero_image']))
+                    <div class="docs-featured-image">
+                        <img src="{{ asset($featured['hero_image']) }}" alt="{{ $featured['title'] }}" loading="lazy">
+                    </div>
+                @endif
+            </a>
+        @endif
+
+        @foreach(['roles', 'modules'] as $sectionKey)
+            @if(isset($sections[$sectionKey]))
+                @php $sec = $sections[$sectionKey]; @endphp
+                <div class="docs-section">
+                    <div class="docs-section-header">
+                        <h2>{{ $sec['title'] }}</h2>
+                        <p>{{ $sec['description'] }}</p>
+                    </div>
+
+                    <div class="card-grid">
+                        @foreach($sec['articles'] as $article)
+                            @if($article['available'])
+                                <a href="{{ route('docs.show', $article['slug']) }}" class="card-tile">
+                                    @if(!empty($article['role_label']))
+                                        <span class="docs-role-badge">{{ $article['role_label'] }}</span>
+                                    @endif
+                                    <h3>{{ $article['title'] }}</h3>
+                                    <p>{{ $article['description'] }}</p>
+                                    <span class="card-tile-foot">
+                                        Lire <i class="fas fa-arrow-right"></i>
+                                    </span>
+                                </a>
+                            @else
+                                <div class="card-tile is-disabled">
+                                    @if(!empty($article['role_label']))
+                                        <span class="docs-role-badge">{{ $article['role_label'] }}</span>
+                                    @endif
+                                    <h3>{{ $article['title'] }}</h3>
+                                    <p>{{ $article['description'] }}</p>
+                                    <span class="card-tile-foot">
+                                        Bientôt disponible <i class="fas fa-clock" style="opacity:.6"></i>
+                                    </span>
+                                </div>
+                            @endif
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+        @endforeach
+
+    </div>
+</section>
+
+@endsection

--- a/resources/views/public/docs/show.blade.php
+++ b/resources/views/public/docs/show.blade.php
@@ -1,0 +1,135 @@
+@extends('layouts.landing')
+
+@section('title', $article['title'])
+@section('description', $article['description'] ?? 'Documentation KLASSCI.')
+@if(!empty($article['hero_image']))
+    @section('og_image', asset($article['hero_image']))
+@endif
+
+@push('styles')
+<style>
+    .doc-breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-family: 'IBM Plex Mono', monospace;
+        font-size: 0.78rem;
+        color: var(--text-muted);
+        margin-bottom: 1rem;
+    }
+    .doc-breadcrumb a { color: var(--text-muted); }
+    .doc-breadcrumb a:hover { color: var(--accent); }
+    .doc-breadcrumb .sep { opacity: 0.5; }
+
+    .doc-header {
+        margin-bottom: 2rem;
+    }
+    .doc-header h1 {
+        font-family: 'IBM Plex Serif', Georgia, serif;
+        font-size: clamp(1.85rem, 4vw, 2.5rem);
+        font-style: normal;
+        font-weight: 400;
+        line-height: 1.2;
+        margin-bottom: 0.85rem;
+        color: var(--accent);
+        letter-spacing: -0.015em;
+    }
+    .doc-header p {
+        font-family: 'IBM Plex Sans', sans-serif;
+        font-size: 1.05rem;
+        color: var(--text-secondary);
+        line-height: 1.6;
+    }
+
+    .doc-toc {
+        font-size: 0.82rem;
+    }
+
+    .doc-toc-l3 {
+        padding-left: 0.85rem !important;
+        font-size: 0.78rem !important;
+    }
+</style>
+@endpush
+
+@section('content')
+
+<section class="page-with-sidebar" style="padding-top:6rem">
+    <div class="container">
+        <div class="page-with-sidebar-inner">
+
+            <aside class="page-sidebar" aria-label="Sommaire de la documentation">
+                <h4>Documentation</h4>
+                @foreach($sidebar as $sectionKey => $sec)
+                    <h4 style="margin-top:1.25rem">{{ $sec['title'] }}</h4>
+                    <ul>
+                        @foreach($sec['articles'] as $a)
+                            @if($a['available'])
+                                <li><a href="{{ route('docs.show', $a['slug']) }}" class="{{ $a['slug'] === $slug ? 'is-active' : '' }}">{{ $a['title'] }}</a></li>
+                            @else
+                                <li><span style="display:block;padding:0.35rem 0.6rem;font-size:0.84rem;color:var(--text-muted);opacity:0.6">{{ $a['title'] }}</span></li>
+                            @endif
+                        @endforeach
+                    </ul>
+                @endforeach
+
+                @if(!empty($toc))
+                    <h4 style="margin-top:1.5rem;padding-top:1rem;border-top:1px solid var(--border)">Sur cette page</h4>
+                    <ul class="doc-toc">
+                        @foreach($toc as $entry)
+                            <li>
+                                <a href="#{{ $entry['anchor'] }}" class="{{ $entry['level'] === 3 ? 'doc-toc-l3' : '' }}">{{ $entry['label'] }}</a>
+                            </li>
+                        @endforeach
+                    </ul>
+                @endif
+            </aside>
+
+            <article class="page-content">
+
+                <nav class="doc-breadcrumb" aria-label="Fil d'ariane">
+                    <a href="{{ route('docs.index') }}">Documentation</a>
+                    <span class="sep">/</span>
+                    @if(!empty($article['role_label']))
+                        <span>{{ $article['role_label'] }}</span>
+                    @else
+                        <span>{{ $sidebar[$article['section']]['title'] ?? '' }}</span>
+                    @endif
+                </nav>
+
+                <header class="doc-header">
+                    <h1>{{ $article['title'] }}</h1>
+                    @if(!empty($article['description']))
+                        <p>{{ $article['description'] }}</p>
+                    @endif
+                </header>
+
+                <div class="prose">
+                    {!! $html !!}
+                </div>
+
+                @if($prev || $next)
+                    <nav class="prev-next" aria-label="Article précédent / suivant">
+                        @if($prev)
+                            <a href="{{ route('docs.show', $prev['slug']) }}">
+                                <span class="prev-next-label">← Précédent</span>
+                                <span class="prev-next-title">{{ $prev['title'] }}</span>
+                            </a>
+                        @else
+                            <span></span>
+                        @endif
+                        @if($next)
+                            <a href="{{ route('docs.show', $next['slug']) }}" class="is-next">
+                                <span class="prev-next-label">Suivant →</span>
+                                <span class="prev-next-title">{{ $next['title'] }}</span>
+                            </a>
+                        @endif
+                    </nav>
+                @endif
+
+            </article>
+        </div>
+    </div>
+</section>
+
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -112,6 +112,11 @@ Route::get('/school', function () {
 // Pages publiques (Documentation, API Reference, Changelog)
 Route::get('/changelog', [\App\Http\Controllers\Public\ChangelogController::class, 'show'])
     ->name('changelog');
+Route::get('/docs', [\App\Http\Controllers\Public\DocsController::class, 'index'])
+    ->name('docs.index');
+Route::get('/docs/{slug}', [\App\Http\Controllers\Public\DocsController::class, 'show'])
+    ->where('slug', '[a-z0-9-]+(?:/[a-z0-9-]+)*')
+    ->name('docs.show');
 
 // Routes pour l'installation
 Route::prefix('install')->group(function () {


### PR DESCRIPTION
## Summary

Pages publiques \`/docs\` (TOC overview) + \`/docs/{slug}\` (articles individuels) avec contenu markdown-driven.

## Architecture

- \`config/docs.php\` — source-of-truth de la table des matières : 3 sections (mise en route / par rôle / par module), 12 articles référencés. \`available: true/false\` distingue les articles livrés des placeholders grisés
- \`DocsController\` — \`index()\` rend la TOC, \`show(\$slug)\` parse le markdown via \`league/commonmark\`, injecte des ids sur h2/h3 pour le sommaire de page, transforme \`:::callout\` / \`:::callout warning\` / \`:::callout note\` en \`<div class=\"callout\">\`
- Cache 24h par article, fallback gracieux si fichier manquant

## 3 articles livrés

1. **\`getting-started\`** (\`resources/docs/getting-started.md\`) — présentation KLASSCI, vocabulaire essentiel (filière/niveau/classe/inscription/matière/UE/ECUE/tronc commun), rôles utilisateurs, sécurité, premières étapes
2. **\`superadmin/onboarding\`** (\`resources/docs/superadmin/onboarding.md\`) — 8 étapes pas-à-pas pour paramétrer un établissement neuf : année universitaire, filières, niveaux, classes, matières (BTS et LMD), frais, comptes personnel, validation finale. Tables markdown, callouts \`warning\` sur les pièges classiques, snippets artisan
3. **\`secretaire/inscriptions\`** (\`resources/docs/secretaire/inscriptions.md\`) — workflow complet d'inscription (4 \`workflow_step\`), création nouvelle, validation individuelle et en lot avec règles métier (paiement requis, classe pleine, tronc commun double inscription), ré-inscription avec reliquat, annulation, export, table de FAQ

## 9 articles placeholder (gris non cliquables)

Pour les rôles \`enseignant\`/\`comptable\`/\`étudiant\` et les modules \`lmd\`/\`emploi-temps\`/\`notes-bulletins\`/\`comptabilité\`/\`présences\`/\`inscriptions\`. Affichage \`bientôt disponible\` pour annoncer le périmètre couvert sans tomber dans le vaporware (recommandation web research).

## Vues

- **\`docs/index.blade.php\`** : page-hero éditorial, card \"À commencer ici\" en featured (Getting started avec hero_image), grilles \`card-grid\` pour roles + modules avec \`docs-role-badge\` Mono uppercase
- **\`docs/show.blade.php\`** : breadcrumb mono, page-hero compact, sidebar sticky double (TOC pages avec is-active sur l'article courant, TOC dans la page avec h2/h3), prose markdown via la classe \`.prose\` du landing.css, navigation prev/next basée sur \`reading_order\`

## Routes

\`\`\`php
Route::get('/docs', [DocsController::class, 'index'])->name('docs.index');
Route::get('/docs/{slug}', [DocsController::class, 'show'])
    ->where('slug', '[a-z0-9-]+(?:/[a-z0-9-]+)*')
    ->name('docs.show');
\`\`\`

La regex permet les slugs imbriqués (\`superadmin/onboarding\`).

## Tests

\`\`\`
INDEX status=200 size=22819 (TOC complète avec 12 entrées)
GS status=200 size=25112 (getting-started)
SA status=200 size=30554 (superadmin/onboarding)
SI status=200 size=28687 (secretaire/inscriptions)
\`\`\`

## Risque

Bas. Aucune route existante modifiée. Le footer/nav du layout pointe automatiquement vers \`/docs\` via \`Route::has('docs.index')\` (déjà en place dans PR0).

## Suite

PR3 = \`/api-reference\` (uniquement \`/api/lms/*\`, bannière Beta, jamais \`/api/cli/*\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)