### PR TITLE
perf(matieres): 4 KPI queries -> 1 SELECT (single aggregated query)

### DIFF
--- a/app/Http/Controllers/ESBTPMatiereController.php
+++ b/app/Http/Controllers/ESBTPMatiereController.php
@@ -188,16 +188,30 @@ class ESBTPMatiereController extends Controller
             });
         }
 
-        // KPIs calculés sur la base filtrée (cohérent avec inscriptions/paiements premium).
-        // Cloner avant paginate, sans les eager-loads ni l'order by (le ORDER BY casse les
-        // agrégats SUM() sur MariaDB strict mode).
-        $kpiBase = (clone $query)->withoutEagerLoads()->reorder();
+        // KPIs calculés sur la base filtrée (cohérent avec inscriptions/paiements
+        // premium). Une seule query avec agrégats conditionnels au lieu de 4 :
+        // -3 round-trips DB par render et par AJAX refresh sur cette page.
+        // reorder() retire l'ORDER BY name (incompatible avec SUM/COUNT global
+        // sur MariaDB strict mode).
+        $row = (clone $query)
+            ->withoutEagerLoads()
+            ->reorder()
+            ->selectRaw("
+                COUNT(*) AS total,
+                SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) AS actifs,
+                SUM(CASE WHEN EXISTS (
+                    SELECT 1 FROM esbtp_matiere_filiere_niveau
+                    WHERE esbtp_matiere_filiere_niveau.matiere_id = esbtp_matieres.id
+                ) THEN 1 ELSE 0 END) AS avec_liaisons,
+                SUM({$totalHeuresExpression}) AS heures_totales
+            ")
+            ->first();
 
         $kpis = [
-            'total'           => (clone $kpiBase)->count(),
-            'actifs'          => (clone $kpiBase)->where('is_active', true)->count(),
-            'avec_liaisons'   => (clone $kpiBase)->whereHas('liaisonsFilieresNiveaux')->count(),
-            'heures_totales'  => (int) (clone $kpiBase)->sum(\DB::raw($totalHeuresExpression)),
+            'total'           => (int) ($row->total ?? 0),
+            'actifs'          => (int) ($row->actifs ?? 0),
+            'avec_liaisons'   => (int) ($row->avec_liaisons ?? 0),
+            'heures_totales'  => (int) ($row->heures_totales ?? 0),
         ];
         $kpis['inactifs']     = $kpis['total'] - $kpis['actifs'];
         $kpis['sans_liaison'] = $kpis['total'] - $kpis['avec_liaisons'];


### PR DESCRIPTION
## Summary

Findings simplify Agent 3 #1 — combine les 4 queries KPI en 1 single SELECT avec agrégats conditionnels.

## Avant / Après

\`\`\`
Avant : 4 queries × (count / where->count / whereHas->count / sum) = 4 round-trips
Après : 1 SELECT(COUNT, SUM CASE, SUM CASE EXISTS, SUM expr) = 1 round-trip
\`\`\`

Plus le paginate count standard. **5 queries → 2 queries par render**.

## Impact

Cette page est très AJAX :
- debounce 350ms par keystroke search
- chaque change de filtre/select
- chaque pagination click

Sur une session active, divisé par ~2.5 le nombre de queries pour les KPIs.

## Verification tinker

\`\`\`sql
-- 1 seule query KPI :
SELECT
    COUNT(*) AS total,
    SUM(CASE WHEN is_active = 1 THEN 1 ELSE 0 END) AS actifs,
    SUM(CASE WHEN EXISTS (
        SELECT 1 FROM esbtp_matiere_filiere_niveau
        WHERE esbtp_matiere_filiere_niveau.matiere_id = esbtp_matieres.id
    ) THEN 1 ELSE 0 END) AS avec_liaisons,
    SUM(COALESCE(heures_cm, 0) + ... + COALESCE(heures_perso, 0)) AS heures_totales
FROM esbtp_matieres
WHERE unite_enseignement_id IS NULL AND deleted_at IS NULL
LIMIT 1
\`\`\`

Filtres soft-delete + unite_enseignement_id préservés. EXISTS subquery directe (pas de N+1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)