### PR TITLE
refactor(matieres.index): kebab custom -> BS5 native dropdown

### DIFF
--- a/public/css/matieres-index.css
+++ b/public/css/matieres-index.css
@@ -466,7 +466,7 @@
     color: #fff;
 }
 
-/* ─── ROW ACTIONS — kebab menu pour secondaires ─── */
+/* ─── ROW ACTIONS — Voir + BS5 native dropdown pour secondaires ─── */
 .mi-actions {
     display: inline-flex;
     align-items: center;
@@ -492,7 +492,6 @@
     border-color: #0369a1;
     color: #0369a1;
 }
-.mi-action-kebab-wrap { position: relative; }
 .mi-action-kebab {
     display: inline-flex;
     align-items: center;
@@ -513,65 +512,35 @@
     border-color: #94a3b8;
     color: #1e293b;
 }
-.mi-action-menu {
-    position: absolute;
-    right: 0;
-    top: calc(100% + 4px);
-    min-width: 180px;
-    background: #fff;
+/* Override BS5 dropdown-menu pour matcher le look premium KLASSCI */
+.mi-action-menu.dropdown-menu {
+    min-width: 200px;
     border: 1px solid #e2e8f0;
     border-radius: 10px;
     box-shadow: 0 10px 32px rgba(15,23,42,.12), 0 2px 6px rgba(15,23,42,.06);
     padding: .35rem;
-    z-index: 100;
-    display: none;
+    z-index: 1050;
 }
-.mi-action-menu.is-open {
-    display: block;
-    animation: mi-menu-fade-in .15s ease;
-}
-@keyframes mi-menu-fade-in {
-    from { opacity: 0; transform: translateY(-4px); }
-    to { opacity: 1; transform: translateY(0); }
-}
-.mi-action-item {
-    display: flex;
-    align-items: center;
-    gap: .5rem;
-    width: 100%;
-    padding: .5rem .65rem;
+.mi-action-menu .dropdown-item {
     border-radius: 6px;
-    background: none;
-    border: none;
-    color: #1e293b;
+    padding: .5rem .65rem;
     font-size: .85rem;
-    text-align: left;
-    cursor: pointer;
-    text-decoration: none;
+    color: #1e293b;
     transition: background .12s;
 }
-.mi-action-item:hover {
+.mi-action-menu .dropdown-item:hover,
+.mi-action-menu .dropdown-item:focus {
     background: #f1f5f9;
     color: #0453cb;
 }
-.mi-action-item i {
-    font-size: .82rem;
-    color: #64748b;
-    width: 14px;
-    text-align: center;
-}
-.mi-action-item:hover i { color: #0453cb; }
-.mi-action-item--danger { color: #dc2626; }
-.mi-action-item--danger i { color: #dc2626; }
-.mi-action-item--danger:hover {
+.mi-action-menu .dropdown-item.text-danger:hover,
+.mi-action-menu .dropdown-item.text-danger:focus {
     background: #fef2f2;
     color: #b91c1c;
 }
-.mi-action-item--danger:hover i { color: #b91c1c; }
-.mi-action-divider {
-    height: 1px;
-    background: #e2e8f0;
+.mi-action-menu .dropdown-divider {
     margin: .25rem -.35rem;
+    border-color: #e2e8f0;
 }
 
 /* ════════════════════════════════════════════════════════════════

--- a/resources/views/esbtp/matieres/index.blade.php
+++ b/resources/views/esbtp/matieres/index.blade.php
@@ -1455,57 +1455,8 @@
         }
     });
 
-    /* ───────────────────────────────────────────────────────────
-       KEBAB MENU — event delegation, persists across AJAX refreshes
-       ─────────────────────────────────────────────────────────── */
-    function closeAllKebabMenus(except) {
-        document.querySelectorAll('[data-mi-kebab-menu].is-open').forEach((menu) => {
-            if (menu === except) return;
-            menu.classList.remove('is-open');
-            const wrap = menu.closest('.mi-action-kebab-wrap');
-            const toggle = wrap?.querySelector('[data-mi-kebab-toggle]');
-            if (toggle) toggle.setAttribute('aria-expanded', 'false');
-        });
-    }
-
-    document.addEventListener('click', (event) => {
-        const toggle = event.target.closest('[data-mi-kebab-toggle]');
-        if (toggle) {
-            event.preventDefault();
-            const wrap = toggle.closest('.mi-action-kebab-wrap');
-            const menu = wrap?.querySelector('[data-mi-kebab-menu]');
-            if (!menu) return;
-            const willOpen = !menu.classList.contains('is-open');
-            closeAllKebabMenus(willOpen ? menu : null);
-            menu.classList.toggle('is-open', willOpen);
-            toggle.setAttribute('aria-expanded', String(willOpen));
-            return;
-        }
-
-        // Click on a menu item → close menu (item handles its own action via data-bs-toggle).
-        const menuItem = event.target.closest('[data-mi-kebab-menu] [role="menuitem"]');
-        if (menuItem) {
-            const menu = menuItem.closest('[data-mi-kebab-menu]');
-            if (menu) {
-                menu.classList.remove('is-open');
-                const wrap = menu.closest('.mi-action-kebab-wrap');
-                const t = wrap?.querySelector('[data-mi-kebab-toggle]');
-                if (t) t.setAttribute('aria-expanded', 'false');
-            }
-            return;
-        }
-
-        // Click outside any kebab → close all.
-        if (!event.target.closest('[data-mi-kebab-menu]')) {
-            closeAllKebabMenus(null);
-        }
-    });
-
-    document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape') {
-            closeAllKebabMenus(null);
-        }
-    });
+    /* Kebab menu : Bootstrap 5 native dropdown gère le toggle / outside-click /
+       Esc / focus management. Aucun JS custom requis. */
 
     /* Empty-state "Effacer les filtres" — délégation pour survivre aux refresh AJAX */
     document.addEventListener('click', (event) => {

--- a/resources/views/esbtp/matieres/partials/matiere-row.blade.php
+++ b/resources/views/esbtp/matieres/partials/matiere-row.blade.php
@@ -90,44 +90,45 @@
                     <i class="fas fa-eye" aria-hidden="true"></i>
                 </a>
 
-                {{-- Kebab menu : Configurer / Modifier / Supprimer --}}
-                <div class="mi-action-kebab-wrap">
+                {{-- Kebab menu BS5 native dropdown : Configurer / Modifier / Supprimer --}}
+                <div class="dropdown">
                     <button type="button"
                             class="mi-action-kebab"
-                            data-mi-kebab-toggle
-                            aria-haspopup="menu"
+                            data-bs-toggle="dropdown"
                             aria-expanded="false"
                             aria-label="Plus d'actions pour {{ $matiere->name }}"
                             title="Plus d'actions">
                         <i class="fas fa-ellipsis-v" aria-hidden="true"></i>
                     </button>
-                    <div class="mi-action-menu" role="menu" data-mi-kebab-menu>
-                        <button type="button"
-                                role="menuitem"
-                                class="mi-action-item configure-matiere-btn"
-                                data-bs-toggle="modal"
-                                data-bs-target="#configureModal"
-                                data-matiere-id="{{ $matiere->id }}"
-                                data-matiere-name="{{ $matiere->name }}">
-                            <i class="fas fa-link" aria-hidden="true"></i>
-                            Configurer les liaisons
-                        </button>
-                        <a href="{{ route('esbtp.matieres.edit', $matiere->id) }}"
-                           role="menuitem"
-                           class="mi-action-item">
-                            <i class="fas fa-edit" aria-hidden="true"></i>
-                            Modifier
-                        </a>
-                        <div class="mi-action-divider"></div>
-                        <button type="button"
-                                role="menuitem"
-                                class="mi-action-item mi-action-item--danger"
-                                data-bs-toggle="modal"
-                                data-bs-target="#deleteModal{{ $matiere->id }}">
-                            <i class="fas fa-trash" aria-hidden="true"></i>
-                            Supprimer
-                        </button>
-                    </div>
+                    <ul class="dropdown-menu dropdown-menu-end mi-action-menu">
+                        <li>
+                            <button type="button"
+                                    class="dropdown-item configure-matiere-btn"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#configureModal"
+                                    data-matiere-id="{{ $matiere->id }}"
+                                    data-matiere-name="{{ $matiere->name }}">
+                                <i class="fas fa-link me-2" aria-hidden="true"></i>
+                                Configurer les liaisons
+                            </button>
+                        </li>
+                        <li>
+                            <a href="{{ route('esbtp.matieres.edit', $matiere->id) }}" class="dropdown-item">
+                                <i class="fas fa-edit me-2" aria-hidden="true"></i>
+                                Modifier
+                            </a>
+                        </li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li>
+                            <button type="button"
+                                    class="dropdown-item text-danger"
+                                    data-bs-toggle="modal"
+                                    data-bs-target="#deleteModal{{ $matiere->id }}">
+                                <i class="fas fa-trash me-2" aria-hidden="true"></i>
+                                Supprimer
+                            </button>
+                        </li>
+                    </ul>
                 </div>
             </div>
             <div class="matiere-actions-spinner" aria-hidden="true">


### PR DESCRIPTION
## Summary

Findings simplify **Agent 1 #2** — remplace le kebab menu custom par le composant native dropdown de Bootstrap 5 (déjà chargé sur la page via le layout).

## Avant / Après

| | Avant | Après |
|---|---|---|
| Markup | \`<div class=\"mi-action-kebab-wrap\">\` + \`[data-mi-kebab-toggle/menu]\` custom | \`<div class=\"dropdown\">\` + \`data-bs-toggle=\"dropdown\"\` + \`<ul class=\"dropdown-menu\">\` |
| JS custom | ~50 lignes event delegation (closeAllKebabMenus + click + keydown Esc) | **0 lignes** — BS5 gère natively |
| CSS | ~50 lignes (.mi-action-menu*, .mi-action-item*, fade-in animation, danger variant) | ~25 lignes d'overrides BS5 |
| ARIA | aria-expanded manuel | natively géré par BS5 |
| Keyboard nav | Esc seulement | arrow keys + Esc + focus return |

## Out-of-scope (volontairement reporté)

**Agent 1 #1 (extract hero vers \`<x-planning-header>\`)** : le composant planning-header est trop couplé au module planning :
- KPIs hardcoded (séances/heures/classes/matières)
- Tabs hardcoded vers \`esbtp.planning-general.*\`
- Logique AJAX nav planning-specific

Une vraie consolidation demanderait un refactor architectural en plusieurs composants atomiques (\`<x-page-hero>\`, \`<x-page-tabs>\`, \`<x-page-kpis>\`) touchant 5+ pages en prod. **Reporté à une PR dédiée plus tard.**

## Verification

\`\`\`
✓ Compile OK (3 fichiers)
✓ 16 contrats critiques préservés (data-matiere-id, configure-matiere-btn, deleteModal{id}, etc.)
✓ Kebab dead code confirmé supprimé (data-mi-kebab-toggle/menu, closeAllKebabMenus, mi-action-item*, mi-action-kebab-wrap, mi-action-divider)
\`\`\`

## Net delta

\`3 files changed, 48 insertions(+), 127 deletions(-)\`

## Risque

**Bas.** BS5 dropdown est utilisé dans 5+ autres pages KLASSCI (notamment classes.show, etudiants.show), donc le pattern est éprouvé. Le \`data-bs-toggle=\"dropdown\"\` cohabite parfaitement avec \`data-bs-toggle=\"modal\"\` sur les items (BS5 chain les events).

🤖 Generated with [Claude Code](https://claude.com/claude-code)