### PR TITLE
fix(frais-optionnels): auto-assigner 'all' + badge orphan + filtre API

### DIFF
--- a/app/Models/ESBTPFraisOption.php
+++ b/app/Models/ESBTPFraisOption.php
@@ -73,11 +73,53 @@ class ESBTPFraisOption extends Model
     }
 
     /**
+     * Boot — filet de sécurité contre les options orphelines.
+     *
+     * Toute option globale créée sans passer par le modal Assignations doit
+     * hériter d'une assignation type='all' pour être visible côté étudiant.
+     * Sans ce hook, une option pouvait être créée puis silencieusement
+     * invisible à tous les étudiants (UI affichait "Tous les étudiants" en
+     * fallback alors que la table des assignations était vide).
+     *
+     * Restreint aux options globales (configuration_id null) — les options
+     * class_based sont déjà scopées via leur configuration.
+     */
+    protected static function booted(): void
+    {
+        static::created(function (self $option): void {
+            if ($option->configuration_id !== null) {
+                return;
+            }
+            if ($option->assignments()->exists()) {
+                return;
+            }
+            $option->assignments()->create([
+                'assignment_type' => 'all',
+                'filiere_id' => null,
+                'niveau_id' => null,
+                'is_active' => true,
+            ]);
+        });
+    }
+
+    /**
      * Scopes
      */
     public function scopeActive($query)
     {
         return $query->where('esbtp_frais_options.is_active', true);
+    }
+
+    /**
+     * Scope : seulement les options qui ont au moins une assignation active.
+     * À utiliser sur les endpoints étudiants pour ne pas exposer d'options
+     * orphelines (créées sans assignation, suppression manuelle, etc.).
+     */
+    public function scopeAssigned($query)
+    {
+        return $query->whereHas('assignments', function ($q) {
+            $q->where('is_active', true);
+        });
     }
 
     public function scopeDefault($query)

--- a/app/Services/FraisManagementService.php
+++ b/app/Services/FraisManagementService.php
@@ -105,9 +105,15 @@ class FraisManagementService
      */
     public function getGlobalOptions(ESBTPFraisCategory $category): Collection
     {
+        // assigned() filtre les options orphelines (sans assignation) qui
+        // sinon s'afficheraient à l'étudiant comme inutiles. L'écran admin
+        // (optional-config.blade.php) lit $category->options direct sans
+        // passer par ce service pour pouvoir afficher le badge "Aucune
+        // assignation" et permettre la correction.
         return ESBTPFraisOption::global()
             ->forFraisCategory($category->id)
             ->active()
+            ->assigned()
             ->ordered()
             ->get();
     }

