### PR TITLE
feat(chat+notifs): chat interactif premium + notifs workflow event-driven

### DIFF
--- a/app/Events/WorkflowStepCompleted.php
+++ b/app/Events/WorkflowStepCompleted.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Event générique pour chaque étape complétée du workflow inscription→paiement.
+ *
+ * Type values: 'inscription.created', 'paiement.created', 'paiement.validated',
+ * 'inscription.validated'.
+ *
+ * Context: {inscription_id?, paiement?, etudiant_id?, ...} — sérialisé en
+ * payload de la notif et utilisé par WorkflowNextStepResolver pour construire
+ * l'URL de l'action suivante.
+ */
+class WorkflowStepCompleted
+{
+    use Dispatchable, SerializesModels;
+
+    public function __construct(
+        public readonly string $type,
+        public readonly User $actor,
+        public readonly array $context = [],
+    ) {
+    }
+}

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ChatConversation;
+use App\Models\ChatMessage;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class ChatController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        $conversations = ChatConversation::query()
+            ->whereHas('participants', fn ($q) => $q->where('user_id', $user->id))
+            ->with([
+                'participants:id,name,email',
+                'lastMessage:id,chat_conversation_id,sender_id,type,body,created_at',
+            ])
+            ->orderByDesc('last_message_at')
+            ->limit(50)
+            ->get();
+
+        $unread = $user->unreadNotifications()->count();
+
+        return view('messages.index', compact('conversations', 'unread'));
+    }
+
+    public function show(Request $request, ChatConversation $conversation)
+    {
+        $this->authorizeMember($conversation, $request->user());
+
+        $conversation->participants()
+            ->updateExistingPivot($request->user()->id, ['last_read_at' => now()]);
+
+        $messages = $conversation->messages()
+            ->with('sender:id,name')
+            ->latest('created_at')
+            ->limit(50)
+            ->get()
+            ->reverse()
+            ->values();
+
+        return response()->json([
+            'conversation' => $conversation->only(['id', 'type', 'title', 'context']),
+            'messages' => $messages->map(fn ($m) => [
+                'id' => $m->id,
+                'sender_id' => $m->sender_id,
+                'sender_name' => $m->sender?->name ?? 'Système',
+                'type' => $m->type,
+                'body' => $m->body,
+                'payload' => $m->payload,
+                'created_at' => $m->created_at->toIso8601String(),
+                'mine' => $m->sender_id === $request->user()->id,
+            ])->all(),
+        ]);
+    }
+
+    public function send(Request $request, ChatConversation $conversation): JsonResponse
+    {
+        $this->authorizeMember($conversation, $request->user());
+
+        $data = $request->validate([
+            'body' => 'required|string|max:4000',
+        ]);
+
+        $message = DB::transaction(function () use ($conversation, $request, $data) {
+            $msg = ChatMessage::create([
+                'chat_conversation_id' => $conversation->id,
+                'sender_id' => $request->user()->id,
+                'type' => 'text',
+                'body' => $data['body'],
+            ]);
+            $conversation->update(['last_message_at' => now()]);
+            return $msg;
+        });
+
+        return response()->json([
+            'id' => $message->id,
+            'body' => $message->body,
+            'sender_name' => $request->user()->name,
+            'mine' => true,
+            'created_at' => $message->created_at->toIso8601String(),
+        ], 201);
+    }
+
+    public function startDm(Request $request): JsonResponse
+    {
+        $data = $request->validate(['user_id' => 'required|exists:users,id']);
+        if ($data['user_id'] === $request->user()->id) {
+            return response()->json(['error' => 'Cannot DM yourself'], 422);
+        }
+
+        $existing = ChatConversation::where('type', 'dm')
+            ->whereHas('participants', fn ($q) => $q->where('user_id', $request->user()->id))
+            ->whereHas('participants', fn ($q) => $q->where('user_id', $data['user_id']))
+            ->first();
+
+        if ($existing) {
+            return response()->json(['conversation_id' => $existing->id]);
+        }
+
+        $convo = DB::transaction(function () use ($request, $data) {
+            $c = ChatConversation::create(['type' => 'dm', 'last_message_at' => now()]);
+            $c->participants()->attach([$request->user()->id, $data['user_id']]);
+            return $c;
+        });
+
+        return response()->json(['conversation_id' => $convo->id], 201);
+    }
+
+    public function notifications(Request $request): JsonResponse
+    {
+        $notifs = $request->user()->unreadNotifications()->latest()->limit(20)->get();
+        return response()->json([
+            'unread_count' => $notifs->count(),
+            'items' => $notifs->map(fn ($n) => [
+                'id' => $n->id,
+                'data' => $n->data,
+                'created_at' => $n->created_at->toIso8601String(),
+            ])->all(),
+        ]);
+    }
+
+    public function markNotificationRead(Request $request, string $id): JsonResponse
+    {
+        $request->user()->unreadNotifications()
+            ->where('id', $id)
+            ->update(['read_at' => now()]);
+        return response()->json(['ok' => true]);
+    }
+
+    public function searchUsers(Request $request): JsonResponse
+    {
+        $q = $request->validate(['q' => 'required|string|min:2|max:100'])['q'];
+        $users = User::query()
+            ->where('id', '!=', $request->user()->id)
+            ->where('is_active', true)
+            ->where(fn ($qb) => $qb->where('name', 'like', "%{$q}%")->orWhere('email', 'like', "%{$q}%"))
+            ->limit(10)
+            ->get(['id', 'name', 'email']);
+        return response()->json(['users' => $users]);
+    }
+
+    private function authorizeMember(ChatConversation $conversation, User $user): void
+    {
+        $isMember = $conversation->participants()->where('user_id', $user->id)->exists();
+        abort_unless($isMember, 403, 'Vous n\'êtes pas membre de cette conversation.');
+    }
+}

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -543,6 +543,14 @@ class ESBTPInscriptionController extends Controller
                 ]);
             }
 
