### PR TITLE
feat(recouvrement): page actionnable WhatsApp + accuracy widget (Sprint 11+10)

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -9,6 +9,7 @@ use App\Jobs\SauvegardeDataJob;
 use App\Jobs\PlanifierRelancesJob;
 use App\Jobs\ComputeAnalyticsPredictionsJob;
 use App\Jobs\DetectAnalyticsAnomaliesJob;
+use App\Jobs\EvaluateAnalyticsAccuracyJob;
 
 class Kernel extends ConsoleKernel
 {
@@ -186,6 +187,14 @@ class Kernel extends ConsoleKernel
             ->everySixHours()
             ->name('analytics-anomaly-detection')
             ->description('Détection anomalies revenue + paiements outliers + notification admin/comptables')
+            ->onOneServer();
+
+        // Évaluation rétrospective de la précision des prédictions (1er du mois 5h)
+        $schedule->job(new EvaluateAnalyticsAccuracyJob)
+            ->monthlyOn(1, '05:00')
+            ->timezone('Africa/Abidjan')
+            ->name('analytics-accuracy-evaluation')
+            ->description('Comparaison predicted vs actual du mois écoulé + update accuracy_score')
             ->onOneServer();
     }
 

--- a/app/Domain/Analytics/AccuracyEvaluator.php
+++ b/app/Domain/Analytics/AccuracyEvaluator.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Domain\Analytics;
+
+use App\Models\AnalyticsPrediction;
+use App\Models\ESBTPPaiement;
+use Illuminate\Support\Carbon;
+
+/**
+ * Évalue la précision a posteriori des prédictions Analytics. Compare la
+ * valeur prédite avec la valeur réelle observée et calcule un score [0,1].
+ *
+ * Le label retourné est en mots compréhensibles par un comptable lambda :
+ * - Excellente (>= 0.85)
+ * - Bonne (>= 0.70)
+ * - À surveiller (< 0.70)
+ *
+ * Pure compute sauf accès Models. Idempotent : ne retraite pas une prédiction
+ * déjà évaluée (actual_value remplie).
+ */
+class AccuracyEvaluator
+{
+    public const LABEL_EXCELLENT = 'excellente';
+    public const LABEL_GOOD = 'bonne';
+    public const LABEL_WATCH = 'a_surveiller';
+
+    public const THRESHOLD_EXCELLENT = 0.85;
+    public const THRESHOLD_GOOD = 0.70;
+
+    /**
+     * Score normalisé [0,1] : 1 = prédiction parfaite, 0 = écart maximal.
+     * Formule : 1 - |predicted - actual| / max(|predicted|, |actual|).
+     * Retourne 1.0 si predicted = actual = 0 (pas d'écart à mesurer).
+     */
+    public static function score(float $predicted, float $actual): float
+    {
+        $denominator = max(abs($predicted), abs($actual));
+        if ($denominator < 0.01) {
+            return 1.0;
+        }
+        $error = abs($predicted - $actual) / $denominator;
+        return max(0.0, min(1.0, 1.0 - $error));
+    }
+
+    public static function labelForScore(float $score): string
+    {
+        return match (true) {
+            $score >= self::THRESHOLD_EXCELLENT => self::LABEL_EXCELLENT,
+            $score >= self::THRESHOLD_GOOD => self::LABEL_GOOD,
+            default => self::LABEL_WATCH,
+        };
+    }
+
+    /**
+     * Évalue toutes les prédictions cash_flow dont target_date est passée
+     * et actual_value pas encore remplie. Calcule actual via SUM des
+     * paiements validés du mois cible.
+     *
+     * @return array{evaluated: int, skipped: int}
+     */
+    public function evaluatePendingCashFlow(): array
+    {
+        $pending = AnalyticsPrediction::query()
+            ->where('predictor', 'cash_flow')
+            ->whereNotNull('target_date')
+            ->whereNotNull('predicted_value')
+            ->whereNull('actual_value')
+            ->where('target_date', '<', Carbon::now()->startOfMonth())
+            ->get();
+
+        $evaluated = 0;
+        $skipped = 0;
+
+        foreach ($pending as $prediction) {
+            $actual = $this->computeActualCashFlow($prediction);
+            if ($actual === null) {
+                $skipped++;
+                continue;
+            }
+
+            $score = self::score((float) $prediction->predicted_value, $actual);
+            $prediction->update([
+                'actual_value' => $actual,
+                'accuracy_score' => $score,
+            ]);
+            $evaluated++;
+        }
+
+        return ['evaluated' => $evaluated, 'skipped' => $skipped];
+    }
+
+    /**
+     * Précision moyenne sur les N dernières prédictions évaluées d'un predictor.
+     */
+    public function averageAccuracy(string $predictor, int $lastN = 6): ?float
+    {
+        $scores = AnalyticsPrediction::query()
+            ->where('predictor', $predictor)
+            ->whereNotNull('accuracy_score')
+            ->orderByDesc('target_date')
+            ->limit($lastN)
+            ->pluck('accuracy_score')
+            ->map(fn ($v) => (float) $v)
+            ->all();
+
+        if (empty($scores)) {
+            return null;
+        }
+
+        return array_sum($scores) / count($scores);
+    }
+
+    private function computeActualCashFlow(AnalyticsPrediction $prediction): ?float
+    {
+        $targetDate = Carbon::parse($prediction->target_date);
+        $start = $targetDate->copy()->startOfMonth();
+        $end = $targetDate->copy()->endOfMonth();
+
+        $context = $prediction->context_json ?? [];
+
+        $query = ESBTPPaiement::query()
+            ->where('status', 'validé')
+            ->whereNull('deleted_at')
+            ->whereBetween('date_paiement', [$start, $end]);
+
+        if (!empty($context['anneeId'])) {
+            $query->whereHas('inscription', fn ($q) => $q->where('annee_universitaire_id', $context['anneeId']));
+        }
+        if (!empty($context['filiereId'])) {
+            $query->whereHas('inscription.classe', fn ($q) => $q->where('filiere_id', $context['filiereId']));
+        }
+        if (!empty($context['classeId'])) {
+            $query->whereHas('inscription', fn ($q) => $q->where('classe_id', $context['classeId']));
+        }
+
+        return (float) $query->sum('montant');
+    }
+}

--- a/app/Domain/Notifications/ChannelDispatch.php
+++ b/app/Domain/Notifications/ChannelDispatch.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Domain\Notifications;
+
+/**
+ * Résultat d'un dispatch via un NotificationChannelInterface.
+ *
+ * - Mode manuel (ex WhatsApp deeplink) : `automated=false`, `deeplinkUrl` rempli.
+ *   L'utilisateur clique le lien pour finaliser l'envoi.
+ * - Mode automatique (ex WhatsApp Business API future) : `automated=true`,
+ *   `deeplinkUrl=null`, `success` reflète le statut API.
+ */
+final class ChannelDispatch
+{
+    public function __construct(
+        public readonly string $channel,
+        public readonly bool $automated,
+        public readonly bool $success,
+        public readonly ?string $deeplinkUrl = null,
+        public readonly ?string $errorReason = null,
+    ) {}
+
+    public static function manual(string $channel, string $deeplinkUrl): self
+    {
+        return new self(
+            channel: $channel,
+            automated: false,
+            success: true,
+            deeplinkUrl: $deeplinkUrl,
+        );
+    }
+
+    public static function unavailable(string $channel, string $reason): self
+    {
+        return new self(
+            channel: $channel,
+            automated: false,
+            success: false,
+            deeplinkUrl: null,
+            errorReason: $reason,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'channel' => $this->channel,
+            'automated' => $this->automated,
+            'success' => $this->success,
+            'deeplink_url' => $this->deeplinkUrl,
+            'error_reason' => $this->errorReason,
+        ];
+    }
+}

--- a/app/Domain/Notifications/Channels/NotificationChannelInterface.php
+++ b/app/Domain/Notifications/Channels/NotificationChannelInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Domain\Notifications\Channels;
+
+use App\Domain\Notifications\ChannelDispatch;
+use App\Domain\Notifications\EtudiantContact;
+
+/**
+ * Contrat d'un canal de notification de relance. Strategy pattern ouvert pour
+ * extensions futures (WhatsApp Business API, SMS gateway, push, etc.) sans
+ * modification du Predictor / Controller / Logger.
+ *
+ * Les implémentations doivent être déterministes (même input = même output).
+ */
+interface NotificationChannelInterface
+{
+    /**
+     * Identifiant snake_case du canal — utilisé en colonne `canal` table relances
+     * et en clé settings.
+     */
+    public function name(): string;
+
+    /**
+     * True si le canal envoie automatiquement (Business API, SMS gateway).
+     * False si le canal génère un lien que l'utilisateur clique (deeplink wa.me, mailto).
+     */
+    public function isAutomated(): bool;
+
+    /**
+     * Construit (mode manuel) ou exécute (mode automatique) l'envoi de la
+     * notification. Le caller persiste le résultat via RelanceActionLogger.
+     */
+    public function dispatch(EtudiantContact $contact, string $message): ChannelDispatch;
+}

