### PR TITLE
fix(matieres.index): search input visible dans la barre de filtres

### DIFF
--- a/resources/views/esbtp/matieres/index.blade.php
+++ b/resources/views/esbtp/matieres/index.blade.php
@@ -213,12 +213,20 @@
 }
 .mi-filters-bar {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr auto;
+    grid-template-columns: minmax(220px, 1.6fr) 1fr 1fr 1fr auto;
     gap: 1rem;
     align-items: end;
     padding: 1rem 1.25rem;
 }
 .mi-filter-group { min-width: 0; }
+.mi-filter-input--search {
+    padding-left: 2.4rem;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: .85rem center;
+    background-size: 14px;
+}
+.mi-filter-input--search::-webkit-search-cancel-button { cursor: pointer; }
 .mi-filter-label {
     display: block;
     font-size: .72rem;
@@ -365,8 +373,13 @@
     border: 0;
 }
 
+@media (max-width: 1100px) {
+    .mi-filters-bar { grid-template-columns: 1fr 1fr 1fr auto; }
+    .mi-filter-group--search { grid-column: 1 / -1; }
+}
 @media (max-width: 768px) {
     .mi-filters-bar { grid-template-columns: 1fr; }
+    .mi-filter-group--search { grid-column: auto; }
     .mi-filters-actions { justify-content: flex-end; }
     .mi-advanced-panel { grid-template-columns: 1fr 1fr; }
 }
@@ -810,10 +823,17 @@ tr[data-matiere-id] {
           action="{{ route('esbtp.matieres.index') }}"
           class="mi-filters">
 
-        {{-- Hidden search input (synced with mi-hero-search) — NE PAS SUPPRIMER --}}
-        <input type="hidden" id="filter-search" name="search" value="{{ $filters['search'] ?? '' }}">
-
         <div class="mi-filters-bar">
+            <div class="mi-filter-group mi-filter-group--search">
+                <label for="filter-search" class="mi-filter-label">Recherche</label>
+                <input type="search"
+                       id="filter-search"
+                       name="search"
+                       class="mi-filter-input mi-filter-input--search"
+                       value="{{ $filters['search'] ?? '' }}"
+                       placeholder="Code, nom, description, filière, niveau..."
+                       autocomplete="off">
+            </div>
             <div class="mi-filter-group">
                 <label for="filter-filiere" class="mi-filter-label">Filière</label>
                 <select name="filiere_filter" id="filter-filiere" class="mi-filter-select">
@@ -1910,6 +1930,24 @@ tr[data-matiere-id] {
             if (event.key === 'Enter') {
                 event.preventDefault();
                 syncFormSearchFromHeader();
+                submitFilterForm();
+            }
+        });
+    }
+
+    // Visible filter-search input (in the filters bar) : miroir du headerSearch.
+    // L'input event sync vers le hero search puis débounce le submit.
+    const filterSearchInput = document.getElementById('filter-search');
+    if (filterSearchInput) {
+        filterSearchInput.addEventListener('input', () => {
+            syncHeaderSearchFromForm();
+            clearTimeout(filterTimer);
+            filterTimer = setTimeout(() => submitFilterForm(), FILTER_DEBOUNCE);
+        });
+        filterSearchInput.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                syncHeaderSearchFromForm();
                 submitFilterForm();
             }
         });


### PR DESCRIPTION
## Summary

Fix immédiat : la search input était invisible dans la barre de filtres après le redesign (PR #273). User a signalé via screenshot. Le \`#filter-search\` hidden ne servait qu'au contrat JS — la recherche ne se faisait que via le hero, pas évident pour quelqu'un qui scrolle.

## Fix

- **Search input visible** en première colonne de \`.mi-filters-bar\` : icône SVG inline (loupe), placeholder explicite \`Code, nom, description, filière, niveau...\`, \`type=\"search\"\` (avec ✕ natif sur webkit)
- **Grid responsive** :
  - \`>1100px\` : \`minmax(220px,1.6fr) 1fr 1fr 1fr auto\` — tout sur une ligne
  - \`768-1100px\` : search full-width row 1, 3 selects + actions row 2
  - \`<768px\` : tout stack 1 colonne
- **JS** : nouveau handler dédié pour \`#filter-search\` (input debounce 350ms + Enter key) miroir du \`headerSearch\` existant. \`syncHeaderSearchFromForm\` garde les deux inputs en cohérence (hero ↔ filters bar)

## Contrat préservé

- \`#filter-search\` ID inchangé
- \`name=\"search\"\` inchangé
- Value bound to \`\$filters['search']\` inchangé
- La sync logic existante fonctionne dans les 2 sens
- Verification compile : OK len=95702, tous les 26 IDs critiques présents

## Risque

**Très bas.** Single-file edit (CSS + HTML + JS handler). Aucun nouveau contrat. Le user verra simplement la search apparaître dans la barre de filtres en plus du hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)