### PR TITLE
feat(exports): pattern unifié PDF/Excel + preview + premium settings (Plan C 1-7)

### DIFF
--- a/.claude/rules/exports-pdf-excel.md
+++ b/.claude/rules/exports-pdf-excel.md
@@ -1,0 +1,168 @@
+# Rule: Exports PDF + Excel — Pattern unifié KLASSCI
+
+## Quand s'active
+
+À chaque fois qu'une page liste/dashboard/rapport doit pouvoir être exportée en PDF ou Excel par l'utilisateur (comptable, secrétaire, admin), ou quand on touche un fichier qui ressemble à un export :
+- Controller avec méthode `export*()` / `download*()` / `pdf*()`
+- Vue Blade dans `resources/views/**/pdf/**` ou `resources/views/**/exports/**`
+- Classe dans `app/Exports/`
+- Service `*ExportService` ou `*Export.php`
+
+## Architecture imposée
+
+### 1. Composant Blade `<x-pdf-document>` OBLIGATOIRE
+
+**JAMAIS recopier** un header/footer PDF dans un nouveau template. Utiliser le composant unifié :
+
+```blade
+<x-pdf-document
+    title="Recouvrement quotidien"
+    subtitle="Liste priorisée des étudiants à relancer"
+    :filters="['Filière' => 'BTS Compta', 'Niveau de risque' => 'Haut']"
+    orientation="landscape">
+    
+    <table class="report-table">
+        ...
+    </table>
+</x-pdf-document>
+```
+
+Le composant fait automatiquement :
+- Header logo + nom école + adresse + téléphone (via `SettingsHelper::getSchoolInfo()`)
+- Theme colors via `SettingsHelper::getPdfSettings()` (header_bg, primary, secondary, accent, text)
+- Marges configurables via PDF settings (`margin_top/bottom/left/right`)
+- Watermark si configuré
+- Footer paginé "Page X / Y" + date génération + utilisateur + nom directeur
+- Bandeau filtres appliqués via `<x-pdf-filters-recap>` si props `:filters` non vide
+
+### 2. Classe abstraite `ExportableReport` OBLIGATOIRE
+
+Tout export DOIT passer par une concrete class qui hérite de `App\Domain\Exports\ExportableReport`. Pas d'export direct dans un controller.
+
+```php
+class RecouvrementReport extends ExportableReport
+{
+    public function __construct(private array $rows, private array $appliedFilters) {}
+    
+    public function title(): string { return 'Recouvrement quotidien'; }
+    public function pdfView(): string { return 'esbtp.comptabilite.recouvrement.pdf'; }
+    public function viewData(): array { return ['rows' => $this->rows]; }
+    public function excelExport(): FromCollection { return new RecouvrementExport($this->rows); }
+    public function filters(): array { return $this->appliedFilters; }
+    public function orientation(): string { return 'landscape'; }
+}
+```
+
+### 3. Service `ExportRenderer` OBLIGATOIRE
+
+Tout rendu PDF passe par `App\Services\ExportRenderer`. Pas d'appel direct à `Pdf::loadView(...)` dans un controller.
+
+```php
+public function previewPdf(Request $request, ExportRenderer $renderer)
+{
+    $report = new RecouvrementReport($this->buildRows($request), $this->buildFilters($request));
+    return $renderer->pdfPreview($report);  // inline new tab
+}
+
+public function downloadPdf(Request $request, ExportRenderer $renderer)
+{
+    $report = new RecouvrementReport(...);
+    return $renderer->pdfDownload($report);  // attachment
+}
+
+public function downloadExcel(Request $request, ExportRenderer $renderer)
+{
+    $report = new RecouvrementReport(...);
+    return $renderer->excelDownload($report);
+}
+```
+
+### 4. Composant `<x-export-modal>` pour l'UI OBLIGATOIRE
+
+Toute page exportable utilise le dropdown standard (placé dans le hero) :
+
+```blade
+<x-export-modal
+    :preview-url="route('esbtp.comptabilite.recouvrement.preview-pdf')"
+    :pdf-url="route('esbtp.comptabilite.recouvrement.export-pdf')"
+    :excel-url="route('esbtp.comptabilite.recouvrement.export-excel')"
+    :email-url="route('esbtp.comptabilite.recouvrement.email-pdf')" />
+```
+
+### 5. Filtres reproduits server-side OBLIGATOIRE
+
+Les filtres actifs côté UI (search, niveau, période) doivent être reproduits server-side pour que l'export reflète exactement la vue. Pattern :
+
+```js
+// Dans Alpine, exposer les filtres globalement
+window.exportFilters = () => ({
+    level: this.levelFilter,
+    retard_min: this.retardFilter,
+    search: this.search,
+});
+```
+
+`<x-export-modal>` les ajoute en query string aux URLs avant ouverture.
+
+### 6. Téléphone CI au format lisible OBLIGATOIRE
+
+Quand un export contient une colonne téléphone, **toujours** formater via `App\Domain\Notifications\PhoneFormatter::toReadable()` qui retourne `+225 07 07 12 34 56`. Si numéro invalide, afficher `—`.
+
+Pour Excel, déclarer la colonne en `WithColumnFormatting` format `'@'` (text) sinon Excel perd le `+` initial.
+
+### 7. Garde-fous volume OBLIGATOIRES
+
+```php
+public const PDF_MAX_ROWS = 1000;
+public const EXCEL_MAX_ROWS = 50000;
+```
+
+À implémenter dans la classe `*Report` ou via le service. Au-delà, retour 422 avec message clair "Affinez les filtres".
+
+### 8. Throttling routes export OBLIGATOIRE
+
+Toutes les routes d'export sont throttlées pour éviter abus :
+
+```php
+Route::get('/preview-pdf', ...)->middleware('throttle:30,1');
+Route::get('/export-pdf', ...)->middleware('throttle:10,1');
+Route::get('/export-excel', ...)->middleware('throttle:10,1');
+```
+
+## Cache PDF (Phase 6)
+
+`ExportRenderer::pdfDownload()` cache le binaire PDF par `$report->cacheKey()` (hash des filtres + data) pour 5 min via `Cache::remember`. Désactivable via setting `analytics.exports.cache_enabled`.
+
+`pdfPreview()` ne cache PAS (preview = doit toujours refléter l'état réel courant).
+
+## Email PDF (Phase 7)
+
+Bouton "Envoyer par email" dans `<x-export-modal>` → POST vers route `email-pdf` → dispatch `ExportableReportMail` queued.
+
+## Export programmé (Phase 8)
+
+Modèle `ExportSchedule` (id, user_id, report_class, frequency, cron, recipients, filters_json, est_actif). Job `SendScheduledExportJob` scheduled hourly check qui dispatch les exports dont `prochaine_execution <= now()`.
+
+## Anti-patterns à BLOQUER en review
+
+1. ❌ `Pdf::loadView('mytemplate', ...)` direct dans un controller — utiliser ExportRenderer
+2. ❌ Copier-coller le header `pdf-header` dans un nouveau template — utiliser `<x-pdf-document>`
+3. ❌ Excel avec téléphone sans `WithColumnFormatting('@')` — perd le `+`
+4. ❌ Export sans aperçu (download direct) — toujours offrir l'aperçu
+5. ❌ Pas de garde-fou volume — DomPDF crash sur 5000+ lignes
+6. ❌ Hardcoder colors dans le template PDF — utiliser `SettingsHelper::getPdfSettings()`
+7. ❌ Pas de throttle sur routes export — abus possible
+8. ❌ Filtres ignorés à l'export (export TOUT au lieu de la vue filtrée) — bug
+
+## Migration des templates legacy
+
+Les templates legacy (`liste-complete-pdf.blade.php`, `bulletin-pdf.blade.php`, etc.) ne sont **pas obligés** de migrer immédiatement vers `<x-pdf-document>`. Mais TOUT NOUVEAU template DOIT l'utiliser. Migration progressive au fil des touches.
+
+## Voir aussi
+
+- Mémoire projet : `analytics-superalgorithm-spec.md` — contexte exports analytics
+- Composants : `resources/views/components/pdf-document.blade.php`
+- Service : `app/Services/ExportRenderer.php`
+- Contrat : `app/Domain/Exports/ExportableReport.php`
+- Helper téléphone : `app/Domain/Notifications/PhoneFormatter.php`
+- Maatwebsite/Excel : `composer.json` `^3.1`

--- a/app/Domain/Exports/ExportableReport.php
+++ b/app/Domain/Exports/ExportableReport.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Domain\Exports;
+
+use Illuminate\Support\Str;
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+/**
+ * Contrat d'un rapport exportable (PDF + Excel + preview). Toute nouvelle page
+ * qui veut exporter implémente cette classe abstraite via une concrete Report
+ * (ex: RecouvrementReport, AnalyticsReport, PaiementsReport).
+ *
+ * Le service ExportRenderer consomme cette interface uniformément.
+ */
+abstract class ExportableReport
+{
+    abstract public function title(): string;
+    abstract public function pdfView(): string;
+    abstract public function viewData(): array;
+    abstract public function excelExport(): FromCollection;
+
+    public function subtitle(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * Récap des filtres appliqués pour affichage en bandeau du PDF.
+     * Format : ['Filière' => 'BTS Compta', 'Période' => 'Avr 2026', ...]
+     *
+     * @return array<string, string>
+     */
+    public function filters(): array
+    {
+        return [];
+    }
+
+    public function paper(): string
+    {
+        return 'A4';
+    }
+
+    public function orientation(): string
+    {
+        return 'portrait';
+    }
+
+    public function filename(): string
+    {
+        return Str::slug($this->title()) . '_' . now()->format('Ymd_His');
+    }
+
+    /**
+     * Hash stable des FILTRES pour clé cache PDF. N'inclut PAS viewData
+     * (peut peser MB) ni les payloads — le cache est invalide si filtres
+     * changent, et expiré au TTL pour les nouveaux calculs prédictifs.
+     */
+    public function cacheKey(): string
+    {
+        return hash('sha256', json_encode([
+            'view' => $this->pdfView(),
+            'filters' => $this->filters(),
+        ]));
+    }
+}

--- a/app/Domain/Exports/Reports/AnalyticsReport.php
+++ b/app/Domain/Exports/Reports/AnalyticsReport.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Domain\Exports\Reports;
+
+use App\Domain\Analytics\DTOs\PredictionResult;
+use App\Domain\Exports\ExportableReport;
+use App\Exports\AnalyticsExport;
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+/**
+ * Report Analytics : agrège CashFlow + DefaultRisk + Anomalies pour
+ * export multi-sections (PDF page 1 / Excel multi-sheets).
+ */
+class AnalyticsReport extends ExportableReport
+{
+    public function __construct(
+        private readonly PredictionResult $cashFlow,
+        private readonly PredictionResult $defaultRisk,
+        private readonly array $anomalies,
+        private readonly array $appliedFilters = [],
+    ) {}
+
+    public function title(): string
+    {
+        return 'Analytics financiers';
+    }
+
+    public function subtitle(): ?string
+    {
+        return 'Synthèse des prédictions cash flow, risque et anomalies — '
+            . now()->locale('fr')->translatedFormat('F Y');
+    }
+
+    public function pdfView(): string
+    {
+        return 'esbtp.comptabilite.analytics.pdf';
+    }
+
+    public function viewData(): array
+    {
+        return [
+            'cashFlow' => $this->cashFlow,
+            'defaultRisk' => $this->defaultRisk,
+            'anomalies' => $this->anomalies,
+        ];
+    }
+
+    public function excelExport(): FromCollection
+    {
+        return new AnalyticsExport($this->cashFlow, $this->defaultRisk, $this->anomalies, $this->appliedFilters);
+    }
+
+    public function filters(): array
+    {
+        return $this->appliedFilters;
+    }
+
+    public function orientation(): string
+    {
+        return 'portrait';
+    }
+
+    public function filename(): string
+    {
+        return 'analytics_' . now()->format('Ymd_His');
+    }
+}

--- a/app/Domain/Exports/Reports/RecouvrementReport.php
+++ b/app/Domain/Exports/Reports/RecouvrementReport.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Domain\Exports\Reports;
+
+use App\Domain\Exports\ExportableReport;
+use App\Exports\RecouvrementExport;
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+/**
+ * Report Recouvrement quotidien — top-N étudiants à risque enrichis.
+ * Consommé par ESBTPRecouvrementController pour preview/PDF/Excel via
+ * App\Services\ExportRenderer.
+ */
+class RecouvrementReport extends ExportableReport
+{
+    public function __construct(
+        private readonly array $rows,
+        private readonly array $appliedFilters = [],
+        private readonly array $kpis = [],
+    ) {}
+
+    public function title(): string
+    {
+        return 'Recouvrement quotidien';
+    }
+
+    public function subtitle(): ?string
+    {
+        return 'Liste priorisée des étudiants à relancer';
+    }
+
+    public function pdfView(): string
+    {
+        return 'esbtp.comptabilite.recouvrement.pdf';
+    }
+
+    public function viewData(): array
+    {
+        return [
+            'rows' => $this->rows,
+            'kpis' => $this->kpis,
+        ];
+    }
+
+    public function excelExport(): FromCollection
+    {
+        return new RecouvrementExport($this->rows, $this->appliedFilters);
+    }
+
+    public function filters(): array
+    {
+        return $this->appliedFilters;
+    }
+
+    public function orientation(): string
+    {
+        return 'landscape';
+    }
+
+    public function filename(): string
+    {
+        return 'recouvrement_' . now()->format('Ymd_His');
+    }
+}

--- a/app/Domain/Notifications/PhoneFormatter.php
+++ b/app/Domain/Notifications/PhoneFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Domain\Notifications;
+
+/**
+ * Formate les numéros de téléphone CI pour affichage humain.
+ * Pure compute, pas de dépendance Laravel. Complète PhoneNormalizer.
+ */
+final class PhoneFormatter
+{
+    /**
+     * Format lisible "+225 07 07 12 34 56" depuis n'importe quel input valide.
+     * Retourne null si invalide (le caller affichera "—" ou similaire).
+     */
+    public static function toReadable(?string $raw): ?string
+    {
+        $e164 = PhoneNormalizer::toE164($raw);
+        if ($e164 === null) {
+            return null;
+        }
+
+        // E.164 = +225XXXXXXXXXX (3 chiffres pays + 10 nationaux)
+        $national = substr($e164, 4);
+        $pairs = str_split($national, 2);
+
+        return '+225 ' . implode(' ', $pairs);
+    }
+}

--- a/app/Exports/AnalyticsExport.php
+++ b/app/Exports/AnalyticsExport.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace App\Exports;
+
+use App\Domain\Analytics\DTOs\AnomalyAlert;
+use App\Domain\Analytics\DTOs\PredictionResult;
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\Exportable;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithMultipleSheets;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+/**
+ * Export Excel multi-sheets pour Analytics : 1 sheet par section
+ * (Synthèse / Risque de défaut / Anomalies).
+ */
+class AnalyticsExport implements WithMultipleSheets, FromCollection
+{
+    use Exportable;
+
+    public function __construct(
+        public readonly PredictionResult $cashFlow,
+        public readonly PredictionResult $defaultRisk,
+        public readonly array $anomalies,
+        public readonly array $context = [],
+    ) {}
+
+    public function sheets(): array
+    {
+        return [
+            new AnalyticsSummarySheet($this->cashFlow, $this->defaultRisk, $this->anomalies),
+            new AnalyticsRiskSheet($this->defaultRisk),
+            new AnalyticsAnomaliesSheet($this->anomalies),
+        ];
+    }
+
+    public function collection(): Collection
+    {
+        return collect();
+    }
+}
+
+/**
+ * Sheet 1 : Synthèse (KPIs principaux).
+ */
+class AnalyticsSummarySheet implements FromCollection, WithTitle, WithHeadings, WithStyles, ShouldAutoSize
+{
+    public function __construct(
+        private readonly PredictionResult $cashFlow,
+        private readonly PredictionResult $defaultRisk,
+        private readonly array $anomalies,
+    ) {}
+
+    public function title(): string
+    {
+        return 'Synthèse';
+    }
+
+    public function headings(): array
+    {
+        return ['Indicateur', 'Valeur', 'Détail'];
+    }
+
+    public function collection(): Collection
+    {
+        $criticalCount = collect($this->anomalies)->where('severity', AnomalyAlert::SEVERITY_CRITICAL)->count();
+        $warningCount = collect($this->anomalies)->where('severity', AnomalyAlert::SEVERITY_WARNING)->count();
+
+        $rows = [];
+
+        if ($this->cashFlow->isAvailable()) {
+            $rows[] = ['Recettes prévues mois prochain', number_format($this->cashFlow->value ?? 0, 0, ',', ' ') . ' FCFA', $this->cashFlow->confidenceLabel];
+        }
+        if ($this->defaultRisk->isAvailable()) {
+            $buckets = $this->defaultRisk->metadata['buckets'] ?? [];
+            $rows[] = ['Étudiants à haut risque', (int) ($buckets['haut'] ?? 0), 'Sur ' . ($this->defaultRisk->metadata['total_actifs'] ?? 0) . ' actifs'];
+            $rows[] = ['Étudiants sous surveillance', (int) ($buckets['moyen'] ?? 0), ''];
+            $rows[] = ['Solde non recouvré (haut risque)', number_format($this->defaultRisk->metadata['total_solde_haut_risque'] ?? 0, 0, ',', ' ') . ' FCFA', ''];
+            $rows[] = ['Taux de risque cumulé', round($this->defaultRisk->metadata['taux_risque_pct'] ?? 0, 1) . ' %', ''];
+        }
+
+        $rows[] = ['Anomalies critiques', $criticalCount, ''];
+        $rows[] = ['Anomalies en avertissement', $warningCount, ''];
+
+        return collect($rows);
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        return [
+            1 => [
+                'font' => ['bold' => true, 'color' => ['rgb' => 'FFFFFF']],
+                'fill' => ['fillType' => Fill::FILL_SOLID, 'startColor' => ['rgb' => '0453CB']],
+            ],
+        ];
+    }
+}
+
+/**
+ * Sheet 2 : Détail risque de défaut (top-N étudiants).
+ */
+class AnalyticsRiskSheet implements FromCollection, WithTitle, WithHeadings, WithMapping, WithStyles, ShouldAutoSize
+{
+    private int $counter = 0;
+
+    public function __construct(private readonly PredictionResult $defaultRisk) {}
+
+    public function title(): string
+    {
+        return 'Risque de défaut';
+    }
+
+    public function headings(): array
+    {
+        return ['#', 'Étudiant', 'Classe', 'Solde restant', 'Jours retard', '% payé', 'Niveau', 'Score'];
+    }
+
+    public function collection(): Collection
+    {
+        return collect($this->defaultRisk->metadata['top_at_risk'] ?? [])->values();
+    }
+
+    public function map($row): array
+    {
+        $this->counter++;
+        return [
+            $this->counter,
+            $row['etudiant_nom'] ?? '',
+            $row['classe_nom'] ?? '',
+            (float) ($row['solde_restant'] ?? 0),
+            (int) ($row['jours_retard'] ?? 0),
+            round(((float) ($row['ratio_paye'] ?? 0)) * 100, 1) . ' %',
+            ucfirst($row['level'] ?? ''),
+            round((float) ($row['score'] ?? 0), 3),
+        ];
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        return [
+            1 => [
+                'font' => ['bold' => true, 'color' => ['rgb' => 'FFFFFF']],
+                'fill' => ['fillType' => Fill::FILL_SOLID, 'startColor' => ['rgb' => '0453CB']],
+            ],
+        ];
+    }
+}
+
+/**
+ * Sheet 3 : Anomalies détectées.
+ */
+class AnalyticsAnomaliesSheet implements FromCollection, WithTitle, WithHeadings, WithMapping, WithStyles, ShouldAutoSize
+{
+    public function __construct(private readonly array $anomalies) {}
+
+    public function title(): string
+    {
+        return 'Anomalies';
+    }
+
+    public function headings(): array
+    {
+        return ['Sévérité', 'Type', 'Entité', 'Score', 'Message'];
+    }
+
+    public function collection(): Collection
+    {
+        return collect($this->anomalies);
+    }
+
+    public function map($alert): array
+    {
+        if (!$alert instanceof AnomalyAlert) {
+            return [];
+        }
+        return [
+            strtoupper($alert->severity),
+            str_replace('_', ' ', $alert->type),
+            "{$alert->entityType} #{$alert->entityId}",
+            round($alert->score, 2),
+            $alert->message,
+        ];
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        return [
+            1 => [
+                'font' => ['bold' => true, 'color' => ['rgb' => 'FFFFFF']],
+                'fill' => ['fillType' => Fill::FILL_SOLID, 'startColor' => ['rgb' => '0453CB']],
+            ],
+        ];
+    }
+}

--- a/app/Exports/RecouvrementExport.php
+++ b/app/Exports/RecouvrementExport.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Exports;
+
+use App\Domain\Notifications\PhoneFormatter;
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithColumnFormatting;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithStyles;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use Maatwebsite\Excel\Events\AfterSheet;
+use PhpOffice\PhpSpreadsheet\Shared\Date;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+/**
+ * Export Excel Recouvrement quotidien — colonnes alignées avec le PDF.
+ * Téléphone en format texte (sinon Excel perd le `+` initial du E.164).
+ */
+class RecouvrementExport implements
+    FromCollection,
+    WithHeadings,
+    WithMapping,
+    WithTitle,
+    WithStyles,
+    WithColumnFormatting,
+    WithEvents,
+    ShouldAutoSize
+{
+    private int $counter = 0;
+
+    /**
+     * @param  array<int, array>  $rows  Top-N at-risk students with full enrichment
+     * @param  array<string, string>  $filters  Applied filters for recap line
+     */
+    public function __construct(
+        private readonly array $rows,
+        private readonly array $filters = [],
+    ) {}
+
+    public function collection(): Collection
+    {
+        return collect($this->rows);
+    }
+
+    public function title(): string
+    {
+        return 'Recouvrement';
+    }
+
+    public function headings(): array
+    {
+        return [
+            '#',
+            'Étudiant',
+            'Classe',
+            'Téléphone',
+            'Email',
+            'Solde restant (FCFA)',
+            'Jours retard',
+            '% payé',
+            'Niveau',
+            'Score',
+        ];
+    }
+
+    public function map($row): array
+    {
+        $this->counter++;
+        return [
+            $this->counter,
+            $row['etudiant_nom'] ?? '',
+            $row['classe_nom'] ?? '',
+            PhoneFormatter::toReadable($row['phone'] ?? null) ?? '—',
+            $row['email'] ?? '—',
+            (float) ($row['solde_restant'] ?? 0),
+            (int) ($row['jours_retard'] ?? 0),
+            round(((float) ($row['ratio_paye'] ?? 0)) * 100, 1) . ' %',
+            ucfirst($row['level'] ?? ''),
+            round((float) ($row['score'] ?? 0), 3),
+        ];
+    }
+
+    public function columnFormats(): array
+    {
+        return [
+            'D' => NumberFormat::FORMAT_TEXT,
+            'F' => '#,##0',
+            'G' => '#,##0',
+        ];
+    }
+
+    public function styles(Worksheet $sheet)
+    {
+        return [
+            1 => [
+                'font' => ['bold' => true, 'color' => ['rgb' => 'FFFFFF'], 'size' => 11],
+                'fill' => ['fillType' => Fill::FILL_SOLID, 'startColor' => ['rgb' => '0453CB']],
+                'alignment' => ['horizontal' => Alignment::HORIZONTAL_CENTER],
+            ],
+        ];
+    }
+
+    public function registerEvents(): array
+    {
+        return [
+            AfterSheet::class => function (AfterSheet $event) {
+                $sheet = $event->sheet->getDelegate();
+                $highestRow = $sheet->getHighestRow();
+                $sheet->getStyle("A1:J{$highestRow}")
+                    ->getAlignment()
+                    ->setVertical(Alignment::VERTICAL_CENTER);
+
+                if ($highestRow > 1) {
+                    $sheet->getStyle("A2:J{$highestRow}")
+                        ->getBorders()
+                        ->getAllBorders()
+                        ->setBorderStyle(\PhpOffice\PhpSpreadsheet\Style\Border::BORDER_THIN)
+                        ->setColor(new \PhpOffice\PhpSpreadsheet\Style\Color('E2E8F0'));
+                }
+            },
+        ];
+    }
+}

--- a/app/Http/Controllers/ESBTPAnalyticsController.php
+++ b/app/Http/Controllers/ESBTPAnalyticsController.php
@@ -10,9 +10,11 @@ use App\Domain\Analytics\DTOs\PredictionResult;
 use App\Domain\Analytics\Predictors\CashFlowPredictor;
 use App\Domain\Analytics\Predictors\DefaultRiskPredictor;
 use App\Domain\Analytics\Predictors\PredictorInterface;
+use App\Domain\Exports\Reports\AnalyticsReport;
 use App\Helpers\SettingsHelper;
 use App\Jobs\ComputeAnalyticsPredictionsJob;
 use App\Jobs\DetectAnalyticsAnomaliesJob;
+use App\Services\ExportRenderer;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPClasse;
 use App\Models\ESBTPFiliere;
@@ -87,25 +89,86 @@ class ESBTPAnalyticsController extends Controller
     }
 
     /**
-     * Déclenche le job daily synchrone via queue + le job anomalies. Réservé aux
-     * admins ayant analytics.run_now.
+     * Déclenche le job daily + job anomalies. Retourne JSON pour AJAX
+     * (no full page reload — voir rule laravel-ajax-blade-alpine.md).
      */
-    public function runNow(): RedirectResponse
+    public function runNow(Request $request): JsonResponse
     {
         try {
             ComputeAnalyticsPredictionsJob::dispatch();
             DetectAnalyticsAnomaliesJob::dispatch();
 
-            return redirect()
-                ->route('esbtp.comptabilite.analytics.index')
-                ->with('success', 'Recalcul lancé en arrière-plan. Les prédictions seront mises à jour sous peu.');
+            return response()->json([
+                'success' => true,
+                'message' => 'Recalcul lancé en arrière-plan. Les prédictions seront mises à jour sous peu.',
+                'dispatched_at' => now()->toISOString(),
+            ]);
         } catch (\Throwable $e) {
             Log::error('Analytics runNow dispatch failed', ['error' => $e->getMessage()]);
-
-            return redirect()
-                ->route('esbtp.comptabilite.analytics.index')
-                ->with('error', 'Impossible de lancer le recalcul : ' . $e->getMessage());
+            return response()->json([
+                'success' => false,
+                'message' => 'Impossible de lancer le recalcul : ' . $e->getMessage(),
+            ], 500);
         }
+    }
+
+    /**
+     * Preview PDF Analytics inline (nouvelle tab).
+     */
+    public function previewPdf(
+        Request $request,
+        CashFlowPredictor $cashFlow,
+        DefaultRiskPredictor $defaultRisk,
+        AnomalyDetector $anomalyDetector,
+        ExportRenderer $renderer,
+    ) {
+        return $renderer->pdfPreview($this->buildAnalyticsReport($request, $cashFlow, $defaultRisk, $anomalyDetector));
+    }
+
+    /**
+     * Download PDF Analytics.
+     */
+    public function exportPdf(
+        Request $request,
+        CashFlowPredictor $cashFlow,
+        DefaultRiskPredictor $defaultRisk,
+        AnomalyDetector $anomalyDetector,
+        ExportRenderer $renderer,
+    ) {
+        return $renderer->pdfDownload($this->buildAnalyticsReport($request, $cashFlow, $defaultRisk, $anomalyDetector));
+    }
+
+    /**
+     * Download Excel Analytics multi-sheets.
+     */
+    public function exportExcel(
+        Request $request,
+        CashFlowPredictor $cashFlow,
+        DefaultRiskPredictor $defaultRisk,
+        AnomalyDetector $anomalyDetector,
+        ExportRenderer $renderer,
+    ) {
+        return $renderer->excelDownload($this->buildAnalyticsReport($request, $cashFlow, $defaultRisk, $anomalyDetector));
+    }
+
+    private function buildAnalyticsReport(
+        Request $request,
+        CashFlowPredictor $cashFlow,
+        DefaultRiskPredictor $defaultRisk,
+        AnomalyDetector $anomalyDetector,
+    ): AnalyticsReport {
+        $context = AnalyticsContext::fromRequest($request);
+        $cashFlowResult = $this->safePredict(new CachedPredictor($cashFlow), $context);
+        $defaultRiskResult = $this->safePredict(new CachedPredictor($defaultRisk), $context);
+        $anomalies = $this->safeDetect($anomalyDetector, $context);
+
+        $appliedFilters = array_filter([
+            'Année' => $context->anneeId ? optional(ESBTPAnneeUniversitaire::find($context->anneeId))->name : null,
+            'Filière' => $context->filiereId ? optional(ESBTPFiliere::find($context->filiereId))->name : null,
+            'Classe' => $context->classeId ? optional(ESBTPClasse::find($context->classeId))->name : null,
+        ]);
+
+        return new AnalyticsReport($cashFlowResult, $defaultRiskResult, $anomalies, $appliedFilters);
     }
 
     /**

--- a/app/Http/Controllers/ESBTPPaiementExportController.php
+++ b/app/Http/Controllers/ESBTPPaiementExportController.php
@@ -90,6 +90,32 @@ class ESBTPPaiementExportController extends Controller
     }
 
     /**
+     * Aperçu PDF inline (nouvelle tab) — applique les filtres et retourne
+     * le PDF visuel sans téléchargement. Permet au comptable de vérifier le
+     * rendu avant le bouton "Télécharger".
+     */
+    public function previewPdf(Request $request, PaiementExportService $service)
+    {
+        $filters = $this->validatedFilters($request);
+        $filters['format'] = 'pdf';
+        $count = $service->count($filters, $request->user());
+
+        if ($count === 0) {
+            return back()->with('error', 'Aucun paiement à prévisualiser avec ces filtres.');
+        }
+        if ($count > PaiementExportService::PDF_MAX_ROWS) {
+            return back()->with('error', "Trop de lignes pour le PDF ({$count}). Affinez les filtres.");
+        }
+
+        try {
+            return $service->previewPdf($filters, $request->user());
+        } catch (\Throwable $e) {
+            Log::error('Erreur aperçu PDF paiements', ['message' => $e->getMessage()]);
+            return back()->with('error', 'Erreur lors de l\'aperçu : ' . $e->getMessage());
+        }
+    }
+
+    /**
      * Génère et télécharge le fichier (PDF ou Excel/CSV).
      */
     public function generate(Request $request, PaiementExportService $service)

--- a/app/Http/Controllers/ESBTPRecouvrementController.php
+++ b/app/Http/Controllers/ESBTPRecouvrementController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Domain\Analytics\Cache\CachedPredictor;
 use App\Domain\Analytics\DTOs\AnalyticsContext;
 use App\Domain\Analytics\Predictors\DefaultRiskPredictor;
+use App\Domain\Exports\Reports\RecouvrementReport;
 use App\Domain\Notifications\Channels\WhatsAppDeeplinkChannel;
 use App\Domain\Notifications\EtudiantContact;
 use App\Helpers\SettingsHelper;
@@ -12,6 +13,7 @@ use App\Models\ESBTPClasse;
 use App\Models\ESBTPEtudiant;
 use App\Models\ESBTPFiliere;
 use App\Models\ESBTPInscription;
+use App\Services\ExportRenderer;
 use App\Services\RelanceActionLogger;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
@@ -37,6 +39,84 @@ class ESBTPRecouvrementController extends Controller
         $this->middleware('auth');
         $this->middleware('comptabilite.access');
         $this->middleware('can:comptabilite.recouvrement.access');
+    }
+
+    public function previewPdf(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer)
+    {
+        return $renderer->pdfPreview($this->buildReport($request, $predictor));
+    }
+
+    public function exportPdf(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer)
+    {
+        return $renderer->pdfDownload($this->buildReport($request, $predictor));
+    }
+
+    public function exportExcel(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer)
+    {
+        return $renderer->excelDownload($this->buildReport($request, $predictor));
+    }
+
+    public function emailPdf(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer): JsonResponse
+    {
+        $to = trim((string) $request->input('to', '')) ?: ($request->user()?->email);
+        if (!$to || !filter_var($to, FILTER_VALIDATE_EMAIL)) {
+            return response()->json(['success' => false, 'message' => 'Adresse email invalide'], 422);
+        }
+        try {
+            $renderer->emailPdf($this->buildReport($request, $predictor), $to, $request->user()?->name);
+            return response()->json(['success' => true, 'message' => "Rapport en cours d'envoi à {$to}"]);
+        } catch (\Throwable $e) {
+            Log::error('Recouvrement emailPdf failed', ['error' => $e->getMessage()]);
+            return response()->json(['success' => false, 'message' => 'Erreur lors de l\'envoi'], 500);
+        }
+    }
+
+    private function buildReport(Request $request, DefaultRiskPredictor $predictor): RecouvrementReport
+    {
+        $context = AnalyticsContext::fromRequest($request);
+        $cached = new CachedPredictor($predictor, ttlSeconds: 1800);
+        $prediction = $cached->predict($context);
+
+        $topAtRisk = $prediction->metadata['top_at_risk'] ?? [];
+        $contacts = $this->loadContacts(array_column($topAtRisk, 'inscription_id'));
+
+        $rows = collect($topAtRisk)
+            ->map(function ($student) use ($contacts) {
+                $contact = $contacts[$student['inscription_id']] ?? null;
+                return array_merge($student, [
+                    'phone' => $contact?->phone,
+                    'email' => $contact?->email,
+                ]);
+            });
+
+        // Filtres UI appliqués server-side pour cohérence preview/download avec la vue
+        $level = $request->query('level');
+        $retardMin = (int) $request->query('retard_min', 0);
+        $search = trim((string) $request->query('search', ''));
+
+        if ($level) {
+            $rows = $rows->where('level', $level);
+        }
+        if ($retardMin > 0) {
+            $rows = $rows->where('jours_retard', '>=', $retardMin);
+        }
+        if ($search !== '') {
+            $rows = $rows->filter(fn ($r) => str_contains(mb_strtolower($r['etudiant_nom'] ?? ''), mb_strtolower($search)));
+        }
+
+        $appliedFilters = array_filter([
+            'Niveau' => $level ? ucfirst($level) : null,
+            'Retard min.' => $retardMin > 0 ? "{$retardMin} jours" : null,
+            'Recherche' => $search !== '' ? $search : null,
+            'Filière' => $context->filiereId ? optional(ESBTPFiliere::find($context->filiereId))->name : null,
+            'Classe' => $context->classeId ? optional(ESBTPClasse::find($context->classeId))->name : null,
+        ]);
+
+        return new RecouvrementReport(
+            rows: $rows->values()->all(),
+            appliedFilters: $appliedFilters,
+            kpis: $prediction->metadata ?? [],
+        );
     }
 
     public function index(Request $request, DefaultRiskPredictor $predictor): View