--- a/app/Domain/Notifications/Channels/WhatsAppDeeplinkChannel.php
+++ b/app/Domain/Notifications/Channels/WhatsAppDeeplinkChannel.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Domain\Notifications\Channels;
+
+use App\Domain\Notifications\ChannelDispatch;
+use App\Domain\Notifications\EtudiantContact;
+use App\Domain\Notifications\PhoneNormalizer;
+
+/**
+ * Canal WhatsApp deeplink (wa.me) — manuel et gratuit. Génère un lien
+ * `https://wa.me/<E164>?text=<encoded>` que le comptable clique pour ouvrir
+ * son WhatsApp avec message pré-rempli.
+ *
+ * Coût : 0. Quota : illimité. Pas d'appel API.
+ *
+ * Quand adminKlassci paywall sera ready, un sibling
+ * `WhatsAppBusinessApiChannel` sera ajouté avec `isAutomated() = true` pour
+ * l'envoi automatique facturé.
+ */
+class WhatsAppDeeplinkChannel implements NotificationChannelInterface
+{
+    private const NAME = 'whatsapp_deeplink';
+    private const BASE_URL = 'https://wa.me/';
+
+    public function name(): string
+    {
+        return self::NAME;
+    }
+
+    public function isAutomated(): bool
+    {
+        return false;
+    }
+
+    public function dispatch(EtudiantContact $contact, string $message): ChannelDispatch
+    {
+        $whatsappId = PhoneNormalizer::toWhatsAppId($contact->phone);
+        if ($whatsappId === null) {
+            return ChannelDispatch::unavailable(
+                self::NAME,
+                'Numéro de téléphone invalide ou manquant',
+            );
+        }
+
+        $url = self::BASE_URL . $whatsappId . '?text=' . rawurlencode($message);
+
+        return ChannelDispatch::manual(self::NAME, $url);
+    }
+}

--- a/app/Domain/Notifications/EtudiantContact.php
+++ b/app/Domain/Notifications/EtudiantContact.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Domain\Notifications;
+
+/**
+ * Contexte de contact d'un étudiant pour notifications/relances. Découple les
+ * channels du modèle Eloquent — testable en pur PHP.
+ */
+final class EtudiantContact
+{
+    public function __construct(
+        public readonly int $etudiantId,
+        public readonly string $nomComplet,
+        public readonly ?string $phone,
+        public readonly ?string $email,
+        public readonly ?string $prenoms = null,
+        public readonly ?string $nom = null,
+    ) {}
+
+    public function hasValidPhone(): bool
+    {
+        return PhoneNormalizer::isValid($this->phone);
+    }
+
+    public function hasEmail(): bool
+    {
+        return !empty($this->email) && filter_var($this->email, FILTER_VALIDATE_EMAIL) !== false;
+    }
+}

--- a/app/Domain/Notifications/PhoneNormalizer.php
+++ b/app/Domain/Notifications/PhoneNormalizer.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Domain\Notifications;
+
+/**
+ * Normalise les numéros de téléphone ivoiriens vers le format E.164 (+225XXXXXXXXXX).
+ *
+ * Préfixes mobiles CI (2026) : 01/02/03 (Moov), 05/06 (Orange), 07/08/09 (MTN, Wave).
+ * Tout numéro non conforme retourne null (pas d'envoi raté plus tard).
+ *
+ * Pure compute — pas de dépendance Laravel.
+ */
+final class PhoneNormalizer
+{
+    private const COUNTRY_CODE = '225';
+    private const E164_PREFIX = '+225';
+    private const MOBILE_PREFIX_REGEX = '/^(01|02|03|05|06|07|08|09)/';
+    private const NATIONAL_LENGTH = 10;
+    private const FULL_LENGTH = 13;
+
+    /**
+     * Tente de normaliser un numéro brut. Retourne null si invalide.
+     */
+    public static function toE164(?string $raw): ?string
+    {
+        if ($raw === null || trim($raw) === '') {
+            return null;
+        }
+
+        $digits = preg_replace('/\D+/', '', $raw);
+        if ($digits === '' || $digits === null) {
+            return null;
+        }
+
+        if (str_starts_with($digits, '00' . self::COUNTRY_CODE)) {
+            $digits = substr($digits, 2);
+        }
+
+        if (strlen($digits) === self::FULL_LENGTH && str_starts_with($digits, self::COUNTRY_CODE)) {
+            $national = substr($digits, 3);
+        } elseif (strlen($digits) === self::NATIONAL_LENGTH) {
+            $national = $digits;
+        } else {
+            return null;
+        }
+
+        if (!preg_match(self::MOBILE_PREFIX_REGEX, $national)) {
+            return null;
+        }
+
+        return self::E164_PREFIX . $national;
+    }
+
+    /**
+     * Format E.164 sans le `+` (utile pour wa.me/22507XXXXXXXX).
+     */
+    public static function toWhatsAppId(?string $raw): ?string
+    {
+        $e164 = self::toE164($raw);
+        return $e164 === null ? null : substr($e164, 1);
+    }
+
+    public static function isValid(?string $raw): bool
+    {
+        return self::toE164($raw) !== null;
+    }
+}

--- a/app/Helpers/SettingsHelper.php
+++ b/app/Helpers/SettingsHelper.php
@@ -220,6 +220,12 @@ class SettingsHelper
                 'payment_outlier_multiplier'  => (float) self::get('analytics.anomaly.payment_outlier_multiplier', 3.0),
                 'notifications_enabled'       => (string) self::get('analytics.anomaly.notifications_enabled', '1') === '1',
             ],
+            'recouvrement' => [
+                'whatsapp_template' => (string) self::get(
+                    'analytics.recouvrement.whatsapp_template',
+                    "Bonjour {prenom}, votre solde de scolarité de {solde} FCFA est en retard de {retard} jours. Merci de régulariser dès que possible. — {ecole}",
+                ),
+            ],
         ];
     }
 

--- a/app/Http/Controllers/ESBTPAnalyticsController.php
+++ b/app/Http/Controllers/ESBTPAnalyticsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Domain\Analytics\AccuracyEvaluator;
 use App\Domain\Analytics\Cache\CachedPredictor;
 use App\Domain\Analytics\Detectors\AnomalyDetector;
 use App\Domain\Analytics\DTOs\AnalyticsContext;
@@ -38,22 +39,25 @@ class ESBTPAnalyticsController extends Controller
         CashFlowPredictor $cashFlow,
         DefaultRiskPredictor $defaultRisk,
         AnomalyDetector $anomalyDetector,
+        AccuracyEvaluator $accuracy,
     ): View {
         $context = AnalyticsContext::fromRequest($request);
 
         $cashFlowResult = $this->safePredict(new CachedPredictor($cashFlow), $context);
         $defaultRiskResult = $this->safePredict(new CachedPredictor($defaultRisk), $context);
         $anomalies = $this->safeDetect($anomalyDetector, $context);
+        $cashFlowAccuracy = $this->safeAccuracy($accuracy, 'cash_flow');
 
         return view('esbtp.comptabilite.analytics.index', [
-            'cashFlow'        => $cashFlowResult,
-            'defaultRisk'     => $defaultRiskResult,
-            'anomalies'       => $anomalies,
-            'context'         => $context,
-            'annees'          => ESBTPAnneeUniversitaire::orderBy('name', 'desc')->get(),
-            'filieres'        => ESBTPFiliere::orderBy('name')->get(),
-            'classes'         => ESBTPClasse::orderBy('name')->get(),
-            'lastComputedAt'  => $this->lastComputedAt(),
+            'cashFlow'         => $cashFlowResult,
+            'defaultRisk'      => $defaultRiskResult,
+            'anomalies'        => $anomalies,
+            'cashFlowAccuracy' => $cashFlowAccuracy,
+            'context'          => $context,
+            'annees'           => ESBTPAnneeUniversitaire::orderBy('name', 'desc')->get(),
+            'filieres'         => ESBTPFiliere::orderBy('name')->get(),
+            'classes'          => ESBTPClasse::orderBy('name')->get(),
+            'lastComputedAt'   => $this->lastComputedAt(),
         ]);
     }
 
@@ -133,6 +137,7 @@ class ESBTPAnalyticsController extends Controller
             'anomaly.z_critical'             => 'required|numeric|min:1.5|max:6',
             'anomaly.payment_outlier_multiplier' => 'required|numeric|min:1.5|max:10',
             'anomaly.notifications_enabled'  => 'nullable|in:0,1',
+            'recouvrement.whatsapp_template' => 'nullable|string|max:1000',
         ]);
 
         $mappings = [
@@ -148,6 +153,7 @@ class ESBTPAnalyticsController extends Controller
             'analytics.anomaly.z_critical'                  => $validated['anomaly']['z_critical'],
             'analytics.anomaly.payment_outlier_multiplier'  => $validated['anomaly']['payment_outlier_multiplier'],
             'analytics.anomaly.notifications_enabled'       => $validated['anomaly']['notifications_enabled'] ?? '0',
+            'analytics.recouvrement.whatsapp_template'      => $validated['recouvrement']['whatsapp_template'] ?? '',
         ];
 
         foreach ($mappings as $key => $value) {
@@ -157,6 +163,26 @@ class ESBTPAnalyticsController extends Controller
         return redirect()
             ->route('esbtp.comptabilite.analytics.settings')
             ->with('success', 'Paramètres Analytics mis à jour.');
+    }
+
+    /**
+     * @return array{score: ?float, label: ?string}
+     */
+    private function safeAccuracy(AccuracyEvaluator $evaluator, string $predictor): array
+    {
+        try {
+            $score = $evaluator->averageAccuracy($predictor);
+            return [
+                'score' => $score,
+                'label' => $score === null ? null : AccuracyEvaluator::labelForScore($score),
+            ];
+        } catch (\Throwable $e) {
+            Log::warning('Analytics accuracy lookup failed', [
+                'predictor' => $predictor,
+                'error' => $e->getMessage(),
+            ]);
+            return ['score' => null, 'label' => null];
+        }
     }
 
     private function safePredict(PredictorInterface $predictor, AnalyticsContext $context): PredictionResult
@@ -204,7 +230,7 @@ class ESBTPAnalyticsController extends Controller
     }
 
     /**
-     * @return array<string, array<string, float|int>>
+     * @return array<string, array<string, mixed>>
      */
     private function defaultSettings(): array
     {
@@ -223,6 +249,9 @@ class ESBTPAnalyticsController extends Controller
                 'z_warning'                  => AnomalyDetector::DEFAULT_Z_WARNING,
                 'z_critical'                 => AnomalyDetector::DEFAULT_Z_CRITICAL,
                 'payment_outlier_multiplier' => AnomalyDetector::DEFAULT_PAYMENT_OUTLIER_MULTIPLIER,
+            ],
+            'recouvrement' => [
+                'whatsapp_template' => "Bonjour {prenom}, votre solde de scolarité de {solde} FCFA est en retard de {retard} jours. Merci de régulariser dès que possible. — {ecole}",
             ],
         ];
     }