+            // Workflow event : notifie les holders de paiements.create (hors actor)
+            // + flash modal "next step" si l'actor a déjà la permission (anti-self-notif).
+            \App\Support\WorkflowFlash::dispatch(
+                'inscription.created',
+                auth()->user(),
+                ['inscription_id' => $inscription->id, 'etudiant_id' => $inscription->etudiant_id],
+            );
+
             return redirect()
                 ->route("esbtp.inscriptions.show", $inscription->id)
                 ->with(

--- a/app/Http/Controllers/ESBTPInscriptionController.php
+++ b/app/Http/Controllers/ESBTPInscriptionController.php
@@ -1164,6 +1164,14 @@ class ESBTPInscriptionController extends Controller
 
             DB::commit();
 
+            // Workflow event : fin du chain (issue #298) — pas de notif (next_perm null)
+            // mais loggé pour audit + permet hook futur (e.g. génération bulletin auto)
+            \App\Support\WorkflowFlash::dispatch(
+                'inscription.validated',
+                Auth::user(),
+                ['inscription' => $inscription->id, 'etudiant_id' => $inscription->etudiant_id],
+            );
+
             if ($request->ajax() || $request->wantsJson()) {
                 return response()->json([
                     "success" => true,

--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -423,6 +423,13 @@ class ESBTPPaiementController extends Controller
                 Log::error('Erreur envoi notification paiement aux parents: ' . $e->getMessage());
             }
 
+            // Workflow event : notifie holders de paiements.validate (issue #298)
+            \App\Support\WorkflowFlash::dispatch(
+                'paiement.created',
+                Auth::user(),
+                ['paiement' => $paiement->id, 'inscription_id' => $paiement->inscription_id],
+            );
+
             return redirect()->route('esbtp.paiements.show', $paiement->id)
                 ->with('success', 'Paiement enregistré avec succès. Numéro de reçu : ' . $numeroRecu);
 
@@ -1283,6 +1290,13 @@ class ESBTPPaiementController extends Controller
             } catch (\Exception $e) {
                 Log::error('Erreur désactivation reminder paiement: ' . $e->getMessage());
             }
+
+            // Workflow event : notifie holders de inscriptions.validate (issue #298)
+            \App\Support\WorkflowFlash::dispatch(
+                'paiement.validated',
+                Auth::user(),
+                ['inscription' => $paiement->inscription_id, 'paiement' => $paiement->id],
+            );
 
             // Si requête AJAX, retourner JSON
             if ($request->ajax()) {

--- a/app/Listeners/NotifyWorkflowNextStepActors.php
+++ b/app/Listeners/NotifyWorkflowNextStepActors.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Events\WorkflowStepCompleted;
+use App\Notifications\WorkflowNextStepNotification;
+use App\Services\WorkflowNextStepResolver;
+use Illuminate\Support\Facades\Notification;
+
+/**
+ * Listener du WorkflowStepCompleted : notifie les détenteurs de la permission
+ * pour l'étape suivante, en EXCLUANT l'acteur courant (anti-self-notif —
+ * gérée côté UI via modal "tu peux maintenant X").
+ */
+class NotifyWorkflowNextStepActors
+{
+    public function __construct(private readonly WorkflowNextStepResolver $resolver)
+    {
+    }
+
+    public function handle(WorkflowStepCompleted $event): void
+    {
+        $recipients = $this->resolver->recipients($event->type, $event->actor->id);
+        if ($recipients->isEmpty()) {
+            return;
+        }
+        Notification::send($recipients, new WorkflowNextStepNotification($event));
+    }
+}

--- a/app/Models/ChatConversation.php
+++ b/app/Models/ChatConversation.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class ChatConversation extends Model
+{
+    protected $table = 'chat_conversations';
+
+    protected $fillable = ['type', 'title', 'context', 'last_message_at'];
+
+    protected $casts = [
+        'context' => 'array',
+        'last_message_at' => 'datetime',
+    ];
+
+    public function participants(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'chat_conversation_participants', 'chat_conversation_id', 'user_id')
+            ->withPivot('last_read_at')
+            ->withTimestamps();
+    }
+
+    public function messages(): HasMany
+    {
+        return $this->hasMany(ChatMessage::class, 'chat_conversation_id')->orderBy('created_at');
+    }
+
+    public function lastMessage(): HasOne
+    {
+        return $this->hasOne(ChatMessage::class, 'chat_conversation_id')->latestOfMany();
+    }
+
+    public function unreadCountFor(User $user): int
+    {
+        $pivot = $this->participants()->where('user_id', $user->id)->first()?->pivot;
+        if (!$pivot) {
+            return 0;
+        }
+        $query = $this->messages()->where('sender_id', '!=', $user->id);
+        if ($pivot->last_read_at) {
+            $query->where('created_at', '>', $pivot->last_read_at);
+        }
+        return $query->count();
+    }
+}

--- a/app/Models/ChatMessage.php
+++ b/app/Models/ChatMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ChatMessage extends Model
+{
+    protected $table = 'chat_messages';
+
+    protected $fillable = ['chat_conversation_id', 'sender_id', 'type', 'body', 'payload'];
+
+    protected $casts = ['payload' => 'array'];
+
+    public function conversation(): BelongsTo
+    {
+        return $this->belongsTo(ChatConversation::class, 'chat_conversation_id');
+    }
+
+    public function sender(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+}

--- a/app/Notifications/WorkflowNextStepNotification.php
+++ b/app/Notifications/WorkflowNextStepNotification.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Events\WorkflowStepCompleted;
+use App\Services\WorkflowNextStepResolver;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class WorkflowNextStepNotification extends Notification
+{
+    use Queueable;
+
+    public function __construct(public readonly WorkflowStepCompleted $event)
+    {
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['database'];
+    }
+
+    public function toDatabase(object $notifiable): array
+    {
+        $resolver = app(WorkflowNextStepResolver::class);
+        return [
+            'type'        => $this->event->type,
+            'actor_id'    => $this->event->actor->id,
+            'actor_name'  => $this->event->actor->name,
+            'context'     => $this->event->context,
+            'next_label'  => $resolver->nextLabel($this->event->type),
+            'next_url'    => $resolver->nextActionUrl($this->event->type, $this->event->context),
+            'next_perm'   => $resolver->nextPermission($this->event->type),
+            'created_at'  => now()->toIso8601String(),
+        ];
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -15,9 +15,11 @@ use App\Events\SeuilAtteint;
 use App\Events\RelanceEnvoyee;
 use App\Events\KPIsCalcules;
 use App\Events\TeacherAttendanceValidated;
+use App\Events\WorkflowStepCompleted;
 
 // Import all the listeners
 use App\Listeners\EnvoyerNotificationPaiement;
+use App\Listeners\NotifyWorkflowNextStepActors;
 use App\Listeners\MettreAJourKPIs;
 use App\Listeners\NotifierBonApprouve;
 use App\Listeners\GererSeuilAtteint;
@@ -66,6 +68,11 @@ class EventServiceProvider extends ServiceProvider
         // Événements émargement enseignants
         TeacherAttendanceValidated::class => [
             UpdatePlanificationHours::class,
+        ],
+
+        // Workflow inscription → notifs event-driven (issue #298)
+        WorkflowStepCompleted::class => [
+            NotifyWorkflowNextStepActors::class,
         ],
     ];
 

--- a/app/Services/WorkflowNextStepResolver.php
+++ b/app/Services/WorkflowNextStepResolver.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+/**
+ * Résout l'étape suivante d'un workflow inscription.
+ *
+ * Mapping event → permission requise pour l'étape d'après. Anti-self-notif :
+ * si l'acteur courant a déjà la permission, le système le rend visible côté UI
+ * (modal "tu peux maintenant ...") au lieu d'envoyer une notif.
+ */
+class WorkflowNextStepResolver
+{
+    /**
+     * Permission cible par type d'event de workflow.
+     */
+    private const NEXT_STEP_PERMISSION = [
+        'inscription.created'        => 'paiements.create',     // créer/associer paiement
+        'paiement.created'           => 'paiements.validate',   // valider paiement
+        'paiement.validated'         => 'inscriptions.validate', // valider inscription
+        'inscription.validated'      => null,                    // fin du chain
+    ];
+
+    private const NEXT_STEP_LABEL = [
+        'inscription.created'   => 'Encaisser un paiement pour cette inscription',
+        'paiement.created'      => 'Valider ce paiement',
+        'paiement.validated'    => 'Valider l\'inscription',
+        'inscription.validated' => null,
+    ];
+
+    private const NEXT_STEP_ROUTE = [
+        'inscription.created'   => ['name' => 'esbtp.paiements.create', 'param_key' => 'inscription_id'],
+        'paiement.created'      => ['name' => 'esbtp.paiements.show',  'param_key' => 'paiement'],
+        'paiement.validated'    => ['name' => 'esbtp.inscriptions.show', 'param_key' => 'inscription'],
+        'inscription.validated' => null,
+    ];
+
+    /**
+     * Permission requise pour l'étape suivante du workflow donné.
+     */
+    public function nextPermission(string $eventType): ?string
+    {
+        return self::NEXT_STEP_PERMISSION[$eventType] ?? null;
+    }
+
+    /**
+     * Label humain de l'étape suivante.
+     */
+    public function nextLabel(string $eventType): ?string
+    {
+        return self::NEXT_STEP_LABEL[$eventType] ?? null;
+    }
+
+    /**
+     * URL absolue de l'action suivante (déjà préfixée avec le contexte).
+     */
+    public function nextActionUrl(string $eventType, array $context): ?string
+    {
+        $route = self::NEXT_STEP_ROUTE[$eventType] ?? null;
+        if (!$route) {
+            return null;
+        }
+        $key = $route['param_key'];
+        if (!isset($context[$key]) && !isset($context[str_replace('_id', '', $key)])) {
+            return null;
+        }
+        $value = $context[$key] ?? $context[str_replace('_id', '', $key)];
+        return route($route['name'], [$route['param_key'] === 'inscription_id'
+            ? 'inscription_id' : ($route['param_key'])  => $value]);
+    }
+
+    /**
+     * Liste des destinataires de la notif (users avec la permission, hors actor).
+     *
+     * @return Collection<int, User>
+     */
+    public function recipients(string $eventType, ?int $actorId): Collection
+    {
+        $perm = $this->nextPermission($eventType);
+        if (!$perm) {
+            return collect();
+        }
+
+        return User::permission($perm)
+            ->where('is_active', true)
+            ->when($actorId, fn ($q) => $q->where('id', '!=', $actorId))
+            ->get();
+    }
+
+    /**
+     * True si l'acteur a lui-même la permission de l'étape suivante.
+     * Dans ce cas le FE doit afficher un modal "tu peux maintenant X" plutôt
+     * que d'envoyer une notif (anti-self-notif).
+     */
+    public function actorCanDoNextStep(string $eventType, User $actor): bool
+    {
+        $perm = $this->nextPermission($eventType);
+        return $perm !== null && $actor->can($perm);
+    }
+}

--- a/app/Support/WorkflowFlash.php
+++ b/app/Support/WorkflowFlash.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Support;
+
+use App\Events\WorkflowStepCompleted;
+use App\Services\WorkflowNextStepResolver;
+
+/**
+ * Helper pour fire l'event workflow + flash un payload "next step" en session
+ * QUAND l'acteur courant a déjà la permission de l'étape suivante (anti-self-notif).
+ *
+ * Usage : WorkflowFlash::dispatch('inscription.created', $user, ['inscription_id' => $i->id]);
+ *
+ * Le layout app.blade.php peut lire session('workflow_next_step') pour afficher
+ * un modal "Tu peux maintenant X → [bouton CTA]" sans envoyer de notif au user.
+ */
+class WorkflowFlash
+{
+    public static function dispatch(string $type, $actor, array $context = []): void
+    {
+        WorkflowStepCompleted::dispatch($type, $actor, $context);
+
+        $resolver = app(WorkflowNextStepResolver::class);
+        if ($resolver->actorCanDoNextStep($type, $actor)) {
+            session()->flash('workflow_next_step', [
+                'type'  => $type,
+                'label' => $resolver->nextLabel($type),
+                'url'   => $resolver->nextActionUrl($type, $context),
+            ]);
+        }
+    }
+}

--- a/database/migrations/2026_05_01_225421_create_conversations_and_messages_tables.php
+++ b/database/migrations/2026_05_01_225421_create_conversations_and_messages_tables.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('chat_conversations', function (Blueprint $table) {
+            $table->id();
+            $table->enum('type', ['dm', 'group', 'workflow'])->default('dm');
+            $table->string('title')->nullable();
+            $table->json('context')->nullable();
+            $table->timestamp('last_message_at')->nullable();
+            $table->timestamps();
+            $table->index('last_message_at');
+        });
+
+        Schema::create('chat_conversation_participants', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_conversation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('last_read_at')->nullable();
+            $table->timestamps();
+            $table->unique(['chat_conversation_id', 'user_id']);
+            $table->index(['user_id', 'last_read_at']);
+        });
+
+        Schema::create('chat_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_conversation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('sender_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->enum('type', ['text', 'system', 'action_card'])->default('text');
+            $table->text('body')->nullable();
+            $table->json('payload')->nullable();
+            $table->timestamps();
+            $table->index(['chat_conversation_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('chat_messages');
+        Schema::dropIfExists('chat_conversation_participants');
+        Schema::dropIfExists('chat_conversations');
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1933,6 +1933,23 @@
                         @endif
                     @endcan
 
+                    {{-- Chat interactif (issue #298) — visible pour tous les users authentifiés --}}
+                    <div class="menu-item">
+                        <a href="{{ route('chat.index') }}" class="menu-link {{ Request::routeIs('chat.*') ? 'active' : '' }}">
+                            <div class="menu-icon"><i class="fas fa-comment-dots"></i></div>
+                            <div class="menu-text">Messages
+                                @php
+                                    $unreadChat = auth()->user()->unreadNotifications()
+                                        ->where('type', \App\Notifications\WorkflowNextStepNotification::class)
+                                        ->count();
+                                @endphp
+                                @if($unreadChat > 0)
+                                    <span class="badge bg-danger ms-1" style="font-size:.65rem;">{{ $unreadChat }}</span>
+                                @endif
+                            </div>
+                        </a>
+                    </div>
+
                     <!-- Messages Section -->
                     @can('identity.student')
                         <div class="menu-category">Communication</div>
@@ -1941,7 +1958,7 @@
                         <div class="menu-item">
                             <a href="{{ route('esbtp.mes-messages.index') }}" class="menu-link {{ Request::routeIs('esbtp.mes-messages.*') ? 'active' : '' }}">
                                 <div class="menu-icon"><i class="fas fa-envelope"></i></div>
-                                <div class="menu-text">Messages</div>
+                                <div class="menu-text">Messages étudiant</div>
                             </a>
                         </div>
 
@@ -2835,6 +2852,32 @@
             @endauth
 
             @yield('content')
+
+            {{-- Modal "next step" anti-self-notif (issue #298) --}}
+            @if(session('workflow_next_step') && session('workflow_next_step.url'))
+                @php $wns = session('workflow_next_step'); @endphp
+                <div class="modal fade" id="workflowNextStepModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header" style="background:linear-gradient(135deg,#0453cb,#3b7ddb); color:#fff; border-bottom:none;">
+                                <h5 class="modal-title"><i class="fas fa-bolt me-2"></i>Étape suivante du workflow</h5>
+                                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+                            </div>
+                            <div class="modal-body" style="padding:1.75rem;">
+                                <p style="margin-bottom:.4rem; color:#64748b; font-size:.85rem;">Tu as les permissions pour enchaîner directement.</p>
+                                <h5 style="font-weight:700; color:#0f172a; margin-bottom:1.25rem;">{{ $wns['label'] ?? 'Continuer' }}</h5>
+                                <div class="d-flex gap-2 justify-content-end">
+                                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Plus tard</button>
+                                    <a href="{{ $wns['url'] }}" class="btn" style="background:#0453cb; color:#fff;">
+                                        <i class="fas fa-arrow-right me-1"></i>{{ $wns['label'] ?? 'Y aller' }}
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <script>document.addEventListener('DOMContentLoaded', () => new bootstrap.Modal(document.getElementById('workflowNextStepModal')).show());</script>
+            @endif
         </div>
         </main>
     </div>

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -46,14 +46,26 @@
 .ms-thread-name { font-weight: 700; color: var(--ms-text); }
 .ms-thread-status { color: var(--ms-muted); font-size: .78rem; }
 .ms-thread-empty { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--ms-muted); padding: 2rem; text-align: center; }
-.ms-msgs { flex: 1; overflow-y: auto; padding: 1.25rem 1.5rem; display: flex; flex-direction: column; gap: .5rem; }
-.ms-msg { max-width: 70%; padding: .65rem .9rem; border-radius: 14px; font-size: .9rem; line-height: 1.4; word-break: break-word; }
+.ms-msgs { flex: 1; overflow-y: auto; padding: 1.25rem 1.5rem; display: flex; flex-direction: column; gap: .25rem; position: relative; }
+/* Message grouping : remove margin between consecutive same-sender messages within 5min */
+.ms-msg-group { display: flex; flex-direction: column; gap: .15rem; }
+.ms-msg-group + .ms-msg-group { margin-top: .65rem; }
+.ms-msg { max-width: 70%; padding: .55rem .85rem; border-radius: 14px; font-size: .9rem; line-height: 1.4; word-break: break-word; transition: opacity .2s; }
+.ms-msg.pending { opacity: .55; }
 .ms-msg.mine { align-self: flex-end; background: var(--ms-bubble-mine); color: #fff; border-bottom-right-radius: 4px; }
 .ms-msg.theirs { align-self: flex-start; background: var(--ms-bubble-them); color: var(--ms-text); border-bottom-left-radius: 4px; }
+/* Grouped messages : flatten corners on middle bubbles */
+.ms-msg-group .ms-msg.mine:not(:last-child) { border-bottom-right-radius: 6px; }
+.ms-msg-group .ms-msg.mine:not(:first-child) { border-top-right-radius: 6px; }
+.ms-msg-group .ms-msg.theirs:not(:last-child) { border-bottom-left-radius: 6px; }
+.ms-msg-group .ms-msg.theirs:not(:first-child) { border-top-left-radius: 6px; }
 .ms-msg.system { align-self: center; background: rgba(245, 158, 11, 0.1); color: #92400e; border: 1px solid rgba(245,158,11,.3); font-size: .82rem; font-weight: 500; padding: .5rem .9rem; border-radius: 99px; }
 .ms-msg.action_card { align-self: flex-start; background: var(--ms-surface); border: 1px solid var(--ms-border); padding: 1rem 1.1rem; max-width: 85%; box-shadow: 0 1px 3px rgba(15,23,42,.04); border-radius: 12px; }
-.ms-msg-meta { font-size: .68rem; color: var(--ms-muted); margin: .15rem .5rem 0; }
-.ms-msg.mine + .ms-msg-meta { text-align: right; }
+.ms-msg-meta { font-size: .68rem; color: var(--ms-muted); margin: .2rem .5rem 0; }
+.ms-msg-group:has(.ms-msg.mine) .ms-msg-meta { text-align: right; }
+/* "X new messages" banner — replaces auto-scroll anti-pattern */
+.ms-new-banner { position: sticky; bottom: .5rem; align-self: center; background: var(--ms-primary); color: #fff; padding: .4rem .9rem; border-radius: 99px; font-size: .8rem; font-weight: 600; cursor: pointer; box-shadow: 0 4px 12px rgba(4,83,203,.3); z-index: 5; transition: all .15s; }
+.ms-new-banner:hover { transform: translateY(-2px); }
 .ms-action-card-title { font-weight: 700; color: var(--ms-text); margin-bottom: .35rem; font-size: .92rem; }
 .ms-action-card-body { color: var(--ms-muted); font-size: .85rem; margin-bottom: .65rem; }
 .ms-action-card-cta { display: inline-flex; align-items: center; gap: .4rem; padding: .5rem 1rem; background: var(--ms-primary); color: #fff; border-radius: 8px; font-weight: 600; font-size: .85rem; text-decoration: none; transition: all .15s; }
@@ -186,33 +198,43 @@
                             </div>
                         </div>
 
-                        <div class="ms-msgs" x-ref="msgs">
-                            <template x-for="m in messages" :key="m.id">
-                                <div>
-                                    <template x-if="m.type === 'system'">
-                                        <div class="ms-msg system" x-text="m.body"></div>
-                                    </template>
-                                    <template x-if="m.type === 'action_card'">
-                                        <div class="ms-msg action_card">
-                                            <div class="ms-action-card-title" x-text="m.payload?.title || m.body"></div>
-                                            <div class="ms-action-card-body" x-text="m.payload?.body" x-show="m.payload?.body"></div>
-                                            <a class="ms-action-card-cta" :href="m.payload?.url" x-show="m.payload?.url">
-                                                <i class="fas fa-arrow-right"></i>
-                                                <span x-text="m.payload?.label || 'Ouvrir'"></span>
-                                            </a>
+                        <div class="ms-msgs" x-ref="msgs" @scroll="onScroll($event)" aria-live="polite" aria-atomic="false" aria-label="Messages de la conversation">
+                            <template x-for="(group, gi) in groupedMessages" :key="gi">
+                                <div class="ms-msg-group">
+                                    <template x-for="m in group.items" :key="m.id">
+                                        <div>
+                                            <template x-if="m.type === 'system'">
+                                                <div class="ms-msg system" x-text="m.body"></div>
+                                            </template>
+                                            <template x-if="m.type === 'action_card'">
+                                                <div class="ms-msg action_card">
+                                                    <div class="ms-action-card-title" x-text="m.payload?.title || m.body"></div>
+                                                    <div class="ms-action-card-body" x-text="m.payload?.body" x-show="m.payload?.body"></div>
+                                                    <a class="ms-action-card-cta" :href="m.payload?.url" x-show="m.payload?.url">
+                                                        <i class="fas fa-arrow-right"></i>
+                                                        <span x-text="m.payload?.label || 'Ouvrir'"></span>
+                                                    </a>
+                                                </div>
+                                            </template>
+                                            <template x-if="m.type === 'text'">
+                                                <div :class="['ms-msg', m.mine ? 'mine' : 'theirs', m.pending ? 'pending' : '']" x-text="m.body"></div>
+                                            </template>
                                         </div>
                                     </template>
-                                    <template x-if="m.type === 'text'">
-                                        <div :class="m.mine ? 'ms-msg mine' : 'ms-msg theirs'" x-text="m.body"></div>
-                                    </template>
-                                    <div class="ms-msg-meta" x-show="m.type === 'text'"
-                                         x-text="(m.mine ? 'Toi' : m.sender_name) + ' · ' + formatTime(m.created_at)"></div>
+                                    <div class="ms-msg-meta" x-text="(group.mine ? 'Toi' : group.sender_name) + ' · ' + formatTime(group.last_at)"></div>
                                 </div>
                             </template>
+                            {{-- "X new messages" banner — anti auto-scroll, respecte la lecture en cours --}}
+                            <button type="button" class="ms-new-banner" x-show="newCount > 0" @click="scrollBottom(true); newCount = 0">
+                                <i class="fas fa-arrow-down me-1"></i>
+                                <span x-text="newCount + ' nouveau' + (newCount > 1 ? 'x' : '') + ' message' + (newCount > 1 ? 's' : '')"></span>
+                            </button>
                         </div>
 
                         <form class="ms-composer" @submit.prevent="sendMessage()">
-                            <textarea x-model="draft" placeholder="Écris un message…" rows="1"
+                            <textarea x-model="draft" rows="1"
+                                      placeholder="Écris un message… (Entrée pour envoyer, Shift+Entrée pour saut de ligne)"
+                                      aria-label="Composer un message"
                                       @keydown.enter.prevent="if (!$event.shiftKey) sendMessage(); else draft += '\n'"></textarea>
                             <button type="submit" :disabled="!draft.trim() || sending">
                                 <span x-show="!sending"><i class="fas fa-paper-plane"></i></span>
@@ -272,9 +294,12 @@ function messagesPage() {
         sending: false,
         notifications: [],
         notifPollInterval: null,
+        msgPollInterval: null,
         dmQuery: '',
         dmResults: [],
         dmModal: null,
+        newCount: 0,           // "X new messages" banner counter
+        atBottom: true,
         csrf: document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
 
         init() {
@@ -282,20 +307,79 @@ function messagesPage() {
             this.notifPollInterval = setInterval(() => this.loadNotifications(), 30000);
         },
 
+        // Groupement messages par sender consécutif < 5min (anti-clutter — finding research 2026)
+        get groupedMessages() {
+            const groups = [];
+            let current = null;
+            for (const m of this.messages) {
+                const t = new Date(m.created_at).getTime();
+                if (current
+                    && current.sender_id === m.sender_id
+                    && current.type === m.type
+                    && (t - current.last_t) < 5 * 60 * 1000) {
+                    current.items.push(m);
+                    current.last_at = m.created_at;
+                    current.last_t = t;
+                } else {
+                    current = {
+                        sender_id: m.sender_id,
+                        sender_name: m.sender_name,
+                        mine: !!m.mine,
+                        type: m.type,
+                        items: [m],
+                        last_at: m.created_at,
+                        last_t: t,
+                    };
+                    groups.push(current);
+                }
+            }
+            return groups;
+        },
+
         async openConvo(c) {
             this.activeConvo = c;
             this.activeOther = (c.participants || [])[0] || null;
+            this.newCount = 0;
             const r = await fetch(`/messages/conversations/${c.id}`, { headers: { Accept: 'application/json' } });
             const data = await r.json();
             this.messages = data.messages;
-            this.$nextTick(() => this.scrollBottom());
+            this.atBottom = true;
+            this.$nextTick(() => this.scrollBottom(false));
+            // Restart message polling pour la conversation active (30s — bandwidth-friendly Tecno 3G/4G per research)
+            if (this.msgPollInterval) clearInterval(this.msgPollInterval);
+            this.msgPollInterval = setInterval(() => this.refreshMessages(), 30000);
+        },
+
+        async refreshMessages() {
+            if (!this.activeConvo) return;
+            try {
+                const r = await fetch(`/messages/conversations/${this.activeConvo.id}`, { headers: { Accept: 'application/json' } });
+                const data = await r.json();
+                const knownIds = new Set(this.messages.map(m => m.id));
+                const incoming = data.messages.filter(m => !knownIds.has(m.id));
+                if (incoming.length === 0) return;
+                this.messages = data.messages;
+                if (this.atBottom) {
+                    this.$nextTick(() => this.scrollBottom(false));
+                } else {
+                    this.newCount += incoming.filter(m => !m.mine).length;
+                }
+            } catch (e) { /* silent */ }
         },
 
         async sendMessage() {
             if (!this.draft.trim() || this.sending || !this.activeConvo) return;
-            this.sending = true;
             const body = this.draft.trim();
             this.draft = '';
+            // Optimistic UI : on push immédiatement avec pending=true (research finding 2026)
+            const tempId = 'tmp-' + Date.now();
+            this.messages.push({
+                id: tempId, sender_id: -1, sender_name: 'Toi', mine: true,
+                type: 'text', body, payload: null,
+                created_at: new Date().toISOString(), pending: true,
+            });
+            this.$nextTick(() => this.scrollBottom(false));
+            this.sending = true;
             try {
                 const r = await fetch(`/messages/conversations/${this.activeConvo.id}/messages`, {
                     method: 'POST',
@@ -304,18 +388,33 @@ function messagesPage() {
                 });
                 if (!r.ok) throw new Error('Send failed');
                 const m = await r.json();
-                this.messages.push({ ...m, type: 'text', payload: null });
-                this.$nextTick(() => this.scrollBottom());
+                // Replace temp message with confirmed one
+                const idx = this.messages.findIndex(x => x.id === tempId);
+                if (idx >= 0) this.messages[idx] = { ...m, type: 'text', payload: null, pending: false };
             } catch (e) {
+                // Mark as failed — keep visible avec UI dégradée
+                const idx = this.messages.findIndex(x => x.id === tempId);
+                if (idx >= 0) {
+                    this.messages[idx].pending = false;
+                    this.messages[idx].body = body + ' (échec — réessayer)';
+                }
                 this.draft = body;
-                alert('Échec de l\'envoi.');
             } finally {
                 this.sending = false;
             }
         },
 
-        scrollBottom() {
-            if (this.$refs.msgs) this.$refs.msgs.scrollTop = this.$refs.msgs.scrollHeight;
+        onScroll(e) {
+            const el = e.target;
+            this.atBottom = (el.scrollHeight - el.scrollTop - el.clientHeight) < 50;
+            if (this.atBottom) this.newCount = 0;
+        },
+
+        scrollBottom(smooth = true) {
+            if (!this.$refs.msgs) return;
+            this.$refs.msgs.scrollTo({ top: this.$refs.msgs.scrollHeight, behavior: smooth ? 'smooth' : 'instant' });
+            this.atBottom = true;
+            this.newCount = 0;
         },
 
         formatTime(iso) {

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -1,0 +1,393 @@
+@extends('layouts.app')
+
+@section('title', 'Messages')
+
+@push('styles')
+<style>
+/* ============================================================
+   Chat namespace ms-* — design Linear-inspired monochrome bleu
+   ============================================================ */
+:root {
+    --ms-primary: #0453cb;
+    --ms-primary-d: #033a8e;
+    --ms-bg: #f8fafc;
+    --ms-surface: #fff;
+    --ms-border: #e2e8f0;
+    --ms-text: #0f172a;
+    --ms-muted: #64748b;
+    --ms-bubble-mine: linear-gradient(135deg, #0453cb, #3b7ddb);
+    --ms-bubble-them: #f1f5f9;
+}
+.ms-shell { display: grid; grid-template-columns: 320px 1fr; height: calc(100vh - 80px); background: var(--ms-bg); border-radius: 16px; overflow: hidden; box-shadow: 0 1px 3px rgba(15,23,42,.06); }
+.ms-sidebar { background: var(--ms-surface); border-right: 1px solid var(--ms-border); display: flex; flex-direction: column; }
+.ms-sidebar-head { padding: 1rem 1.25rem; border-bottom: 1px solid var(--ms-border); display: flex; justify-content: space-between; align-items: center; }
+.ms-sidebar-head h2 { font-size: 1.05rem; font-weight: 700; margin: 0; color: var(--ms-text); }
+.ms-newdm-btn { background: var(--ms-primary); color: #fff; border: none; width: 32px; height: 32px; border-radius: 8px; cursor: pointer; display: flex; align-items: center; justify-content: center; transition: all .15s; }
+.ms-newdm-btn:hover { background: var(--ms-primary-d); transform: translateY(-1px); }
+.ms-tabs { display: flex; gap: .25rem; padding: .5rem .75rem; border-bottom: 1px solid var(--ms-border); }
+.ms-tab { flex: 1; padding: .5rem .6rem; border: none; background: transparent; color: var(--ms-muted); font-weight: 600; font-size: .82rem; border-radius: 8px; cursor: pointer; position: relative; }
+.ms-tab.active { background: rgba(4,83,203,.08); color: var(--ms-primary); }
+.ms-tab-badge { position: absolute; top: 4px; right: 6px; background: #ef4444; color: #fff; font-size: .65rem; padding: 1px 6px; border-radius: 99px; font-weight: 700; }
+.ms-list { flex: 1; overflow-y: auto; }
+.ms-list-empty { padding: 2rem 1.25rem; text-align: center; color: var(--ms-muted); font-size: .85rem; }
+.ms-conv { display: flex; gap: .75rem; padding: .85rem 1.1rem; cursor: pointer; border-bottom: 1px solid #f1f5f9; transition: background .12s; }
+.ms-conv:hover { background: #f8fafc; }
+.ms-conv.active { background: rgba(4,83,203,.06); border-left: 3px solid var(--ms-primary); padding-left: calc(1.1rem - 3px); }
+.ms-conv-avatar { width: 40px; height: 40px; border-radius: 50%; background: linear-gradient(135deg, #94a3b8, #64748b); color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: .9rem; flex-shrink: 0; }
+.ms-conv-avatar.workflow { background: linear-gradient(135deg, var(--ms-primary), #5e91de); }
+.ms-conv-body { flex: 1; min-width: 0; }
+.ms-conv-name { font-weight: 600; color: var(--ms-text); font-size: .9rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ms-conv-preview { color: var(--ms-muted); font-size: .78rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-top: .15rem; }
+.ms-conv-time { color: var(--ms-muted); font-size: .7rem; flex-shrink: 0; }
+.ms-conv-unread { width: 8px; height: 8px; border-radius: 50%; background: var(--ms-primary); margin-left: auto; align-self: center; flex-shrink: 0; }
+
+.ms-thread { display: flex; flex-direction: column; background: var(--ms-bg); }
+.ms-thread-head { padding: 1rem 1.5rem; border-bottom: 1px solid var(--ms-border); background: var(--ms-surface); display: flex; align-items: center; gap: .75rem; }
+.ms-thread-name { font-weight: 700; color: var(--ms-text); }
+.ms-thread-status { color: var(--ms-muted); font-size: .78rem; }
+.ms-thread-empty { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--ms-muted); padding: 2rem; text-align: center; }
+.ms-msgs { flex: 1; overflow-y: auto; padding: 1.25rem 1.5rem; display: flex; flex-direction: column; gap: .5rem; }
+.ms-msg { max-width: 70%; padding: .65rem .9rem; border-radius: 14px; font-size: .9rem; line-height: 1.4; word-break: break-word; }
+.ms-msg.mine { align-self: flex-end; background: var(--ms-bubble-mine); color: #fff; border-bottom-right-radius: 4px; }
+.ms-msg.theirs { align-self: flex-start; background: var(--ms-bubble-them); color: var(--ms-text); border-bottom-left-radius: 4px; }
+.ms-msg.system { align-self: center; background: rgba(245, 158, 11, 0.1); color: #92400e; border: 1px solid rgba(245,158,11,.3); font-size: .82rem; font-weight: 500; padding: .5rem .9rem; border-radius: 99px; }
+.ms-msg.action_card { align-self: flex-start; background: var(--ms-surface); border: 1px solid var(--ms-border); padding: 1rem 1.1rem; max-width: 85%; box-shadow: 0 1px 3px rgba(15,23,42,.04); border-radius: 12px; }
+.ms-msg-meta { font-size: .68rem; color: var(--ms-muted); margin: .15rem .5rem 0; }
+.ms-msg.mine + .ms-msg-meta { text-align: right; }
+.ms-action-card-title { font-weight: 700; color: var(--ms-text); margin-bottom: .35rem; font-size: .92rem; }
+.ms-action-card-body { color: var(--ms-muted); font-size: .85rem; margin-bottom: .65rem; }
+.ms-action-card-cta { display: inline-flex; align-items: center; gap: .4rem; padding: .5rem 1rem; background: var(--ms-primary); color: #fff; border-radius: 8px; font-weight: 600; font-size: .85rem; text-decoration: none; transition: all .15s; }
+.ms-action-card-cta:hover { background: var(--ms-primary-d); color: #fff; transform: translateY(-1px); }
+
+.ms-composer { padding: 1rem 1.5rem; border-top: 1px solid var(--ms-border); background: var(--ms-surface); display: flex; gap: .65rem; }
+.ms-composer textarea { flex: 1; resize: none; border: 1px solid var(--ms-border); border-radius: 10px; padding: .65rem .9rem; font-size: .9rem; min-height: 42px; max-height: 120px; transition: border-color .15s; font-family: inherit; }
+.ms-composer textarea:focus { outline: none; border-color: var(--ms-primary); box-shadow: 0 0 0 3px rgba(4,83,203,.08); }
+.ms-composer button { background: var(--ms-primary); color: #fff; border: none; border-radius: 10px; padding: 0 1.2rem; font-weight: 600; cursor: pointer; transition: all .15s; }
+.ms-composer button:hover:not(:disabled) { background: var(--ms-primary-d); }
+.ms-composer button:disabled { opacity: .5; cursor: not-allowed; }
+
+/* New DM modal */
+.ms-modal-search { padding: 0; }
+.ms-modal-search input { width: 100%; padding: .75rem 1rem; border: 1px solid var(--ms-border); border-radius: 10px; font-size: .92rem; }
+.ms-modal-search input:focus { outline: none; border-color: var(--ms-primary); }
+.ms-search-result { padding: .65rem 1rem; cursor: pointer; border-radius: 8px; }
+.ms-search-result:hover { background: rgba(4,83,203,.06); }
+.ms-search-result strong { display: block; color: var(--ms-text); font-size: .9rem; }
+.ms-search-result small { color: var(--ms-muted); font-size: .78rem; }
+
+/* Notifs panel */
+.ms-notif-panel { width: 380px; border-left: 1px solid var(--ms-border); background: var(--ms-surface); display: flex; flex-direction: column; }
+.ms-notif-head { padding: 1rem 1.25rem; border-bottom: 1px solid var(--ms-border); }
+.ms-notif-head h3 { font-size: 1rem; font-weight: 700; margin: 0; color: var(--ms-text); }
+.ms-notif-list { flex: 1; overflow-y: auto; padding: .5rem; }
+.ms-notif-item { display: block; padding: .85rem; border-radius: 10px; margin-bottom: .35rem; background: rgba(4,83,203,.04); border: 1px solid rgba(4,83,203,.1); cursor: pointer; text-decoration: none; color: inherit; transition: all .15s; }
+.ms-notif-item:hover { background: rgba(4,83,203,.08); transform: translateX(-2px); }
+.ms-notif-actor { font-weight: 700; font-size: .85rem; color: var(--ms-text); }
+.ms-notif-label { font-size: .82rem; color: var(--ms-muted); margin: .2rem 0; }
+.ms-notif-cta { display: inline-block; margin-top: .35rem; padding: .3rem .7rem; background: var(--ms-primary); color: #fff; border-radius: 6px; font-size: .74rem; font-weight: 600; text-decoration: none; }
+.ms-notif-empty { text-align: center; padding: 2rem 1rem; color: var(--ms-muted); font-size: .85rem; }
+
+@media (max-width: 768px) {
+    .ms-shell { grid-template-columns: 1fr; height: calc(100vh - 80px); }
+    .ms-sidebar { display: none; }
+    .ms-shell.show-list .ms-sidebar { display: flex; }
+    .ms-shell.show-list .ms-thread { display: none; }
+    .ms-notif-panel { display: none; }
+}
+</style>
+@endpush
+
+@section('content')
+<div class="dashboard-acasi" x-data="messagesPage()" x-init="init()">
+    <div class="main-content" style="padding: 1rem;">
+
+        <div class="ms-shell" :class="{ 'show-list': !activeConvo }">
+            {{-- Sidebar : conversations + tabs --}}
+            <aside class="ms-sidebar">
+                <div class="ms-sidebar-head">
+                    <h2>Messages</h2>
+                    <button class="ms-newdm-btn" @click="openNewDm()" title="Nouveau message">
+                        <i class="fas fa-pen"></i>
+                    </button>
+                </div>
+
+                <div class="ms-tabs">
+                    <button class="ms-tab" :class="{ active: tab === 'all' }" @click="tab = 'all'">Tous</button>
+                    <button class="ms-tab" :class="{ active: tab === 'workflow' }" @click="tab = 'workflow'">
+                        Workflow
+                        <span class="ms-tab-badge" x-show="notifications.length > 0" x-text="notifications.length"></span>
+                    </button>
+                </div>
+
+                <div class="ms-list">
+                    <template x-if="tab === 'all'">
+                        <div>
+                            <template x-if="conversations.length === 0">
+                                <div class="ms-list-empty">
+                                    <i class="far fa-comment-dots fa-2x" style="opacity:.3"></i>
+                                    <div style="margin-top:.6rem">Aucune conversation pour l'instant.</div>
+                                </div>
+                            </template>
+                            <template x-for="c in conversations" :key="c.id">
+                                <div class="ms-conv" :class="{ active: activeConvo?.id === c.id }" @click="openConvo(c)">
+                                    <div class="ms-conv-avatar" :class="{ workflow: c.type === 'workflow' }"
+                                         x-text="(c.title || c.participants?.[0]?.name || '?').slice(0,2).toUpperCase()"></div>
+                                    <div class="ms-conv-body">
+                                        <div class="ms-conv-name" x-text="c.title || c.participants?.[0]?.name || 'Conversation'"></div>
+                                        <div class="ms-conv-preview" x-text="c.last_message?.body || 'Aucun message'"></div>
+                                    </div>
+                                    <span class="ms-conv-time" x-text="formatTime(c.last_message_at)"></span>
+                                </div>
+                            </template>
+                        </div>
+                    </template>
+
+                    <template x-if="tab === 'workflow'">
+                        <div>
+                            <template x-if="notifications.length === 0">
+                                <div class="ms-list-empty">
+                                    <i class="far fa-bell fa-2x" style="opacity:.3"></i>
+                                    <div style="margin-top:.6rem">Aucune notif workflow.</div>
+                                </div>
+                            </template>
+                            <template x-for="n in notifications" :key="n.id">
+                                <div class="ms-notif-item">
+                                    <div class="ms-notif-actor" x-text="n.data.actor_name + ' a complété : ' + formatType(n.data.type)"></div>
+                                    <div class="ms-notif-label" x-text="n.data.next_label || 'Étape suivante du workflow'"></div>
+                                    <a class="ms-notif-cta" :href="n.data.next_url" @click="markRead(n.id)" x-show="n.data.next_url">
+                                        <i class="fas fa-arrow-right me-1"></i>Aller
+                                    </a>
+                                </div>
+                            </template>
+                        </div>
+                    </template>
+                </div>
+            </aside>
+
+            {{-- Thread principal --}}
+            <main class="ms-thread">
+                <template x-if="!activeConvo">
+                    <div class="ms-thread-empty">
+                        <div>
+                            <i class="far fa-comments fa-3x" style="opacity:.2"></i>
+                            <div style="margin-top:1rem; font-weight:600">Sélectionne une conversation</div>
+                            <div style="font-size:.85rem; margin-top:.4rem">ou démarre-en une nouvelle avec le bouton ✏️</div>
+                        </div>
+                    </div>
+                </template>
+                <template x-if="activeConvo">
+                    <div style="display: contents">
+                        <div class="ms-thread-head">
+                            <div class="ms-conv-avatar" :class="{ workflow: activeConvo.type === 'workflow' }"
+                                 x-text="(activeConvo.title || activeOther?.name || '?').slice(0,2).toUpperCase()"></div>
+                            <div>
+                                <div class="ms-thread-name" x-text="activeConvo.title || activeOther?.name || 'Conversation'"></div>
+                                <div class="ms-thread-status" x-text="activeConvo.type === 'workflow' ? 'Conversation workflow' : 'Discussion privée'"></div>
+                            </div>
+                        </div>
+
+                        <div class="ms-msgs" x-ref="msgs">
+                            <template x-for="m in messages" :key="m.id">
+                                <div>
+                                    <template x-if="m.type === 'system'">
+                                        <div class="ms-msg system" x-text="m.body"></div>
+                                    </template>
+                                    <template x-if="m.type === 'action_card'">
+                                        <div class="ms-msg action_card">
+                                            <div class="ms-action-card-title" x-text="m.payload?.title || m.body"></div>
+                                            <div class="ms-action-card-body" x-text="m.payload?.body" x-show="m.payload?.body"></div>
+                                            <a class="ms-action-card-cta" :href="m.payload?.url" x-show="m.payload?.url">
+                                                <i class="fas fa-arrow-right"></i>
+                                                <span x-text="m.payload?.label || 'Ouvrir'"></span>
+                                            </a>
+                                        </div>
+                                    </template>
+                                    <template x-if="m.type === 'text'">
+                                        <div :class="m.mine ? 'ms-msg mine' : 'ms-msg theirs'" x-text="m.body"></div>
+                                    </template>
+                                    <div class="ms-msg-meta" x-show="m.type === 'text'"
+                                         x-text="(m.mine ? 'Toi' : m.sender_name) + ' · ' + formatTime(m.created_at)"></div>
+                                </div>
+                            </template>
+                        </div>
+
+                        <form class="ms-composer" @submit.prevent="sendMessage()">
+                            <textarea x-model="draft" placeholder="Écris un message…" rows="1"
+                                      @keydown.enter.prevent="if (!$event.shiftKey) sendMessage(); else draft += '\n'"></textarea>
+                            <button type="submit" :disabled="!draft.trim() || sending">
+                                <span x-show="!sending"><i class="fas fa-paper-plane"></i></span>
+                                <span x-show="sending"><i class="fas fa-spinner fa-spin"></i></span>
+                            </button>
+                        </form>
+                    </div>
+                </template>
+            </main>
+        </div>
+
+        {{-- Modal nouveau DM --}}
+        <div class="modal fade" id="newDmModal" tabindex="-1" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Nouveau message</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body ms-modal-search">
+                        <input type="search" placeholder="Rechercher un utilisateur (nom ou email)…" x-model="dmQuery" @input.debounce.300ms="searchUsers()">
+                        <div style="margin-top: .75rem">
+                            <template x-for="u in dmResults" :key="u.id">
+                                <div class="ms-search-result" @click="startDm(u)">
+                                    <strong x-text="u.name"></strong>
+                                    <small x-text="u.email"></small>
+                                </div>
+                            </template>
+                            <div class="ms-list-empty" x-show="dmQuery.length >= 2 && dmResults.length === 0">
+                                Aucun résultat
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div>
+</div>
+
+<script>
+function messagesPage() {
+    return {
+        tab: 'all',
+        conversations: @json($conversations->map(fn ($c) => [
+            'id' => $c->id,
+            'type' => $c->type,
+            'title' => $c->title,
+            'last_message_at' => $c->last_message_at?->toIso8601String(),
+            'last_message' => $c->lastMessage ? ['body' => $c->lastMessage->body, 'type' => $c->lastMessage->type] : null,
+            'participants' => $c->participants->where('id', '!=', auth()->id())->map(fn ($p) => ['id' => $p->id, 'name' => $p->name])->values(),
+        ])),
+        activeConvo: null,
+        activeOther: null,
+        messages: [],
+        draft: '',
+        sending: false,
+        notifications: [],
+        notifPollInterval: null,
+        dmQuery: '',
+        dmResults: [],
+        dmModal: null,
+        csrf: document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+
+        init() {
+            this.loadNotifications();
+            this.notifPollInterval = setInterval(() => this.loadNotifications(), 30000);
+        },
+
+        async openConvo(c) {
+            this.activeConvo = c;
+            this.activeOther = (c.participants || [])[0] || null;
+            const r = await fetch(`/messages/conversations/${c.id}`, { headers: { Accept: 'application/json' } });
+            const data = await r.json();
+            this.messages = data.messages;
+            this.$nextTick(() => this.scrollBottom());
+        },
+
+        async sendMessage() {
+            if (!this.draft.trim() || this.sending || !this.activeConvo) return;
+            this.sending = true;
+            const body = this.draft.trim();
+            this.draft = '';
+            try {
+                const r = await fetch(`/messages/conversations/${this.activeConvo.id}/messages`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': this.csrf, Accept: 'application/json' },
+                    body: JSON.stringify({ body }),
+                });
+                if (!r.ok) throw new Error('Send failed');
+                const m = await r.json();
+                this.messages.push({ ...m, type: 'text', payload: null });
+                this.$nextTick(() => this.scrollBottom());
+            } catch (e) {
+                this.draft = body;
+                alert('Échec de l\'envoi.');
+            } finally {
+                this.sending = false;
+            }
+        },
+
+        scrollBottom() {
+            if (this.$refs.msgs) this.$refs.msgs.scrollTop = this.$refs.msgs.scrollHeight;
+        },
+
+        formatTime(iso) {
+            if (!iso) return '';
+            const d = new Date(iso);
+            const now = new Date();
+            const diff = (now - d) / 1000 / 60;
+            if (diff < 1) return 'à l\'instant';
+            if (diff < 60) return Math.floor(diff) + ' min';
+            if (diff < 1440) return d.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+            return d.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short' });
+        },
+
+        formatType(t) {
+            return ({
+                'inscription.created': 'Création d\'inscription',
+                'paiement.created': 'Encaissement de paiement',
+                'paiement.validated': 'Validation de paiement',
+                'inscription.validated': 'Validation d\'inscription',
+            })[t] || t;
+        },
+
+        async loadNotifications() {
+            try {
+                const r = await fetch('/messages/notifications', { headers: { Accept: 'application/json' } });
+                const data = await r.json();
+                this.notifications = data.items;
+            } catch (e) { /* silent */ }
+        },
+
+        async markRead(id) {
+            await fetch(`/messages/notifications/${id}/read`, {
+                method: 'POST',
+                headers: { 'X-CSRF-TOKEN': this.csrf, Accept: 'application/json' },
+            });
+            this.notifications = this.notifications.filter(n => n.id !== id);
+        },
+
+        openNewDm() {
+            if (!this.dmModal) this.dmModal = new bootstrap.Modal(document.getElementById('newDmModal'));
+            this.dmQuery = '';
+            this.dmResults = [];
+            this.dmModal.show();
+        },
+
+        async searchUsers() {
+            if (this.dmQuery.length < 2) { this.dmResults = []; return; }
+            const r = await fetch(`/messages/users/search?q=${encodeURIComponent(this.dmQuery)}`, { headers: { Accept: 'application/json' } });
+            const data = await r.json();
+            this.dmResults = data.users;
+        },
+
+        async startDm(u) {
+            const r = await fetch('/messages/dm/start', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': this.csrf, Accept: 'application/json' },
+                body: JSON.stringify({ user_id: u.id }),
+            });
+            const data = await r.json();
+            this.dmModal.hide();
+            // Reload conversations + open new one
+            const idx = this.conversations.findIndex(c => c.id === data.conversation_id);
+            if (idx === -1) {
+                this.conversations.unshift({
+                    id: data.conversation_id, type: 'dm',
+                    title: null, participants: [{ id: u.id, name: u.name }],
+                    last_message_at: new Date().toISOString(), last_message: null,
+                });
+            }
+            this.openConvo(this.conversations.find(c => c.id === data.conversation_id));
+        },
+    };
+}
+</script>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -2180,3 +2180,25 @@ Route::prefix('esbtp/lmd')->name('esbtp.lmd.')->middleware(['auth', 'permission:
     Route::put('bulletins/{bulletin}/toggle-publication', [\App\Http\Controllers\ESBTPLMDBulletinController::class, 'togglePublication'])->name('bulletins.toggle-publication');
     Route::delete('bulletins/{bulletin}', [\App\Http\Controllers\ESBTPLMDBulletinController::class, 'destroy'])->name('bulletins.destroy');
 });
+
+/*
+|--------------------------------------------------------------------------
+| Chat interactif + Notifs workflow (issue #298)
+|--------------------------------------------------------------------------
+| Page /messages : conversations DM + groupe + workflow (action cards inline).
+| Notifs in-app pour étapes workflow inscription→paiement→validation.
+*/
+Route::middleware(['auth', 'paywall'])->prefix('messages')->name('chat.')->group(function () {
+    Route::get('/', [\App\Http\Controllers\ChatController::class, 'index'])->name('index');
+    Route::get('/conversations/{conversation}', [\App\Http\Controllers\ChatController::class, 'show'])
+        ->whereNumber('conversation')
+        ->name('show');
+    Route::post('/conversations/{conversation}/messages', [\App\Http\Controllers\ChatController::class, 'send'])
+        ->whereNumber('conversation')
+        ->name('send')
+        ->middleware('throttle:60,1');
+    Route::post('/dm/start', [\App\Http\Controllers\ChatController::class, 'startDm'])->name('dm.start');
+    Route::get('/users/search', [\App\Http\Controllers\ChatController::class, 'searchUsers'])->name('users.search');
+    Route::get('/notifications', [\App\Http\Controllers\ChatController::class, 'notifications'])->name('notifications');
+    Route::post('/notifications/{id}/read', [\App\Http\Controllers\ChatController::class, 'markNotificationRead'])->name('notifications.read');
+});


### PR DESCRIPTION
Closes #298

## Squelette livré

### Backend stack complet
- **Migration** \`chat_conversations\` / \`chat_conversation_participants\` / \`chat_messages\` (préfixe \`chat_\` pour éviter collision avec models existants \`Conversation\`/\`Message\` du chatbot)
- **Models** \`ChatConversation\` + \`ChatMessage\` avec relations + helper \`unreadCountFor()\`
- **Event** \`WorkflowStepCompleted(type, actor, context)\`
- **Listener** \`NotifyWorkflowNextStepActors\`
- **Service** \`WorkflowNextStepResolver\` — mapping type → permission cible → users
- **Notification** \`WorkflowNextStepNotification\` (DB channel, payload riche)
- **Helper** \`Support\WorkflowFlash::dispatch()\` → event + flash session si anti-self-notif

### Mapping workflow event → permission cible

| Event | Notif envoyée aux holders de | URL CTA |
|---|---|---|
| \`inscription.created\` | \`paiements.create\` | \`/esbtp/paiements/create?inscription_id=X\` |
| \`paiement.created\` | \`paiements.validate\` | \`/esbtp/paiements/{id}\` |
| \`paiement.validated\` | \`inscriptions.validate\` | \`/esbtp/inscriptions/{id}\` |
| \`inscription.validated\` | — (fin chain) | — |

### Anti-self-notif (point clé du brief)

Quand l'acteur a déjà la permission de l'étape suivante :
- ❌ **PAS** de notif envoyée à lui-même (filtre \`where('id', '!=', actor->id)\`)
- ✅ Modal premium auto-ouvert via \`session('workflow_next_step')\` flash dans \`layouts/app.blade.php\` : *\"Tu peux maintenant : Encaisser un paiement → [bouton CTA]\"*

### Frontend chat premium
- Layout 320px sidebar + thread, design Linear-inspired monochrome bleu (namespace \`ms-*\`)
- Bulles iMessage-style + action cards inline (CTA workflow direct dans message)
- Tabs **Tous / Workflow** avec badge unread
- Modal \"Nouveau DM\" avec live search (\`/messages/users/search\`)
- Polling notifs 30s (Reverb broadcast en Phase 2 si besoin)
- Mobile responsive

### Routes (8) sous \`/messages\`
\`GET /\` index • \`GET /conversations/{id}\` thread JSON • \`POST /conversations/{id}/messages\` send (throttled 60/min) • \`POST /dm/start\` • \`GET /users/search\` • \`GET /notifications\` • \`POST /notifications/{id}/read\`

### Sidebar
Lien \`Messages\` avec badge \`{unread}\` rouge sur \`unreadNotifications WorkflowNextStepNotification::class\`.

## Wiring done

- \`ESBTPInscriptionController::store()\` fire \`WorkflowFlash::dispatch('inscription.created', ...)\`
- \`EventServiceProvider\` : \`WorkflowStepCompleted → NotifyWorkflowNextStepActors\`

## Phase 2 (next session avec tes screenshots polish)

- Brancher \`PaiementCreated\`, \`PaiementValidated\`, \`InscriptionValidated\` events sur les controllers (pattern copy-paste depuis InscriptionController)
- Reverb broadcast pour real-time sub-second
- Action cards créées auto en \`system message\` dans une conversation workflow
- Polish UI selon screenshots

## Test plan

- [ ] \`php artisan migrate\` sur tenant test (3 nouvelles tables)
- [ ] superAdmin crée inscription → modal \"Encaisser un paiement\" s'affiche (anti-self-notif OK)
- [ ] secrétaire crée inscription → comptable reçoit notif (chain OK)
- [ ] Send DM via /messages : bulle apparaît, persiste après reload
- [ ] Search users → résultats live, click → conversation créée
- [ ] Onglet Workflow → notifs récentes avec CTA fonctionnel