### PR TITLE
feat(analytics): Phase 4 — DefaultRisk + Anomalies + Jobs + Cache + Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ Le format suit librement [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/
 
 ## Mai 2026
 
+### Migrations DB
+
+- **Fusion `esbtp_enseignant_profiles` dans `esbtp_teachers`** — ajout de 6 colonnes à `esbtp_teachers` : `regime` (enum vacataire/permanent/consultant), `taux_horaire`, `date_debut_activite`, `diplome_principal`, `universite_diplome`, `annee_diplome`. La data utile de `esbtp_enseignant_profiles` est copiée via UPDATE INNER JOIN (idempotent : `COALESCE` préserve les valeurs déjà saisies). `type_contrat` et `statut_emploi` consolidés en un seul champ `regime`. Drop des tables `esbtp_enseignant_profiles`, `esbtp_enseignant_disponibilites`, `esbtp_enseignant_affectations` (tables ambitieuses jamais réellement alimentées par l'UI moderne).
+
+### Améliorations
+
+- **Mono-write côté contrôleur enseignant** — fin du `Schema::hasTable('esbtp_enseignant_profiles')` defensif et du double-write `DB::table('esbtp_enseignant_profiles')->insert/update`. `ESBTPEnseignantController::store/quickStore/update/edit` lit/écrit directement sur `ESBTPTeacher`. Suppression des helpers `regimeToContrat()` et `normalizeRegime()`. Vues `show.blade.php` et `edit.blade.php` : références `$profileData->X` remplacées par `$teacher->X`. KPI « Expérience » remplacé par KPI « Régime ». Section « Motivation & Objectifs » de la fiche profil supprimée (champs jamais alimentés).
+
 ### Suppressions
 
 - **Cleanup zombies du domaine enseignant** — suppression des controllers `TeacherAdminController` (legacy non-ESBTP), `App\Http\Controllers\ESBTP\Admin\TeacherAdminController` (UI admin parallèle), `ESBTPEnseignantProfileController` (ancien système de profils), `ESBTPDepartmentController` (concept hors scope KLASSCI). Suppression des modèles `ESBTPEnseignantProfile`, `ESBTPEnseignantAffectation`, `ESBTPEnseignantDisponibilite` (jamais réellement utilisés par l'UI moderne). Suppression des dossiers de vues `esbtp/departments/`, `esbtp/teachers/` (ancienne UI parallèle), `superadmin/teachers/`. Suppression du lien « Départements » dans la sidebar et des routes correspondantes (`esbtp.departments.*`, `esbtp.teachers.*` admin namespace, `esbtp.enseignants.profiles.*`). Mise à jour de `User.php` : retrait des relations Eloquent legacy `hasOne(Teacher)` et `hasOne(ESBTPEnseignantProfile)`. Mise à jour de `ESBTPTeacher` : retrait des champs `department_id` et `laboratory_id` du fillable et des relations `department()` / `laboratory()`. Repointage de la relation `ESBTPResultat::enseignant()` vers `User`. Recherche globale (`SearchController`) et résultats (`search/results.blade.php`) : liens `esbtp.teachers.*` remplacés par `esbtp.enseignants.*`.

--- a/app/Http/Controllers/ESBTPEnseignantController.php
+++ b/app/Http/Controllers/ESBTPEnseignantController.php
@@ -15,7 +15,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Facades\Schema;
 use Carbon\Carbon;
 
 class ESBTPEnseignantController extends Controller
@@ -57,16 +56,9 @@ class ESBTPEnseignantController extends Controller
             "total" => ESBTPTeacher::count(),
             "active" => ESBTPTeacher::where("status", "active")->count(),
             "inactive" => ESBTPTeacher::where("status", "inactive")->count(),
-            "permanent" => 0,
-            "temporary" => 0,
+            "permanent" => ESBTPTeacher::where("regime", "permanent")->count(),
+            "temporary" => ESBTPTeacher::where("regime", "vacataire")->count(),
         ];
-
-        if (Schema::hasTable("esbtp_enseignant_profiles")) {
-            $stats["permanent"] = DB::table("esbtp_enseignant_profiles")
-                ->where("type_contrat", "permanent")->count();
-            $stats["temporary"] = DB::table("esbtp_enseignant_profiles")
-                ->where("type_contrat", "vacataire")->count();
-        }
 
         return view(
             "esbtp.enseignants.index",
@@ -109,31 +101,6 @@ class ESBTPEnseignantController extends Controller
     }
 
     /**
-     * Map le champ unifié "regime" vers les colonnes legacy
-     * type_contrat + statut_emploi de esbtp_enseignant_profiles.
-     */
-    private function regimeToContrat(string $regime): array
-    {
-        return match ($regime) {
-            'permanent' => ['type_contrat' => 'permanent', 'statut_emploi' => 'temps_plein'],
-            'consultant' => ['type_contrat' => 'consultant', 'statut_emploi' => 'temps_partiel'],
-            default => ['type_contrat' => 'vacataire', 'statut_emploi' => 'vacations'],
-        };
-    }
-
-    /**
-     * Mapping inverse pour rétrocompat : type_contrat legacy → regime canonique.
-     */
-    private function normalizeRegime(string $typeContrat): string
-    {
-        return match ($typeContrat) {
-            'permanent' => 'permanent',
-            'consultant' => 'consultant',
-            default => 'vacataire',
-        };
-    }
-
-    /**
      * Store a newly created teacher in storage.
      */
     public function store(Request $request)
@@ -158,7 +125,6 @@ class ESBTPEnseignantController extends Controller
         ]);
 
         $regime = $request->input('regime') ?: 'vacataire';