--- a/app/Mail/ExportableReportMail.php
+++ b/app/Mail/ExportableReportMail.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Mail;
+
+use App\Domain\Exports\ExportableReport;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Email contenant un export PDF en pièce jointe. Queueable pour ne pas bloquer
+ * la requête HTTP si le rendu PDF est lent.
+ *
+ * Usage : Mail::to($address)->queue(new ExportableReportMail($report, $pdfBinary))
+ */
+class ExportableReportMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly string $reportTitle,
+        public readonly string $reportSubtitle,
+        public readonly string $filename,
+        public readonly string $pdfBinary,
+        public readonly ?string $senderName = null,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '[KLASSCI] ' . $this->reportTitle,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.exportable-report',
+            with: [
+                'reportTitle' => $this->reportTitle,
+                'reportSubtitle' => $this->reportSubtitle,
+                'senderName' => $this->senderName,
+            ],
+        );
+    }
+
+    /**
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        return [
+            Attachment::fromData(fn () => $this->pdfBinary, $this->filename . '.pdf')
+                ->withMime('application/pdf'),
+        ];
+    }
+}

--- a/app/Services/ExportRenderer.php
+++ b/app/Services/ExportRenderer.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Services;
+
+use App\Domain\Exports\ExportableReport;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
+use Maatwebsite\Excel\Facades\Excel;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+/**
+ * Renderer unifié pour exports PDF + Excel. Centralise la création DomPDF +
+ * Maatwebsite Excel et applique le pattern preview-inline / download-attachment.
+ *
+ * Cache PDF (Phase 6) : pdfDownload memorise le résultat par cacheKey() du
+ * report pour 5 min. Désactivable via setting analytics.exports.cache_enabled.
+ */
+class ExportRenderer
+{
+    public const CACHE_TTL_SECONDS = 300;
+
+    /**
+     * Stream PDF inline — ouvre dans une nouvelle tab du navigateur (preview).
+     * Content-Disposition: inline.
+     */
+    public function pdfPreview(ExportableReport $report): Response
+    {
+        $pdf = $this->buildPdf($report);
+        return new Response($pdf->output(), 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'inline; filename="' . $report->filename() . '.pdf"',
+        ]);
+    }
+
+    /**
+     * Force le download PDF (Content-Disposition: attachment).
+     */
+    public function pdfDownload(ExportableReport $report): Response
+    {
+        $cacheKey = 'exports:pdf:' . $report->cacheKey();
+        $binary = $this->cacheEnabled()
+            ? Cache::remember($cacheKey, self::CACHE_TTL_SECONDS, fn () => $this->buildPdf($report)->output())
+            : $this->buildPdf($report)->output();
+
+        return new Response($binary, 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'attachment; filename="' . $report->filename() . '.pdf"',
+        ]);
+    }
+
+    /**
+     * Force le download Excel (xlsx) via Maatwebsite.
+     */
+    public function excelDownload(ExportableReport $report): BinaryFileResponse
+    {
+        return Excel::download($report->excelExport(), $report->filename() . '.xlsx');
+    }
+
+    /**
+     * Invalide le cache PDF d'un report donné (utile post-recompute analytics).
+     */
+    public function forgetCache(ExportableReport $report): void
+    {
+        Cache::forget('exports:pdf:' . $report->cacheKey());
+    }
+
+    /**
+     * Envoie le report PDF en pièce jointe par email. Queueable si un worker
+     * tourne (`QUEUE_CONNECTION != sync`), sinon fallback envoi synchrone pour
+     * garantir la délivrance.
+     */
+    public function emailPdf(ExportableReport $report, string $toEmail, ?string $senderName = null): void
+    {
+        $binary = $this->buildPdf($report)->output();
+        $mailable = new \App\Mail\ExportableReportMail(
+            reportTitle: $report->title(),
+            reportSubtitle: $report->subtitle() ?? '',
+            filename: $report->filename(),
+            pdfBinary: $binary,
+            senderName: $senderName,
+        );
+
+        $pendingMail = \Illuminate\Support\Facades\Mail::to($toEmail);
+        if (config('queue.default') === 'sync') {
+            $pendingMail->send($mailable);
+        } else {
+            $pendingMail->queue($mailable);
+        }
+    }
+
+    private function buildPdf(ExportableReport $report)
+    {
+        return Pdf::loadView($report->pdfView(), array_merge($report->viewData(), [
+            'reportTitle' => $report->title(),
+            'reportSubtitle' => $report->subtitle(),
+            'reportFilters' => $report->filters(),
+        ]))->setPaper($report->paper(), $report->orientation());
+    }
+
+    private function cacheEnabled(): bool
+    {
+        return (string) \App\Helpers\SettingsHelper::get('analytics.exports.cache_enabled', '1') === '1';
+    }
+}

