### PR TITLE
fix(enseignants): RelationNotFound + modals legacy + aliases User->teacher/enseignant

### DIFF
--- a/app/Http/Controllers/ESBTPEmploiTempsController.php
+++ b/app/Http/Controllers/ESBTPEmploiTempsController.php
@@ -644,7 +644,7 @@ class ESBTPEmploiTempsController extends Controller
         // Récupérer les enseignants disponibles (tous les enseignants, mais marquer ceux qui sont assignés)
         $tousLesEnseignants = \App\Models\User::role('enseignant')
             ->where('is_active', true)
-            ->with('enseignantProfile')
+            ->with('teacherProfile')
             ->get();
 
         $enseignantsDisponibles = collect();

--- a/app/Http/Controllers/ESBTPSeanceCoursController.php
+++ b/app/Http/Controllers/ESBTPSeanceCoursController.php
@@ -266,8 +266,6 @@ class ESBTPSeanceCoursController extends Controller
             // Get default colors
             $defaultColors = ESBTPSeanceCours::DEFAULT_COLORS;
 
-            $departments = \App\Models\ESBTPDepartment::where('is_active', true)->get();
-
             $titres_academiques = [
                 'M.' => 'Monsieur',
                 'Mme' => 'Madame',
@@ -283,19 +281,6 @@ class ESBTPSeanceCoursController extends Controller
                 'professeur' => 'Professeur'
             ];
 
-            $types_contrat = [
-                'permanent' => 'Permanent',
-                'temporaire' => 'Temporaire',
-                'vacataire' => 'Vacataire',
-                'consultant' => 'Consultant'
-            ];
-
-            $statuts_emploi = [
-                'temps_plein' => 'Temps Plein',
-                'temps_partiel' => 'Temps Partiel',
-                'vacations' => 'Vacations'
-            ];
-
             return view('esbtp.seances-cours.create', compact(
                 'emploiTemps',
                 'teachers',
@@ -306,11 +291,8 @@ class ESBTPSeanceCoursController extends Controller
                 'request',
                 'planificationData',
                 'availabilityData',
-                'departments',
                 'titres_academiques',
-                'grades_academiques',
-                'types_contrat',
-                'statuts_emploi'
+                'grades_academiques'
             ));
         } catch (\Exception $e) {
             Log::error('Error in SeanceCoursController@create: '.$e->getMessage());

--- a/app/Http/Requests/Enseignant/QuickStoreEnseignantRequest.php
+++ b/app/Http/Requests/Enseignant/QuickStoreEnseignantRequest.php
@@ -25,7 +25,9 @@ class QuickStoreEnseignantRequest extends FormRequest
             'grade_academique' => 'nullable|string|max:50',
             'specialization' => 'required|string|max:255',
             'regime' => ['nullable', Rule::in(TeacherRegime::values())],
-            // type_contrat est legacy (clients AJAX antérieurs) — toléré pour rétrocompat.
+            // @deprecated 2026-Q3 — type_contrat/statut_emploi/date_embauche : retrocompat AJAX clients
+            // d'avant PR #287. Les modals quick-create modernes envoient regime + date_debut_activite.
+            // À retirer après audit confirmant zéro client legacy actif.
             'type_contrat' => 'nullable|in:permanent,temporaire,vacataire,consultant',
             'statut_emploi' => 'nullable|in:temps_plein,temps_partiel,vacations',
             'date_debut_activite' => 'nullable|date',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -129,6 +129,18 @@ class User extends Authenticatable
         return $this->hasOne(\App\Models\ESBTPTeacher::class);
     }
 
+    /** Alias rétrocompat : $user->teacher → ESBTPTeacher (utilisé par TeacherController, GradeController, NotificationController). */
+    public function teacher()
+    {
+        return $this->teacherProfile();
+    }
+
+    /** Alias rétrocompat : $user->enseignant → ESBTPTeacher (utilisé par TeacherGradeController, TeacherAttendanceController). */
+    public function enseignant()
+    {
+        return $this->teacherProfile();
+    }
+
     public function parent()
     {
         return $this->hasOne(ESBTPParent::class);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -124,6 +124,11 @@ class User extends Authenticatable
         return $this->hasOne(\App\Models\ESBTPEtudiant::class);
     }
 