--- a/resources/views/esbtp/frais/optional-config.blade.php
+++ b/resources/views/esbtp/frais/optional-config.blade.php
@@ -125,6 +125,14 @@
     border: 1px solid rgba(16,185,129,0.2);
 }
 .oc-assign-tag.empty { background: #f3f4f6; color: #9ca3af; border-color: #e5e7eb; }
+.oc-assign-orphan {
+    background: #fef2f2; color: #dc2626; border: 1px solid #fecaca;
+    padding: 4px 9px; border-radius: 6px; font-size: 11px; font-weight: 600;
+    cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
+    transition: all .15s;
+}
+.oc-assign-orphan:hover { background: #dc2626; color: #fff; border-color: #dc2626; }
+.oc-assign-orphan i { font-size: 10px; }
 .oc-option-price {
     font-size: 15px; font-weight: 800; color: #0453cb;
     white-space: nowrap; text-align: right; min-width: 120px;
@@ -483,9 +491,12 @@ body.modal-open * {
                                                     </span>
                                                 @endforeach
                                             @else
-                                                <span class="oc-assign-tag empty">
-                                                    <i class="fas fa-minus"></i>Non assigné
-                                                </span>
+                                                <button type="button"
+                                                        class="oc-assign-tag oc-assign-orphan"
+                                                        onclick="manageAssignments({{ $option->id }}, '{{ addslashes($option->name) }}')"
+                                                        title="Cette formule est invisible aux étudiants. Cliquez pour configurer.">
+                                                    <i class="fas fa-exclamation-triangle"></i>Aucune assignation
+                                                </button>
                                             @endif
                                         </div>
                                     </div>

--- a/tests/Feature/FraisOptionAutoAssignmentTest.php
+++ b/tests/Feature/FraisOptionAutoAssignmentTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ESBTPFraisCategory;
+use App\Models\ESBTPFraisOption;
+use App\Models\ESBTPOptionAssignment;
+use App\Services\FraisManagementService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FraisOptionAutoAssignmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeOptionalCategory(): ESBTPFraisCategory
+    {
+        return ESBTPFraisCategory::create([
+            'name' => 'CANTINE',
+            'code' => 'CANTINE',
+            'is_mandatory' => false,
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_global_option_auto_creates_all_assignment_on_creation(): void
+    {
+        $category = $this->makeOptionalCategory();
+
+        $option = ESBTPFraisOption::create([
+            'configuration_id' => null,
+            'frais_category_id' => $category->id,
+            'name' => 'Cantine 5 jours',
+            'additional_amount' => 50000,
+            'is_default' => false,
+            'is_active' => true,
+            'option_type' => 'global',
+        ]);
+
+        $assignments = $option->fresh()->assignments;
+
+        $this->assertCount(1, $assignments, 'Une assignation doit être auto-créée');
+        $this->assertSame('all', $assignments->first()->assignment_type);
+        $this->assertNull($assignments->first()->filiere_id);
+        $this->assertNull($assignments->first()->niveau_id);
+        $this->assertTrue((bool) $assignments->first()->is_active);
+    }
+
+    public function test_class_based_option_does_not_auto_create_assignment(): void
+    {
+        $category = $this->makeOptionalCategory();
+
+        $option = ESBTPFraisOption::create([
+            'configuration_id' => 1,
+            'frais_category_id' => $category->id,
+            'name' => 'Option BTS1',
+            'additional_amount' => 0,
+            'is_default' => false,
+            'is_active' => true,
+            'option_type' => 'class_based',
+        ]);
+
+        $this->assertCount(0, $option->fresh()->assignments);
+    }
+
+    public function test_orphan_option_is_excluded_from_student_facing_service(): void
+    {
+        $category = $this->makeOptionalCategory();
+
+        $option = ESBTPFraisOption::create([
+            'configuration_id' => null,
+            'frais_category_id' => $category->id,
+            'name' => 'Cantine orpheline',
+            'additional_amount' => 30000,
+            'is_default' => false,
+            'is_active' => true,
+            'option_type' => 'global',
+        ]);
+
+        // Suppression manuelle de toutes les assignations → option devient orpheline
+        ESBTPOptionAssignment::where('option_id', $option->id)->delete();
+        $this->assertCount(0, $option->fresh()->assignments);
+
+        // Le service student-facing l'exclut
+        $service = app(FraisManagementService::class);
+        $globalOptions = $service->getGlobalOptions($category);
+
+        $this->assertNotContains($option->id, $globalOptions->pluck('id')->all());
+
+        // L'admin la voit toujours via la relation directe (pour pouvoir corriger)
+        $this->assertContains($option->id, $category->options()->pluck('id')->all());
+    }
+
+    public function test_caller_explicit_assignment_is_not_duplicated(): void
+    {
+        $category = $this->makeOptionalCategory();
+
+        $option = ESBTPFraisOption::create([
+            'configuration_id' => null,
+            'frais_category_id' => $category->id,
+            'name' => 'Avec assignation explicite',
+            'additional_amount' => 25000,
+            'is_default' => false,
+            'is_active' => true,
+            'option_type' => 'global',
+        ]);
+
+        // Caller redéfinit immédiatement les assignations
+        ESBTPOptionAssignment::updateAssignmentsForOption(
+            $option->id,
+            'filiere',
+            [1],
+            []
+        );
+
+        $assignments = $option->fresh()->assignments;
+        // L'auto-create du hook a inséré 'all', updateAssignmentsForOption
+        // a tout supprimé puis recréé 'filiere' → 1 seule assignation type filiere.
+        $this->assertCount(1, $assignments);
+        $this->assertSame('filiere', $assignments->first()->assignment_type);
+    }
+}


### PR DESCRIPTION
Bug : création d'une formule \"+ Ajouter une formule\" ne créait pas d'assignation → invisible aux étudiants.\n\nA) Hook `booted::created` sur ESBTPFraisOption auto-crée assignation type='all' (options globales uniquement, idempotent).\nC) Badge rouge \"Aucune assignation\" actionnable + scope `assigned()` + `getGlobalOptions` filtré pour student-facing.\n\n4 tests Feature.