### PR TITLE
fix(matieres.search): restreindre la recherche au nom/code/description

### DIFF
--- a/app/Http/Controllers/ESBTPMatiereController.php
+++ b/app/Http/Controllers/ESBTPMatiereController.php
@@ -173,20 +173,18 @@ class ESBTPMatiereController extends Controller
         }
 
         if ($search !== '') {
+            // Recherche restreinte aux champs propres de la matière. Pour filtrer
+            // par filière ou niveau, l'utilisateur dispose des dropdowns dédiés
+            // (filiere_filter / niveau_filter). L'élargissement aux relations
+            // produisait des résultats contre-intuitifs : taper "Marketing"
+            // retournait toutes les matières liées à la filière Marketing au
+            // lieu de la seule matière dont le nom contient "Marketing".
             $query->where(function ($q) use ($search) {
                 $like = '%'.str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $search).'%';
 
                 $q->where('name', 'like', $like)
                     ->orWhere('code', 'like', $like)
-                    ->orWhere('description', 'like', $like)
-                    ->orWhereHas('filieres', function ($filieresQuery) use ($like) {
-                        $filieresQuery->where('name', 'like', $like)
-                            ->orWhere('code', 'like', $like);
-                    })
-                    ->orWhereHas('niveaux', function ($niveauxQuery) use ($like) {
-                        $niveauxQuery->where('name', 'like', $like)
-                            ->orWhere('code', 'like', $like);
-                    });
+                    ->orWhere('description', 'like', $like);
             });
         }
 

--- a/resources/views/esbtp/matieres/index.blade.php
+++ b/resources/views/esbtp/matieres/index.blade.php
@@ -768,9 +768,9 @@ tr[data-matiere-id] {
                 <input type="search"
                        class="mi-hero-search"
                        id="matieres-header-search"
-                       placeholder="Rechercher une matière..."
+                       placeholder="Rechercher par nom ou code..."
                        value="{{ $filters['search'] ?? '' }}"
-                       aria-label="Rechercher une matière">
+                       aria-label="Rechercher une matière par nom ou code">
                 <a href="{{ route('esbtp.matieres.create') }}" class="mi-btn--white">
                     <i class="fas fa-plus" aria-hidden="true"></i>
                     Nouvelle matière
@@ -831,7 +831,7 @@ tr[data-matiere-id] {
                        name="search"
                        class="mi-filter-input mi-filter-input--search"
                        value="{{ $filters['search'] ?? '' }}"
-                       placeholder="Code, nom, description, filière, niveau..."
+                       placeholder="Nom, code ou description..."
                        autocomplete="off">
             </div>
             <div class="mi-filter-group">


### PR DESCRIPTION
## Summary

User a tapé \"Marketing\" et a vu 3 matières (Algorithme + Anglais + Marketing digital) au lieu de la seule \"Marketing digital\". Cause : la search query cumulait \`orWhereHas('filieres')\` et \`orWhereHas('niveaux')\` — donc une matière matchait si elle était LIÉE à une filière/niveau dont le nom/code contenait le terme recherché.

Comportement contre-intuitif sur une page \"Gestion des matières\" : le user cherche LA matière, pas les matières DE la filière concernée. Le filtrage par filière/niveau est déjà couvert par les dropdowns dédiés (\`filiere_filter\` / \`niveau_filter\`).

## Fix

- **Controller** : retrait de \`orWhereHas('filieres')\` + \`orWhereHas('niveaux')\` dans \`prepareMatieresListing()\`. La recherche reste sur \`name\` + \`code\` + \`description\` (les champs propres de la matière).
- **Placeholders** updated pour aligner promesse UI ↔ comportement :
  - hero search → \"Rechercher par nom ou code...\"
  - filter search → \"Nom, code ou description...\"

## Avant / Après

\`\`\`
Avant : tape \"Marketing\" → Algorithme + Anglais + Marketing digital (3 résultats)
Après : tape \"Marketing\" → Marketing digital (1 résultat)
\`\`\`

## Risque

**Très bas.** Seul le scope de la recherche change. Le user qui voulait l'ancien comportement (matières liées à la filière X) utilise le dropdown Filière dédié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)