+    public function teacherProfile()
+    {
+        return $this->hasOne(\App\Models\ESBTPTeacher::class);
+    }
+
     public function parent()
     {
         return $this->hasOne(ESBTPParent::class);

--- a/resources/views/esbtp/planning-general/index.blade.php
+++ b/resources/views/esbtp/planning-general/index.blade.php
@@ -2228,10 +2228,6 @@
                         </div>
                     </div>
 
-                    @php
-                        $teacherDepartments = \App\Models\ESBTPDepartment::where('is_active', true)->orderBy('name')->get();
-                    @endphp
-
                     <div class="row g-3">
                         <div class="col-md-6">
                             <label class="form-label">Nom complet <span class="text-danger">*</span></label>
@@ -2250,40 +2246,24 @@
                             <input type="text" name="specialization" class="form-control" required>
                         </div>
                         <div class="col-md-6">
-                            <label class="form-label">Département <span class="text-danger">*</span></label>
-                            <select name="department_id" class="form-select" required>
-                                <option value="">Sélectionner</option>
-                                @foreach($teacherDepartments as $department)
-                                    <option value="{{ $department->id }}">{{ $department->name }}</option>
+                            <label class="form-label">Régime <span class="text-danger">*</span></label>
+                            <select name="regime" class="form-select" required>
+                                @foreach(\App\Enums\TeacherRegime::cases() as $regime)
+                                    <option value="{{ $regime->value }}" {{ $regime === \App\Enums\TeacherRegime::Vacataire ? 'selected' : '' }}>
+                                        {{ $regime->label() }} — {{ $regime->description() }}
+                                    </option>
                                 @endforeach
                             </select>
                         </div>
                         <div class="col-md-6">
-                            <label class="form-label">Type de contrat <span class="text-danger">*</span></label>
-                            <select name="type_contrat" class="form-select" required>
-                                <option value="">Sélectionner</option>
-                                <option value="permanent">Permanent</option>
-                                <option value="temporaire">Temporaire</option>
-                                <option value="vacataire">Vacataire</option>
-                                <option value="consultant">Consultant</option>
-                            </select>
-                        </div>
-                        <div class="col-md-6">
-                            <label class="form-label">Statut d'emploi <span class="text-danger">*</span></label>
-                            <select name="statut_emploi" class="form-select" required>
-                                <option value="">Sélectionner</option>
-                                <option value="temps_plein">Temps Plein</option>
-                                <option value="temps_partiel">Temps Partiel</option>
-                                <option value="vacations">Vacations</option>
-                            </select>
-                        </div>
-                        <div class="col-md-6">
-                            <label class="form-label">Date d'embauche <span class="text-danger">*</span></label>
-                            <input type="date" name="date_embauche" class="form-control" required>
+                            <label class="form-label">Date de début d'activité</label>
+                            <input type="date" name="date_debut_activite" class="form-control" value="{{ now()->toDateString() }}">
+                            <small class="text-muted">Pré-rempli à aujourd'hui. Modifiable.</small>
                         </div>
                         <div class="col-md-6">
                             <label class="form-label">Charge horaire max/semaine</label>
                             <input type="number" name="charge_horaire_max_semaine" class="form-control" min="1" max="60" value="40">
+                            <small class="text-muted">Utilisé uniquement pour les enseignants Permanents.</small>
                         </div>
                     </div>
                 </div>

--- a/resources/views/esbtp/seances-cours/create.blade.php
+++ b/resources/views/esbtp/seances-cours/create.blade.php
@@ -640,7 +640,7 @@
                                 </select>
                             </div>
                         </div>
-                        <div class="col-lg-6">
+                        <div class="col-lg-12">
                             <div class="form-group">
                                 <label class="form-label">Spécialisation <span class="text-danger">*</span></label>
                                 <input type="text" name="specialization" id="teacher_specialization" class="form-control" required>
@@ -648,44 +648,23 @@
                         </div>
                         <div class="col-lg-6">
                             <div class="form-group">
-                                <label class="form-label">Département <span class="text-danger">*</span></label>
-                                <select name="department_id" id="teacher_department" class="form-select" required>
-                                    <option value="">Sélectionner</option>
-                                    @foreach($departments as $department)
-                                        <option value="{{ $department->id }}">{{ $department->name }}</option>
+                                <label class="form-label">Régime <span class="text-danger">*</span></label>
+                                <select name="regime" id="teacher_regime" class="form-select" required>
+                                    @foreach(\App\Enums\TeacherRegime::cases() as $regime)
+                                        <option value="{{ $regime->value }}" {{ $regime === \App\Enums\TeacherRegime::Vacataire ? 'selected' : '' }}>
+                                            {{ $regime->label() }} — {{ $regime->description() }}
+                                        </option>
                                     @endforeach
                                 </select>
                             </div>
                         </div>
-                        <div class="col-lg-4">
+                        <div class="col-lg-3">
                             <div class="form-group">
-                                <label class="form-label">Type de contrat <span class="text-danger">*</span></label>
-                                <select name="type_contrat" id="teacher_contract" class="form-select" required>
-                                    <option value="">Sélectionner</option>
-                                    @foreach($types_contrat as $key => $value)
-                                        <option value="{{ $key }}">{{ $value }}</option>
-                                    @endforeach
-                                </select>
+                                <label class="form-label">Date de début d'activité</label>
+                                <input type="date" name="date_debut_activite" id="teacher_hire_date" class="form-control" value="{{ now()->toDateString() }}">
                             </div>
                         </div>
-                        <div class="col-lg-4">
-                            <div class="form-group">
-                                <label class="form-label">Statut d'emploi <span class="text-danger">*</span></label>
-                                <select name="statut_emploi" id="teacher_status" class="form-select" required>
-                                    <option value="">Sélectionner</option>
-                                    @foreach($statuts_emploi as $key => $value)
-                                        <option value="{{ $key }}">{{ $value }}</option>
-                                    @endforeach
-                                </select>
-                            </div>
-                        </div>
-                        <div class="col-lg-4">
-                            <div class="form-group">
-                                <label class="form-label">Date d'embauche <span class="text-danger">*</span></label>
-                                <input type="date" name="date_embauche" id="teacher_hire_date" class="form-control" required>
-                            </div>
-                        </div>
-                        <div class="col-lg-4">
+                        <div class="col-lg-3">
                             <div class="form-group">
                                 <label class="form-label">Charge horaire max/semaine</label>
                                 <input type="number" name="charge_horaire_max_semaine" id="teacher_weekly_hours" class="form-control" min="1" max="60" value="40">


### PR DESCRIPTION
## Bug rapporté par Marcel

`RelationNotFoundException: Call to undefined relationship [enseignantProfile] on model [App\Models\User]` sur la page `/esbtp/planning-general`. Plus modals quick-create avec champs obsolètes (Département, Type contrat, Statut emploi, Date embauche).

## Root cause

La PR #290 a supprimé le modèle `ESBTPEnseignantProfile` et la relation `User::enseignantProfile()`, mais 3 endroits actifs y faisaient référence :
1. `ESBTPEmploiTempsController:647` : `with('enseignantProfile')` 
2. Modal `planning-general/index.blade.php#teacherCreateModal` : champs obsolètes
3. Modal `seances-cours/create.blade.php` : champs obsolètes

Et **5 autres callsites prod hard-broken** découverts par les review agents simplify :
- `TeacherController:381,421` (`->teacher`)
- `GradeController:122` (`->teacher`)
- `NotificationController:296` (`->teacher`)
- `TeacherGradeController:194,301,372,410,474,500,533` (`->enseignant`)
- `ESBTP/TeacherAttendanceController:61,67` (`->enseignant`)

## Fix

### Commit 1 (`d75185a4`)
- `User::teacherProfile()` hasOne(ESBTPTeacher) ajoutée
- `ESBTPEmploiTempsController` : `with('enseignantProfile')` → `with('teacherProfile')`
- Modal planning-general : Département/Contrat/Statut/Embauche → Régime + Date début activité (utilise `TeacherRegime::cases()`)
- Modal seances-cours : même refonte
- `ESBTPSeanceCoursController` : retire `\$departments` / `\$types_contrat` / `\$statuts_emploi` du compact() — économise 1 query par page load

### Commit 2 (`b233d6fa`) — simplify findings
- `User::teacher()` + `User::enseignant()` aliases vers `teacherProfile()` — répare 12+ callsites prod sans toucher chaque controller
- `@deprecated 2026-Q3` sur `type_contrat`/`statut_emploi`/`date_embauche` dans `QuickStoreEnseignantRequest::rules()` (symétrique au `@deprecated` déjà sur `ESBTPEnseignantController:200`)

## Verification

- [x] `php -l` clean
- [x] Grep `enseignantProfile|enseignant_profile|EnseignantProfile` retourne 0 dans `app/` et `resources/views/`
- [x] Grep `type_contrat|statut_emploi|date_embauche` retourne 0 dans `resources/views/` (sauf le @deprecated FormRequest)
- [x] 3 review agents simplify : reuse + quality + efficiency = approve

## Économies perf

- `/esbtp/planning-general` : -1 query par render (`ESBTPDepartment::where(is_active)->orderBy(name)->get()`)
- `/esbtp/seances-cours/create` : -1 query par render (même)

## Test plan

- [ ] `/esbtp/planning-general` charge sans erreur
- [ ] Modal "Créer un enseignant" sur planning-general affiche Régime + Date début activité (plus de Département/Contrat/Statut/Embauche)
- [ ] Submit modal → enseignant créé OK
- [ ] `/esbtp/seances-cours/create` charge + modal teacher OK
- [ ] `/esbtp/teacher-grades` (TeacherGradeController) charge sans `RelationNotFound` (alias `enseignant()`)