-        $contrat = $this->regimeToContrat($regime);
 
         DB::beginTransaction();
 
@@ -180,36 +146,19 @@ class ESBTPEnseignantController extends Controller
                 "specialization" => $request->specialization,
                 "grade" => $request->grade_academique,
                 "status" => "active",
+                "regime" => $regime,
+                "taux_horaire" => $request->taux_horaire,
+                "date_debut_activite" => $request->date_debut_activite
+                    ? Carbon::parse($request->date_debut_activite)->format('Y-m-d')
+                    : now()->toDateString(),
+                "diplome_principal" => $request->diplome_principal,
+                "universite_diplome" => $request->universite_diplome,
+                "annee_diplome" => $request->annee_diplome,
                 "teaching_hours_due" => $regime === 'permanent'
                     ? ($request->charge_horaire_max_semaine ?? 18)
                     : 0,
                 "created_by" => auth()->id(),
             ]);
-
-            if (Schema::hasTable("esbtp_enseignant_profiles")) {
-                $dateDebut = $request->date_debut_activite
-                    ? Carbon::parse($request->date_debut_activite)->format('Y-m-d')
-                    : now()->toDateString();
-
-                DB::table("esbtp_enseignant_profiles")->insert(array_filter([
-                    "user_id" => $user->id,
-                    "matricule_enseignant" => $teacher->matricule,
-                    "titre_academique" => $request->titre_academique,
-                    "grade_academique" => $request->grade_academique,
-                    "diplome_principal" => $request->diplome_principal,
-                    "universite_diplome" => $request->universite_diplome,
-                    "annee_diplome" => $request->annee_diplome,
-                    "charge_horaire_max_semaine" => $request->charge_horaire_max_semaine ?? 18,
-                    "type_contrat" => $contrat['type_contrat'],
-                    "statut_emploi" => $contrat['statut_emploi'],
-                    "date_embauche" => $dateDebut,
-                    "taux_horaire" => $request->taux_horaire,
-                    "statut" => "actif",
-                    "created_by" => auth()->id(),
-                    "created_at" => now(),
-                    "updated_at" => now(),
-                ], fn($v) => $v !== null));
-            }
 
             DB::commit();
 
@@ -285,10 +234,18 @@ class ESBTPEnseignantController extends Controller
             $role = \Spatie\Permission\Models\Role::firstOrCreate(['name' => 'enseignant']);
             $user->assignRole($role);
 
-            // Régime unifié (préféré) ou retombée sur type_contrat legacy.
+            // Régime unifié — fallback sur type_contrat legacy si client AJAX antérieur.
             $regime = $request->input('regime')
-                ?: ($request->input('type_contrat') ? $this->normalizeRegime($request->input('type_contrat')) : 'vacataire');
-            $contrat = $this->regimeToContrat($regime);
+                ?: match ($request->input('type_contrat')) {
+                    'permanent' => 'permanent',
+                    'consultant' => 'consultant',
+                    default => 'vacataire',
+                };
+
+            $dateDebut = $request->date_debut_activite ?: $request->date_embauche;
+            $dateDebut = $dateDebut
+                ? Carbon::parse($dateDebut)->format('Y-m-d')
+                : now()->toDateString();
 
             $teacher = ESBTPTeacher::create([
                 "user_id" => $user->id,
@@ -297,66 +254,14 @@ class ESBTPEnseignantController extends Controller
                 "specialization" => $request->specialization,
                 "grade" => $request->grade_academique,
                 "status" => "active",
+                "regime" => $regime,
+                "taux_horaire" => $request->taux_horaire,
+                "date_debut_activite" => $dateDebut,
                 "teaching_hours_due" => $regime === 'permanent'
                     ? ($request->charge_horaire_max_semaine ?? 18)
                     : 0,
                 "created_by" => auth()->id(),
             ]);