--- a/app/Http/Controllers/ESBTPRecouvrementController.php
+++ b/app/Http/Controllers/ESBTPRecouvrementController.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Domain\Analytics\Cache\CachedPredictor;
+use App\Domain\Analytics\DTOs\AnalyticsContext;
+use App\Domain\Analytics\Predictors\DefaultRiskPredictor;
+use App\Domain\Notifications\Channels\WhatsAppDeeplinkChannel;
+use App\Domain\Notifications\EtudiantContact;
+use App\Helpers\SettingsHelper;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Services\RelanceActionLogger;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+/**
+ * Page Recouvrement Optimizer : transforme la prédiction DefaultRisk en
+ * liste actionnable du jour. Le comptable voit les étudiants prioritaires
+ * et clique pour ouvrir WhatsApp / appel / email avec message pré-rempli.
+ *
+ * Architecture extensible : aujourd'hui canal `whatsapp_deeplink` (gratuit).
+ * Quand adminKlassci paywall ready → bascule `whatsapp_business_api`
+ * automatique via Strategy pattern (NotificationChannelInterface).
+ */
+class ESBTPRecouvrementController extends Controller
+{
+    private const TEMPLATE_DEFAULT = "Bonjour {prenom}, votre solde de scolarité de {solde} FCFA est en retard de {retard} jours. Merci de régulariser dès que possible. — {ecole}";
+
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('comptabilite.access');
+        $this->middleware('can:comptabilite.recouvrement.access');
+    }
+
+    public function index(Request $request, DefaultRiskPredictor $predictor): View
+    {
+        $context = AnalyticsContext::fromRequest($request);
+        $cached = new CachedPredictor($predictor, ttlSeconds: 1800);
+        $prediction = $cached->predict($context);
+
+        $topAtRisk = $prediction->metadata['top_at_risk'] ?? [];
+        $contacts = $this->loadContacts(array_column($topAtRisk, 'inscription_id'));
+
+        $intentLogger = app(\App\Services\RelanceActionLogger::class);
+        $rows = collect($topAtRisk)
+            ->map(function ($student) use ($contacts, $intentLogger) {
+                $contact = $contacts[$student['inscription_id']] ?? null;
+                if ($contact === null) {
+                    Log::warning('Recouvrement: contact introuvable pour inscription at-risk', [
+                        'inscription_id' => $student['inscription_id'],
+                    ]);
+                }
+                return array_merge($student, [
+                    'phone' => $contact?->phone,
+                    'email' => $contact?->email,
+                    'prenoms' => $contact?->prenoms ?? '',
+                    'has_valid_phone' => $contact?->hasValidPhone() ?? false,
+                    'relances_today' => $intentLogger->countIntentsToday($student['etudiant_id'] ?? 0),
+                ]);
+            })
+            ->values()
+            ->all();
+
+        return view('esbtp.comptabilite.recouvrement.index', [
+            'rows' => $rows,
+            'totalActifs' => $prediction->metadata['total_actifs'] ?? 0,
+            'buckets' => $prediction->metadata['buckets'] ?? [],
+            'tauxRisque' => $prediction->metadata['taux_risque_pct'] ?? 0.0,
+            'totalSoldeHaut' => $prediction->metadata['total_solde_haut_risque'] ?? 0.0,
+            'context' => $context,
+            'annees' => \App\Models\ESBTPAnneeUniversitaire::orderBy('name', 'desc')->get(),
+            'filieres' => ESBTPFiliere::orderBy('name')->get(),
+            'classes' => ESBTPClasse::orderBy('name')->get(),
+            'whatsappTemplate' => $this->whatsappTemplate(),
+            'schoolName' => SettingsHelper::get('school_name', config('app.name', 'KLASSCI')),
+        ]);
+    }
+
+    /**
+     * Enregistre une intention de relance via un canal donné. Retourne le
+     * deeplink à ouvrir côté front (wa.me / mailto: / tel:).
+     */
+    public function logIntent(
+        Request $request,
+        WhatsAppDeeplinkChannel $whatsapp,
+        RelanceActionLogger $logger,
+    ): JsonResponse {
+        $validated = $request->validate([
+            'inscription_id' => 'required|integer|exists:esbtp_inscriptions,id',
+            'channel' => 'required|in:whatsapp_deeplink,email,tel,manuel',
+            'message' => 'required|string|max:2000',
+        ]);
+
+        $inscription = ESBTPInscription::with('etudiant:id,nom,prenoms,telephone,email')
+            ->findOrFail($validated['inscription_id']);
+        $etudiant = $inscription->etudiant;
+
+        if (!$etudiant) {
+            return response()->json(['success' => false, 'error' => 'Étudiant introuvable'], 404);
+        }
+
+        $contact = new EtudiantContact(
+            etudiantId: (int) $etudiant->id,
+            nomComplet: trim(($etudiant->prenoms ?? '') . ' ' . ($etudiant->nom ?? '')),
+            phone: $etudiant->telephone,
+            email: $etudiant->email,
+            prenoms: $etudiant->prenoms,
+            nom: $etudiant->nom,
+        );
+
+        $dispatch = match ($validated['channel']) {
+            'whatsapp_deeplink' => $whatsapp->dispatch($contact, $validated['message']),
+            'email' => $this->buildEmailDispatch($contact, $validated['message']),
+            'tel' => $this->buildTelDispatch($contact),
+            'manuel' => \App\Domain\Notifications\ChannelDispatch::manual('manuel', '#'),
+        };
+
+        try {
+            $relance = $logger->logIntent($contact, (int) $inscription->id, $dispatch, $validated['message']);
+        } catch (\Throwable $e) {
+            Log::error('Recouvrement logIntent failed', [
+                'error' => $e->getMessage(),
+                'inscription_id' => $validated['inscription_id'],
+            ]);
+            return response()->json(['success' => false, 'error' => 'Erreur technique'], 500);
+        }
+
+        return response()->json([
+            'success' => $dispatch->success,
+            'channel' => $dispatch->channel,
+            'deeplink_url' => $dispatch->deeplinkUrl,
+            'error_reason' => $dispatch->errorReason,
+            'relance_id' => $relance->id,
+        ]);
+    }
+
+    /**
+     * Confirme qu'une relance précédemment loggée en `intent` a effectivement
+     * été envoyée. Utilisé par le bouton "Marqué relancé".
+     */
+    public function confirmSent(Request $request, RelanceActionLogger $logger): JsonResponse
+    {
+        $validated = $request->validate([
+            'relance_id' => 'required|integer|exists:esbtp_relances,id',
+        ]);
+
+        try {
+            $relance = $logger->confirmSent((int) $validated['relance_id']);
+        } catch (\Throwable $e) {
+            Log::error('Recouvrement confirmSent failed', [
+                'error' => $e->getMessage(),
+                'relance_id' => $validated['relance_id'],
+            ]);
+            return response()->json(['success' => false, 'error' => 'Erreur technique'], 500);
+        }
+
+        return response()->json([
+            'success' => true,
+            'confirmed_at' => $relance->confirmee_a?->toISOString(),
+        ]);
+    }
+
+    /**
+     * Crée une relance "marquée relancée" en un seul clic (sans intent log
+     * canal). Utile quand le comptable a relancé hors-app (appel, en personne).
+     */
+    public function markDone(
+        Request $request,
+        RelanceActionLogger $logger,
+    ): JsonResponse {
+        $validated = $request->validate([
+            'inscription_id' => 'required|integer|exists:esbtp_inscriptions,id',
+            'note' => 'nullable|string|max:500',
+        ]);
+
+        $inscription = ESBTPInscription::with('etudiant:id,nom,prenoms,telephone,email')
+            ->findOrFail($validated['inscription_id']);
+        $etudiant = $inscription->etudiant;
+
+        $contact = new EtudiantContact(
+            etudiantId: (int) ($etudiant?->id ?? 0),
+            nomComplet: trim(($etudiant?->prenoms ?? '') . ' ' . ($etudiant?->nom ?? '')),
+            phone: $etudiant?->telephone,
+            email: $etudiant?->email,
+            prenoms: $etudiant?->prenoms,
+            nom: $etudiant?->nom,
+        );
+
+        $relance = $logger->logSent(
+            $contact,
+            (int) $inscription->id,
+            $validated['note'] ?? 'Relancé manuellement',
+        );
+
+        return response()->json([
+            'success' => true,
+            'relance_id' => $relance->id,
+        ]);
+    }
+
+    /**
+     * @return array<int, EtudiantContact>  keyed by inscription_id
+     */
+    private function loadContacts(array $inscriptionIds): array
+    {
+        if (empty($inscriptionIds)) {
+            return [];
+        }
+
+        return ESBTPInscription::with('etudiant:id,nom,prenoms,telephone,email')
+            ->whereIn('id', $inscriptionIds)
+            ->get()
+            ->mapWithKeys(function (ESBTPInscription $inscription) {
+                $etudiant = $inscription->etudiant;
+                if (!$etudiant) {
+                    return [$inscription->id => null];
+                }
+                return [
+                    $inscription->id => new EtudiantContact(
+                        etudiantId: (int) $etudiant->id,
+                        nomComplet: trim(($etudiant->prenoms ?? '') . ' ' . ($etudiant->nom ?? '')),
+                        phone: $etudiant->telephone,
+                        email: $etudiant->email,
+                        prenoms: $etudiant->prenoms,
+                        nom: $etudiant->nom,
+                    ),
+                ];
+            })
+            ->filter()
+            ->all();
+    }
+
+    private function whatsappTemplate(): string
+    {
+        $template = SettingsHelper::get('analytics.recouvrement.whatsapp_template');
+        return is_string($template) && trim($template) !== '' ? $template : self::TEMPLATE_DEFAULT;
+    }
+
+    private function buildEmailDispatch(EtudiantContact $contact, string $message): \App\Domain\Notifications\ChannelDispatch
+    {
+        if (!$contact->hasEmail()) {
+            return \App\Domain\Notifications\ChannelDispatch::unavailable('email', 'Email étudiant manquant ou invalide');
+        }
+        $subject = rawurlencode('Solde de scolarité');
+        $body = rawurlencode($message);
+        return \App\Domain\Notifications\ChannelDispatch::manual(
+            'email',
+            "mailto:{$contact->email}?subject={$subject}&body={$body}",
+        );
+    }
+
+    private function buildTelDispatch(EtudiantContact $contact): \App\Domain\Notifications\ChannelDispatch
+    {
+        $e164 = \App\Domain\Notifications\PhoneNormalizer::toE164($contact->phone);
+        if ($e164 === null) {
+            return \App\Domain\Notifications\ChannelDispatch::unavailable('tel', 'Numéro de téléphone invalide');
+        }
+        return \App\Domain\Notifications\ChannelDispatch::manual('tel', "tel:{$e164}");
+    }
+}