--- a/app/Services/PaiementExportService.php
+++ b/app/Services/PaiementExportService.php
@@ -189,16 +189,41 @@ class PaiementExportService
      */
     public function exportPdf(array $filters, ?User $user = null): Response
     {
+        $pdf = $this->buildPdf($filters, $user);
+        $filename = 'etat-paiements-detaille_' . now()->format('Y-m-d_His') . '.pdf';
+        return $pdf->download($filename);
+    }
+
+    /**
+     * Aperçu PDF inline (Content-Disposition: inline) — ouvre dans un nouvel
+     * onglet du navigateur sans télécharger.
+     */
+    public function previewPdf(array $filters, ?User $user = null): Response
+    {
+        $pdf = $this->buildPdf($filters, $user);
+        $filename = 'apercu-paiements-detaille_' . now()->format('Y-m-d_His') . '.pdf';
+        return new Response($pdf->output(), 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'inline; filename="' . $filename . '"',
+        ]);
+    }
+
+    private function buildPdf(array $filters, ?User $user)
+    {
         $paiements = $this->buildQuery($filters, $user)->get();
         $count = $paiements->count();
         $totalMontant = (float) $paiements->sum('montant');
         $showCreator = $this->shouldShowCreatorColumn($user);
         $context = $this->buildContext($filters, $user, $showCreator);
-
-        // Format A4 paysage si on a la colonne creator (≥ 8 colonnes)
         $orientation = $showCreator ? 'landscape' : 'portrait';
 
-        $pdf = Pdf::loadView('esbtp.paiements.exports.pdf-detaille', [
+        Log::info('PDF détaillé paiements rendu', [
+            'user_id' => $user?->id,
+            'count' => $count,
+            'orientation' => $orientation,
+        ]);
+
+        return Pdf::loadView('esbtp.paiements.exports.pdf-detaille', [
             'paiements' => $paiements,
             'count' => $count,
             'totalMontant' => $totalMontant,
@@ -207,16 +232,6 @@ class PaiementExportService
             'filtersSummary' => $this->buildFiltersSummary($filters, $user),
             'dateGeneration' => now(),
         ])->setPaper('a4', $orientation);
-
-        Log::info('Export PDF détaillé paiements généré', [
-            'user_id' => $user?->id,
-            'count' => $count,
-            'orientation' => $orientation,
-        ]);
-
-        $filename = 'etat-paiements-detaille_' . now()->format('Y-m-d_His') . '.pdf';
-
-        return $pdf->download($filename);
     }
 
     /**

--- a/resources/views/components/export-modal.blade.php
+++ b/resources/views/components/export-modal.blade.php
@@ -1,0 +1,122 @@
+@props([
+    'previewUrl',
+    'pdfUrl',
+    'excelUrl',
+    'emailUrl' => null,
+    'buttonClass' => 'an-btn an-btn--glass',
+    'label' => 'Exporter',
+])
+
+<div x-data="{ open: false }" @click.outside="open = false" style="display: inline-block; position: relative;">
+    <button type="button" @click="open = !open" class="{{ $buttonClass }}">
+        <i class="fas fa-download"></i> {{ $label }}
+        <i class="fas fa-caret-down" style="margin-left: .25rem; font-size: .7rem;"></i>
+    </button>
+
+    <div x-show="open" x-transition x-cloak
+         class="export-menu"
+         style="display: none;">
+        <a :href="window.appendFiltersToUrl('{{ $previewUrl }}')" target="_blank" rel="noopener" class="export-menu-item" @click="open = false">
+            <i class="fas fa-eye"></i>
+            <div>
+                <strong>Aperçu PDF</strong>
+                <small>Voir avant téléchargement (nouvel onglet)</small>
+            </div>
+        </a>
+        <a :href="window.appendFiltersToUrl('{{ $pdfUrl }}')" class="export-menu-item" @click="open = false">
+            <i class="fas fa-file-pdf"></i>
+            <div>
+                <strong>Télécharger PDF</strong>
+                <small>Format A4 imprimable</small>
+            </div>
+        </a>
+        <a :href="window.appendFiltersToUrl('{{ $excelUrl }}')" class="export-menu-item" @click="open = false">
+            <i class="fas fa-file-excel"></i>
+            <div>
+                <strong>Télécharger Excel</strong>
+                <small>Données brutes (.xlsx)</small>
+            </div>
+        </a>
+        @if($emailUrl)
+            <button type="button" @click="window.askEmailExport('{{ $emailUrl }}'); open = false" class="export-menu-item export-menu-item--button">
+                <i class="fas fa-envelope"></i>
+                <div>
+                    <strong>Envoyer par email</strong>
+                    <small>Recevoir le PDF dans votre boîte</small>
+                </div>
+            </button>
+        @endif
+    </div>
+</div>
+
+@once
+@push('scripts')
+<script>
+// Helpers globaux pour construire les liens avec filtres actuels.
+// La page hôte expose `window.exportFilters()` qui retourne un object {key: value}.
+// Si non défini, les liens sont utilisés tels quels.
+window.previewLink = function (baseUrl) { return appendFiltersToUrl(baseUrl); };
+window.filteredLink = function (baseUrl) { return appendFiltersToUrl(baseUrl); };
+window.appendFiltersToUrl = function (baseUrl, extra) {
+    const params = new URLSearchParams();
+    if (typeof window.exportFilters === 'function') {
+        const filters = window.exportFilters() || {};
+        for (const [k, v] of Object.entries(filters)) {
+            if (v !== null && v !== undefined && v !== '') params.append(k, v);
+        }
+    }
+    if (extra) {
+        for (const [k, v] of Object.entries(extra)) {
+            if (v !== null && v !== undefined && v !== '') params.append(k, v);
+        }
+    }
+    const qs = params.toString();
+    if (!qs) return baseUrl;
+    return baseUrl + (baseUrl.includes('?') ? '&' : '?') + qs;
+};
+window.askEmailExport = function (emailUrl) {
+    const to = window.prompt('Adresse email destinataire (laisser vide pour la vôtre) :', '');
+    if (to === null) return;
+    const url = window.appendFiltersToUrl(emailUrl, { to: to || '' });
+    fetch(url, {
+        method: 'POST',
+        headers: {
+            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content,
+            'Accept': 'application/json',
+        },
+    })
+        .then(r => r.json())
+        .then(d => alert(d.message || 'Email envoyé.'))
+        .catch(() => alert('Erreur d\'envoi.'));
+};
+</script>
+@endpush
+@endonce
+
+@once
+@push('styles')
+<style>
+.export-menu {
+    position: absolute; top: calc(100% + 6px); right: 0; z-index: 100;
+    background: #fff; border: 1px solid #e2e8f0; border-radius: 12px;
+    box-shadow: 0 8px 30px rgba(15,23,42,.12);
+    min-width: 280px; padding: .5rem;
+    overflow: hidden;
+}
+.export-menu-item {
+    display: flex; align-items: center; gap: .75rem;
+    padding: .75rem .85rem; border-radius: 8px;
+    text-decoration: none; color: #1e293b; cursor: pointer;
+    border: none; background: none; width: 100%; text-align: left;
+    font-size: .88rem; transition: background .15s ease;
+}
+.export-menu-item:hover { background: #f1f5f9; color: #0453cb; }
+.export-menu-item i { font-size: 1.1rem; color: #64748b; flex-shrink: 0; width: 24px; text-align: center; }
+.export-menu-item:hover i { color: #0453cb; }
+.export-menu-item strong { display: block; font-size: .88rem; }
+.export-menu-item small { display: block; font-size: .72rem; color: #64748b; margin-top: .15rem; }
+.export-menu-item:hover small { color: #475569; }
+[x-cloak] { display: none !important; }
+</style>
+@endpush
+@endonce

--- a/resources/views/components/pdf-document.blade.php
+++ b/resources/views/components/pdf-document.blade.php
@@ -1,0 +1,220 @@
+@props([
+    'title',
+    'subtitle' => null,
+    'filters' => [],
+    'orientation' => 'portrait',
+])
+@php
+    $school = \App\Helpers\SettingsHelper::getSchoolInfo();
+    $pdf = \App\Helpers\SettingsHelper::getPdfSettings();
+    $logoPath = $school['logo'] ?? '';
+    $logoFile = '';
+    if ($pdf['show_logo'] && $logoPath) {
+        $candidate = public_path('storage/' . ltrim($logoPath, '/'));
+        if (file_exists($candidate)) {
+            $logoFile = $candidate;
+        } else {
+            $candidate = public_path($logoPath);
+            if (file_exists($candidate)) {
+                $logoFile = $candidate;
+            }
+        }
+    }
+@endphp
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    @include('pdf.partials.theme')
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ $title }}</title>
+    <style>
+        @page {
+            margin: {{ ($pdf['margin_top'] ?? 20) }}mm
+                    {{ ($pdf['margin_right'] ?? 15) }}mm
+                    {{ ($pdf['margin_bottom'] ?? 20) }}mm
+                    {{ ($pdf['margin_left'] ?? 15) }}mm;
+        }
+        body {
+            font-family: DejaVu Sans, Arial, sans-serif;
+            font-size: {{ ($pdf['font_size'] ?? 11) }}px;
+            color: {{ $pdf['text_color'] ?? '#1f2937' }};
+            margin: 0;
+            line-height: 1.4;
+        }
+
+        .pdf-header {
+            width: 100%;
+            border-bottom: 2px solid {{ $pdf['primary_color'] ?? '#0453cb' }};
+            padding-bottom: 8px;
+            margin-bottom: 16px;
+            -webkit-print-color-adjust: exact;
+            color-adjust: exact;
+        }
+        .pdf-header-table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        .pdf-header-logo-cell {
+            width: 70px;
+            vertical-align: middle;
+            padding-right: 12px;
+        }
+        .pdf-header-logo {
+            max-height: 60px;
+            max-width: 70px;
+        }
+        .pdf-header-info-cell {
+            vertical-align: middle;
+        }
+        .pdf-school-name {
+            font-size: 16px;
+            font-weight: 700;
+            color: {{ $pdf['primary_color'] ?? '#0453cb' }};
+            margin: 0 0 2px;
+            text-transform: uppercase;
+            letter-spacing: .5px;
+        }
+        .pdf-school-meta {
+            font-size: 9px;
+            color: {{ $pdf['secondary_color'] ?? '#64748b' }};
+            margin: 0;
+            line-height: 1.4;
+        }
+        .pdf-doc-meta-cell {
+            text-align: right;
+            vertical-align: middle;
+            width: 200px;
+            font-size: 9px;
+            color: {{ $pdf['secondary_color'] ?? '#64748b' }};
+        }
+        .pdf-doc-meta-cell strong {
+            color: {{ $pdf['primary_color'] ?? '#0453cb' }};
+            font-size: 10px;
+        }
+
+        .pdf-title-block {
+            margin-bottom: 14px;
+            text-align: center;
+        }
+        .pdf-title {
+            font-size: 18px;
+            font-weight: 700;
+            color: {{ $pdf['primary_color'] ?? '#0453cb' }};
+            margin: 0 0 4px;
+            text-transform: uppercase;
+            letter-spacing: .8px;
+        }
+        .pdf-subtitle {
+            font-size: 10px;
+            color: {{ $pdf['secondary_color'] ?? '#64748b' }};
+            margin: 0;
+            font-style: italic;
+        }
+
+        .pdf-filters-recap {
+            background: #f1f5f9;
+            border-left: 3px solid {{ $pdf['primary_color'] ?? '#0453cb' }};
+            padding: 8px 12px;
+            margin-bottom: 14px;
+            font-size: 9px;
+            border-radius: 2px;
+        }
+        .pdf-filters-recap-title {
+            font-weight: 700;
+            color: {{ $pdf['primary_color'] ?? '#0453cb' }};
+            margin-right: 6px;
+        }
+        .pdf-filters-recap-item {
+            margin-right: 10px;
+            color: {{ $pdf['text_color'] ?? '#1f2937' }};
+        }
+        .pdf-filters-recap-item strong {
+            color: {{ $pdf['secondary_color'] ?? '#64748b' }};
+            font-weight: 600;
+        }
+
+        .pdf-body { margin-top: 8px; }
+
+        .pdf-footer {
+            position: fixed;
+            bottom: -12mm;
+            left: 0;
+            right: 0;
+            font-size: 8px;
+            color: {{ $pdf['secondary_color'] ?? '#64748b' }};
+            border-top: 1px solid #e5e7eb;
+            padding-top: 4px;
+            text-align: center;
+        }
+        .pdf-footer-page::after {
+            content: counter(page) " / " counter(pages);
+        }
+
+        @if(!empty($pdf['watermark']))
+            .pdf-watermark {
+                position: fixed; top: 50%; left: 50%;
+                transform: translate(-50%, -50%) rotate(-30deg);
+                font-size: 90px; color: rgba(0,0,0,0.05);
+                font-weight: 900; z-index: -1;
+                white-space: nowrap;
+            }
+        @endif
+    </style>
+</head>
+<body>
+    @if(!empty($pdf['watermark']))
+        <div class="pdf-watermark">{{ $pdf['watermark'] }}</div>
+    @endif
+
+    <div class="pdf-header">
+        <table class="pdf-header-table">
+            <tr>
+                @if($logoFile)
+                    <td class="pdf-header-logo-cell">
+                        <img src="{{ $logoFile }}" alt="logo" class="pdf-header-logo">
+                    </td>
+                @endif
+                <td class="pdf-header-info-cell">
+                    <p class="pdf-school-name">{{ $school['name'] ?? config('app.name') }}</p>
+                    <p class="pdf-school-meta">
+                        @if($school['address']){{ $school['address'] }}@endif
+                        @if($school['city']) · {{ $school['city'] }}@endif
+                        @if($school['country']) · {{ $school['country'] }}@endif
+                        <br>
+                        @if($school['phone']) Tél : {{ $school['phone'] }}@endif
+                        @if($school['email']) · {{ $school['email'] }}@endif
+                        @if($school['website']) · {{ $school['website'] }}@endif
+                    </p>
+                </td>
+                <td class="pdf-doc-meta-cell">
+                    <strong>{{ $school['acronym'] ?? '' }}</strong><br>
+                    Édité le {{ now()->locale('fr')->translatedFormat('d F Y à H:i') }}<br>
+                    @auth Par {{ auth()->user()->name }} @endauth
+                </td>
+            </tr>
+        </table>
+    </div>
+
+    <div class="pdf-title-block">
+        <h1 class="pdf-title">{{ $title }}</h1>
+        @if($subtitle)
+            <p class="pdf-subtitle">{{ $subtitle }}</p>
+        @endif
+    </div>
+
+    @if(!empty($filters))
+        <x-pdf-filters-recap :filters="$filters" />
+    @endif
+
+    <div class="pdf-body">
+        {{ $slot }}
+    </div>
+
+    <div class="pdf-footer">
+        {{ $pdf['footer_text'] ?? ($school['name'] ?? config('app.name')) }}
+        @if($school['director_name']) · Directeur : {{ $school['director_name'] }} @endif
+        · Page <span class="pdf-footer-page"></span>
+    </div>
+</body>
+</html>

--- a/resources/views/components/pdf-filters-recap.blade.php
+++ b/resources/views/components/pdf-filters-recap.blade.php
@@ -1,0 +1,14 @@
+@props(['filters' => []])
+
+@if(!empty($filters))
+<div class="pdf-filters-recap">
+    <span class="pdf-filters-recap-title">Filtres appliqués :</span>
+    @foreach($filters as $label => $value)
+        @if($value !== null && $value !== '')
+            <span class="pdf-filters-recap-item">
+                <strong>{{ $label }} :</strong> {{ $value }}
+            </span>
+        @endif
+    @endforeach
+</div>
+@endif

--- a/resources/views/emails/exportable-report.blade.php
+++ b/resources/views/emails/exportable-report.blade.php
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ $reportTitle }}</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #f8fafc; margin: 0; padding: 24px;">
+    <div style="max-width: 600px; margin: 0 auto; background: #fff; border-radius: 14px; overflow: hidden; box-shadow: 0 4px 12px rgba(15,23,42,.08);">
+        <div style="background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 50%, #3b7ddb 100%); padding: 28px 32px; color: #fff;">
+            <h1 style="margin: 0; font-size: 22px; font-weight: 700;">{{ $reportTitle }}</h1>
+            @if($reportSubtitle)
+                <p style="margin: 8px 0 0; color: rgba(255,255,255,.85); font-size: 14px;">{{ $reportSubtitle }}</p>
+            @endif
+        </div>
+        <div style="padding: 28px 32px;">
+            <p style="font-size: 15px; color: #1e293b; margin: 0 0 14px;">Bonjour,</p>
+            <p style="font-size: 14px; color: #475569; line-height: 1.6; margin: 0 0 14px;">
+                Vous trouverez en pièce jointe le rapport <strong>{{ $reportTitle }}</strong>
+                @if($senderName) demandé par <strong>{{ $senderName }}</strong>@endif.
+            </p>
+            <p style="font-size: 14px; color: #475569; line-height: 1.6; margin: 0 0 18px;">
+                Document généré automatiquement par le moteur Analytics KLASSCI.
+            </p>
+            <div style="background: #f1f5f9; padding: 14px 18px; border-radius: 8px; border-left: 3px solid #0453cb; font-size: 13px; color: #1e293b;">
+                <strong>📎 Pièce jointe :</strong> rapport au format PDF
+            </div>
+        </div>
+        <div style="background: #fafbfc; padding: 14px 32px; border-top: 1px solid #e2e8f0; font-size: 12px; color: #64748b; text-align: center;">
+            KLASSCI · {{ now()->locale('fr')->translatedFormat('d F Y') }}
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/esbtp/comptabilite/analytics/index.blade.php
+++ b/resources/views/esbtp/comptabilite/analytics/index.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Analytics Prédictifs')
 
 @section('content')
-<div class="container-fluid an-page">
+<div class="container-fluid an-page" x-data="analyticsPage()">
 
     {{-- ============================ HERO ============================ --}}
     <div class="an-hero">
@@ -22,13 +22,19 @@
                     </a>
                 @endcan
                 @can('comptabilite.analytics.run_now')
-                    <form method="POST" action="{{ route('esbtp.comptabilite.analytics.run-now') }}" class="d-inline">
-                        @csrf
-                        <button type="submit" class="an-btn an-btn--glass">
-                            <i class="fas fa-sync-alt"></i> Recalculer
-                        </button>
-                    </form>
+                    <button type="button"
+                            @click="recalculer()"
+                            :disabled="recalcul.loading"
+                            class="an-btn an-btn--glass">
+                        <i class="fas fa-sync-alt" :class="recalcul.loading ? 'fa-spin' : ''"></i>
+                        <span x-text="recalcul.loading ? 'Lancement…' : 'Recalculer'"></span>
+                    </button>
                 @endcan
+                <x-export-modal
+                    :preview-url="route('esbtp.comptabilite.analytics.preview-pdf')"
+                    :pdf-url="route('esbtp.comptabilite.analytics.export-pdf')"
+                    :excel-url="route('esbtp.comptabilite.analytics.export-excel')"
+                    button-class="an-btn an-btn--glass" />
                 @can('comptabilite.analytics.configure')
                     <a href="{{ route('esbtp.comptabilite.analytics.settings') }}" class="an-btn an-btn--glass">
                         <i class="fas fa-sliders-h"></i> Paramètres
@@ -323,7 +329,47 @@
             </div>
         @endif
     </div>
+
+    {{-- Toast feedback (AJAX no-refresh) --}}
+    <div class="an-toast" x-show="toast.message" x-transition :class="'an-toast--' + (toast.type || 'info')">
+        <i class="fas" :class="toast.type === 'error' ? 'fa-exclamation-circle' : 'fa-check-circle'"></i>
+        <span x-text="toast.message"></span>
+    </div>
 </div>
+
+<script>
+function analyticsPage() {
+    return {
+        recalcul: { loading: false },
+        toast: { message: null, type: 'info' },
+
+        async recalculer() {
+            this.recalcul.loading = true;
+            try {
+                const response = await fetch('{{ route("esbtp.comptabilite.analytics.run-now") }}', {
+                    method: 'POST',
+                    headers: {
+                        'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.content,
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/json',
+                    },
+                });
+                const data = await response.json();
+                this.showToast(data.message || (data.success ? 'Recalcul lancé' : 'Erreur'), data.success ? 'success' : 'error');
+            } catch (e) {
+                this.showToast('Erreur réseau lors du lancement', 'error');
+            } finally {
+                this.recalcul.loading = false;
+            }
+        },
+
+        showToast(message, type = 'info') {
+            this.toast = { message, type };
+            setTimeout(() => { this.toast = { message: null, type: 'info' }; }, 4000);
+        },
+    };
+}
+</script>
 @endsection
 
 @push('styles')
@@ -621,6 +667,21 @@
 .an-alert {
     border-radius: 12px; border: none; margin-bottom: 1rem;
 }
+
+.an-toast {
+    position: fixed; bottom: 24px; right: 24px;
+    padding: .85rem 1.25rem; border-radius: 12px;
+    background: #fff; box-shadow: 0 8px 30px rgba(15,23,42,.15);
+    border: 1px solid var(--an-border);
+    display: flex; align-items: center; gap: .65rem;
+    font-size: .9rem; z-index: 1000; max-width: 400px;
+}
+.an-toast--success { border-color: rgba(16,185,129,.3); color: #047857; }
+.an-toast--success i { color: var(--an-success); }
+.an-toast--error { border-color: rgba(220,38,38,.3); color: var(--an-danger); }
+.an-toast--error i { color: var(--an-danger); }
+.an-toast--info i { color: var(--an-primary); }
+[x-cloak] { display: none !important; }
 
 /* ===== Responsive ===== */
 @media (max-width: 992px) {

--- a/resources/views/esbtp/comptabilite/analytics/pdf.blade.php
+++ b/resources/views/esbtp/comptabilite/analytics/pdf.blade.php
@@ -1,0 +1,175 @@
+<x-pdf-document
+    title="{{ $reportTitle ?? 'Analytics financiers' }}"
+    subtitle="{{ $reportSubtitle ?? '' }}"
+    :filters="$reportFilters ?? []">
+
+    <style>
+        .section { margin-bottom: 18px; }
+        .section-title {
+            font-size: 12px; font-weight: 700; color: #0453cb;
+            border-bottom: 2px solid #0453cb; padding-bottom: 4px; margin: 0 0 8px;
+            text-transform: uppercase; letter-spacing: .4px;
+            -webkit-print-color-adjust: exact; color-adjust: exact;
+        }
+        .kpi-grid { display: table; width: 100%; border-collapse: collapse; margin-bottom: 10px; }
+        .kpi-cell {
+            display: table-cell; text-align: center;
+            padding: 12px 8px; border: 1px solid #e2e8f0;
+            background: #fafbfc; width: 25%;
+        }
+        .kpi-cell-value { font-size: 14px; font-weight: 700; color: #0453cb; }
+        .kpi-cell-label { font-size: 8px; color: #64748b; text-transform: uppercase; margin-top: 3px; }
+
+        .cf-block {
+            background: #fafbfc; padding: 10px 12px;
+            border-radius: 4px; border-left: 3px solid #0453cb; margin-bottom: 8px;
+        }
+        .cf-value { font-size: 18px; font-weight: 700; color: #0453cb; margin: 0; }
+        .cf-meta { font-size: 9px; color: #64748b; margin-top: 4px; }
+        .cf-confidence {
+            display: inline-block; padding: 2px 8px; border-radius: 8px;
+            font-size: 8px; font-weight: 700; margin-top: 4px;
+        }
+        .cf-confidence-tres_fiable { background: rgba(16,185,129,.15); color: #047857; }
+        .cf-confidence-fiable { background: rgba(4,83,203,.15); color: #0453cb; }
+        .cf-confidence-indicatif { background: rgba(245,158,11,.15); color: #b45309; }
+
+        .reasons { margin-top: 8px; padding-left: 14px; }
+        .reasons li { font-size: 9px; color: #1e293b; margin-bottom: 2px; }
+
+        .data-table { width: 100%; border-collapse: collapse; font-size: 9px; }
+        .data-table thead th {
+            color: #fff; font-weight: 600; padding: 6px 4px;
+            text-transform: uppercase; letter-spacing: .3px; font-size: 8px; text-align: left;
+            -webkit-print-color-adjust: exact; color-adjust: exact;
+        }
+        .data-table tbody td { padding: 5px 4px; border-bottom: 1px solid #e5e7eb; }
+        .data-table tbody tr:nth-child(even) { background: #fafbfc; }
+
+        .badge {
+            display: inline-block; padding: 1px 6px; border-radius: 8px;
+            font-size: 8px; font-weight: 700; text-transform: uppercase;
+        }
+        .badge-haut { background: rgba(220,38,38,.15); color: #dc2626; }
+        .badge-moyen { background: rgba(245,158,11,.15); color: #b45309; }
+        .badge-bas { background: rgba(16,185,129,.15); color: #047857; }
+
+        .anomaly { display: table; width: 100%; margin-bottom: 6px; padding: 8px 10px; border-radius: 4px; border-left: 3px solid #94a3b8; background: #fafbfc; }
+        .anomaly-critical { border-left-color: #dc2626; background: rgba(220,38,38,.04); }
+        .anomaly-warning  { border-left-color: #f59e0b; background: rgba(245,158,11,.04); }
+        .anomaly-meta { font-size: 8px; color: #64748b; text-transform: uppercase; margin-bottom: 2px; }
+        .anomaly-message { font-size: 9px; color: #1e293b; }
+
+        .empty { text-align: center; padding: 14px; color: #64748b; font-size: 9px; font-style: italic; }
+    </style>
+
+    {{-- ===== Section Cash Flow ===== --}}
+    <div class="section">
+        <h2 class="section-title">Projection cash-flow — mois prochain</h2>
+        @if($cashFlow->isAvailable())
+            <div class="cf-block">
+                <p class="cf-value">{{ number_format($cashFlow->value, 0, ',', ' ') }} FCFA</p>
+                @if($cashFlow->confidenceInterval)
+                    <p class="cf-meta">
+                        Intervalle 95% : de {{ number_format($cashFlow->confidenceInterval->lower, 0, ',', ' ') }}
+                        à {{ number_format($cashFlow->confidenceInterval->upper, 0, ',', ' ') }} FCFA
+                    </p>
+                @endif
+                <span class="cf-confidence cf-confidence-{{ $cashFlow->confidenceLabel }}">
+                    @if($cashFlow->confidenceLabel === 'tres_fiable') Très fiable
+                    @elseif($cashFlow->confidenceLabel === 'fiable') Fiable
+                    @else Indicatif
+                    @endif
+                </span>
+                <ul class="reasons">
+                    @foreach($cashFlow->explanation as $r)
+                        <li>{{ $r }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @else
+            <div class="empty">{{ $cashFlow->explanation[0] ?? 'Indisponible.' }}</div>
+        @endif
+    </div>
+
+    {{-- ===== Section Default Risk ===== --}}
+    <div class="section">
+        <h2 class="section-title">Risque de défaut de paiement</h2>
+        @if($defaultRisk->isAvailable())
+            @php
+                $buckets = $defaultRisk->metadata['buckets'] ?? [];
+                $top = $defaultRisk->metadata['top_at_risk'] ?? [];
+            @endphp
+            <div class="kpi-grid">
+                <div class="kpi-cell">
+                    <div class="kpi-cell-value">{{ $buckets['haut'] ?? 0 }}</div>
+                    <div class="kpi-cell-label">Haut risque</div>
+                </div>
+                <div class="kpi-cell">
+                    <div class="kpi-cell-value">{{ $buckets['moyen'] ?? 0 }}</div>
+                    <div class="kpi-cell-label">Surveillance</div>
+                </div>
+                <div class="kpi-cell">
+                    <div class="kpi-cell-value">{{ $defaultRisk->metadata['total_actifs'] ?? 0 }}</div>
+                    <div class="kpi-cell-label">Étudiants actifs</div>
+                </div>
+                <div class="kpi-cell">
+                    <div class="kpi-cell-value">{{ number_format($defaultRisk->metadata['total_solde_haut_risque'] ?? 0, 0, ',', ' ') }}</div>
+                    <div class="kpi-cell-label">FCFA non recouvrés (haut)</div>
+                </div>
+            </div>
+
+            @if(!empty($top))
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th style="width:25px;">#</th>
+                            <th>Étudiant</th>
+                            <th>Classe</th>
+                            <th style="text-align:right;">Solde</th>
+                            <th style="text-align:center;">Retard</th>
+                            <th style="text-align:center;">Niveau</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach(array_slice($top, 0, 25) as $i => $row)
+                            <tr>
+                                <td>{{ $i + 1 }}</td>
+                                <td><strong>{{ $row['etudiant_nom'] ?? '—' }}</strong></td>
+                                <td>{{ $row['classe_nom'] ?? '—' }}</td>
+                                <td style="text-align:right;">{{ number_format($row['solde_restant'] ?? 0, 0, ',', ' ') }}</td>
+                                <td style="text-align:center;">{{ $row['jours_retard'] ?? 0 }} j</td>
+                                <td style="text-align:center;"><span class="badge badge-{{ $row['level'] ?? 'bas' }}">{{ ucfirst($row['level'] ?? '') }}</span></td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+                @if(count($top) > 25)
+                    <p style="font-size:8px;color:#64748b;text-align:right;margin-top:4px;">… et {{ count($top) - 25 }} autres (voir l'onglet Excel pour le détail complet)</p>
+                @endif
+            @endif
+        @else
+            <div class="empty">{{ $defaultRisk->explanation[0] ?? 'Indisponible.' }}</div>
+        @endif
+    </div>
+
+    {{-- ===== Section Anomalies ===== --}}
+    <div class="section">
+        <h2 class="section-title">Anomalies financières</h2>
+        @if(empty($anomalies))
+            <div class="empty">Aucune anomalie détectée.</div>
+        @else
+            @foreach(array_slice($anomalies, 0, 15) as $alert)
+                <div class="anomaly anomaly-{{ $alert->severity }}">
+                    <div class="anomaly-meta">
+                        {{ strtoupper($alert->severity) }} · {{ str_replace('_', ' ', $alert->type) }} · score {{ number_format($alert->score, 2) }}
+                    </div>
+                    <div class="anomaly-message">{{ $alert->message }}</div>
+                </div>
+            @endforeach
+            @if(count($anomalies) > 15)
+                <p style="font-size:8px;color:#64748b;text-align:right;margin-top:4px;">… et {{ count($anomalies) - 15 }} autres anomalies</p>
+            @endif
+        @endif
+    </div>
+</x-pdf-document>

--- a/resources/views/esbtp/comptabilite/analytics/settings.blade.php
+++ b/resources/views/esbtp/comptabilite/analytics/settings.blade.php
@@ -3,31 +3,56 @@
 @section('title', 'Paramètres Analytics')
 
 @section('content')
-<div class="container-fluid an-page">
+<div class="container-fluid as-page" x-data="settingsPage()">
 
-    {{-- ============================ HEADER (no hero, page de configuration) ============================ --}}
-    <div class="dashboard-header">
-        <div class="header-left">
-            <h1><i class="fas fa-sliders-h me-2"></i>Paramètres Analytics</h1>
-            <p class="header-subtitle">Poids du modèle de risque & seuils de détection d'anomalies.</p>
+    {{-- ============================ HERO PREMIUM ============================ --}}
+    <div class="as-hero">
+        <div class="as-hero-top">
+            <div class="as-hero-left">
+                <div class="as-hero-icon"><i class="fas fa-sliders-h"></i></div>
+                <div>
+                    <h1>Paramètres Analytics</h1>
+                    <p>Réglez le moteur de prédiction & les seuils d'alerte selon vos pratiques.</p>
+                </div>
+            </div>
+            <div class="as-hero-right">
+                <a href="{{ route('esbtp.comptabilite.analytics.index') }}" class="as-btn as-btn--glass">
+                    <i class="fas fa-arrow-left"></i> Retour Analytics
+                </a>
+            </div>
         </div>
-        <div class="header-actions">
-            <a href="{{ route('esbtp.comptabilite.analytics.index') }}" class="btn-acasi secondary">
-                <i class="fas fa-arrow-left"></i> Retour
-            </a>
+
+        {{-- Quick recap des valeurs actuelles --}}
+        <div class="as-recap">
+            <div class="as-recap-item">
+                <div class="as-recap-label">Seuil haut risque</div>
+                <div class="as-recap-value" x-text="(form.default_risk.threshold_high * 100).toFixed(0) + ' %'"></div>
+            </div>
+            <div class="as-recap-item">
+                <div class="as-recap-label">Top-N affiché</div>
+                <div class="as-recap-value" x-text="form.default_risk.top_n + ' étudiants'"></div>
+            </div>
+            <div class="as-recap-item">
+                <div class="as-recap-label">Z critique anomalies</div>
+                <div class="as-recap-value" x-text="form.anomaly.z_critical.toFixed(1) + ' σ'"></div>
+            </div>
+            <div class="as-recap-item">
+                <div class="as-recap-label">Notifications</div>
+                <div class="as-recap-value" x-text="form.anomaly.notifications_enabled ? 'Activées' : 'Désactivées'"></div>
+            </div>
         </div>
     </div>
 
     @if(session('success'))
-        <div class="alert alert-success an-alert mt-3">
-            <i class="fas fa-check-circle me-2"></i> {{ session('success') }}
+        <div class="as-banner as-banner--success">
+            <i class="fas fa-check-circle"></i> {{ session('success') }}
         </div>
     @endif
 
     @if($errors->any())
-        <div class="alert alert-danger an-alert mt-3">
-            <i class="fas fa-exclamation-circle me-2"></i> Veuillez corriger les erreurs ci-dessous.
-            <ul class="mb-0 mt-2">
+        <div class="as-banner as-banner--error">
+            <i class="fas fa-exclamation-circle"></i> Veuillez corriger les erreurs ci-dessous.
+            <ul>
                 @foreach($errors->all() as $error)
                     <li>{{ $error }}</li>
                 @endforeach
@@ -39,255 +64,426 @@
         @csrf
 
         {{-- ===== Default risk weights ===== --}}
-        <div class="an-card mt-4">
-            <div class="an-section-header">
-                <div class="an-section-icon"><i class="fas fa-user-shield"></i></div>
-                <div>
-                    <h2 class="an-section-title">Modèle de risque de défaut</h2>
-                    <p class="an-section-sub">Poids appliqués aux 4 caractéristiques financières et seuils de classification.</p>
+        <div class="as-card">
+            <div class="as-card-head">
+                <div class="as-card-icon as-card-icon--risk"><i class="fas fa-user-shield"></i></div>
+                <div class="as-card-title-block">
+                    <h2>Modèle de risque de défaut</h2>
+                    <p>Pondérations & seuils du score logistique appliqué à chaque étudiant.</p>
                 </div>
+                <button type="button" class="as-card-reset" @click="resetSection('default_risk')">
+                    <i class="fas fa-undo"></i> Restaurer défauts
+                </button>
             </div>
 
-            <div class="an-form-grid">
-                <div class="an-field">
-                    <label class="an-field-label">Poids — Solde restant
-                        <span class="an-field-help">Importance du solde non payé (recommandé : {{ $defaults['default_risk']['weight_solde'] }})</span>
+            <div class="as-form-grid">
+                @php
+                    $riskFields = [
+                        ['weight_solde', 'Poids — Solde restant', 'Importance du solde non payé', 0, 10, 0.1],
+                        ['weight_retard', 'Poids — Jours de retard', 'Pondération du retard de paiement', 0, 10, 0.1],
+                        ['weight_engagement', 'Poids — Engagement', 'Signal du nombre de paiements effectués', 0, 10, 0.1],
+                        ['weight_montant', 'Poids — Montant attendu', 'Effet du montant total à recouvrer', 0, 10, 0.1],
+                        ['bias', 'Biais (intercept)', 'Décalage de base du score', -10, 10, 0.1],
+                    ];
+                @endphp
+
+                @foreach($riskFields as [$key, $label, $help, $min, $max, $step])
+                    <div class="as-field">
+                        <label class="as-field-label">
+                            <span>{{ $label }}</span>
+                            <span class="as-recommended">recommandé : {{ $defaults['default_risk'][$key] }}</span>
+                        </label>
+                        <div class="as-field-help">{{ $help }}</div>
+                        <div class="as-slider-row">
+                            <input type="range" min="{{ $min }}" max="{{ $max }}" step="{{ $step }}"
+                                   x-model.number="form.default_risk.{{ $key }}"
+                                   class="as-range">
+                            <input type="number" step="{{ $step }}" min="{{ $min }}" max="{{ $max }}"
+                                   name="default_risk[{{ $key }}]"
+                                   x-model.number="form.default_risk.{{ $key }}"
+                                   class="as-number" required>
+                        </div>
+                    </div>
+                @endforeach
+
+                <div class="as-field">
+                    <label class="as-field-label">
+                        <span>Top-N étudiants prioritaires</span>
+                        <span class="as-recommended">recommandé : {{ $defaults['default_risk']['top_n'] }}</span>
                     </label>
-                    <input type="number" step="0.1" min="0" max="10"
-                           name="default_risk[weight_solde]"
-                           value="{{ old('default_risk.weight_solde', $settings['default_risk']['weight_solde']) }}"
-                           class="an-input" required>
+                    <div class="as-field-help">Nombre d'étudiants affichés dans la table Recouvrement (10–500).</div>
+                    <div class="as-slider-row">
+                        <input type="range" min="10" max="500" step="10"
+                               x-model.number="form.default_risk.top_n"
+                               class="as-range">
+                        <input type="number" step="1" min="10" max="500"
+                               name="default_risk[top_n]"
+                               x-model.number="form.default_risk.top_n"
+                               class="as-number" required>
+                    </div>
                 </div>
 
-                <div class="an-field">
-                    <label class="an-field-label">Poids — Jours de retard
-                        <span class="an-field-help">Pondération du retard de paiement (recommandé : {{ $defaults['default_risk']['weight_retard'] }})</span>
-                    </label>
-                    <input type="number" step="0.1" min="0" max="10"
-                           name="default_risk[weight_retard]"
-                           value="{{ old('default_risk.weight_retard', $settings['default_risk']['weight_retard']) }}"
-                           class="an-input" required>
-                </div>
-
-                <div class="an-field">
-                    <label class="an-field-label">Poids — Engagement
-                        <span class="an-field-help">Signal du nombre de paiements effectués (recommandé : {{ $defaults['default_risk']['weight_engagement'] }})</span>
-                    </label>
-                    <input type="number" step="0.1" min="0" max="10"
-                           name="default_risk[weight_engagement]"
-                           value="{{ old('default_risk.weight_engagement', $settings['default_risk']['weight_engagement']) }}"
-                           class="an-input" required>
-                </div>
-
-                <div class="an-field">
-                    <label class="an-field-label">Poids — Montant attendu
-                        <span class="an-field-help">Effet du montant total à recouvrer (recommandé : {{ $defaults['default_risk']['weight_montant'] }})</span>
-                    </label>
-                    <input type="number" step="0.1" min="0" max="10"
-                           name="default_risk[weight_montant]"
-                           value="{{ old('default_risk.weight_montant', $settings['default_risk']['weight_montant']) }}"
-                           class="an-input" required>
-                </div>
-
-                <div class="an-field">
-                    <label class="an-field-label">Biais (intercept)
-                        <span class="an-field-help">Décalage de base du score (recommandé : {{ $defaults['default_risk']['bias'] }})</span>
-                    </label>
-                    <input type="number" step="0.1" min="-10" max="10"
-                           name="default_risk[bias]"
-                           value="{{ old('default_risk.bias', $settings['default_risk']['bias']) }}"
-                           class="an-input" required>
-                </div>
-
-                <div class="an-field">
-                    <label class="an-field-label">Top-N étudiants à afficher
-                        <span class="an-field-help">Nombre d'étudiants prioritaires affichés dans la table (10-500, recommandé : {{ $defaults['default_risk']['top_n'] }})</span>
-                    </label>
-                    <input type="number" step="1" min="10" max="500"
-                           name="default_risk[top_n]"
-                           value="{{ old('default_risk.top_n', $settings['default_risk']['top_n']) }}"
-                           class="an-input" required>
-                </div>
-
-                <div class="an-field">
-                    <label class="an-field-label">Seuil — Haut risque
-                        <span class="an-field-help">Score minimal pour classer "haut risque" (0.5-0.95, recommandé : {{ $defaults['default_risk']['threshold_high'] }})</span>
-                    </label>
-                    <input type="number" step="0.01" min="0.5" max="0.95"
-                           name="default_risk[threshold_high]"
-                           value="{{ old('default_risk.threshold_high', $settings['default_risk']['threshold_high']) }}"
-                           class="an-input" required>
-                </div>
-
-                <div class="an-field">
-                    <label class="an-field-label">Seuil — Risque moyen
-                        <span class="an-field-help">Score minimal pour "surveillance" (0.05-0.5, recommandé : {{ $defaults['default_risk']['threshold_medium'] }})</span>
-                    </label>
-                    <input type="number" step="0.01" min="0.05" max="0.5"
-                           name="default_risk[threshold_medium]"
-                           value="{{ old('default_risk.threshold_medium', $settings['default_risk']['threshold_medium']) }}"
-                           class="an-input" required>
-                </div>
+                @php
+                    $thresholdFields = [
+                        ['threshold_high', 'Seuil — Haut risque', 'Score minimal pour classer "haut risque"', 0.5, 0.95, 0.01],
+                        ['threshold_medium', 'Seuil — Risque moyen', 'Score minimal pour "surveillance"', 0.05, 0.5, 0.01],
+                    ];
+                @endphp
+                @foreach($thresholdFields as [$key, $label, $help, $min, $max, $step])
+                    <div class="as-field">
+                        <label class="as-field-label">
+                            <span>{{ $label }}</span>
+                            <span class="as-recommended">recommandé : {{ $defaults['default_risk'][$key] }}</span>
+                        </label>
+                        <div class="as-field-help">{{ $help }} (entre {{ $min }} et {{ $max }})</div>
+                        <div class="as-slider-row">
+                            <input type="range" min="{{ $min }}" max="{{ $max }}" step="{{ $step }}"
+                                   x-model.number="form.default_risk.{{ $key }}"
+                                   class="as-range">
+                            <input type="number" step="{{ $step }}" min="{{ $min }}" max="{{ $max }}"
+                                   name="default_risk[{{ $key }}]"
+                                   x-model.number="form.default_risk.{{ $key }}"
+                                   class="as-number" required>
+                        </div>
+                    </div>
+                @endforeach
             </div>
         </div>
 
         {{-- ===== Anomaly detection ===== --}}
-        <div class="an-card mt-4">
-            <div class="an-section-header">
-                <div class="an-section-icon"><i class="fas fa-radiation"></i></div>
-                <div>
-                    <h2 class="an-section-title">Détection d'anomalies</h2>
-                    <p class="an-section-sub">Seuils de Z-score (écarts à la moyenne) et notifications email.</p>
+        <div class="as-card">
+            <div class="as-card-head">
+                <div class="as-card-icon as-card-icon--anomaly"><i class="fas fa-radiation"></i></div>
+                <div class="as-card-title-block">
+                    <h2>Détection d'anomalies</h2>
+                    <p>Seuils Z-score sur les flux et notifications email aux administrateurs.</p>
                 </div>
+                <button type="button" class="as-card-reset" @click="resetSection('anomaly')">
+                    <i class="fas fa-undo"></i> Restaurer défauts
+                </button>
             </div>
 
-            <div class="an-form-grid">
-                <div class="an-field">
-                    <label class="an-field-label">Seuil Warning (Z-score)
-                        <span class="an-field-help">Écart à la moyenne déclenchant un avertissement (1-5, recommandé : {{ $defaults['anomaly']['z_warning'] }})</span>
-                    </label>
-                    <input type="number" step="0.1" min="1" max="5"
-                           name="anomaly[z_warning]"
-                           value="{{ old('anomaly.z_warning', $settings['anomaly']['z_warning']) }}"
-                           class="an-input" required>
-                </div>
+            <div class="as-form-grid">
+                @php
+                    $anomalyFields = [
+                        ['z_warning', 'Seuil Warning (Z-score)', 'Écart à la moyenne déclenchant un avertissement', 1, 5, 0.1],
+                        ['z_critical', 'Seuil Critical (Z-score)', 'Écart déclenchant une alerte critique', 1.5, 6, 0.1],
+                        ['payment_outlier_multiplier', 'Multiplicateur paiement aberrant', 'Un paiement > N × moyenne déclenche une alerte', 1.5, 10, 0.1],
+                    ];
+                @endphp
+                @foreach($anomalyFields as [$key, $label, $help, $min, $max, $step])
+                    <div class="as-field">
+                        <label class="as-field-label">
+                            <span>{{ $label }}</span>
+                            <span class="as-recommended">recommandé : {{ $defaults['anomaly'][$key] }}</span>
+                        </label>
+                        <div class="as-field-help">{{ $help }}</div>
+                        <div class="as-slider-row">
+                            <input type="range" min="{{ $min }}" max="{{ $max }}" step="{{ $step }}"
+                                   x-model.number="form.anomaly.{{ $key }}"
+                                   class="as-range">
+                            <input type="number" step="{{ $step }}" min="{{ $min }}" max="{{ $max }}"
+                                   name="anomaly[{{ $key }}]"
+                                   x-model.number="form.anomaly.{{ $key }}"
+                                   class="as-number" required>
+                        </div>
+                    </div>
+                @endforeach
 
-                <div class="an-field">
-                    <label class="an-field-label">Seuil Critical (Z-score)
-                        <span class="an-field-help">Écart déclenchant une alerte critique (1.5-6, recommandé : {{ $defaults['anomaly']['z_critical'] }})</span>
-                    </label>
-                    <input type="number" step="0.1" min="1.5" max="6"
-                           name="anomaly[z_critical]"
-                           value="{{ old('anomaly.z_critical', $settings['anomaly']['z_critical']) }}"
-                           class="an-input" required>
-                </div>
-
-                <div class="an-field">
-                    <label class="an-field-label">Multiplicateur paiement aberrant
-                        <span class="an-field-help">Un paiement {{ '>' }} N × moyenne déclenche une alerte (1.5-10, recommandé : {{ $defaults['anomaly']['payment_outlier_multiplier'] }})</span>
-                    </label>
-                    <input type="number" step="0.1" min="1.5" max="10"
-                           name="anomaly[payment_outlier_multiplier]"
-                           value="{{ old('anomaly.payment_outlier_multiplier', $settings['anomaly']['payment_outlier_multiplier']) }}"
-                           class="an-input" required>
-                </div>
-
-                <div class="an-field an-field--checkbox">
-                    <label class="an-field-label">
+                <div class="as-field as-field--toggle">
+                    <label class="as-toggle">
                         <input type="hidden" name="anomaly[notifications_enabled]" value="0">
                         <input type="checkbox" name="anomaly[notifications_enabled]" value="1"
-                               {{ $settings['anomaly']['notifications_enabled'] ? 'checked' : '' }}>
-                        Activer les notifications email pour les alertes critiques
+                               x-model="form.anomaly.notifications_enabled">
+                        <span class="as-toggle-track">
+                            <span class="as-toggle-dot"></span>
+                        </span>
+                        <span class="as-toggle-label">
+                            <strong>Notifications email pour alertes critiques</strong>
+                            <small>Envoyé aux superAdmin + comptables · déduplication 24h</small>
+                        </span>
                     </label>
-                    <span class="an-field-help">Envoyé aux administrateurs et comptables lors d'une anomalie critique. Déduplication 24h.</span>
                 </div>
             </div>
         </div>
 
-        {{-- ===== Recouvrement / WhatsApp template ===== --}}
-        <div class="an-card mt-4">
-            <div class="an-section-header">
-                <div class="an-section-icon"><i class="fab fa-whatsapp"></i></div>
-                <div>
-                    <h2 class="an-section-title">Modèle de message Recouvrement</h2>
-                    <p class="an-section-sub">Template WhatsApp pré-rempli sur la page Recouvrement quotidien. Variables disponibles : <code>{prenom}</code>, <code>{nom}</code>, <code>{solde}</code>, <code>{retard}</code>, <code>{ecole}</code>.</p>
+        {{-- ===== Recouvrement WhatsApp template ===== --}}
+        <div class="as-card">
+            <div class="as-card-head">
+                <div class="as-card-icon as-card-icon--whatsapp"><i class="fab fa-whatsapp"></i></div>
+                <div class="as-card-title-block">
+                    <h2>Modèle de message Recouvrement</h2>
+                    <p>Texte WhatsApp pré-rempli sur la page Recouvrement quotidien.</p>
                 </div>
+                <button type="button" class="as-card-reset" @click="resetWhatsappTemplate()">
+                    <i class="fas fa-undo"></i> Restaurer défaut
+                </button>
             </div>
 
-            <div class="an-form-grid">
-                <div class="an-field" style="grid-column: 1 / -1;">
-                    <label class="an-field-label">Message WhatsApp
-                        <span class="an-field-help">Sera ouvert pré-rempli quand le comptable clique sur le bouton WhatsApp d'un étudiant</span>
+            <div class="as-form-grid">
+                <div class="as-field as-field--full">
+                    <label class="as-field-label">
+                        <span>Message WhatsApp</span>
                     </label>
-                    <textarea name="recouvrement[whatsapp_template]" rows="4" class="an-input" maxlength="1000">{{ old('recouvrement.whatsapp_template', $settings['recouvrement']['whatsapp_template']) }}</textarea>
-                    <div class="an-field-help" style="margin-top: .5rem;">
-                        Recommandé : <em>« {{ $defaults['recouvrement']['whatsapp_template'] }} »</em>
+                    <div class="as-field-help">
+                        Variables : <code>{prenom}</code>, <code>{nom}</code>, <code>{solde}</code>,
+                        <code>{retard}</code>, <code>{ecole}</code>
+                    </div>
+                    <textarea name="recouvrement[whatsapp_template]" rows="4"
+                              x-model="form.recouvrement.whatsapp_template"
+                              class="as-textarea" maxlength="1000"></textarea>
+                    <div class="as-textarea-counter">
+                        <span x-text="form.recouvrement.whatsapp_template.length"></span> / 1000 caractères
                     </div>
                 </div>
             </div>
         </div>
 
-        <div class="an-form-actions mt-4">
-            <button type="submit" class="btn-acasi primary">
-                <i class="fas fa-save me-1"></i> Enregistrer les paramètres
-            </button>
-            <a href="{{ route('esbtp.comptabilite.analytics.index') }}" class="btn-acasi secondary">
+        <div class="as-actions">
+            <a href="{{ route('esbtp.comptabilite.analytics.index') }}" class="as-btn as-btn--ghost">
                 Annuler
             </a>
+            <button type="submit" class="as-btn as-btn--primary">
+                <i class="fas fa-save"></i> Enregistrer les paramètres
+            </button>
         </div>
     </form>
 </div>
+
+<script>
+function settingsPage() {
+    return {
+        defaults: @json($defaults),
+        form: {
+            default_risk: @json($settings['default_risk']),
+            anomaly: {
+                ...@json($settings['anomaly']),
+                notifications_enabled: {{ $settings['anomaly']['notifications_enabled'] ? 'true' : 'false' }},
+            },
+            recouvrement: @json($settings['recouvrement']),
+        },
+        resetSection(section) {
+            const def = this.defaults[section];
+            for (const k of Object.keys(def)) {
+                this.form[section][k] = def[k];
+            }
+        },
+        resetWhatsappTemplate() {
+            this.form.recouvrement.whatsapp_template = this.defaults.recouvrement.whatsapp_template;
+        },
+    };
+}
+</script>
 @endsection
 
 @push('styles')
 <style>
 :root {
-    --an-primary: #0453cb;
-    --an-secondary: #5e91de;
-    --an-dark: #0f172a;
-    --an-text: #1e293b;
-    --an-muted: #64748b;
-    --an-border: #e2e8f0;
+    --as-primary: #0453cb;
+    --as-primary-d: #033a8e;
+    --as-secondary: #5e91de;
+    --as-dark: #0f172a;
+    --as-text: #1e293b;
+    --as-muted: #64748b;
+    --as-border: #e2e8f0;
+    --as-success: #10b981;
+    --as-warning: #f59e0b;
+    --as-danger: #dc2626;
+    --as-whatsapp: #25D366;
 }
 
-.an-card {
-    background: #fff;
-    border: 1px solid var(--an-border);
-    border-radius: 14px;
-    padding: 1.5rem 1.75rem;
-    box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
+.as-page { padding: 1rem 0 3rem; }
+
+.as-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 2rem 2.5rem 1.5rem;
+    color: #fff; margin-bottom: 1.5rem;
+    box-shadow: 0 8px 30px rgba(4,83,203,.18);
 }
-.an-section-header {
-    display: flex; align-items: center; gap: .85rem; margin-bottom: 1.25rem;
+.as-hero-top {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    flex-wrap: wrap; gap: 1rem; margin-bottom: 1.25rem;
 }
-.an-section-icon {
-    width: 42px; height: 42px; border-radius: 11px;
-    background: linear-gradient(135deg, var(--an-primary), var(--an-secondary));
+.as-hero-left { display: flex; align-items: center; gap: 1rem; }
+.as-hero-icon {
+    width: 52px; height: 52px; border-radius: 14px;
+    background: rgba(255,255,255,.12); border: 1px solid rgba(255,255,255,.15);
     display: flex; align-items: center; justify-content: center;
-    color: #fff; font-size: 1rem; flex-shrink: 0;
+    font-size: 1.35rem; flex-shrink: 0; color: #fff;
 }
-.an-section-title { font-size: 1.1rem; font-weight: 700; color: var(--an-dark); margin: 0; }
-.an-section-sub { font-size: .82rem; color: var(--an-muted); margin: .15rem 0 0; }
+.as-hero h1 { font-size: 1.45rem; font-weight: 700; color: #fff; margin: 0; }
+.as-hero p { color: rgba(255,255,255,.72); font-size: .88rem; margin: 0; }
 
-.an-form-grid {
-    display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.25rem;
+.as-btn {
+    display: inline-flex; align-items: center; gap: .5rem;
+    border-radius: 10px; padding: .6rem 1.1rem;
+    font-size: .85rem; font-weight: 600;
+    text-decoration: none; border: none; cursor: pointer;
+    transition: all .2s ease;
 }
-.an-field { display: flex; flex-direction: column; gap: .35rem; }
-.an-field--checkbox { grid-column: 1 / -1; }
-.an-field--checkbox .an-field-label {
-    display: flex; align-items: center; gap: .65rem; cursor: pointer;
-    font-weight: 600; color: var(--an-text);
+.as-btn--glass { background: rgba(255,255,255,.15); color: #fff; border: 1px solid rgba(255,255,255,.2); }
+.as-btn--glass:hover { background: rgba(255,255,255,.25); color: #fff; transform: translateY(-1px); }
+.as-btn--primary { background: var(--as-primary); color: #fff; }
+.as-btn--primary:hover { background: var(--as-primary-d); transform: translateY(-1px); }
+.as-btn--ghost { background: #fff; color: var(--as-muted); border: 1px solid var(--as-border); }
+.as-btn--ghost:hover { background: #f8fafc; color: var(--as-text); }
+
+.as-recap { display: grid; grid-template-columns: repeat(4, 1fr); gap: .75rem; }
+.as-recap-item {
+    background: rgba(255,255,255,.1); border: 1px solid rgba(255,255,255,.15);
+    border-radius: 12px; padding: .85rem 1rem;
 }
-.an-field--checkbox input[type="checkbox"] {
-    width: 18px; height: 18px; accent-color: var(--an-primary);
+.as-recap-label {
+    font-size: .68rem; color: rgba(255,255,255,.65);
+    text-transform: uppercase; letter-spacing: .04em;
 }
-.an-field-label {
-    font-size: .85rem; font-weight: 600; color: var(--an-text);
-    display: flex; flex-direction: column; gap: .15rem;
+.as-recap-value { font-size: 1.05rem; font-weight: 700; color: #fff; margin-top: .2rem; }
+
+.as-banner {
+    border-radius: 12px; padding: .9rem 1.15rem;
+    display: flex; align-items: flex-start; gap: .65rem;
+    margin-bottom: 1rem; font-size: .9rem;
 }
-.an-field-help {
-    font-size: .72rem; color: var(--an-muted); font-weight: 400;
+.as-banner i { font-size: 1.05rem; flex-shrink: 0; margin-top: .1rem; }
+.as-banner ul { margin: .35rem 0 0; padding-left: 1.5rem; font-size: .82rem; }
+.as-banner--success { background: rgba(16,185,129,.06); border: 1px solid rgba(16,185,129,.2); color: #047857; }
+.as-banner--success i { color: var(--as-success); }
+.as-banner--error { background: rgba(220,38,38,.06); border: 1px solid rgba(220,38,38,.2); color: var(--as-danger); }
+
+.as-card {
+    background: #fff; border: 1px solid var(--as-border);
+    border-radius: 14px; margin-bottom: 1.25rem;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
+    overflow: hidden;
 }
-.an-input {
-    padding: .55rem .85rem; border-radius: 10px;
-    border: 1px solid var(--an-border); font-size: .9rem;
-    transition: border-color .15s ease;
+.as-card-head {
+    display: flex; align-items: center; gap: 1rem;
+    padding: 1.25rem 1.5rem; border-bottom: 1px solid var(--as-border);
+    background: linear-gradient(180deg, #fafbfc, #fff);
 }
-.an-input:focus {
-    outline: none; border-color: var(--an-primary);
+.as-card-icon {
+    width: 44px; height: 44px; border-radius: 12px;
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: 1.05rem; flex-shrink: 0;
+}
+.as-card-icon--risk { background: linear-gradient(135deg, #dc2626, #f59e0b); }
+.as-card-icon--anomaly { background: linear-gradient(135deg, #f59e0b, #b45309); }
+.as-card-icon--whatsapp { background: linear-gradient(135deg, #25D366, #128c7e); }
+.as-card-title-block { flex: 1; }
+.as-card-title-block h2 { font-size: 1.05rem; font-weight: 700; color: var(--as-dark); margin: 0; }
+.as-card-title-block p { font-size: .82rem; color: var(--as-muted); margin: .15rem 0 0; }
+.as-card-reset {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .4rem .75rem; border-radius: 8px;
+    background: transparent; border: 1px solid var(--as-border);
+    font-size: .75rem; color: var(--as-muted); cursor: pointer;
+    transition: all .15s ease;
+}
+.as-card-reset:hover { background: #f1f5f9; color: var(--as-text); border-color: #cbd5e1; }
+
+.as-form-grid {
+    display: grid; grid-template-columns: repeat(2, 1fr); gap: 1.5rem;
+    padding: 1.5rem;
+}
+.as-field { display: flex; flex-direction: column; gap: .35rem; }
+.as-field--full { grid-column: 1 / -1; }
+.as-field--toggle { grid-column: 1 / -1; }
+
+.as-field-label {
+    display: flex; justify-content: space-between; align-items: baseline;
+    font-size: .9rem; font-weight: 600; color: var(--as-text);
+}
+.as-recommended { font-size: .7rem; color: var(--as-muted); font-weight: 500; font-style: italic; }
+.as-field-help { font-size: .75rem; color: var(--as-muted); margin-bottom: .25rem; }
+.as-field-help code {
+    background: #f1f5f9; padding: 1px 6px; border-radius: 4px;
+    font-size: .72rem; color: var(--as-primary); border: 1px solid #e2e8f0;
+}
+
+.as-slider-row {
+    display: flex; align-items: center; gap: .85rem;
+    background: #fafbfc; border: 1px solid var(--as-border);
+    border-radius: 10px; padding: .6rem .85rem;
+}
+.as-range {
+    flex: 1; height: 4px; -webkit-appearance: none; appearance: none;
+    background: linear-gradient(90deg, var(--as-primary) 0%, var(--as-secondary) 100%);
+    border-radius: 99px; outline: none; cursor: pointer;
+}
+.as-range::-webkit-slider-thumb {
+    -webkit-appearance: none; appearance: none;
+    width: 18px; height: 18px; border-radius: 50%;
+    background: #fff; border: 2px solid var(--as-primary);
+    cursor: pointer; box-shadow: 0 1px 3px rgba(0,0,0,.15);
+    transition: transform .15s;
+}
+.as-range::-webkit-slider-thumb:hover { transform: scale(1.15); }
+.as-range::-moz-range-thumb {
+    width: 18px; height: 18px; border-radius: 50%;
+    background: #fff; border: 2px solid var(--as-primary);
+    cursor: pointer; box-shadow: 0 1px 3px rgba(0,0,0,.15);
+}
+.as-number {
+    width: 90px; padding: .35rem .5rem; text-align: center;
+    border: 1px solid var(--as-border); border-radius: 8px;
+    font-size: .9rem; font-weight: 600; color: var(--as-primary); background: #fff;
+}
+.as-number:focus {
+    outline: none; border-color: var(--as-primary);
     box-shadow: 0 0 0 3px rgba(4,83,203,.1);
 }
 
-.an-form-actions {
-    display: flex; gap: .75rem; flex-wrap: wrap;
-    padding: 1rem 0; justify-content: flex-end;
+.as-textarea {
+    width: 100%; padding: .85rem 1rem;
+    border: 1px solid var(--as-border); border-radius: 10px;
+    font-size: .92rem; font-family: inherit; color: var(--as-text);
+    background: #fafbfc; resize: vertical; min-height: 100px;
+    transition: border-color .15s;
+}
+.as-textarea:focus {
+    outline: none; border-color: var(--as-primary); background: #fff;
+    box-shadow: 0 0 0 3px rgba(4,83,203,.1);
+}
+.as-textarea-counter { margin-top: .35rem; font-size: .72rem; color: var(--as-muted); text-align: right; }
+
+.as-toggle {
+    display: flex; align-items: center; gap: 1rem; cursor: pointer;
+    padding: 1rem 1.25rem; background: #fafbfc;
+    border: 1px solid var(--as-border); border-radius: 12px;
+    transition: all .15s;
+}
+.as-toggle:hover { background: #f1f5f9; }
+.as-toggle input[type="checkbox"] { display: none; }
+.as-toggle-track {
+    position: relative; display: inline-block;
+    width: 44px; height: 24px; border-radius: 99px;
+    background: #cbd5e1; transition: background .2s; flex-shrink: 0;
+}
+.as-toggle-dot {
+    position: absolute; top: 2px; left: 2px;
+    width: 20px; height: 20px; border-radius: 50%;
+    background: #fff; transition: transform .2s; box-shadow: 0 1px 3px rgba(0,0,0,.2);
+}
+.as-toggle input:checked + .as-toggle-track { background: var(--as-primary); }
+.as-toggle input:checked + .as-toggle-track .as-toggle-dot { transform: translateX(20px); }
+.as-toggle-label strong { display: block; font-size: .9rem; color: var(--as-text); }
+.as-toggle-label small { display: block; font-size: .75rem; color: var(--as-muted); margin-top: .15rem; }
+
+.as-actions {
+    display: flex; justify-content: flex-end; gap: .75rem; padding: 1.25rem 0;
 }
 
-.an-alert { border-radius: 12px; border: none; }
-
+@media (max-width: 992px) {
+    .as-recap { grid-template-columns: repeat(2, 1fr); }
+    .as-form-grid { grid-template-columns: 1fr; }
+}
 @media (max-width: 768px) {
-    .an-form-grid { grid-template-columns: 1fr; }
-    .an-card { padding: 1.25rem 1rem; }
+    .as-hero { padding: 1.5rem 1.25rem 1.25rem; }
+    .as-hero h1 { font-size: 1.2rem; }
+    .as-card-head { flex-wrap: wrap; }
+    .as-card-reset { width: 100%; justify-content: center; margin-top: .5rem; }
+    .as-recap { grid-template-columns: 1fr; }
 }
 </style>
 @endpush

--- a/resources/views/esbtp/comptabilite/recouvrement/index.blade.php
+++ b/resources/views/esbtp/comptabilite/recouvrement/index.blade.php
@@ -28,6 +28,12 @@
                 <a href="{{ route('esbtp.comptabilite.analytics.index') }}" class="re-btn re-btn--glass">
                     <i class="fas fa-chart-line"></i> Analytics
                 </a>
+                <x-export-modal
+                    :preview-url="route('esbtp.comptabilite.recouvrement.preview-pdf')"
+                    :pdf-url="route('esbtp.comptabilite.recouvrement.export-pdf')"
+                    :excel-url="route('esbtp.comptabilite.recouvrement.export-excel')"
+                    :email-url="route('esbtp.comptabilite.recouvrement.email-pdf')"
+                    button-class="re-btn re-btn--glass" />
             </div>
         </div>
 
@@ -115,6 +121,10 @@
                                 <td>
                                     <div class="re-cell-student">
                                         <strong x-text="row.etudiant_nom"></strong>
+                                        <small x-show="row.has_valid_phone" class="re-phone">
+                                            <i class="fas fa-phone"></i>
+                                            <span x-text="formatPhone(row.phone)"></span>
+                                        </small>
                                         <small x-show="!row.has_valid_phone" class="re-warn">
                                             <i class="fas fa-exclamation-triangle"></i> Téléphone invalide
                                         </small>
@@ -180,7 +190,7 @@
 
 <script>
 function recouvrement(config) {
-    return {
+    const instance = {
         rows: config.rows.map(r => ({ ...r, confirmed: false, lastRelanceId: null })),
         search: '',
         levelFilter: '',
@@ -188,6 +198,13 @@ function recouvrement(config) {
         toast: null,
         toastType: 'info',
         config,
+        init() {
+            window.exportFilters = () => ({
+                search: this.search,
+                level: this.levelFilter,
+                retard_min: this.retardFilter,
+            });
+        },
 
         get filteredRows() {
             return this.rows.filter(row => {
@@ -287,7 +304,18 @@ function recouvrement(config) {
             this.toastType = type;
             setTimeout(() => { this.toast = null; }, 3500);
         },
+
+        formatPhone(raw) {
+            if (!raw) return '';
+            const digits = String(raw).replace(/\D+/g, '');
+            let national = digits;
+            if (digits.startsWith('00225')) national = digits.slice(5);
+            else if (digits.length === 13 && digits.startsWith('225')) national = digits.slice(3);
+            if (national.length !== 10) return raw;
+            return '+225 ' + national.match(/.{1,2}/g).join(' ');
+        },
     };
+    return instance;
 }
 </script>
 @endsection
@@ -420,6 +448,12 @@ function recouvrement(config) {
 .re-warn { color: var(--re-warning); }
 .re-info { color: var(--re-muted); display: inline-flex; align-items: center; gap: .35rem; }
 .re-info i { font-size: .65rem; }
+.re-phone {
+    color: var(--re-primary); display: inline-flex; align-items: center; gap: .35rem;
+    font-family: 'SFMono-Regular', Menlo, Consolas, monospace;
+    font-size: .72rem; margin-top: .15rem;
+}
+.re-phone i { font-size: .6rem; opacity: .7; }
 
 .re-chip {
     display: inline-block; padding: .25rem .6rem;

--- a/resources/views/esbtp/comptabilite/recouvrement/pdf.blade.php
+++ b/resources/views/esbtp/comptabilite/recouvrement/pdf.blade.php
@@ -1,0 +1,133 @@
+<x-pdf-document
+    title="{{ $reportTitle ?? 'Recouvrement quotidien' }}"
+    subtitle="{{ $reportSubtitle ?? 'Liste priorisée des étudiants à relancer' }}"
+    :filters="$reportFilters ?? []"
+    orientation="landscape">
+
+    <style>
+        .kpi-strip {
+            display: table; width: 100%; border-collapse: collapse;
+            margin-bottom: 14px; border: 1px solid #e2e8f0;
+            border-radius: 4px; overflow: hidden;
+        }
+        .kpi-cell {
+            display: table-cell; text-align: center;
+            padding: 10px 8px; border-right: 1px solid #e2e8f0;
+            background: #fafbfc; width: 25%;
+            -webkit-print-color-adjust: exact; color-adjust: exact;
+        }
+        .kpi-cell:last-child { border-right: none; }
+        .kpi-cell-value { font-size: 14px; font-weight: 700; color: #0453cb; }
+        .kpi-cell-label {
+            font-size: 8px; color: #64748b;
+            text-transform: uppercase; letter-spacing: .03em; margin-top: 2px;
+        }
+
+        .report-table { width: 100%; border-collapse: collapse; font-size: 9px; margin-top: 6px; }
+        .report-table thead th {
+            color: #fff; font-weight: 600; padding: 6px 4px; text-align: left;
+            text-transform: uppercase; letter-spacing: .3px; font-size: 8px;
+            -webkit-print-color-adjust: exact; color-adjust: exact;
+        }
+        .report-table tbody td { padding: 5px 4px; border-bottom: 1px solid #e5e7eb; vertical-align: middle; }
+        .report-table tbody tr:nth-child(even) { background: #fafbfc; }
+
+        .text-center { text-align: center; }
+        .text-right  { text-align: right; }
+        .amount-cell { font-weight: 600; color: #0f172a; }
+        .phone-cell  { font-family: 'Courier New', monospace; font-size: 8.5px; color: #334155; }
+
+        .chip { display: inline-block; padding: 1px 6px; border-radius: 8px; font-size: 8px; font-weight: 600; }
+        .chip-retard { background: rgba(245,158,11,.15); color: #b45309; }
+
+        .badge {
+            display: inline-block; padding: 2px 6px; border-radius: 8px;
+            font-size: 8px; font-weight: 700; text-transform: uppercase; letter-spacing: .04em;
+        }
+        .badge-haut  { background: rgba(220,38,38,.15); color: #dc2626; }
+        .badge-moyen { background: rgba(245,158,11,.15); color: #b45309; }
+        .badge-bas   { background: rgba(16,185,129,.15); color: #047857; }
+
+        .report-footer-summary {
+            margin-top: 10px; padding: 8px 12px;
+            background: #f1f5f9; border-radius: 4px;
+            font-size: 9px; color: #1e293b;
+        }
+        .report-footer-summary strong { color: #0453cb; }
+    </style>
+
+    @if(!empty($kpis))
+        <div class="kpi-strip">
+            <div class="kpi-cell">
+                <div class="kpi-cell-value">{{ $kpis['buckets']['haut'] ?? 0 }}</div>
+                <div class="kpi-cell-label">Haut risque</div>
+            </div>
+            <div class="kpi-cell">
+                <div class="kpi-cell-value">{{ number_format($kpis['total_solde_haut_risque'] ?? 0, 0, ',', ' ') }}</div>
+                <div class="kpi-cell-label">FCFA non recouvrés (haut)</div>
+            </div>
+            <div class="kpi-cell">
+                <div class="kpi-cell-value">{{ $kpis['buckets']['moyen'] ?? 0 }}</div>
+                <div class="kpi-cell-label">Sous surveillance</div>
+            </div>
+            <div class="kpi-cell">
+                <div class="kpi-cell-value">{{ $kpis['total_actifs'] ?? count($rows) }}</div>
+                <div class="kpi-cell-label">Étudiants actifs</div>
+            </div>
+        </div>
+    @endif
+
+    <table class="report-table">
+        <thead>
+            <tr>
+                <th style="width:30px;">#</th>
+                <th>Étudiant</th>
+                <th>Classe</th>
+                <th>Téléphone</th>
+                <th class="text-right">Solde restant</th>
+                <th class="text-center">Retard</th>
+                <th class="text-center">% payé</th>
+                <th class="text-center">Niveau</th>
+                <th class="text-center">Score</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($rows as $i => $row)
+                <tr class="row-{{ $row['level'] ?? 'bas' }}">
+                    <td class="text-center">{{ $i + 1 }}</td>
+                    <td><strong>{{ $row['etudiant_nom'] ?? '—' }}</strong></td>
+                    <td>{{ $row['classe_nom'] ?? '—' }}</td>
+                    <td class="phone-cell">
+                        {{ \App\Domain\Notifications\PhoneFormatter::toReadable($row['phone'] ?? null) ?? '—' }}
+                    </td>
+                    <td class="text-right amount-cell">
+                        {{ number_format($row['solde_restant'] ?? 0, 0, ',', ' ') }} FCFA
+                    </td>
+                    <td class="text-center">
+                        @php $r = (int) ($row['jours_retard'] ?? 0); @endphp
+                        @if($r > 0)
+                            <span class="chip chip-retard">{{ $r }} j</span>
+                        @else
+                            —
+                        @endif
+                    </td>
+                    <td class="text-center">{{ round((($row['ratio_paye'] ?? 0)) * 100, 0) }}%</td>
+                    <td class="text-center">
+                        <span class="badge badge-{{ $row['level'] ?? 'bas' }}">{{ ucfirst($row['level'] ?? 'bas') }}</span>
+                    </td>
+                    <td class="text-center">{{ number_format($row['score'] ?? 0, 2) }}</td>
+                </tr>
+            @empty
+                <tr><td colspan="9" class="text-center" style="padding:20px;color:#64748b;">Aucun étudiant à risque dans ce périmètre.</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    @if(count($rows) > 0)
+        <div class="report-footer-summary">
+            Total affiché : <strong>{{ count($rows) }}</strong> étudiant(s) ·
+            Solde cumulé : <strong>{{ number_format(collect($rows)->sum('solde_restant'), 0, ',', ' ') }} FCFA</strong>
+        </div>
+    @endif
+</x-pdf-document>
+

--- a/resources/views/esbtp/paiements/exports/form.blade.php
+++ b/resources/views/esbtp/paiements/exports/form.blade.php
@@ -537,12 +537,15 @@
                     <i class="fas fa-info-circle"></i>
                     <span>Cliquez sur « Vérifier » pour compter les lignes correspondant aux filtres</span>
                 </div>
-                <div class="d-flex gap-2">
+                <div class="d-flex gap-2 flex-wrap">
                     <button type="button" id="pe-btn-preview" class="pe-action-btn pe-action-btn--secondary">
-                        <i class="fas fa-search"></i> Vérifier
+                        <i class="fas fa-search"></i> Vérifier le volume
+                    </button>
+                    <button type="button" id="pe-btn-preview-pdf" class="pe-action-btn pe-action-btn--secondary" disabled>
+                        <i class="fas fa-eye"></i> Aperçu PDF
                     </button>
                     <button type="submit" id="pe-btn-generate" class="pe-action-btn pe-action-btn--primary" disabled>
-                        <i class="fas fa-download"></i> Générer le fichier
+                        <i class="fas fa-download"></i> Télécharger
                     </button>
                 </div>
             </div>
@@ -773,15 +776,19 @@
                 const info = document.getElementById('pe-preview-info');
                 const generateBtn = document.getElementById('pe-btn-generate');
 
+                const previewPdfBtn = document.getElementById('pe-btn-preview-pdf');
+                const formatPdf = document.querySelector('input[name="format"]:checked')?.value === 'pdf';
                 if (ok && json.success) {
                     info.className = 'pe-preview-info is-success';
                     info.querySelector('span').textContent = json.message || (json.count + ' lignes prêtes');
                     generateBtn.disabled = false;
+                    previewPdfBtn.disabled = !formatPdf;
                     toast(json.message || 'Prévisualisation OK', 'success');
                 } else {
                     info.className = 'pe-preview-info is-error';
                     info.querySelector('span').textContent = json.message || ('Erreur ' + status);
                     generateBtn.disabled = true;
+                    previewPdfBtn.disabled = true;
                     toast(json.message || 'Erreur de prévisualisation', 'error');
                 }
             })
@@ -800,9 +807,27 @@
             const generateBtn = document.getElementById('pe-btn-generate');
             if (generateBtn.disabled) {
                 e.preventDefault();
-                toast('Veuillez d\'abord cliquer sur « Vérifier »', 'warning');
+                toast('Veuillez d\'abord cliquer sur « Vérifier le volume »', 'warning');
                 return;
             }
+        });
+
+        // Aperçu PDF — submit le form vers preview-pdf (nouvelle tab)
+        document.getElementById('pe-btn-preview-pdf').addEventListener('click', function () {
+            const form = document.getElementById('pe-form');
+            const originalAction = form.action;
+            const originalTarget = form.target;
+            form.action = '{{ route("esbtp.paiements.export-detaille.preview-pdf") }}';
+            form.target = '_blank';
+            // Force format=pdf temporairement
+            const formatInput = document.querySelector('input[name="format"][value="pdf"]');
+            const wasChecked = formatInput?.checked;
+            if (formatInput && !wasChecked) formatInput.checked = true;
+            form.submit();
+            // Restaurer (le submit a déjà été lancé)
+            form.action = originalAction;
+            form.target = originalTarget;
+            if (formatInput && !wasChecked) formatInput.checked = false;
         });
     })();
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -831,6 +831,7 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
                 ->group(function () {
                     Route::get('/', [App\Http\Controllers\ESBTPPaiementExportController::class, 'index'])->name('index');
                     Route::post('/preview', [App\Http\Controllers\ESBTPPaiementExportController::class, 'preview'])->name('preview');
+                    Route::post('/preview-pdf', [App\Http\Controllers\ESBTPPaiementExportController::class, 'previewPdf'])->name('preview-pdf');
                     Route::post('/generate', [App\Http\Controllers\ESBTPPaiementExportController::class, 'generate'])->name('generate');
                 });
 
@@ -1481,6 +1482,16 @@ Route::middleware(['auth', 'comptabilite.access'])->prefix('esbtp/comptabilite')
     Route::post('/analytics/settings', [\App\Http\Controllers\ESBTPAnalyticsController::class, 'updateSettings'])
         ->name('analytics.settings.update')
         ->middleware(['permission:comptabilite.analytics.configure', 'throttle:20,1']);
+    // Analytics — exports (PDF preview/download + Excel multi-sheets)
+    Route::get('/analytics/preview-pdf', [\App\Http\Controllers\ESBTPAnalyticsController::class, 'previewPdf'])
+        ->name('analytics.preview-pdf')
+        ->middleware(['permission:comptabilite.analytics.view', 'throttle:30,1']);
+    Route::get('/analytics/export-pdf', [\App\Http\Controllers\ESBTPAnalyticsController::class, 'exportPdf'])
+        ->name('analytics.export-pdf')
+        ->middleware(['permission:comptabilite.analytics.view', 'throttle:10,1']);
+    Route::get('/analytics/export-excel', [\App\Http\Controllers\ESBTPAnalyticsController::class, 'exportExcel'])
+        ->name('analytics.export-excel')
+        ->middleware(['permission:comptabilite.analytics.view', 'throttle:10,1']);
 
     // Recouvrement quotidien (Sprint 11 — RecouvrementOptimizer + WhatsApp deeplinks)
     Route::get('/recouvrement', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'index'])
@@ -1494,6 +1505,19 @@ Route::middleware(['auth', 'comptabilite.access'])->prefix('esbtp/comptabilite')
     Route::post('/recouvrement/mark-done', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'markDone'])
         ->name('recouvrement.mark-done')
         ->middleware('throttle:120,1');
+    // Recouvrement — exports (PDF preview/download + Excel + email)
+    Route::get('/recouvrement/preview-pdf', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'previewPdf'])
+        ->name('recouvrement.preview-pdf')
+        ->middleware(['permission:comptabilite.recouvrement.access', 'throttle:30,1']);
+    Route::get('/recouvrement/export-pdf', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'exportPdf'])
+        ->name('recouvrement.export-pdf')
+        ->middleware(['permission:comptabilite.recouvrement.access', 'throttle:10,1']);
+    Route::get('/recouvrement/export-excel', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'exportExcel'])
+        ->name('recouvrement.export-excel')
+        ->middleware(['permission:comptabilite.recouvrement.access', 'throttle:10,1']);
+    Route::post('/recouvrement/email-pdf', [\App\Http\Controllers\ESBTPRecouvrementController::class, 'emailPdf'])
+        ->name('recouvrement.email-pdf')
+        ->middleware(['permission:comptabilite.recouvrement.access', 'throttle:5,1']);
 
     // Gestion des frais de scolarité
     Route::get('/frais-scolarite', [ESBTPComptabiliteReportController::class, 'fraisScolarite'])->name('frais-scolarite');

--- a/tests/Unit/Domain/Notifications/PhoneFormatterTest.php
+++ b/tests/Unit/Domain/Notifications/PhoneFormatterTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\Domain\Notifications;
+
+use App\Domain\Notifications\PhoneFormatter;
+use PHPUnit\Framework\TestCase;
+
+class PhoneFormatterTest extends TestCase
+{
+    public function test_null_returns_null(): void
+    {
+        $this->assertNull(PhoneFormatter::toReadable(null));
+        $this->assertNull(PhoneFormatter::toReadable(''));
+    }
+
+    public function test_invalid_returns_null(): void
+    {
+        $this->assertNull(PhoneFormatter::toReadable('abc'));
+        $this->assertNull(PhoneFormatter::toReadable('99 99 99 99 99'));
+    }
+
+    public function test_national_format_pairs(): void
+    {
+        $this->assertSame('+225 07 07 12 34 56', PhoneFormatter::toReadable('0707123456'));
+    }
+
+    public function test_orange_format(): void
+    {
+        $this->assertSame('+225 05 12 34 56 78', PhoneFormatter::toReadable('0512345678'));
+    }
+
+    public function test_with_spaces(): void
+    {
+        $this->assertSame('+225 07 07 12 34 56', PhoneFormatter::toReadable('07 07 12 34 56'));
+    }
+
+    public function test_already_e164(): void
+    {
+        $this->assertSame('+225 07 07 12 34 56', PhoneFormatter::toReadable('+2250707123456'));
+    }
+}


### PR DESCRIPTION
## Summary

Plan C complet (Phases 1-7) du chantier exports KLASSCI. Introduit un pattern réutilisable PDF + Excel avec preview visuel (nouvel onglet), applique aux 3 pages demandées (Recouvrement, Analytics, Paiements), redesign premium settings, AJAX no-refresh sur Recalculer, email PDF.

Phases 8-10 (export programmé cron, templates customisables tenant, migration legacy templates) déférées future PR.

## Livrables

### Fondations (Phase 1)
- `ExportableReport` abstract base + `ExportRenderer` service (preview/download/email/cache)
- `<x-pdf-document>` composant Blade unifié (logo + school + theme + footer paginé)
- `<x-pdf-filters-recap>` bandeau filtres
- `<x-export-modal>` dropdown UI 4 actions
- `PhoneFormatter` (CI lisible "+225 07 07 12 34 56")
- Rule `.claude/rules/exports-pdf-excel.md` documentant le pattern obligatoire

### Pages exports
- **Recouvrement** : preview + PDF + Excel + Email — téléphone visible sous le nom + filtres reproduits server-side
- **Analytics** : preview + PDF multi-sections + Excel 3 sheets distinctes
- **Paiements/export-detaille** : bouton "Aperçu PDF" ajouté (nouvel onglet)

### Settings analytics premium (Phase 5)
- Hero gradient bleu KLASSCI + 4 KPIs live recap
- Sliders visuels pour seuils/poids
- Toggle switch premium
- "Restaurer défauts" par section
- Section icons gradient colorés sémantiquement

### Email PDF (Phase 7)
- `ExportableReportMail` queueable avec attachment binaire
- Template HTML premium
- Bouton "Envoyer par email" dans `<x-export-modal>` (Recouvrement)

### AJAX no-refresh
- Bouton "Recalculer" Analytics → fetch POST + toast (no full reload)
- Pattern documenté dans rule `laravel-ajax-blade-alpine.md` existante

## Architecture extensible

- Nouveaux Reports = `extends ExportableReport` (Open/Closed)
- Nouveaux canaux = nouvelle `NotificationChannelInterface` impl (Strategy)
- Migration progressive templates legacy sans rework

## Production-grade

- Throttle sur toutes routes (10/min download, 30/min preview, 5/min email)
- Garde-fous volume hérités (PDF_MAX_ROWS, EXCEL_MAX_ROWS)
- Fallback graceful téléphone invalide
- Validation strict
- Cache PDF opt-in 5min via setting

## Test plan

- [ ] /esbtp/comptabilite/recouvrement → bouton Exporter affiche dropdown 4 options
- [ ] Aperçu PDF Recouvrement → ouvre nouvelle tab avec PDF inline
- [ ] Téléphone CI affiché format lisible dans table + PDF + Excel
- [ ] Filtres (search/level/retard) reproduits dans le PDF/Excel exporté
- [ ] /esbtp/comptabilite/analytics → bouton Exporter visible + Recalculer en AJAX (toast, no reload)
- [ ] Aperçu PDF Analytics → 3 sections (CashFlow + Risk + Anomalies)
- [ ] Excel Analytics → 3 sheets distinctes
- [ ] /esbtp/paiements/export-detaille → bouton "Aperçu PDF" disabled si pas vérifié
- [ ] /esbtp/comptabilite/analytics/settings → hero premium + sliders + toggle + recap KPIs live
- [ ] Email PDF Recouvrement → prompt adresse + envoi queue