### PR TITLE
refactor(enseignants): simplify post-merge — 5 quality fixes

### DIFF
--- a/app/Http/Controllers/ESBTPEnseignantController.php
+++ b/app/Http/Controllers/ESBTPEnseignantController.php
@@ -52,12 +52,20 @@ class ESBTPEnseignantController extends Controller
 
         $specializations = ESBTPTeacher::distinct()->pluck("specialization")->filter();
 
+        $row = ESBTPTeacher::selectRaw(
+            "COUNT(*) as total,
+             SUM(status = 'active') as active,
+             SUM(status = 'inactive') as inactive,
+             SUM(regime = 'permanent') as permanent,
+             SUM(regime = 'vacataire') as temporary"
+        )->first();
+
         $stats = [
-            "total" => ESBTPTeacher::count(),
-            "active" => ESBTPTeacher::where("status", "active")->count(),
-            "inactive" => ESBTPTeacher::where("status", "inactive")->count(),
-            "permanent" => ESBTPTeacher::where("regime", "permanent")->count(),
-            "temporary" => ESBTPTeacher::where("regime", "vacataire")->count(),
+            "total" => (int) ($row->total ?? 0),
+            "active" => (int) ($row->active ?? 0),
+            "inactive" => (int) ($row->inactive ?? 0),
+            "permanent" => (int) ($row->permanent ?? 0),
+            "temporary" => (int) ($row->temporary ?? 0),
         ];
 
         return view(
@@ -893,8 +901,7 @@ class ESBTPEnseignantController extends Controller
      */
     public function destroy(ESBTPTeacher $teacher)
     {
-        // Empêcher la suppression de son propre compte
-        if ($teacher->user_id === Auth::id()) {
+        if ($teacher->user_id === auth()->id()) {
             return redirect()->back()->with('error', 'Vous ne pouvez pas supprimer votre propre compte.');
         }
 

--- a/resources/views/esbtp/enseignants/edit.blade.php
+++ b/resources/views/esbtp/enseignants/edit.blade.php
@@ -342,8 +342,8 @@ input[type="checkbox"]:checked + .ee-status-switch::before { transform: translat
                         </div>
 
                         <div class="ee-field">
-                            <label for="phone" class="ee-label">Téléphone <span class="req">*</span></label>
-                            <input type="tel" name="phone" id="phone" required
+                            <label for="phone" class="ee-label">Téléphone</label>
+                            <input type="tel" name="phone" id="phone"
                                    value="{{ old('phone', $teacher->user->phone ?? '') }}"
                                    class="ee-input @error('phone') is-invalid @enderror">
                             @error('phone') <div class="ee-error">{{ $message }}</div> @enderror

--- a/resources/views/esbtp/enseignants/index.blade.php
+++ b/resources/views/esbtp/enseignants/index.blade.php
@@ -552,7 +552,7 @@
                     <div class="te-hero-title">
                         <i class="fas fa-chalkboard-teacher"></i>Gestion des Enseignants
                     </div>
-                    <div class="te-hero-subtitle">Profils, disponibilités et affectations du corps enseignant</div>
+                    <div class="te-hero-subtitle">Vue secondaire — la gestion principale est dans <strong>Personnel</strong>.</div>
                 </div>
                 <div class="te-hero-actions">
                     <button type="button" class="te-hero-btn" data-bs-toggle="modal" data-bs-target="#bulkAvailabilityModal">

--- a/routes/web.php
+++ b/routes/web.php
@@ -1328,7 +1328,7 @@ Route::prefix('secretaires')->name('secretaires.')->middleware(['auth', 'permiss
 });
 
 // Routes pour la gestion des enseignants
-Route::prefix('esbtp')->name('esbtp.')->middleware(['auth', 'permission:admin.access', 'permission:module.enseignants.access'])->group(function () {
+Route::prefix('esbtp')->name('esbtp.')->middleware(['auth', 'permission:admin.access', 'permission:module.enseignants.access', 'throttle:60,1'])->group(function () {
     Route::get('enseignants/duplicates', [ESBTPEnseignantController::class, 'duplicates'])->name('enseignants.duplicates');
     Route::post('enseignants/quick-create', [ESBTPEnseignantController::class, 'quickStore'])->name('enseignants.quick-create');
     Route::get('enseignants/bulk-availability', [ESBTPEnseignantController::class, 'bulkAvailability'])->name('enseignants.bulk-availability');
@@ -1339,7 +1339,7 @@ Route::prefix('esbtp')->name('esbtp.')->middleware(['auth', 'permission:admin.ac
     Route::post('enseignants/{teacher}/assign-matieres', [ESBTPEnseignantController::class, 'assignMatieres'])->name('enseignants.assign-matieres');
     Route::post('enseignants/{teacher}/toggle-status', [ESBTPEnseignantController::class, 'toggleStatus'])->name('enseignants.toggleStatus');
     Route::post('enseignants/{enseignant}/update-availability', [ESBTPEnseignantController::class, 'updateAvailability'])->name('enseignants.update-availability');
-    Route::post('enseignants/{enseignant}/reset-password', [ESBTPEnseignantController::class, 'resetPassword'])->name('enseignants.reset-password');
+    Route::post('enseignants/{enseignant}/reset-password', [ESBTPEnseignantController::class, 'resetPassword'])->middleware('throttle:5,1')->name('enseignants.reset-password');
     Route::resource('specialties', ESBTPSpecialtyController::class);
     Route::put('specialties/{id}/restore', [ESBTPSpecialtyController::class, 'restore'])->name('specialties.restore');
     Route::resource('continuing-education', ESBTPContinuingEducationController::class);


### PR DESCRIPTION
## Résumé

5 fixes HIGH severity remontés par 3 review agents (reuse / quality / efficiency) sur les commits enseignants 7bd66053..04cfa909.

## Fixes

| # | Type | Issue | Fix |
|---|---|---|---|
| 1 | **Bug** | `Auth::id()` sans `use` dans `destroy()` ligne 905 → fatal `Class not found` | `auth()->id()` (cohérent avec le reste du fichier) |
| 2 | **UX bloquant** | HTML5 `required` sur phone edit empêchait submit pour legacy teachers à phone NULL (server validait `nullable`) | retiré `required` + asterisk |
| 3 | **Performance N+1** | `index()` faisait 5 `count()` séparés (5 round-trips DB par page load) | 1 `SELECT` avec `SUM(condition)` |
| 4 | **Sécurité** | Aucun throttle sur les routes enseignants | `throttle:60,1` sur le groupe + `throttle:5,1` spécifique sur `reset-password` (création password random) |
| 5 | **UX** | Subtitle index "Profils, disponibilités et **affectations**" → tables `affectations` droppées en PR #291 | "Vue secondaire — la gestion principale est dans Personnel" |

## Differé (séparate PR)

Findings MED severity remontés par les agents mais hors scope de ce simplify :

- BackedEnum `TeacherRegime` / `TeacherStatus` (regime stringly-typed 9× : migration enum + view radios + validation `in:` + match() + `=== 'permanent'`)
- FormRequests `StoreEnseignantRequest` / `UpdateEnseignantRequest` (validation dupliquée 3×)
- Extraction CSS partial commun `.ec-*` / `.ee-*` (~200 lignes identiques entre create/edit)
- `buildPlanningPourEnseignant` 280 lignes nested 4 levels → `App\Services\TeacherPlanningService`

## Test plan

- [x] `index()` stats identiques (5 valeurs : total/active/inactive/permanent/temporary)
- [x] `destroy()` : auth()->id() consistent
- [x] Edit : phone laissé vide passe → soumet OK
- [x] Subtitle : reformulation visible
- [x] Throttle : routes appliquent middleware (vérifié via `route:list`)