### PR TITLE
fix(landing): footer Ressources pointe vers les vraies pages publiques

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -2698,9 +2698,9 @@
             <div class="footer-col">
                 <h4>Ressources</h4>
                 <ul>
-                    <li><a href="#">Documentation</a></li>
-                    <li><a href="#">API Reference</a></li>
-                    <li><a href="#">Changelog</a></li>
+                    <li><a href="{{ route('docs.index') }}">Documentation</a></li>
+                    <li><a href="{{ route('api-reference') }}">API Reference</a></li>
+                    <li><a href="{{ route('changelog') }}">Changelog</a></li>
                 </ul>
             </div>
             <div class="footer-col">


### PR DESCRIPTION
## Summary

Fix immédiat : le footer de \`welcome.blade.php\` (la landing en prod sur klassci.com) avait toujours 3 liens \`href=\"#\"\` morts pour Documentation / API Reference / Changelog. Bien que les pages aient été livrées dans PR #267-#270, le footer de welcome n'avait pas été mis à jour (welcome reste self-contained, pas encore migré vers \`layouts.landing\`).

User a signalé l'erreur en hover sur klassci.com production.

## Fix

\`\`\`diff
- <li><a href=\"#\">Documentation</a></li>
- <li><a href=\"#\">API Reference</a></li>
- <li><a href=\"#\">Changelog</a></li>
+ <li><a href=\"{{ route('docs.index') }}\">Documentation</a></li>
+ <li><a href=\"{{ route('api-reference') }}\">API Reference</a></li>
+ <li><a href=\"{{ route('changelog') }}\">Changelog</a></li>
\`\`\`

## Risque

Bas. Single-line edit dans 1 fichier. Les 3 routes existent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)