--- a/app/Jobs/EvaluateAnalyticsAccuracyJob.php
+++ b/app/Jobs/EvaluateAnalyticsAccuracyJob.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Domain\Analytics\AccuracyEvaluator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Job mensuel (1er du mois, 5h Africa/Abidjan) qui évalue rétrospectivement
+ * la précision des prédictions cash flow du mois écoulé. Met à jour
+ * actual_value et accuracy_score dans analytics_predictions.
+ *
+ * Le widget Précision sur /analytics agrège ensuite ces scores en label
+ * Excellente/Bonne/À surveiller.
+ */
+class EvaluateAnalyticsAccuracyJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 300;
+    public array $backoff = [60, 180, 300];
+
+    public function __construct()
+    {
+        $this->onQueue('low');
+    }
+
+    public function handle(AccuracyEvaluator $evaluator): void
+    {
+        try {
+            $result = $evaluator->evaluatePendingCashFlow();
+            Log::info('Analytics accuracy evaluation completed', $result);
+        } catch (\Throwable $e) {
+            Log::error('Analytics accuracy evaluation failed', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+            throw $e;
+        }
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::error('EvaluateAnalyticsAccuracyJob failed permanently', [
+            'error' => $exception->getMessage(),
+            'attempts' => $this->attempts(),
+        ]);
+    }
+}

--- a/app/Models/ESBTPRelance.php
+++ b/app/Models/ESBTPRelance.php
@@ -14,20 +14,30 @@ class ESBTPRelance extends Model
 
     protected $fillable = [
         'etudiant_id',
+        'inscription_id',
         'facture_id',
         'type',
+        'canal',
         'niveau',
         'template_utilise',
         'contenu_message',
         'date_envoi',
+        'confirmee_a',
         'statut',
-        'response_data'
+        'declenchee_par',
+        'response_data',
     ];
 
     protected $casts = [
         'date_envoi' => 'datetime',
-        'response_data' => 'json'
+        'confirmee_a' => 'datetime',
+        'response_data' => 'json',
     ];
+
+    public const STATUT_INTENT = 'intent';
+    public const STATUT_ENVOYEE = 'envoyee';
+    public const STATUT_PLANIFIEE = 'planifiee';
+    public const STATUT_ECHEC = 'echec';
 
     /**
      * Relations

--- a/app/Services/RelanceActionLogger.php
+++ b/app/Services/RelanceActionLogger.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Services;
+
+use App\Domain\Notifications\ChannelDispatch;
+use App\Domain\Notifications\EtudiantContact;
+use App\Models\ESBTPRelance;
+use Illuminate\Support\Facades\Auth;
+
+/**
+ * Persiste les actions de relance dans `esbtp_relances`. Distingue 2 états :
+ *
+ * - **intent** : le comptable a cliqué le bouton (ex WhatsApp deeplink) — on
+ *   ne sait pas s'il a vraiment envoyé. Sert d'audit trail.
+ * - **envoyee** : le comptable a confirmé l'envoi via le bouton "Marqué relancé".
+ *
+ * Permet de suivre le funnel intent → envoi confirmé pour analytics futurs.
+ */
+class RelanceActionLogger
+{
+    /**
+     * Enregistre une intention de relance (clic sur un bouton canal).
+     */
+    public function logIntent(
+        EtudiantContact $contact,
+        ?int $inscriptionId,
+        ChannelDispatch $dispatch,
+        string $message,
+    ): ESBTPRelance {
+        return ESBTPRelance::create([
+            'etudiant_id' => $contact->etudiantId,
+            'inscription_id' => $inscriptionId,
+            'type' => 'recouvrement',
+            'canal' => $dispatch->channel,
+            'niveau' => 1,
+            'template_utilise' => 'recouvrement_default',
+            'contenu_message' => $message,
+            'date_envoi' => now(),
+            'statut' => $dispatch->success ? ESBTPRelance::STATUT_INTENT : ESBTPRelance::STATUT_ECHEC,
+            'declenchee_par' => Auth::id(),
+            'response_data' => $dispatch->toArray(),
+        ]);
+    }
+
+    /**
+     * Confirme qu'un envoi (intent ou direct) a effectivement eu lieu.
+     */
+    public function confirmSent(int $relanceId): ESBTPRelance
+    {
+        $relance = ESBTPRelance::findOrFail($relanceId);
+        $relance->update([
+            'statut' => ESBTPRelance::STATUT_ENVOYEE,
+            'confirmee_a' => now(),
+        ]);
+        return $relance;
+    }
+
+    /**
+     * Crée et confirme une relance en un seul INSERT (canal manuel hors-app :
+     * appel direct, en personne, etc.). Évite l'aller-retour intent → confirm.
+     */
+    public function logSent(
+        EtudiantContact $contact,
+        ?int $inscriptionId,
+        string $note,
+    ): ESBTPRelance {
+        $now = now();
+        return ESBTPRelance::create([
+            'etudiant_id' => $contact->etudiantId,
+            'inscription_id' => $inscriptionId,
+            'type' => 'recouvrement',
+            'canal' => 'manuel',
+            'niveau' => 1,
+            'template_utilise' => 'recouvrement_manuel',
+            'contenu_message' => $note,
+            'date_envoi' => $now,
+            'confirmee_a' => $now,
+            'statut' => ESBTPRelance::STATUT_ENVOYEE,
+            'declenchee_par' => Auth::id(),
+        ]);
+    }
+
+    /**
+     * Compteur d'intents par étudiant (anti-spam UX : afficher "déjà relancé X fois").
+     */
+    public function countIntentsToday(int $etudiantId): int
+    {
+        return ESBTPRelance::where('etudiant_id', $etudiantId)
+            ->where('type', 'recouvrement')
+            ->whereDate('date_envoi', today())
+            ->count();
+    }
+}

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -303,6 +303,44 @@ return [
             'icon' => 'fa-edit',
             'aliases' => ['edit_filieres'],
         ],
