### PR TITLE
refactor(enseignants): migrate ESBTPTeacher::where(user_id) to User->teacherProfile relation

### DIFF
--- a/app/Http/Controllers/API/BaseApiController.php
+++ b/app/Http/Controllers/API/BaseApiController.php
@@ -251,7 +251,7 @@ class BaseApiController extends Controller
 
             case 'evaluations':
                 // Autoriser plusieurs chemins pour retrouver les évaluations de l'enseignant
-                $teacher = ESBTPTeacher::where('user_id', $user->id)->first();
+                $teacher = $user->teacherProfile;
                 $teacherId = $teacher ? $teacher->id : null;
 
                 return $query->where(function ($subQuery) use ($user, $annee, $teacherId) {

--- a/app/Http/Controllers/API/LMSDataController.php
+++ b/app/Http/Controllers/API/LMSDataController.php
@@ -1305,7 +1305,7 @@ class LMSDataController extends BaseApiController
 
         // Récupérer le teacher associé à l'utilisateur connecté (table esbtp_teachers)
         // IMPORTANT: teacher_id dans les séances référence esbtp_teachers.id, PAS users.id
-        $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
         $teacherId = $teacher ? $teacher->id : null;
 
         if (!$teacherId) {
@@ -2333,7 +2333,7 @@ class LMSDataController extends BaseApiController
 
         // Vérifier si c'est l'enseignant
         if ($user->can('identity.teach')) {
-            $teacher = \App\Models\ESBTPTeacher::where('user_id', $userId)->first();
+            $teacher = $user->teacherProfile;
 
             if ($teacher && $seance->teacher_id == $teacher->id) {
                 $authorized = true;
@@ -2785,7 +2785,7 @@ class LMSDataController extends BaseApiController
         }
         // Si c'est un enseignant
         elseif ($user->can('identity.teach')) {
-            $teacher = \App\Models\ESBTPTeacher::where('user_id', $userId)->first();
+            $teacher = $user->teacherProfile;
 
             if ($teacher) {
                 $preferences['channels']['whatsapp']['phone'] = $teacher->telephone ?? $user->phone;

--- a/app/Http/Controllers/ESBTP/Admin/ESBTPTeacherAttendanceController.php
+++ b/app/Http/Controllers/ESBTP/Admin/ESBTPTeacherAttendanceController.php
@@ -47,9 +47,9 @@ class ESBTPTeacherAttendanceController extends Controller
     private function showTeacherAttendancePage()
     {
         $user = auth()->user();
-        
+
         // Récupérer le modèle enseignant associé à l'utilisateur
-        $teacherModel = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacherModel = $user->teacherProfile;
         $teacherId = $teacherModel ? $teacherModel->id : null;
         $teacherUserId = $user->id;
 
@@ -154,9 +154,9 @@ class ESBTPTeacherAttendanceController extends Controller
         
         // Get current teacher
         $user = auth()->user();
-        
+
         // Récupérer le modèle enseignant associé à l'utilisateur
-        $teacherModel = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacherModel = $user->teacherProfile;
         if (!$teacherModel) {
             return redirect()->back()->with('error', 'Aucun profil enseignant associé à ce compte.');
         }

--- a/app/Http/Controllers/ESBTP/ESBTPTeacherAttendanceController.php
+++ b/app/Http/Controllers/ESBTP/ESBTPTeacherAttendanceController.php
@@ -22,7 +22,7 @@ class ESBTPTeacherAttendanceController extends Controller
     public function index()
     {
         $user = Auth::user();
-        $teacherModel = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacherModel = $user->teacherProfile;
         $teacherId = $teacherModel ? $teacherModel->id : null;
         $today = \Carbon\Carbon::today()->format('Y-m-d');
 
@@ -81,7 +81,7 @@ class ESBTPTeacherAttendanceController extends Controller
             $settings = config('esbtp.attendance', []);
 
             // Récupérer le modèle enseignant lié à l'utilisateur
-            $teacherModel = \App\Models\ESBTPTeacher::where('user_id', $teacher->id)->first();
+            $teacherModel = $teacher->teacherProfile;
             if (!$teacherModel) {
                 throw new \Exception('Aucun profil enseignant associé à ce compte.');
             }

--- a/app/Http/Controllers/ESBTP/SessionReportController.php
+++ b/app/Http/Controllers/ESBTP/SessionReportController.php
@@ -20,7 +20,7 @@ class SessionReportController extends Controller
         $user = Auth::user();
 
         // Récupérer le teacher associé à l'utilisateur
-        $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
         if (!$teacher) {
             abort(403, 'Vous n\'êtes pas enregistré comme enseignant.');
         }
@@ -54,7 +54,7 @@ class SessionReportController extends Controller
         $user = Auth::user();
 
         // Récupérer le teacher associé à l'utilisateur
-        $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
         if (!$teacher) {
             abort(403, 'Vous n\'êtes pas enregistré comme enseignant.');
         }

--- a/app/Http/Controllers/ESBTP/TeacherAttendanceController.php
+++ b/app/Http/Controllers/ESBTP/TeacherAttendanceController.php
@@ -116,7 +116,7 @@ class TeacherAttendanceController extends Controller
             $seanceCours = ESBTPSeanceCours::findOrFail($request->course_id);
 
             // Get the teacher record from esbtp_teachers table
-            $teacher = ESBTPTeacher::where('user_id', $user->id)->first();
+            $teacher = $user->teacherProfile;
 
             if (!$teacher) {
                 return back()->with('error', 'Profil enseignant non trouvé.');
@@ -661,7 +661,7 @@ class TeacherAttendanceController extends Controller
         $seance = ESBTPSeanceCours::with(['matiere', 'classe'])->findOrFail($seanceId);
 
         // Récupérer le modèle enseignant associé à l'utilisateur
-        $teacherModel = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacherModel = $user->teacherProfile;
         if (!$teacherModel) {
             return redirect()->route('teacher.dashboard')
                 ->with('error', 'Aucun profil enseignant associé à ce compte.');

--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -105,7 +105,7 @@ class ESBTPClasseController extends Controller
 
         // Enseignant : ne voir que les classes où il a des séances dans l'emploi du temps
         if ($user && $user->can('can_teach')) {
-            $teacher = ESBTPTeacher::where('user_id', $user->id)->first();
+            $teacher = $user->teacherProfile;
             if ($teacher && $anneeCourante) {
                 $classeIds = ESBTPSeanceCours::query()
                     ->join('esbtp_emploi_temps', 'esbtp_seance_cours.emploi_temps_id', '=', 'esbtp_emploi_temps.id')

--- a/app/Http/Controllers/ESBTPNoteController.php
+++ b/app/Http/Controllers/ESBTPNoteController.php
@@ -65,7 +65,7 @@ class ESBTPNoteController extends Controller
         // Enseignant : ne voir que les classes où il a des séances dans l'emploi du temps
         $user = Auth::user();
         if ($user && $user->can('identity.teach')) {
-            $teacher = ESBTPTeacher::where('user_id', $user->id)->first();
+            $teacher = $user->teacherProfile;
             if ($teacher && $anneeCourante) {
                 $classeIds = ESBTPSeanceCours::query()
                     ->join('esbtp_emploi_temps', 'esbtp_seance_cours.emploi_temps_id', '=', 'esbtp_emploi_temps.id')

--- a/app/Http/Controllers/TeacherController.php
+++ b/app/Http/Controllers/TeacherController.php
@@ -375,7 +375,7 @@ class TeacherController extends Controller
     public function profile()
     {
         // Essayer d'abord ESBTPTeacher, puis Teacher
-        $teacher = \App\Models\ESBTPTeacher::where('user_id', Auth::id())->first();
+        $teacher = auth()->user()?->teacherProfile;
 
         if (!$teacher) {
             $teacher = Auth::user()->teacher;
@@ -415,7 +415,7 @@ class TeacherController extends Controller
         $user = Auth::user();
 
         // Essayer d'abord ESBTPTeacher, puis Teacher
-        $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
 
         if (!$teacher) {
             $teacher = $user->teacher;

--- a/app/Http/Controllers/TeacherDashboardController.php
+++ b/app/Http/Controllers/TeacherDashboardController.php
@@ -34,7 +34,7 @@ class TeacherDashboardController extends Controller
     public function index()
     {
         $user = Auth::user();
-        $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
         $teacherId = $teacher ? $teacher->id : null;
         $anneeEnCours = ESBTPAnneeUniversitaire::where('is_current', true)->first();
         \Log::info('Dashboard enseignant - user_id', ['user_id' => $user->id, 'teacher_id' => $teacherId]);
@@ -161,7 +161,7 @@ class TeacherDashboardController extends Controller
         $callType = request()->get('type', 'start');
 
         // Récupérer le teacher associé à l'utilisateur connecté
-        $teacher = ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
         if (! $teacher) {
             abort(403, 'Vous n\'êtes pas enregistré comme enseignant.');
         }
@@ -246,7 +246,7 @@ class TeacherDashboardController extends Controller
         $callType = $request->input('call_type', 'start');
 
         // Récupérer le teacher associé à l'utilisateur connecté
-        $teacher = ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
         if (! $teacher) {
             abort(403, 'Vous n\'êtes pas enregistré comme enseignant.');
         }
@@ -472,7 +472,7 @@ class TeacherDashboardController extends Controller
     public function closeCourse($seanceId)
     {
         $user = Auth::user();
-        $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
 
         $seance = ESBTPSeanceCours::where('id', $seanceId)
             ->where('teacher_id', $teacher->id ?? null)
@@ -512,7 +512,7 @@ class TeacherDashboardController extends Controller
     public function showTimetable(Request $request)
     {
         $user = Auth::user();
-        $teacherModel = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacherModel = $user->teacherProfile;
         $teacherId = $teacherModel ? $teacherModel->id : null;
 
         // Navigation par période (semaine par défaut)
@@ -798,7 +798,7 @@ class TeacherDashboardController extends Controller
     public function showAttendance()
     {
         $user = Auth::user();
-        $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
         $teacherId = $teacher ? $teacher->id : null;
 
         // Récupérer les séances de cours pour lesquelles l'enseignant a enregistré des présences
@@ -912,7 +912,7 @@ class TeacherDashboardController extends Controller
     public function showAvailability()
     {
         $user = Auth::user();
-        $teacher = ESBTPTeacher::where('user_id', $user->id)->first();
+        $teacher = $user->teacherProfile;
 
         if (! $teacher) {
             return redirect()->route('teacher.dashboard')
@@ -932,7 +932,7 @@ class TeacherDashboardController extends Controller
     {
         try {
             $user = Auth::user();
-            $teacher = ESBTPTeacher::where('user_id', $user->id)->first();
+            $teacher = $user->teacherProfile;
 
             if (! $teacher) {
                 return response()->json([

--- a/resources/views/dashboard/teacher.blade.php
+++ b/resources/views/dashboard/teacher.blade.php
@@ -458,7 +458,7 @@
                     $hasCoursesToday = $todayClasses->count() > 0;
 
                     // Récupérer le teacher_id correct
-                    $teacherModel = \App\Models\ESBTPTeacher::where('user_id', Auth::id())->first();
+                    $teacherModel = auth()->user()?->teacherProfile;
                     $teacherId = $teacherModel ? $teacherModel->id : null;
 
                     // Compter les émargements DÉBUT et FIN séparément
@@ -729,7 +729,7 @@
                                             ->first();
 
                                         // Récupérer le teacher_id correct (ESBTPTeacher.id pas User.id)
-                                        $teacherModel = \App\Models\ESBTPTeacher::where('user_id', Auth::id())->first();
+                                        $teacherModel = auth()->user()?->teacherProfile;
                                         $teacherId = $teacherModel ? $teacherModel->id : null;
 
                                         // Vérifier émargements DÉBUT et FIN

--- a/resources/views/esbtp/attendance/mark.blade.php
+++ b/resources/views/esbtp/attendance/mark.blade.php
@@ -324,7 +324,7 @@
             @php
                 // Debug plus détaillé
                 $user = Auth::user();
-                $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+                $teacher = $user->teacherProfile;
                 echo "<!-- Debug: User ID = {$user->id}, Teacher = " . ($teacher ? $teacher->id : 'NULL') . " -->";
             @endphp
             
@@ -366,7 +366,7 @@
 
                                 // Récupérer l'ID enseignant (ESBTPTeacher, PAS User!)
                                 $user = Auth::user();
-                                $teacher = \App\Models\ESBTPTeacher::where('user_id', $user->id)->first();
+                                $teacher = $user->teacherProfile;
                                 $teacherId = $teacher ? $teacher->id : null;
 
                                 $dailyCode = \App\Models\ESBTPDailyCode::where('status', 'active')


### PR DESCRIPTION
## Summary

Migrate **28 callsites** of the verbose pattern `ESBTPTeacher::where('user_id', X)->first()` to the new Eloquent relation `\$user->teacherProfile` introduced in #287/#291/#300.

**Why**: The verbose pattern was leftover from before the relation existed. The relation accessor:
- Caches the result on the User instance (no re-query on subsequent access)
- Is eager-loadable via `->with('teacherProfile')` for future N+1 cleanup
- Reads cleaner at the callsite (1 line instead of an `ESBTPTeacher` static query)

## Files touched (12)

**Controllers (10):**
- `app/Http/Controllers/TeacherDashboardController.php` (8 callsites)
- `app/Http/Controllers/TeacherController.php` (2 callsites)
- `app/Http/Controllers/API/LMSDataController.php` (3 callsites — see Pattern C below)
- `app/Http/Controllers/API/BaseApiController.php` (1)
- `app/Http/Controllers/ESBTP/Admin/ESBTPTeacherAttendanceController.php` (2)
- `app/Http/Controllers/ESBTP/ESBTPTeacherAttendanceController.php` (2)
- `app/Http/Controllers/ESBTP/TeacherAttendanceController.php` (2)
- `app/Http/Controllers/ESBTP/SessionReportController.php` (2)
- `app/Http/Controllers/ESBTPClasseController.php` (1)
- `app/Http/Controllers/ESBTPNoteController.php` (1)

**Views (2):**
- `resources/views/dashboard/teacher.blade.php` (2 callsites)
- `resources/views/esbtp/attendance/mark.blade.php` (2 callsites)

## Pattern C exception (1 callsite intentionally left as direct query)

**`app/Http/Controllers/API/LMSDataController.php:2099`** (in `upcomingSeances`) keeps the direct query:
```php
\$teacher = \App\Models\ESBTPTeacher::where('user_id', \$teacherId)->first();
```
because `\$teacherId` is a raw request-input ID (`\$request->input('teacher_id')`) and the route does not load a User instance. Per the migration spec, loading the User just to traverse the relation would add an unnecessary query.

## Pattern E investigation (no bug)

`app/Http/Controllers/ESBTP/ESBTPTeacherAttendanceController.php:84` had the suspicious shape `where('user_id', \$teacher->id)`. After reading the surrounding context, `\$teacher` there is actually `Auth::user()` (a User instance), so `\$teacher->id` was the user_id — the rewrite to `\$teacher->teacherProfile` is correct. The variable is just misleadingly named (it shadows the eventual ESBTPTeacher returned). Not a bug.

## Out-of-scope notes

- **TeacherController.php** has a fallback `\$teacher = \$user->teacher` after the new `\$teacher = \$user->teacherProfile`. Both relations are aliases of the same `hasOne(ESBTPTeacher)` (per `app/Models/User.php:127-142`), so the fallback is dead code. This was already dead before this PR (the original `where()->first()` and `\$user->teacher` both returned ESBTPTeacher), so removing it is not part of this refactor — ticket separately if desired.

## Test plan
- [x] `php -l` clean on all 10 touched controllers
- [x] `php artisan view:cache` succeeds (Blade compiles cleanly)
- [x] Global re-grep confirms zero `ESBTPTeacher::where('user_id'` callsites remain in `app/` and `resources/views/` except the 1 intentional Pattern C
- [ ] Smoke test on staging: teacher login → dashboard loads, roll-call, timetable, attendance marking, availability page
- [ ] LMS API endpoints `/api/lms/me/teacher-dashboard`, `/api/lms/seances/upcoming`, `/api/lms/notifications/preferences/{userId}` return expected shape