-
-            if (Schema::hasTable("esbtp_enseignant_profiles")) {
-                try {
-                    $dateDebut = $request->date_debut_activite
-                        ?: $request->date_embauche;
-                    $dateDebut = $dateDebut
-                        ? Carbon::parse($dateDebut)->format('Y-m-d')
-                        : now()->toDateString();
-
-                    $profileData = [
-                        "user_id" => $user->id,
-                        "matricule_enseignant" => $teacher->matricule,
-                        "titre_academique" => $request->titre_academique,
-                        "grade_academique" => $request->grade_academique,
-                        "charge_horaire_max_semaine" =>
-                            $request->charge_horaire_max_semaine ?? 18,
-                        "type_contrat" => $contrat['type_contrat'],
-                        "statut_emploi" => $contrat['statut_emploi'],
-                        "date_embauche" => $dateDebut,
-                        "taux_horaire" => $request->taux_horaire,
-                        "statut" => "actif",
-                        "created_by" => auth()->id(),
-                        "created_at" => now(),
-                        "updated_at" => now(),
-                    ];
-
-                    // Colonnes optionnelles — vérifier leur existence avant insertion
-                    $optionalColumns = [
-                        'diplome_principal' => null,
-                        'universite_diplome' => null,
-                        'annee_diplome' => null,
-                        'annees_experience_enseignement' => 0,
-                        'annees_experience_professionnelle' => 0,
-                        'fin_contrat' => null,
-                        'taux_horaire' => null,
-                        'accepte_enseignement_distance' => false,
-                        'accepte_cours_weekend' => false,
-                        'accepte_cours_soir' => false,
-                        'motivation' => null,
-                        'objectifs_pedagogiques' => null,
-                    ];
-
-                    foreach ($optionalColumns as $col => $default) {
-                        if (Schema::hasColumn('esbtp_enseignant_profiles', $col)) {
-                            $profileData[$col] = $default;
-                        }
-                    }
-
-                    DB::table("esbtp_enseignant_profiles")->insert($profileData);
-                } catch (\Exception $profileEx) {
-                    \Log::warning(
-                        "Profil enseignant non créé (non-bloquant): " . $profileEx->getMessage(),
-                    );
-                }
-            }
 
             if ($request->has("availability")) {
                 ESBTPTeacherAvailability::where("teacher_id", $teacher->id)->delete();
@@ -512,14 +417,6 @@ class ESBTPEnseignantController extends Controller
             $periode,
         );
 
-        // Récupérer les informations additionnelles si elles existent
-        $profileData = null;
-        if (Schema::hasTable("esbtp_enseignant_profiles")) {
-            $profileData = DB::table("esbtp_enseignant_profiles")
-                ->where("user_id", $enseignant->user_id)
-                ->first();
-        }
-
         // Préparer les données de disponibilité réelles
         $realAvailability = $this->prepareAvailabilityData($enseignant);
 
@@ -529,7 +426,6 @@ class ESBTPEnseignantController extends Controller
             "esbtp.enseignants.show",
             compact(
                 "teacher",
-                "profileData",
                 "realAvailability",
                 "teachingPlanning",
                 "anneeCourante",
@@ -878,19 +774,6 @@ class ESBTPEnseignantController extends Controller
     public function edit(ESBTPTeacher $enseignant)
     {
         $enseignant->load(["user", "availabilities"]);
-
-        $profileData = null;
-        if (Schema::hasTable("esbtp_enseignant_profiles")) {
-            $profileData = DB::table("esbtp_enseignant_profiles")
-                ->where("user_id", $enseignant->user_id)
-                ->first();
-        }
-
-        // Régime canonique reconstruit depuis le profil legacy.
-        $currentRegime = $profileData && !empty($profileData->type_contrat)
-            ? $this->normalizeRegime($profileData->type_contrat)
-            : 'vacataire';
-
         $availabilityData = $this->prepareAvailabilityData($enseignant);
 
         // Compatibilité vue (variable $teacher).
@@ -900,8 +783,6 @@ class ESBTPEnseignantController extends Controller
             "esbtp.enseignants.edit",
             [
                 "teacher" => $teacher,
-                "profileData" => $profileData,
-                "currentRegime" => $currentRegime,
                 "availabilityData" => $availabilityData,
                 "titres_academiques" => $this->titresAcademiques(),
                 "grades_academiques" => $this->gradesAcademiques(),
@@ -940,7 +821,6 @@ class ESBTPEnseignantController extends Controller
         ]);
 
         $regime = $request->input('regime') ?: 'vacataire';
-        $contrat = $this->regimeToContrat($regime);
 
         DB::beginTransaction();
 
@@ -951,10 +831,20 @@ class ESBTPEnseignantController extends Controller
                 "phone" => $request->phone,
             ]);
 