+        'filieres.delete' => [
+            'label' => 'Supprimer une filière',
+            'group' => 'Académique',
+            'icon' => 'fa-trash',
+            'aliases' => ['delete_filieres'],
+        ],
+
+        // ===== Années universitaires =====
+        'annees.view' => [
+            'label' => 'Voir les années universitaires',
+            'group' => 'Académique',
+            'icon' => 'fa-calendar-alt',
+            'aliases' => ['view_annees_universitaires'],
+        ],
+        'annees.create' => [
+            'label' => 'Créer une année universitaire',
+            'group' => 'Académique',
+            'icon' => 'fa-plus',
+            'aliases' => ['create_annees_universitaires'],
+        ],
+        'annees.edit' => [
+            'label' => 'Modifier une année universitaire',
+            'group' => 'Académique',
+            'icon' => 'fa-edit',
+            'aliases' => ['edit_annees_universitaires'],
+        ],
+        'annees.delete' => [
+            'label' => 'Supprimer une année universitaire',
+            'group' => 'Académique',
+            'icon' => 'fa-trash',
+            'aliases' => ['delete_annees_universitaires'],
+        ],
+        'annees.set_current' => [
+            'label' => 'Définir l\'année universitaire en cours',
+            'group' => 'Académique',
+            'icon' => 'fa-star',
+            'aliases' => ['set_current_annee_universitaire'],
+        ],
 
         // ===== Niveaux d'études =====
         'niveaux.view' => [
@@ -635,6 +673,11 @@ return [
             'label' => 'Configurer les seuils & poids du moteur analytics',
             'group' => 'Comptabilité',
             'icon' => 'fa-sliders-h',
+        ],
+        'comptabilite.recouvrement.access' => [
+            'label' => 'Accéder à la page Recouvrement quotidien (liste actionnable)',
+            'group' => 'Comptabilité',
+            'icon' => 'fa-hand-holding-usd',
         ],
         'comptabilite.relances.send' => [
             'label' => 'Envoyer des relances de paiement',
@@ -1118,6 +1161,7 @@ return [
             'comptabilite.frais.view', 'comptabilite.frais.configure',
             'comptabilite.analytics.view', 'comptabilite.analytics.refresh',
             'comptabilite.analytics.run_now', 'comptabilite.analytics.configure',
+            'comptabilite.recouvrement.access',
             'paiements.view', 'paiements.create', 'paiements.edit', 'paiements.validate',
             'paiements.export',  // Lot 15
             'frais.view', 'frais.create', 'frais.edit', 'frais.configure',

--- a/database/migrations/2026_05_01_215927_add_canal_to_esbtp_relances.php
+++ b/database/migrations/2026_05_01_215927_add_canal_to_esbtp_relances.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('esbtp_relances', function (Blueprint $table) {
+            if (!Schema::hasColumn('esbtp_relances', 'canal')) {
+                $table->string('canal', 40)->nullable()->after('type')
+                    ->comment('Canal utilisé : whatsapp_deeplink, sms, email, tel, manuel');
+            }
+            if (!Schema::hasColumn('esbtp_relances', 'inscription_id')) {
+                $table->foreignId('inscription_id')->nullable()->after('etudiant_id')
+                    ->constrained('esbtp_inscriptions')->nullOnDelete();
+            }
+            if (!Schema::hasColumn('esbtp_relances', 'declenchee_par')) {
+                $table->foreignId('declenchee_par')->nullable()->after('statut')
+                    ->constrained('users')->nullOnDelete()
+                    ->comment('Utilisateur ayant déclenché la relance (intent ou confirmé)');
+            }
+            if (!Schema::hasColumn('esbtp_relances', 'confirmee_a')) {
+                $table->timestamp('confirmee_a')->nullable()->after('date_envoi')
+                    ->comment('Quand le comptable a confirmé que la relance a été effectivement envoyée');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('esbtp_relances', function (Blueprint $table) {
+            if (Schema::hasColumn('esbtp_relances', 'confirmee_a')) {
+                $table->dropColumn('confirmee_a');
+            }
+            if (Schema::hasColumn('esbtp_relances', 'declenchee_par')) {
+                $table->dropConstrainedForeignId('declenchee_par');
+            }
+            if (Schema::hasColumn('esbtp_relances', 'inscription_id')) {
+                $table->dropConstrainedForeignId('inscription_id');
+            }
+            if (Schema::hasColumn('esbtp_relances', 'canal')) {
+                $table->dropColumn('canal');
+            }
+        });
+    }
+};

--- a/resources/views/esbtp/comptabilite/analytics/index.blade.php
+++ b/resources/views/esbtp/comptabilite/analytics/index.blade.php
@@ -16,6 +16,11 @@
                 </div>
             </div>
             <div class="an-hero-right">
+                @can('comptabilite.recouvrement.access')
+                    <a href="{{ route('esbtp.comptabilite.recouvrement.index') }}" class="an-btn an-btn--glass">
+                        <i class="fas fa-hand-holding-usd"></i> Recouvrement
+                    </a>
+                @endcan
                 @can('comptabilite.analytics.run_now')
                     <form method="POST" action="{{ route('esbtp.comptabilite.analytics.run-now') }}" class="d-inline">
                         @csrf
@@ -110,6 +115,22 @@
                 <p class="an-section-sub">Modèle saisonnier (Holt-Winters) + régression linéaire sur 24 mois d'historique.</p>
             </div>
         </div>
+
+        @if(($cashFlowAccuracy['label'] ?? null) !== null)
+            @php $accLabel = $cashFlowAccuracy['label']; @endphp
+            <div class="an-accuracy an-accuracy--{{ $accLabel }}">
+                <i class="fas fa-shield-alt"></i>
+                <span>
+                    <strong>Précision du modèle :
+                    @if($accLabel === 'excellente') Excellente
+                    @elseif($accLabel === 'bonne') Bonne
+                    @else À surveiller
+                    @endif
+                    </strong>
+                    — évaluée sur les 6 derniers mois de prédictions vs paiements réellement encaissés.
+                </span>
+            </div>
+        @endif
 
         @if($cashFlow->isAvailable())
             <div class="an-cf">
@@ -571,6 +592,22 @@
 .an-anomaly-score {
     font-size: .75rem; color: var(--an-muted); font-style: italic;
 }
+
+/* ===== Accuracy banner ===== */
+.an-accuracy {
+    display: flex; align-items: center; gap: .65rem;
+    padding: .75rem 1rem; border-radius: 10px;
+    font-size: .85rem; margin-bottom: 1rem;
+    border: 1px solid;
+}
+.an-accuracy i { font-size: 1rem; flex-shrink: 0; }
+.an-accuracy strong { font-weight: 700; }
+.an-accuracy--excellente { background: rgba(16,185,129,.06); border-color: rgba(16,185,129,.2); color: #047857; }
+.an-accuracy--excellente i { color: var(--an-success); }
+.an-accuracy--bonne { background: rgba(4,83,203,.05); border-color: rgba(4,83,203,.2); color: var(--an-primary); }
+.an-accuracy--bonne i { color: var(--an-primary); }
+.an-accuracy--a_surveiller { background: rgba(245,158,11,.06); border-color: rgba(245,158,11,.25); color: #b45309; }
+.an-accuracy--a_surveiller i { color: var(--an-warning); }
 
 /* ===== Empty / Alerts ===== */
 .an-empty {

--- a/resources/views/esbtp/comptabilite/analytics/settings.blade.php
+++ b/resources/views/esbtp/comptabilite/analytics/settings.blade.php
@@ -184,6 +184,29 @@
             </div>
         </div>
 
+        {{-- ===== Recouvrement / WhatsApp template ===== --}}
+        <div class="an-card mt-4">
+            <div class="an-section-header">
+                <div class="an-section-icon"><i class="fab fa-whatsapp"></i></div>
+                <div>
+                    <h2 class="an-section-title">Modèle de message Recouvrement</h2>
+                    <p class="an-section-sub">Template WhatsApp pré-rempli sur la page Recouvrement quotidien. Variables disponibles : <code>{prenom}</code>, <code>{nom}</code>, <code>{solde}</code>, <code>{retard}</code>, <code>{ecole}</code>.</p>
+                </div>
+            </div>
+
+            <div class="an-form-grid">
+                <div class="an-field" style="grid-column: 1 / -1;">
+                    <label class="an-field-label">Message WhatsApp
+                        <span class="an-field-help">Sera ouvert pré-rempli quand le comptable clique sur le bouton WhatsApp d'un étudiant</span>
+                    </label>
+                    <textarea name="recouvrement[whatsapp_template]" rows="4" class="an-input" maxlength="1000">{{ old('recouvrement.whatsapp_template', $settings['recouvrement']['whatsapp_template']) }}</textarea>
+                    <div class="an-field-help" style="margin-top: .5rem;">
+                        Recommandé : <em>« {{ $defaults['recouvrement']['whatsapp_template'] }} »</em>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div class="an-form-actions mt-4">
             <button type="submit" class="btn-acasi primary">
                 <i class="fas fa-save me-1"></i> Enregistrer les paramètres

--- a/resources/views/esbtp/comptabilite/recouvrement/index.blade.php
+++ b/resources/views/esbtp/comptabilite/recouvrement/index.blade.php
@@ -1,0 +1,503 @@
+@extends('layouts.app')
+
+@section('title', 'Recouvrement quotidien')
+
+@section('content')
+<div class="container-fluid re-page"
+     x-data="recouvrement(@js([
+        'rows' => $rows,
+        'whatsappTemplate' => $whatsappTemplate,
+        'schoolName' => $schoolName,
+        'logIntentUrl' => route('esbtp.comptabilite.recouvrement.log-intent'),
+        'confirmSentUrl' => route('esbtp.comptabilite.recouvrement.confirm-sent'),
+        'markDoneUrl' => route('esbtp.comptabilite.recouvrement.mark-done'),
+        'csrf' => csrf_token(),
+     ]))">
+
+    {{-- ============================ HERO ============================ --}}
+    <div class="re-hero">
+        <div class="re-hero-top">
+            <div class="re-hero-left">
+                <div class="re-hero-icon"><i class="fas fa-hand-holding-usd"></i></div>
+                <div>
+                    <h1>Recouvrement quotidien</h1>
+                    <p>Liste priorisée des étudiants à relancer aujourd'hui — appel direct, WhatsApp ou email en 1 clic.</p>
+                </div>
+            </div>
+            <div class="re-hero-right">
+                <a href="{{ route('esbtp.comptabilite.analytics.index') }}" class="re-btn re-btn--glass">
+                    <i class="fas fa-chart-line"></i> Analytics
+                </a>
+            </div>
+        </div>
+
+        <div class="re-kpis">
+            <div class="re-kpi">
+                <div class="re-kpi-icon"><i class="fas fa-fire"></i></div>
+                <div>
+                    <div class="re-kpi-value">{{ $buckets['haut'] ?? 0 }}</div>
+                    <div class="re-kpi-label">Étudiants à haut risque</div>
+                </div>
+            </div>
+
+            <div class="re-kpi">
+                <div class="re-kpi-icon"><i class="fas fa-coins"></i></div>
+                <div>
+                    <div class="re-kpi-value">{{ number_format($totalSoldeHaut, 0, ',', ' ') }} <span class="re-kpi-unit">FCFA</span></div>
+                    <div class="re-kpi-label">Solde non recouvré (haut risque)</div>
+                </div>
+            </div>
+
+            <div class="re-kpi">
+                <div class="re-kpi-icon"><i class="fas fa-eye"></i></div>
+                <div>
+                    <div class="re-kpi-value">{{ $buckets['moyen'] ?? 0 }}</div>
+                    <div class="re-kpi-label">Sous surveillance</div>
+                </div>
+            </div>
+
+            <div class="re-kpi">
+                <div class="re-kpi-icon"><i class="fas fa-users"></i></div>
+                <div>
+                    <div class="re-kpi-value">{{ $totalActifs }}</div>
+                    <div class="re-kpi-label">Total étudiants actifs</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- ============================ FILTERS ============================ --}}
+    <div class="re-filters">
+        <input type="text" class="re-input" placeholder="Rechercher par nom..." x-model="search">
+
+        <select class="re-input" x-model="levelFilter">
+            <option value="">Tous les niveaux</option>
+            <option value="haut">Haut risque uniquement</option>
+            <option value="moyen">Surveillance</option>
+            <option value="bas">Bas risque</option>
+        </select>
+
+        <select class="re-input" x-model="retardFilter">
+            <option value="">Tout retard</option>
+            <option value="30">≥ 30 jours</option>
+            <option value="60">≥ 60 jours</option>
+            <option value="90">≥ 90 jours</option>
+        </select>
+
+        <div class="re-filter-stat" x-text="`${filteredRows.length} / ${rows.length} étudiants`"></div>
+    </div>
+
+    {{-- ============================ TABLE ============================ --}}
+    <div class="re-card">
+        <template x-if="filteredRows.length === 0">
+            <div class="re-empty">
+                <i class="fas fa-check-circle"></i>
+                <p x-text="rows.length === 0 ? 'Aucun étudiant à risque dans ce périmètre.' : 'Aucun résultat avec ces filtres.'"></p>
+            </div>
+        </template>
+
+        <template x-if="filteredRows.length > 0">
+            <div class="table-responsive">
+                <table class="re-table">
+                    <thead>
+                        <tr>
+                            <th>Étudiant</th>
+                            <th>Classe</th>
+                            <th class="text-end">Solde</th>
+                            <th class="text-center">Retard</th>
+                            <th class="text-center">Niveau</th>
+                            <th class="text-center" style="min-width: 280px;">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <template x-for="row in filteredRows" :key="row.inscription_id">
+                            <tr :class="row.confirmed ? 're-row--done' : ''">
+                                <td>
+                                    <div class="re-cell-student">
+                                        <strong x-text="row.etudiant_nom"></strong>
+                                        <small x-show="!row.has_valid_phone" class="re-warn">
+                                            <i class="fas fa-exclamation-triangle"></i> Téléphone invalide
+                                        </small>
+                                        <small x-show="row.relances_today > 0" class="re-info">
+                                            <i class="fas fa-history"></i>
+                                            <span x-text="`Déjà ${row.relances_today} relance(s) aujourd'hui`"></span>
+                                        </small>
+                                    </div>
+                                </td>
+                                <td x-text="row.classe_nom"></td>
+                                <td class="text-end">
+                                    <strong x-text="formatMoney(row.solde_restant)"></strong> FCFA
+                                </td>
+                                <td class="text-center">
+                                    <span class="re-chip re-chip--retard" x-text="row.jours_retard + ' j'"></span>
+                                </td>
+                                <td class="text-center">
+                                    <span class="re-level" :class="'re-level--' + row.level" x-text="capitalize(row.level)"></span>
+                                </td>
+                                <td>
+                                    <div class="re-actions">
+                                        <button class="re-action re-action--whatsapp"
+                                                :disabled="!row.has_valid_phone || row.confirmed"
+                                                @click="dispatch(row, 'whatsapp_deeplink')"
+                                                title="Envoyer un WhatsApp">
+                                            <i class="fab fa-whatsapp"></i>
+                                        </button>
+                                        <button class="re-action re-action--tel"
+                                                :disabled="!row.has_valid_phone || row.confirmed"
+                                                @click="dispatch(row, 'tel')"
+                                                title="Appeler">
+                                            <i class="fas fa-phone"></i>
+                                        </button>
+                                        <button class="re-action re-action--email"
+                                                :disabled="!row.email || row.confirmed"
+                                                @click="dispatch(row, 'email')"
+                                                title="Envoyer un email">
+                                            <i class="fas fa-envelope"></i>
+                                        </button>
+                                        <button class="re-action re-action--done"
+                                                :disabled="row.confirmed"
+                                                @click="markDone(row)"
+                                                title="Marquer comme relancé">
+                                            <i class="fas fa-check"></i>
+                                            <span x-show="row.confirmed">Relancé</span>
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        </template>
+                    </tbody>
+                </table>
+            </div>
+        </template>
+    </div>
+
+    {{-- Toast feedback --}}
+    <div class="re-toast" x-show="toast" x-transition :class="'re-toast--' + (toastType || 'info')">
+        <i class="fas" :class="toastType === 'error' ? 'fa-exclamation-circle' : 'fa-check-circle'"></i>
+        <span x-text="toast"></span>
+    </div>
+</div>
+
+<script>
+function recouvrement(config) {
+    return {
+        rows: config.rows.map(r => ({ ...r, confirmed: false, lastRelanceId: null })),
+        search: '',
+        levelFilter: '',
+        retardFilter: '',
+        toast: null,
+        toastType: 'info',
+        config,
+
+        get filteredRows() {
+            return this.rows.filter(row => {
+                if (this.levelFilter && row.level !== this.levelFilter) return false;
+                if (this.retardFilter && row.jours_retard < parseInt(this.retardFilter)) return false;
+                if (this.search && !row.etudiant_nom.toLowerCase().includes(this.search.toLowerCase())) return false;
+                return true;
+            });
+        },
+
+        formatMoney(value) {
+            return new Intl.NumberFormat('fr-FR').format(Math.round(value || 0));
+        },
+
+        capitalize(s) {
+            return s ? s.charAt(0).toUpperCase() + s.slice(1) : '';
+        },
+
+        buildMessage(row) {
+            const prenom = row.prenoms || row.etudiant_nom.split(' ')[0];
+            return this.config.whatsappTemplate
+                .replace(/\{prenom\}/g, prenom)
+                .replace(/\{nom\}/g, row.etudiant_nom)
+                .replace(/\{solde\}/g, this.formatMoney(row.solde_restant))
+                .replace(/\{retard\}/g, row.jours_retard)
+                .replace(/\{ecole\}/g, this.config.schoolName);
+        },
+
+        async dispatch(row, channel) {
+            const message = this.buildMessage(row);
+            try {
+                const response = await fetch(this.config.logIntentUrl, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': this.config.csrf,
+                        'Accept': 'application/json',
+                    },
+                    body: JSON.stringify({
+                        inscription_id: row.inscription_id,
+                        channel: channel,
+                        message: message,
+                    }),
+                });
+                const data = await response.json();
+
+                if (!data.success) {
+                    this.showToast(data.error_reason || data.error || 'Erreur', 'error');
+                    return;
+                }
+
+                row.lastRelanceId = data.relance_id;
+                if (data.deeplink_url && data.deeplink_url !== '#') {
+                    window.open(data.deeplink_url, '_blank', 'noopener');
+                }
+                this.showToast('Action enregistrée — pensez à confirmer après envoi', 'info');
+            } catch (e) {
+                this.showToast('Erreur réseau', 'error');
+            }
+        },
+
+        async markDone(row) {
+            try {
+                let url, body;
+                if (row.lastRelanceId) {
+                    url = this.config.confirmSentUrl;
+                    body = { relance_id: row.lastRelanceId };
+                } else {
+                    url = this.config.markDoneUrl;
+                    body = { inscription_id: row.inscription_id };
+                }
+
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-TOKEN': this.config.csrf,
+                        'Accept': 'application/json',
+                    },
+                    body: JSON.stringify(body),
+                });
+                const data = await response.json();
+
+                if (data.success) {
+                    row.confirmed = true;
+                    this.showToast('Relance confirmée', 'success');
+                } else {
+                    this.showToast(data.error || 'Erreur', 'error');
+                }
+            } catch (e) {
+                this.showToast('Erreur réseau', 'error');
+            }
+        },
+
+        showToast(message, type = 'info') {
+            this.toast = message;
+            this.toastType = type;
+            setTimeout(() => { this.toast = null; }, 3500);
+        },
+    };
+}
+</script>
+@endsection
+
+@push('styles')
+<style>
+:root {
+    --re-primary: #0453cb;
+    --re-primary-d: #033a8e;
+    --re-secondary: #5e91de;
+    --re-dark: #0f172a;
+    --re-text: #1e293b;
+    --re-muted: #64748b;
+    --re-border: #e2e8f0;
+    --re-success: #10b981;
+    --re-warning: #f59e0b;
+    --re-danger: #dc2626;
+    --re-whatsapp: #25D366;
+}
+
+.re-page { padding: 1rem 0; }
+
+/* Hero */
+.re-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 2rem 2.5rem 1.75rem;
+    color: #fff;
+    margin-bottom: 1.25rem;
+    box-shadow: 0 8px 30px rgba(4,83,203,.18);
+}
+.re-hero-top {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    flex-wrap: wrap; gap: 1rem;
+}
+.re-hero-left { display: flex; align-items: center; gap: 1rem; }
+.re-hero-icon {
+    width: 52px; height: 52px; border-radius: 14px;
+    background: rgba(255,255,255,.12); backdrop-filter: blur(8px);
+    border: 1px solid rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.35rem; flex-shrink: 0; color: #fff;
+}
+.re-hero h1 { font-size: 1.45rem; font-weight: 700; color: #fff; margin: 0; }
+.re-hero p { color: rgba(255,255,255,.72); font-size: .88rem; margin: 0; }
+.re-hero-right { display: flex; gap: .5rem; flex-wrap: wrap; }
+
+.re-btn {
+    display: inline-flex; align-items: center; gap: .5rem;
+    border-radius: 10px; padding: .5rem 1rem;
+    font-size: .82rem; font-weight: 600;
+    text-decoration: none; border: none; cursor: pointer;
+    transition: all .2s ease;
+}
+.re-btn--glass {
+    background: rgba(255,255,255,.15); color: #fff;
+    border: 1px solid rgba(255,255,255,.2);
+}
+.re-btn--glass:hover {
+    background: rgba(255,255,255,.25); color: #fff;
+    transform: translateY(-1px);
+}
+
+.re-kpis { display: flex; gap: .75rem; margin-top: 1.5rem; flex-wrap: wrap; }
+.re-kpi {
+    flex: 1; min-width: 180px;
+    background: rgba(255,255,255,.1);
+    border: 1px solid rgba(255,255,255,.15);
+    border-radius: 12px;
+    padding: .9rem 1rem;
+    display: flex; align-items: center; gap: .75rem;
+}
+.re-kpi-icon {
+    width: 40px; height: 40px; border-radius: 10px;
+    background: rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1rem; color: #fff; flex-shrink: 0;
+}
+.re-kpi-value { font-size: 1.25rem; font-weight: 700; color: #fff; line-height: 1.1; }
+.re-kpi-unit { font-size: .68rem; font-weight: 500; opacity: .65; }
+.re-kpi-label { font-size: .72rem; color: rgba(255,255,255,.65); margin-top: .15rem; }
+
+/* Filters */
+.re-filters {
+    display: flex; gap: .75rem; flex-wrap: wrap; align-items: center;
+    background: #fff; padding: 1rem 1.25rem; border-radius: 12px;
+    border: 1px solid var(--re-border); margin-bottom: 1rem;
+}
+.re-input {
+    padding: .55rem .85rem; border-radius: 10px;
+    border: 1px solid var(--re-border); font-size: .88rem;
+    transition: border-color .15s ease;
+    flex: 1; min-width: 180px; max-width: 280px;
+}
+.re-input:focus {
+    outline: none; border-color: var(--re-primary);
+    box-shadow: 0 0 0 3px rgba(4,83,203,.1);
+}
+.re-filter-stat {
+    margin-left: auto; font-size: .82rem; color: var(--re-muted); font-weight: 600;
+}
+
+/* Card */
+.re-card {
+    background: #fff;
+    border: 1px solid var(--re-border);
+    border-radius: 14px;
+    padding: 0;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
+    overflow: hidden;
+}
+
+/* Table */
+.re-table { width: 100%; border-collapse: collapse; font-size: .88rem; }
+.re-table thead th {
+    background: #fafbfc; font-weight: 600; color: var(--re-text);
+    border-bottom: 2px solid var(--re-border); padding: 1rem .85rem;
+    text-align: left; font-size: .8rem; text-transform: uppercase;
+    letter-spacing: .03em;
+}
+.re-table .text-end { text-align: right; }
+.re-table .text-center { text-align: center; }
+.re-table tbody td { padding: .85rem; vertical-align: middle; border-bottom: 1px solid var(--re-border); }
+.re-table tbody tr:last-child td { border-bottom: none; }
+.re-table tbody tr:hover { background: rgba(4,83,203,.02); }
+.re-row--done { opacity: .55; background: rgba(16,185,129,.04) !important; }
+
+.re-cell-student strong { color: var(--re-dark); }
+.re-cell-student small { display: block; margin-top: .15rem; font-size: .72rem; }
+.re-warn { color: var(--re-warning); }
+.re-info { color: var(--re-muted); display: inline-flex; align-items: center; gap: .35rem; }
+.re-info i { font-size: .65rem; }
+
+.re-chip {
+    display: inline-block; padding: .25rem .6rem;
+    border-radius: 999px; font-size: .72rem; font-weight: 600;
+}
+.re-chip--retard { background: rgba(245,158,11,.12); color: #b45309; }
+
+.re-level {
+    display: inline-block; padding: .25rem .65rem;
+    border-radius: 999px; font-size: .72rem; font-weight: 600;
+}
+.re-level--haut { background: rgba(220,38,38,.12); color: var(--re-danger); }
+.re-level--moyen { background: rgba(245,158,11,.12); color: #b45309; }
+.re-level--bas { background: rgba(16,185,129,.12); color: #047857; }
+
+/* Actions */
+.re-actions { display: flex; gap: .35rem; justify-content: center; }
+.re-action {
+    width: 38px; height: 38px; border-radius: 10px;
+    border: 1px solid var(--re-border); background: #fff;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: .95rem; cursor: pointer; transition: all .15s ease;
+    color: var(--re-muted);
+}
+.re-action:hover:not(:disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(15,23,42,.08);
+}
+.re-action:disabled { opacity: .35; cursor: not-allowed; }
+
+.re-action--whatsapp { color: var(--re-whatsapp); border-color: rgba(37,211,102,.2); }
+.re-action--whatsapp:hover:not(:disabled) { background: rgba(37,211,102,.08); }
+
+.re-action--tel { color: var(--re-primary); border-color: rgba(4,83,203,.2); }
+.re-action--tel:hover:not(:disabled) { background: rgba(4,83,203,.08); }
+
+.re-action--email { color: var(--re-muted); }
+.re-action--email:hover:not(:disabled) { background: rgba(100,116,139,.08); color: var(--re-text); }
+
+.re-action--done {
+    color: var(--re-success); border-color: rgba(16,185,129,.25);
+    width: auto; padding: 0 .85rem; gap: .35rem;
+    font-size: .82rem; font-weight: 600;
+}
+.re-action--done:hover:not(:disabled) { background: rgba(16,185,129,.08); }
+
+/* Empty */
+.re-empty { text-align: center; padding: 3rem 1rem; color: var(--re-muted); }
+.re-empty i { font-size: 2.5rem; color: var(--re-success); margin-bottom: .75rem; }
+.re-empty p { margin: 0; font-size: .9rem; }
+
+/* Toast */
+.re-toast {
+    position: fixed; bottom: 24px; right: 24px;
+    padding: .85rem 1.25rem; border-radius: 12px;
+    background: #fff; box-shadow: 0 8px 30px rgba(15,23,42,.15);
+    border: 1px solid var(--re-border);
+    display: flex; align-items: center; gap: .65rem;
+    font-size: .9rem; z-index: 1000; max-width: 400px;
+}
+.re-toast--success { border-color: rgba(16,185,129,.3); color: #047857; }
+.re-toast--success i { color: var(--re-success); }
+.re-toast--error { border-color: rgba(220,38,38,.3); color: var(--re-danger); }
+.re-toast--error i { color: var(--re-danger); }
+.re-toast--info i { color: var(--re-primary); }
+
+/* Responsive */
+@media (max-width: 992px) {
+    .re-actions { flex-wrap: wrap; }
+}
+@media (max-width: 768px) {
+    .re-hero { padding: 1.5rem 1.25rem 1.25rem; }
+    .re-hero h1 { font-size: 1.2rem; }
+    .re-kpi { min-width: 140px; }
+    .re-table { font-size: .82rem; }
+    .re-table thead th, .re-table tbody td { padding: .65rem .5rem; }
+    .re-action { width: 34px; height: 34px; font-size: .85rem; }
+    .re-action--done { padding: 0 .65rem; }
+}
+</style>
+@endpush

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1997,6 +1997,20 @@
                                     <span>Relances</span>
                                 </a>
                                 @endcan
+                                {{-- Recouvrement quotidien --}}
+                                @can('comptabilite.recouvrement.access')
+                                <a href="{{ route('esbtp.comptabilite.recouvrement.index') }}" class="menu-sublink {{ Request::routeIs('esbtp.comptabilite.recouvrement.*') ? 'active' : '' }}">
+                                    <span class="menu-dot"></span>
+                                    <span>Recouvrement quotidien</span>
+                                </a>
+                                @endcan
+                                {{-- Analytics prédictifs --}}
+                                @can('comptabilite.analytics.view')
+                                <a href="{{ route('esbtp.comptabilite.analytics.index') }}" class="menu-sublink {{ Request::routeIs('esbtp.comptabilite.analytics.*') ? 'active' : '' }}">
+                                    <span class="menu-dot"></span>
+                                    <span>Analytics prédictifs</span>
+                                </a>
+                                @endcan
                             </div>
                         </div>
                     @endcan

--- a/routes/web.php
+++ b/routes/web.php
@@ -1395,6 +1395,19 @@ Route::middleware(['auth', 'comptabilite.access'])->prefix('esbtp/comptabilite')
         ->name('analytics.settings.update')
         ->middleware(['permission:comptabilite.analytics.configure', 'throttle:20,1']);
 
+    // Recouvrement quotidien (Sprint 11 — RecouvrementOptimizer + WhatsApp deeplinks)
+    Route::get('/recouvrement', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'index'])
+        ->name('recouvrement.index');
+    Route::post('/recouvrement/log-intent', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'logIntent'])
+        ->name('recouvrement.log-intent')
+        ->middleware('throttle:120,1');
+    Route::post('/recouvrement/confirm-sent', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'confirmSent'])
+        ->name('recouvrement.confirm-sent')
+        ->middleware('throttle:120,1');
+    Route::post('/recouvrement/mark-done', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'markDone'])
+        ->name('recouvrement.mark-done')
+        ->middleware('throttle:120,1');
+
     // Gestion des frais de scolarité
     Route::get('/frais-scolarite', [ESBTPComptabiliteReportController::class, 'fraisScolarite'])->name('frais-scolarite');
     Route::get('/frais-scolarite/create', [ESBTPComptabiliteFraisController::class, 'createFraisScolarite'])->name('frais-scolarite.create');

--- a/tests/Unit/Domain/Analytics/AccuracyEvaluatorTest.php
+++ b/tests/Unit/Domain/Analytics/AccuracyEvaluatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Unit\Domain\Analytics;
+
+use App\Domain\Analytics\AccuracyEvaluator;
+use PHPUnit\Framework\TestCase;
+
+class AccuracyEvaluatorTest extends TestCase
+{
+    public function test_score_perfect_match(): void
+    {
+        $this->assertSame(1.0, AccuracyEvaluator::score(1000.0, 1000.0));
+    }
+
+    public function test_score_both_zero(): void
+    {
+        $this->assertSame(1.0, AccuracyEvaluator::score(0.0, 0.0));
+    }
+
+    public function test_score_half_off(): void
+    {
+        $this->assertEqualsWithDelta(0.5, AccuracyEvaluator::score(1000.0, 500.0), 0.001);
+        $this->assertEqualsWithDelta(0.5, AccuracyEvaluator::score(500.0, 1000.0), 0.001);
+    }
+
+    public function test_score_clamped_to_zero(): void
+    {
+        $this->assertSame(0.0, AccuracyEvaluator::score(0.0, 1000.0));
+    }
+
+    public function test_score_within_bounds(): void
+    {
+        for ($i = 0; $i < 100; $i++) {
+            $a = mt_rand(0, 1_000_000);
+            $b = mt_rand(0, 1_000_000);
+            $score = AccuracyEvaluator::score((float) $a, (float) $b);
+            $this->assertGreaterThanOrEqual(0.0, $score);
+            $this->assertLessThanOrEqual(1.0, $score);
+        }
+    }
+
+    public function test_label_excellent(): void
+    {
+        $this->assertSame(AccuracyEvaluator::LABEL_EXCELLENT, AccuracyEvaluator::labelForScore(0.95));
+        $this->assertSame(AccuracyEvaluator::LABEL_EXCELLENT, AccuracyEvaluator::labelForScore(0.85));
+    }
+
+    public function test_label_good(): void
+    {
+        $this->assertSame(AccuracyEvaluator::LABEL_GOOD, AccuracyEvaluator::labelForScore(0.80));
+        $this->assertSame(AccuracyEvaluator::LABEL_GOOD, AccuracyEvaluator::labelForScore(0.70));
+    }
+
+    public function test_label_watch(): void
+    {
+        $this->assertSame(AccuracyEvaluator::LABEL_WATCH, AccuracyEvaluator::labelForScore(0.60));
+        $this->assertSame(AccuracyEvaluator::LABEL_WATCH, AccuracyEvaluator::labelForScore(0.0));
+    }
+}

--- a/tests/Unit/Domain/Notifications/PhoneNormalizerTest.php
+++ b/tests/Unit/Domain/Notifications/PhoneNormalizerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Unit\Domain\Notifications;
+
+use App\Domain\Notifications\PhoneNormalizer;
+use PHPUnit\Framework\TestCase;
+
+class PhoneNormalizerTest extends TestCase
+{
+    public function test_null_returns_null(): void
+    {
+        $this->assertNull(PhoneNormalizer::toE164(null));
+        $this->assertNull(PhoneNormalizer::toE164(''));
+        $this->assertNull(PhoneNormalizer::toE164('   '));
+    }
+
+    public function test_national_format_mtn(): void
+    {
+        $this->assertSame('+2250707123456', PhoneNormalizer::toE164('0707123456'));
+    }
+
+    public function test_national_format_orange(): void
+    {
+        $this->assertSame('+2250512345678', PhoneNormalizer::toE164('0512345678'));
+    }
+
+    public function test_national_format_with_spaces(): void
+    {
+        $this->assertSame('+2250707123456', PhoneNormalizer::toE164('07 07 12 34 56'));
+    }
+
+    public function test_national_format_with_dashes(): void
+    {
+        $this->assertSame('+2250707123456', PhoneNormalizer::toE164('07-07-12-34-56'));
+    }
+
+    public function test_already_e164(): void
+    {
+        $this->assertSame('+2250707123456', PhoneNormalizer::toE164('+2250707123456'));
+    }
+
+    public function test_double_zero_country_code(): void
+    {
+        $this->assertSame('+2250707123456', PhoneNormalizer::toE164('002250707123456'));
+    }
+
+    public function test_invalid_prefix_returns_null(): void
+    {
+        $this->assertNull(PhoneNormalizer::toE164('1234567890'));
+        $this->assertNull(PhoneNormalizer::toE164('99 99 99 99 99'));
+    }
+
+    public function test_too_short_returns_null(): void
+    {
+        $this->assertNull(PhoneNormalizer::toE164('07071234'));
+    }
+
+    public function test_too_long_returns_null(): void
+    {
+        $this->assertNull(PhoneNormalizer::toE164('070712345678901'));
+    }
+
+    public function test_letters_returns_null(): void
+    {
+        $this->assertNull(PhoneNormalizer::toE164('abc'));
+    }
+
+    public function test_to_whatsapp_id_strips_plus(): void
+    {
+        $this->assertSame('2250707123456', PhoneNormalizer::toWhatsAppId('0707123456'));
+        $this->assertNull(PhoneNormalizer::toWhatsAppId('invalid'));
+    }
+
+    public function test_is_valid(): void
+    {
+        $this->assertTrue(PhoneNormalizer::isValid('0707123456'));
+        $this->assertFalse(PhoneNormalizer::isValid('invalid'));
+        $this->assertFalse(PhoneNormalizer::isValid(null));
+    }
+}

--- a/tests/Unit/Domain/Notifications/WhatsAppDeeplinkChannelTest.php
+++ b/tests/Unit/Domain/Notifications/WhatsAppDeeplinkChannelTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Unit\Domain\Notifications;
+
+use App\Domain\Notifications\Channels\WhatsAppDeeplinkChannel;
+use App\Domain\Notifications\EtudiantContact;
+use PHPUnit\Framework\TestCase;
+
+class WhatsAppDeeplinkChannelTest extends TestCase
+{
+    public function test_dispatch_with_valid_phone_returns_deeplink(): void
+    {
+        $channel = new WhatsAppDeeplinkChannel();
+        $contact = new EtudiantContact(
+            etudiantId: 1,
+            nomComplet: 'Konan Yao',
+            phone: '0707123456',
+            email: null,
+        );
+
+        $result = $channel->dispatch($contact, 'Bonjour');
+
+        $this->assertTrue($result->success);
+        $this->assertSame('whatsapp_deeplink', $result->channel);
+        $this->assertFalse($result->automated);
+        $this->assertSame('https://wa.me/2250707123456?text=Bonjour', $result->deeplinkUrl);
+    }
+
+    public function test_dispatch_url_encodes_message(): void
+    {
+        $channel = new WhatsAppDeeplinkChannel();
+        $contact = new EtudiantContact(1, 'Test', '0707123456', null);
+
+        $result = $channel->dispatch($contact, "Bonjour Konan,\nVotre solde est 50 000 FCFA");
+
+        $this->assertStringContainsString('Bonjour%20Konan%2C%0AVotre%20solde%20est%2050%20000%20FCFA', $result->deeplinkUrl);
+    }
+
+    public function test_dispatch_with_invalid_phone_returns_unavailable(): void
+    {
+        $channel = new WhatsAppDeeplinkChannel();
+        $contact = new EtudiantContact(1, 'Test', 'invalid', null);
+
+        $result = $channel->dispatch($contact, 'Bonjour');
+
+        $this->assertFalse($result->success);
+        $this->assertNull($result->deeplinkUrl);
+        $this->assertSame('Numéro de téléphone invalide ou manquant', $result->errorReason);
+    }
+
+    public function test_dispatch_with_null_phone_returns_unavailable(): void
+    {
+        $channel = new WhatsAppDeeplinkChannel();
+        $contact = new EtudiantContact(1, 'Test', null, null);
+
+        $result = $channel->dispatch($contact, 'Bonjour');
+
+        $this->assertFalse($result->success);
+    }
+
+    public function test_is_not_automated(): void
+    {
+        $channel = new WhatsAppDeeplinkChannel();
+        $this->assertFalse($channel->isAutomated());
+        $this->assertSame('whatsapp_deeplink', $channel->name());
+    }
+}


### PR DESCRIPTION
## Summary

Sprint 11 (RecouvrementOptimizer) + Sprint 10 simplifié (Accuracy widget) — transforme DefaultRiskPredictor en workflow quotidien actionnable pour le comptable.

Contexte ivoirien : WhatsApp = canal #1, deeplinks gratuits (wa.me) sans API Meta requise.

## Sprint 11 — Recouvrement Optimizer

Page /esbtp/comptabilite/recouvrement avec :
- Hero premium namespace re-* (4 KPIs)
- Table actionnable top-N étudiants priorisés
- 4 boutons par étudiant : WhatsApp / Tel / Email / Marquer relancé
- Filtres Alpine (recherche, niveau risque, jours retard)
- Toast feedback
- Mobile-first responsive (Tecno-friendly)

Architecture extensible vers WhatsApp Business API future :
- Strategy pattern : NotificationChannelInterface + WhatsAppDeeplinkChannel
- DTOs immutables : ChannelDispatch, EtudiantContact
- Pure-math : PhoneNormalizer (CI 01/02/03/05/06/07/08/09 → +225)
- Service RelanceActionLogger : intent + confirmation séparée

## Sprint 10 — Accuracy widget

- AccuracyEvaluator : score 1 - |predicted-actual| / max
- Labels mots simples : Excellente / Bonne / À surveiller
- Job mensuel EvaluateAnalyticsAccuracyJob (1er du mois 5h Africa/Abidjan)
- Widget banner sur /analytics au-dessus de Cash Flow

## Tests

26 nouveaux unit tests (100% pass) :
- PhoneNormalizer : 13 tests (formats CI, edge cases)
- WhatsAppDeeplinkChannel : 5 tests
- AccuracyEvaluator : 8 tests
- Total Domain : 55 tests verts

## Production-grade

- 0 coût opérationnel (deeplinks gratuits)
- 0 décision business pending
- Throttling 120/min
- Validation strict
- Fallback graceful si phone invalide
- N+1 protection (CachedPredictor + JOIN whereIn pour contacts)

## Permission

comptabilite.recouvrement.access — granté comptable + superAdmin

## Test plan

- [ ] php artisan migrate (canal/inscription_id/declenchee_par/confirmee_a)
- [ ] php bin/deploy/fix_permissions.php (permission recouvrement.access)
- [ ] /esbtp/comptabilite/recouvrement rend la table avec étudiants à risque
- [ ] Bouton WhatsApp ouvre wa.me dans nouvelle tab
- [ ] Bouton Marquer relancé désactive la ligne
- [ ] /esbtp/comptabilite/analytics affiche le badge Précision
- [ ] /esbtp/comptabilite/analytics/settings permet d'éditer le template WhatsApp
- [ ] Sidebar comptabilité affiche Recouvrement + Analytics
- [ ] php artisan schedule:list montre analytics-accuracy-evaluation