+            $dateDebut = $request->date_debut_activite
+                ? Carbon::parse($request->date_debut_activite)->format('Y-m-d')
+                : $enseignant->date_debut_activite;
+
             $enseignant->update([
                 "title" => $request->titre_academique,
                 "specialization" => $request->specialization,
                 "grade" => $request->grade_academique,
+                "regime" => $regime,
+                "taux_horaire" => $request->taux_horaire,
+                "date_debut_activite" => $dateDebut,
+                "diplome_principal" => $request->diplome_principal,
+                "universite_diplome" => $request->universite_diplome,
+                "annee_diplome" => $request->annee_diplome,
                 "bio" => $request->bio,
                 "website" => $request->website,
                 "status" => $request->status ?? $enseignant->status,
@@ -963,45 +853,6 @@ class ESBTPEnseignantController extends Controller
                     : 0,
                 "updated_by" => auth()->id(),
             ]);
-
-            // Mise à jour profil étendu (legacy table conservée jusqu'à PR fusion).
-            if (Schema::hasTable("esbtp_enseignant_profiles")) {
-                $dateDebut = $request->date_debut_activite
-                    ? Carbon::parse($request->date_debut_activite)->format('Y-m-d')
-                    : null;
-
-                $profileUpdate = array_filter([
-                    "titre_academique" => $request->titre_academique,
-                    "grade_academique" => $request->grade_academique,
-                    "diplome_principal" => $request->diplome_principal,
-                    "universite_diplome" => $request->universite_diplome,
-                    "annee_diplome" => $request->annee_diplome,
-                    "type_contrat" => $contrat['type_contrat'],
-                    "statut_emploi" => $contrat['statut_emploi'],
-                    "taux_horaire" => $request->taux_horaire,
-                    "charge_horaire_max_semaine" => $request->charge_horaire_max_semaine,
-                    "date_embauche" => $dateDebut,
-                    "updated_at" => now(),
-                ], fn($v) => $v !== null);
-
-                $exists = DB::table("esbtp_enseignant_profiles")
-                    ->where("user_id", $enseignant->user_id)
-                    ->exists();
-
-                if ($exists) {
-                    DB::table("esbtp_enseignant_profiles")
-                        ->where("user_id", $enseignant->user_id)
-                        ->update($profileUpdate);
-                } else {
-                    DB::table("esbtp_enseignant_profiles")->insert(array_merge($profileUpdate, [
-                        "user_id" => $enseignant->user_id,
-                        "matricule_enseignant" => $enseignant->matricule,
-                        "statut" => "actif",
-                        "created_by" => auth()->id(),
-                        "created_at" => now(),
-                    ]));
-                }
-            }
 
             // Disponibilités : reset + recréation si fournies.
             if ($request->has("availability")) {

--- a/app/Models/ESBTPTeacher.php
+++ b/app/Models/ESBTPTeacher.php
@@ -18,6 +18,12 @@ class ESBTPTeacher extends Model
         'title',
         'specialization',
         'status',
+        'regime',
+        'taux_horaire',
+        'date_debut_activite',
+        'diplome_principal',
+        'universite_diplome',
+        'annee_diplome',
         'teaching_hours_due',
         'phone',
         'email',
@@ -38,7 +44,10 @@ class ESBTPTeacher extends Model
 
     protected $casts = [
         'research_interests' => 'array',
-        'is_active' => 'boolean'
+        'is_active' => 'boolean',
+        'taux_horaire' => 'decimal:2',
+        'date_debut_activite' => 'date',
+        'annee_diplome' => 'integer',
     ];
 
     protected static function boot()

--- a/database/migrations/2026_05_01_180000_add_regime_columns_to_esbtp_teachers_table.php
+++ b/database/migrations/2026_05_01_180000_add_regime_columns_to_esbtp_teachers_table.php
@@ -1,0 +1,72 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Fusion DB : `esbtp_enseignant_profiles` est aboli, ses colonnes pertinentes
+     * sont ramenées dans `esbtp_teachers`. Migration idempotente.
+     */
+    public function up(): void
+    {
+        Schema::table('esbtp_teachers', function (Blueprint $table) {
+            if (!Schema::hasColumn('esbtp_teachers', 'regime')) {
+                $table->enum('regime', ['vacataire', 'permanent', 'consultant'])
+                    ->default('vacataire')
+                    ->after('status');
+            }
+            if (!Schema::hasColumn('esbtp_teachers', 'taux_horaire')) {
+                $table->decimal('taux_horaire', 10, 2)->nullable()->after('regime');
+            }
+            if (!Schema::hasColumn('esbtp_teachers', 'date_debut_activite')) {
+                $table->date('date_debut_activite')->nullable()->after('taux_horaire');
+            }
+            if (!Schema::hasColumn('esbtp_teachers', 'diplome_principal')) {
+                $table->string('diplome_principal')->nullable()->after('date_debut_activite');
+            }
+            if (!Schema::hasColumn('esbtp_teachers', 'universite_diplome')) {
+                $table->string('universite_diplome')->nullable()->after('diplome_principal');
+            }
+            if (!Schema::hasColumn('esbtp_teachers', 'annee_diplome')) {
+                $table->year('annee_diplome')->nullable()->after('universite_diplome');
+            }
+        });
+
+        // Data copy depuis esbtp_enseignant_profiles si la table existe (tenant déjà migré).
+        // Idempotent : ré-exécuter écrase avec les mêmes valeurs.
+        if (Schema::hasTable('esbtp_enseignant_profiles')) {
+            DB::statement("
+                UPDATE esbtp_teachers t
+                INNER JOIN esbtp_enseignant_profiles p ON p.user_id = t.user_id
+                SET
+                    t.regime = CASE
+                        WHEN p.type_contrat = 'permanent' THEN 'permanent'
+                        WHEN p.type_contrat = 'consultant' THEN 'consultant'
+                        ELSE 'vacataire'
+                    END,
+                    t.taux_horaire = COALESCE(t.taux_horaire, p.taux_horaire),
+                    t.date_debut_activite = COALESCE(t.date_debut_activite, p.date_embauche),
+                    t.diplome_principal = COALESCE(t.diplome_principal, p.diplome_principal),
+                    t.universite_diplome = COALESCE(t.universite_diplome, p.universite_diplome),
+                    t.annee_diplome = COALESCE(t.annee_diplome, p.annee_diplome)
+            ");
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('esbtp_teachers', function (Blueprint $table) {
+            $columns = ['regime', 'taux_horaire', 'date_debut_activite',
+                'diplome_principal', 'universite_diplome', 'annee_diplome'];
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('esbtp_teachers', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};

--- a/database/migrations/2026_05_01_180100_drop_legacy_enseignant_profile_tables.php
+++ b/database/migrations/2026_05_01_180100_drop_legacy_enseignant_profile_tables.php
@@ -1,0 +1,78 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Fusion DB — Phase 2 : drop des 3 tables legacy.
+     * Les données utiles ont été copiées dans `esbtp_teachers` par la migration
+     * 2026_05_01_180000. Les colonnes non utilisées par l'UI moderne sont
+     * abandonnées (specialites JSON, methodes_enseignement_preferees, etc.).
+     *
+     * Idempotent : `dropIfExists` ne lève pas si la table n'existe plus.
+     * Ordre : enfants avant parents (FK dépendantes).
+     */
+    public function up(): void
+    {
+        Schema::dropIfExists('esbtp_enseignant_disponibilites');
+        Schema::dropIfExists('esbtp_enseignant_affectations');
+        Schema::dropIfExists('esbtp_enseignant_profiles');
+    }
+
+    /**
+     * Reverse migration : recrée les tables vides (data perdue).
+     * Best-effort pour permettre le rollback en dev. En prod, restaurer depuis backup.
+     */
+    public function down(): void
+    {
+        Schema::create('esbtp_enseignant_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->string('matricule_enseignant')->unique()->nullable();
+            $table->string('titre_academique')->nullable();
+            $table->string('grade_academique')->nullable();
+            $table->string('diplome_principal')->nullable();
+            $table->string('universite_diplome')->nullable();
+            $table->year('annee_diplome')->nullable();
+            $table->enum('type_contrat', ['permanent', 'temporaire', 'vacataire', 'consultant'])->default('vacataire');
+            $table->enum('statut_emploi', ['temps_plein', 'temps_partiel', 'vacations'])->default('vacations');
+            $table->decimal('taux_horaire', 10, 2)->nullable();
+            $table->date('date_embauche')->nullable();
+            $table->date('fin_contrat')->nullable();
+            $table->integer('charge_horaire_max_semaine')->default(40);
+            $table->string('statut')->default('actif');
+            $table->foreignId('created_by')->nullable()->constrained('users')->onDelete('set null');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+
+        Schema::create('esbtp_enseignant_disponibilites', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('enseignant_profile_id')
+                ->constrained('esbtp_enseignant_profiles')
+                ->onDelete('cascade');
+            $table->integer('jour_semaine');
+            $table->time('heure_debut');
+            $table->time('heure_fin');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+
+        Schema::create('esbtp_enseignant_affectations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('enseignant_profile_id')
+                ->constrained('esbtp_enseignant_profiles')
+                ->onDelete('cascade');
+            $table->foreignId('matiere_id')
+                ->constrained('esbtp_matieres')
+                ->onDelete('cascade');
+            $table->date('date_debut');
+            $table->date('date_fin')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+};

--- a/resources/views/esbtp/enseignants/edit.blade.php
+++ b/resources/views/esbtp/enseignants/edit.blade.php
@@ -398,10 +398,10 @@ input[type="checkbox"]:checked + .ee-status-switch::before { transform: translat
                             'permanent' => ['label' => 'Permanent', 'desc' => 'Salaire mensuel, charge fixe', 'icon' => 'fa-user-tie'],
                             'consultant' => ['label' => 'Consultant', 'desc' => 'Mission ponctuelle, expertise', 'icon' => 'fa-handshake'],
                         ];
-                        $selectedRegime = old('regime', $currentRegime ?? 'vacataire');
-                        $currentDate = old('date_debut_activite', !empty($profileData->date_embauche) ? \Carbon\Carbon::parse($profileData->date_embauche)->format('Y-m-d') : '');
-                        $currentTaux = old('taux_horaire', $profileData->taux_horaire ?? '');
-                        $currentCharge = old('charge_horaire_max_semaine', $profileData->charge_horaire_max_semaine ?? $teacher->teaching_hours_due ?? 18);
+                        $selectedRegime = old('regime', $teacher->regime ?? 'vacataire');
+                        $currentDate = old('date_debut_activite', $teacher->date_debut_activite ? $teacher->date_debut_activite->format('Y-m-d') : '');
+                        $currentTaux = old('taux_horaire', $teacher->taux_horaire ?? '');
+                        $currentCharge = old('charge_horaire_max_semaine', $teacher->teaching_hours_due ?? 18);
                     @endphp
 
                     <div class="ee-regime-grid" id="regimeGrid">
@@ -446,9 +446,9 @@ input[type="checkbox"]:checked + .ee-status-switch::before { transform: translat
             </div>
 
             {{-- Section : Profil détaillé (collapsable) --}}
-            <div class="ee-card" data-collapsed="{{ $profileData && ($profileData->diplome_principal || $profileData->grade_academique) ? 'false' : 'true' }}" id="profileCard">
+            <div class="ee-card" data-collapsed="{{ ($teacher->diplome_principal || $teacher->grade) ? 'false' : 'true' }}" id="profileCard">
                 <div class="ee-card-body">
-                    <button type="button" class="ee-collapse-toggle" id="profileToggle" aria-expanded="{{ $profileData && ($profileData->diplome_principal || $profileData->grade_academique) ? 'true' : 'false' }}">
+                    <button type="button" class="ee-collapse-toggle" id="profileToggle" aria-expanded="{{ ($teacher->diplome_principal || $teacher->grade) ? 'true' : 'false' }}">
                         <div class="ee-section-icon"><i class="fas fa-graduation-cap"></i></div>
                         <div>
                             <h3 class="ee-section-title">Profil détaillé</h3>
@@ -464,7 +464,7 @@ input[type="checkbox"]:checked + .ee-status-switch::before { transform: translat
                                 <select name="grade_academique" id="grade_academique" class="ee-select">
                                     <option value="">—</option>
                                     @foreach($grades_academiques as $key => $value)
-                                        <option value="{{ $key }}" {{ old('grade_academique', $teacher->grade ?? ($profileData->grade_academique ?? '')) == $key ? 'selected' : '' }}>{{ $value }}</option>
+                                        <option value="{{ $key }}" {{ old('grade_academique', $teacher->grade ?? '') == $key ? 'selected' : '' }}>{{ $value }}</option>
                                     @endforeach
                                 </select>
                             </div>
@@ -472,21 +472,21 @@ input[type="checkbox"]:checked + .ee-status-switch::before { transform: translat
                             <div class="ee-field">
                                 <label for="diplome_principal" class="ee-label">Diplôme principal</label>
                                 <input type="text" name="diplome_principal" id="diplome_principal"
-                                       value="{{ old('diplome_principal', $profileData->diplome_principal ?? '') }}"
+                                       value="{{ old('diplome_principal', $teacher->diplome_principal ?? '') }}"
                                        class="ee-input">
                             </div>
 
                             <div class="ee-field">
                                 <label for="universite_diplome" class="ee-label">Université / Institut</label>
                                 <input type="text" name="universite_diplome" id="universite_diplome"
-                                       value="{{ old('universite_diplome', $profileData->universite_diplome ?? '') }}"
+                                       value="{{ old('universite_diplome', $teacher->universite_diplome ?? '') }}"
                                        class="ee-input">
                             </div>
 
                             <div class="ee-field">
                                 <label for="annee_diplome" class="ee-label">Année d'obtention</label>
                                 <input type="number" name="annee_diplome" id="annee_diplome"
-                                       value="{{ old('annee_diplome', $profileData->annee_diplome ?? '') }}"
+                                       value="{{ old('annee_diplome', $teacher->annee_diplome ?? '') }}"
                                        min="1950" max="{{ date('Y') }}"
                                        class="ee-input">
                             </div>

--- a/resources/views/esbtp/enseignants/show.blade.php
+++ b/resources/views/esbtp/enseignants/show.blade.php
@@ -559,8 +559,8 @@
             <div class="es-kpi">
                 <i class="fas fa-graduation-cap es-kpi-icon"></i>
                 <div>
-                    <div class="es-kpi-val">{{ $profileData->annees_experience_enseignement ?? 0 }} ans</div>
-                    <div class="es-kpi-lbl">Experience</div>
+                    <div class="es-kpi-val">{{ ucfirst($teacher->regime ?? 'vacataire') }}</div>
+                    <div class="es-kpi-lbl">Regime</div>
                 </div>
             </div>
             <div class="es-kpi">
@@ -624,11 +624,11 @@
                     </div>
                     <div class="es-info-row">
                         <span class="es-info-label"><i class="fas fa-award"></i> Titre academique</span>
-                        <span class="es-info-value">{{ $profileData->titre_academique ?? 'Non renseigne' }}</span>
+                        <span class="es-info-value">{{ $teacher->title ?? 'Non renseigne' }}</span>
                     </div>
                     <div class="es-info-row">
                         <span class="es-info-label"><i class="fas fa-medal"></i> Grade academique</span>
-                        <span class="es-info-value">{{ $profileData->grade_academique ?? 'Non renseigne' }}</span>
+                        <span class="es-info-value">{{ $teacher->grade ?? 'Non renseigne' }}</span>
                     </div>
                 </div>
 
@@ -658,16 +658,22 @@
                             </span>
                         </span>
                     </div>
-                    @if($profileData && $profileData->type_contrat)
+                    @if($teacher->regime)
                     <div class="es-info-row">
-                        <span class="es-info-label"><i class="fas fa-file-contract"></i> Type de contrat</span>
-                        <span class="es-info-value">{{ ucfirst($profileData->type_contrat) }}</span>
+                        <span class="es-info-label"><i class="fas fa-file-contract"></i> Regime</span>
+                        <span class="es-info-value">{{ ucfirst($teacher->regime) }}</span>
                     </div>
                     @endif
-                    @if($profileData && $profileData->statut_emploi)
+                    @if($teacher->taux_horaire)
                     <div class="es-info-row">
-                        <span class="es-info-label"><i class="fas fa-user-tie"></i> Statut d'emploi</span>
-                        <span class="es-info-value">{{ str_replace('_', ' ', ucfirst($profileData->statut_emploi)) }}</span>
+                        <span class="es-info-label"><i class="fas fa-coins"></i> Taux horaire</span>
+                        <span class="es-info-value">{{ number_format($teacher->taux_horaire, 0, ',', ' ') }} FCFA/h</span>
+                    </div>
+                    @endif
+                    @if($teacher->date_debut_activite)
+                    <div class="es-info-row">
+                        <span class="es-info-label"><i class="fas fa-calendar-check"></i> Debut d'activite</span>
+                        <span class="es-info-value">{{ $teacher->date_debut_activite->format('d/m/Y') }}</span>
                     </div>
                     @endif
 
@@ -697,7 +703,7 @@
             </div>
 
             {{-- Qualifications & Formation --}}
-            @if($profileData)
+            @if($teacher->diplome_principal || $teacher->universite_diplome || $teacher->annee_diplome)
             <div class="es-card">
                 <div class="es-card-header">
                     <div class="es-card-title">
@@ -707,36 +713,22 @@
                 </div>
                 <div class="es-grid-2">
                     <div>
-                        @if($profileData->diplome_principal)
+                        @if($teacher->diplome_principal)
                         <div class="es-info-row">
                             <span class="es-info-label"><i class="fas fa-scroll"></i> Diplome principal</span>
-                            <span class="es-info-value">{{ $profileData->diplome_principal }}</span>
+                            <span class="es-info-value">{{ $teacher->diplome_principal }}</span>
                         </div>
                         @endif
-                        @if($profileData->universite_diplome)
+                        @if($teacher->universite_diplome)
                         <div class="es-info-row">
                             <span class="es-info-label"><i class="fas fa-university"></i> Universite</span>
-                            <span class="es-info-value">{{ $profileData->universite_diplome }}</span>
+                            <span class="es-info-value">{{ $teacher->universite_diplome }}</span>
                         </div>
                         @endif
-                        @if($profileData->annee_diplome)
+                        @if($teacher->annee_diplome)
                         <div class="es-info-row">
                             <span class="es-info-label"><i class="fas fa-calendar"></i> Annee d'obtention</span>
-                            <span class="es-info-value">{{ $profileData->annee_diplome }}</span>
-                        </div>
-                        @endif
-                    </div>
-                    <div>
-                        @if($profileData->annees_experience_enseignement)
-                        <div class="es-info-row">
-                            <span class="es-info-label"><i class="fas fa-chalkboard-teacher"></i> Experience enseignement</span>
-                            <span class="es-info-value">{{ $profileData->annees_experience_enseignement }} annees</span>
-                        </div>
-                        @endif
-                        @if($profileData->annees_experience_professionnelle)
-                        <div class="es-info-row">
-                            <span class="es-info-label"><i class="fas fa-briefcase"></i> Experience professionnelle</span>
-                            <span class="es-info-value">{{ $profileData->annees_experience_professionnelle }} annees</span>
+                            <span class="es-info-value">{{ $teacher->annee_diplome }}</span>
                         </div>
                         @endif
                     </div>
@@ -754,30 +746,6 @@
                     </div>
                 </div>
                 <div class="es-bio-text">{{ $teacher->bio }}</div>
-            </div>
-            @endif
-
-            {{-- Motivation & Objectifs --}}
-            @if($profileData && ($profileData->motivation || $profileData->objectifs_pedagogiques))
-            <div class="es-card">
-                <div class="es-card-header">
-                    <div class="es-card-title">
-                        <div class="es-card-title-icon"><i class="fas fa-lightbulb"></i></div>
-                        Motivation & Objectifs
-                    </div>
-                </div>
-                @if($profileData->motivation)
-                <div class="es-info-row">
-                    <span class="es-info-label"><i class="fas fa-heart"></i> Motivation</span>
-                    <span class="es-info-value">{{ $profileData->motivation }}</span>
-                </div>
-                @endif
-                @if($profileData->objectifs_pedagogiques)
-                <div class="es-info-row">
-                    <span class="es-info-label"><i class="fas fa-bullseye"></i> Objectifs pedagogiques</span>
-                    <span class="es-info-value">{{ $profileData->objectifs_pedagogiques }}</span>
-                </div>
-                @endif
             </div>
             @endif
 


### PR DESCRIPTION
## Summary

Phase 4 du moteur Analytics premium KLASSCI. Complète Phase 2 (scaffolding) + Phase 3 (CashFlowPredictor) avec :
- 2 nouveaux Predictors : **DefaultRiskPredictor** (risque de défaut multi-features) + **AnomalyDetector** (Z-score sur revenue + outliers paiements)
- **2 jobs scheduled** : compute quotidien 4h + détection anomalies toutes les 6h
- **Cache decorator** + **persistence** dans audit trail
- **Page settings** premium pour configurer poids et seuils par tenant
- **Vue index réécrite** en premium namespace an-* (3 cards alive : cash flow + risk + anomalies)

Production-grade strict : règle no-mvp-only-premium.md appliquée — aucun MVP, design front+back complet.

## Permissions ajoutées

- comptabilite.analytics.run_now → bouton Recalculer
- comptabilite.analytics.configure → page settings

## Tests

29 unit tests, 100% pass (LogisticScoring 11 + LinearRegression 4 + Statistics 10 + AnalyticsContext 4).

## Critic 4-axes appliqué

2 blockers + 4 high résolus avant commit :
- Carbon cast via first()->computed_at
- notifications_enabled lu depuis validated
- Dedup signature inclut severity + scoreBucket
- Filtre date avant Z-score compute
- Persist rollback (cohérence cache/DB)

## Defaults business (B1-B4)

- B1 : 3 use cases shipped (CashFlow + DefaultRisk + AnomalyDetector)
- B2 : superAdmin + comptable
- B3 : Email seul (Telegram/SMS roadmap)
- B4 : Z-warning=2.0, Z-critical=3.0, payment outlier=3.0× (configurables)

## Test plan

- [ ] php artisan migrate
- [ ] php bin/deploy/fix_permissions.php
- [ ] Vérifier /esbtp/comptabilite/analytics rend les 3 cards
- [ ] Vérifier /esbtp/comptabilite/analytics/settings rend la grid
- [ ] Tester bouton Recalculer (dispatch jobs)
- [ ] php artisan schedule:list montre analytics-predictions-daily + analytics-anomaly-detection
- [ ] dispatch(new App\Jobs\ComputeAnalyticsPredictionsJob) → ligne dans analytics_predictions