### PR TITLE
feat(enseignants): redesign premium bulk-availability — chaque item premium

### DIFF
--- a/resources/views/esbtp/enseignants/bulk-availability.blade.php
+++ b/resources/views/esbtp/enseignants/bulk-availability.blade.php
@@ -5,457 +5,460 @@
 @section('styles')
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 <style>
-    .bulk-availability-header {
-        background: linear-gradient(135deg, #0f3f87 0%, #0453cb 100%);
-        color: white;
-        padding: var(--space-xl);
-        border-radius: var(--radius-large);
-        margin-bottom: var(--space-xl);
-        position: relative;
-        overflow: hidden;
-    }
+/* ═══════════════════════════════════════════════════════════
+   BULK AVAILABILITY — Premium (namespace bav-*)
+   Couleurs sémantiques préservées : vert (disponible) / bleu KLASSCI
+   (préféré) / rouge (indisponible).
+   ═══════════════════════════════════════════════════════════ */
 
-    .bulk-availability-header::before {
-        content: '';
-        position: absolute;
-        top: -50%;
-        right: -20%;
-        width: 60%;
-        height: 200%;
-        background: radial-gradient(circle, rgba(255,255,255,0.1) 0%, transparent 70%);
-        pointer-events: none;
-    }
+/* -- Hero ----------------------------------------------------- */
+.bav-hero {
+    position: relative;
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 0 0 22px 22px;
+    margin-bottom: 1.75rem;
+    overflow: hidden;
+}
+.bav-hero::before {
+    content: '';
+    position: absolute; inset: 0;
+    background: radial-gradient(circle at 85% 20%, rgba(255,255,255,.12) 0%, transparent 50%);
+    pointer-events: none;
+}
+.bav-hero-inner {
+    position: relative; z-index: 2;
+    max-width: 1280px; margin: 0 auto;
+    padding: 28px 32px 24px;
+    display: flex; align-items: center; gap: 18px; flex-wrap: wrap;
+}
+.bav-hero-icon {
+    width: 52px; height: 52px;
+    border-radius: 14px;
+    background: rgba(255,255,255,.15);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255,255,255,.2);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.35rem; color: #fff; flex-shrink: 0;
+    box-shadow: 0 4px 16px rgba(0,0,0,.15);
+}
+.bav-hero-text { flex: 1; min-width: 220px; color: #fff; }
+.bav-hero-title { font-size: 1.45rem; font-weight: 800; margin: 0 0 4px; letter-spacing: -.02em; color: #fff; }
+.bav-hero-sub { font-size: .85rem; opacity: .8; margin: 0 0 10px; }
+.bav-hero-pills { display: flex; gap: 6px; flex-wrap: wrap; }
+.bav-hero-pill {
+    display: inline-flex; align-items: center; gap: 5px;
+    background: rgba(255,255,255,.15);
+    backdrop-filter: blur(6px);
+    border: 1px solid rgba(255,255,255,.25);
+    color: #fff; font-size: .73rem; font-weight: 600;
+    padding: 4px 10px; border-radius: 20px; white-space: nowrap;
+}
+.bav-hero-btns { display: flex; gap: 8px; margin-left: auto; flex-shrink: 0; }
+.bav-hero-btn {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 8px 16px; border-radius: 10px; font-size: .82rem; font-weight: 600;
+    text-decoration: none; cursor: pointer;
+    transition: all .18s ease; white-space: nowrap;
+    background: rgba(255,255,255,.15); color: #fff;
+    border: 1px solid rgba(255,255,255,.3);
+}
+.bav-hero-btn:hover { background: rgba(255,255,255,.25); color: #fff; text-decoration: none; }
+@media (max-width: 768px) {
+    .bav-hero-inner { padding: 20px 16px; flex-direction: column; align-items: flex-start; }
+    .bav-hero-btns { margin-left: 0; width: 100%; }
+    .bav-hero-btn { flex: 1; justify-content: center; }
+}
 
-    .bulk-availability-header h1 {
-        font-size: 1.8rem;
-        font-weight: 700;
-        margin: 0 0 var(--space-sm) 0;
-        position: relative;
-        z-index: 1;
-    }
+/* -- Item card (un par enseignant) ---------------------------- */
+.bav-item {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 16px;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
+    margin-bottom: 1.25rem;
+    overflow: hidden;
+    transition: box-shadow .25s ease;
+}
+.bav-item:hover {
+    box-shadow: 0 8px 30px rgba(4,83,203,.08), 0 2px 8px rgba(15,23,42,.04);
+}
+.bav-item.bav-edit-active {
+    box-shadow: 0 0 0 2px rgba(4,83,203,.18), 0 8px 30px rgba(4,83,203,.12);
+}
 
-    .bulk-availability-header p {
-        opacity: 0.9;
-        margin: 0;
-        position: relative;
-        z-index: 1;
-    }
+/* Header item (bandeau avec avatar + nom + meta + actions) */
+.bav-item-header {
+    display: flex; align-items: center; gap: 1rem;
+    padding: 1.1rem 1.4rem;
+    background: linear-gradient(135deg, #f8fafc 0%, #ffffff 60%);
+    border-bottom: 1px solid #e2e8f0;
+    flex-wrap: wrap;
+}
+.bav-avatar {
+    width: 44px; height: 44px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, #0453cb, #3b7ddb);
+    color: #fff;
+    display: flex; align-items: center; justify-content: center;
+    font-size: .92rem; font-weight: 800; letter-spacing: .02em;
+    flex-shrink: 0;
+    box-shadow: 0 3px 10px rgba(4,83,203,.25);
+}
+.bav-item-info { flex: 1; min-width: 200px; }
+.bav-item-name { font-size: 1.02rem; font-weight: 700; color: #0f172a; margin: 0; letter-spacing: -.01em; }
+.bav-item-meta {
+    font-size: .78rem; color: #64748b; margin: .15rem 0 0;
+    display: flex; gap: .5rem; flex-wrap: wrap; align-items: center;
+}
+.bav-item-meta-sep { color: #cbd5e1; }
+.bav-item-actions { display: flex; align-items: center; gap: .5rem; flex-shrink: 0; }
 
-    .accordion-item {
-        border: none;
-        border-radius: var(--radius-large) !important;
-        margin-bottom: var(--space-lg);
-        box-shadow: var(--shadow-card);
-        overflow: hidden;
-    }
+.bav-status-pill {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 4px 10px; border-radius: 20px;
+    font-size: .72rem; font-weight: 700;
+    letter-spacing: .02em;
+}
+.bav-status-pill.is-active { background: rgba(16,185,129,.12); color: #047857; border: 1px solid rgba(16,185,129,.25); }
+.bav-status-pill.is-inactive { background: #f1f5f9; color: #64748b; border: 1px solid #e2e8f0; }
+.bav-status-pill .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
 
-    .main-card-header {
-        background: linear-gradient(135deg, #f8fafc 0%, #ffffff 100%);
-        padding: var(--space-lg);
-        border-bottom: 1px solid var(--border);
-    }
+.bav-btn-link {
+    display: inline-flex; align-items: center; gap: 5px;
+    padding: 6px 12px; border-radius: 8px;
+    font-size: .78rem; font-weight: 600;
+    color: #0453cb; background: #fff;
+    border: 1px solid #cbd5e1;
+    text-decoration: none;
+    transition: all .15s ease;
+}
+.bav-btn-link:hover { background: #0453cb; color: #fff; border-color: #0453cb; text-decoration: none; }
 
-    .main-card-title {
-        font-size: 1.2rem;
-        font-weight: 700;
-        color: var(--text-primary);
-        display: flex;
-        align-items: center;
-        gap: var(--space-sm);
-    }
+.bav-toggle-chevron {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 32px; height: 32px;
+    border-radius: 8px;
+    background: #f8fafc;
+    border: 1px solid #e2e8f0;
+    color: #64748b;
+    cursor: pointer;
+    transition: all .2s ease;
+}
+.bav-toggle-chevron:hover { background: #0453cb; color: #fff; border-color: #0453cb; }
+.bav-toggle-chevron i { transition: transform .25s ease; }
+.bav-toggle-chevron[aria-expanded="true"] i { transform: rotate(180deg); }
 
-    .main-card-title i {
-        color: var(--primary);
-    }
+/* -- Body item (stats + actions + grille + légende) ----------- */
+.bav-item-body { padding: 1.25rem 1.4rem 1.5rem; }
 
-    .accordion-toggle {
-        border: none;
-        background: var(--surface-secondary);
-        border-radius: var(--radius-medium);
-        padding: var(--space-sm) var(--space-md);
-        transition: all 0.2s ease;
-    }
+/* Stats premium */
+.bav-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: .75rem;
+    margin-bottom: 1.1rem;
+}
+.bav-stat {
+    display: flex; align-items: center; gap: .75rem;
+    padding: .85rem 1rem;
+    border-radius: 12px;
+    border: 1px solid;
+    transition: transform .15s ease;
+}
+.bav-stat:hover { transform: translateY(-1px); }
+.bav-stat-icon {
+    width: 38px; height: 38px;
+    border-radius: 10px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1rem; flex-shrink: 0;
+}
+.bav-stat-content { flex: 1; min-width: 0; }
+.bav-stat-value { font-size: 1.4rem; font-weight: 800; line-height: 1; letter-spacing: -.02em; }
+.bav-stat-label { font-size: .72rem; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; opacity: .85; margin-top: .15rem; }
 
-    .accordion-toggle:hover {
-        background: var(--primary);
-        color: white;
-    }
+.bav-stat--preferred {
+    background: linear-gradient(135deg, rgba(4,83,203,.04) 0%, rgba(59,125,219,.06) 100%);
+    border-color: rgba(4,83,203,.18);
+    color: #1d4ed8;
+}
+.bav-stat--preferred .bav-stat-icon { background: rgba(4,83,203,.12); color: #1d4ed8; }
 
-    .accordion-toggle-icon {
-        transition: transform 0.3s ease;
-    }
+.bav-stat--available {
+    background: linear-gradient(135deg, rgba(16,185,129,.04) 0%, rgba(34,197,94,.06) 100%);
+    border-color: rgba(16,185,129,.2);
+    color: #047857;
+}
+.bav-stat--available .bav-stat-icon { background: rgba(16,185,129,.14); color: #059669; }
 
-    .accordion-button:not(.collapsed) .accordion-toggle-icon {
-        transform: rotate(180deg);
-    }
+.bav-stat--unavailable {
+    background: linear-gradient(135deg, rgba(220,38,38,.04) 0%, rgba(239,68,68,.06) 100%);
+    border-color: rgba(220,38,38,.18);
+    color: #991b1b;
+}
+.bav-stat--unavailable .bav-stat-icon { background: rgba(220,38,38,.12); color: #b91c1c; }
 
-    .accordion-body {
-        padding: 0;
-    }
+/* Actions premium */
+.bav-actions {
+    display: flex; gap: .5rem; flex-wrap: wrap;
+    margin-bottom: 1.1rem;
+}
+.bav-btn {
+    display: inline-flex; align-items: center; gap: .5rem;
+    padding: .55rem 1.05rem;
+    border-radius: 10px;
+    font-size: .85rem; font-weight: 600;
+    border: none; cursor: pointer;
+    transition: all .18s ease;
+    text-decoration: none; white-space: nowrap;
+}
+.bav-btn--edit {
+    background: linear-gradient(135deg, #0453cb 0%, #3b7ddb 100%);
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(4,83,203,.25);
+}
+.bav-btn--edit:hover { transform: translateY(-1px); box-shadow: 0 4px 12px rgba(4,83,203,.35); color: #fff; }
 
-    /* =============================================
-       CALENDRIER HEBDOMADAIRE - DESIGN MODERNE
-       ============================================= */
+.bav-btn--save {
+    background: linear-gradient(135deg, #10b981 0%, #059669 100%);
+    color: #fff;
+    box-shadow: 0 2px 6px rgba(16,185,129,.3);
+}
+.bav-btn--save:hover { transform: translateY(-1px); box-shadow: 0 4px 12px rgba(16,185,129,.4); color: #fff; }
 
-    .availability-grid {
-        display: grid;
-        grid-template-columns: 72px repeat(7, 1fr);
-        background: #ffffff;
-        padding: 16px;
-        border-radius: 12px;
-        border: 1px solid #e2e8f0;
-        gap: 0;
-        overflow: hidden;
-    }
+.bav-btn--cancel {
+    background: #fff;
+    color: #64748b;
+    border: 1px solid #cbd5e1;
+}
+.bav-btn--cancel:hover { background: #fee2e2; color: #b91c1c; border-color: #fecaca; }
 
-    /* En-tête "Horaires" */
-    .availability-time-header {
-        grid-column: 1;
-        font-weight: 700;
-        font-size: 0.7rem;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        color: #94a3b8;
-        text-align: center;
-        padding: 10px 4px;
-        background: #f8fafc;
-        border-bottom: 2px solid #e2e8f0;
-        border-right: 2px solid #e2e8f0;
-    }
+.bav-edit-banner {
+    display: none;
+    align-items: center; gap: .55rem;
+    padding: .55rem .9rem;
+    margin-bottom: 1rem;
+    border-radius: 10px;
+    background: linear-gradient(135deg, rgba(245,158,11,.08), rgba(217,119,6,.06));
+    border: 1px solid rgba(245,158,11,.25);
+    color: #92400e;
+    font-size: .82rem; font-weight: 500;
+}
+.bav-item.bav-edit-active .bav-edit-banner { display: flex; }
+.bav-edit-banner i { color: #d97706; }
 
-    /* En-têtes des jours */
-    .availability-day-header {
-        text-align: center;
-        font-weight: 700;
-        font-size: 0.8rem;
-        color: #1e40af;
-        padding: 10px 4px;
-        background: linear-gradient(180deg, #eff6ff 0%, #f8fafc 100%);
-        border-bottom: 2px solid #e2e8f0;
-        border-right: 1px solid #f1f5f9;
-        letter-spacing: 0.3px;
-    }
+/* -- Grille calendrier premium ------------------------------- */
+.bav-grid {
+    display: grid;
+    grid-template-columns: 76px repeat(7, 1fr);
+    gap: 0;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(15,23,42,.03);
+}
 
-    .availability-day-header:last-of-type {
-        border-right: none;
-    }
+.bav-grid-time-header,
+.bav-grid-day-header {
+    padding: .65rem .35rem;
+    text-align: center;
+    font-size: .7rem; font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+    background: #f8fafc;
+    border-bottom: 2px solid #e2e8f0;
+    color: #475569;
+}
+.bav-grid-time-header { color: #94a3b8; border-right: 2px solid #e2e8f0; }
+.bav-grid-day-header { border-right: 1px solid #f1f5f9; color: #1d4ed8; }
+.bav-grid-day-header:last-of-type { border-right: none; }
 
-    /* Créneaux horaires (colonne gauche) */
-    .availability-time-slot {
-        text-align: center;
-        padding: 0 4px;
-        font-size: 0.75rem;
-        font-weight: 600;
-        color: #64748b;
-        border-right: 2px solid #e2e8f0;
-        border-bottom: 1px solid #f1f5f9;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: #f8fafc;
-        min-height: 38px;
-    }
+.bav-grid-time {
+    padding: 0 .4rem;
+    font-size: .76rem; font-weight: 600; color: #64748b;
+    text-align: center;
+    background: #f8fafc;
+    border-right: 2px solid #e2e8f0;
+    border-bottom: 1px solid #f1f5f9;
+    display: flex; align-items: center; justify-content: center;
+    min-height: 42px;
+}
 
-    /* Cellules du calendrier */
-    .availability-slot {
-        padding: 4px 2px;
-        text-align: center;
-        font-size: 0.72rem;
-        font-weight: 600;
-        transition: all 0.15s ease;
-        min-height: 38px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border-bottom: 1px solid #f1f5f9;
-        border-right: 1px solid #f1f5f9;
-        position: relative;
-        gap: 3px;
-        user-select: none;
-    }
+.bav-grid-cell {
+    min-height: 42px;
+    padding: 4px 2px;
+    display: flex; align-items: center; justify-content: center;
+    gap: 4px;
+    font-size: .72rem; font-weight: 600;
+    border-bottom: 1px solid #f1f5f9;
+    border-right: 1px solid #f1f5f9;
+    transition: all .15s ease;
+    user-select: none;
+    position: relative;
+}
+.bav-grid-cell:nth-child(8n) { border-right: none; }
 
-    .availability-slot:last-child {
-        border-right: none;
-    }
+/* Statuts (couleurs sémantiques préservées) */
+.bav-grid-cell.preferred {
+    background: linear-gradient(135deg, #dbeafe 0%, #eff6ff 100%);
+    color: #1d4ed8;
+}
+.bav-grid-cell.preferred i { color: #2563eb; }
+.bav-grid-cell.available {
+    background: linear-gradient(135deg, #dcfce7 0%, #f0fdf4 100%);
+    color: #15803d;
+}
+.bav-grid-cell.available i { color: #16a34a; }
+.bav-grid-cell.unavailable {
+    background: linear-gradient(135deg, #fee2e2 0%, #fef2f2 100%);
+    color: #991b1b;
+}
+.bav-grid-cell.unavailable i { color: #dc2626; opacity: .55; }
 
-    /* Statut: Disponible */
-    .availability-slot.available {
-        background: #dcfce7;
-        color: #15803d;
-        border-bottom-color: #bbf7d0;
-    }
+/* Hover seulement en mode edit */
+.bav-item.bav-edit-active .bav-grid-cell {
+    cursor: pointer;
+}
+.bav-item.bav-edit-active .bav-grid-cell:hover {
+    transform: scale(1.05);
+    box-shadow: inset 0 0 0 2px #0453cb;
+    z-index: 2;
+}
 
-    .availability-slot.available i {
-        color: #16a34a;
-        font-size: 0.7rem;
-    }
+/* Cellule modifiée */
+.bav-grid-cell.modified {
+    box-shadow: inset 0 0 0 2px #f59e0b;
+}
+.bav-grid-cell.modified::after {
+    content: '';
+    position: absolute;
+    top: 4px; right: 4px;
+    width: 7px; height: 7px;
+    background: #f59e0b;
+    border-radius: 50%;
+    box-shadow: 0 0 0 2px #fff;
+}
 
-    /* Statut: Préféré */
-    .availability-slot.preferred {
-        background: #dbeafe;
-        color: #1d4ed8;
-        border-bottom-color: #bfdbfe;
-    }
+.bav-slot-label { font-size: .68rem; }
 
-    .availability-slot.preferred i {
-        color: #2563eb;
-        font-size: 0.7rem;
-    }
+/* -- Légende premium ----------------------------------------- */
+.bav-legend {
+    display: flex; gap: .6rem; flex-wrap: wrap;
+    margin-top: 1rem;
+    padding: .8rem 1rem;
+    background: #f8fafc;
+    border-radius: 12px;
+    border: 1px solid #e2e8f0;
+}
+.bav-legend-item {
+    display: inline-flex; align-items: center; gap: .5rem;
+    font-size: .78rem; font-weight: 600;
+    padding: .25rem .5rem;
+}
+.bav-legend-swatch {
+    width: 22px; height: 22px;
+    border-radius: 7px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: .68rem;
+    flex-shrink: 0;
+}
+.bav-legend-swatch.preferred {
+    background: linear-gradient(135deg, #dbeafe, #eff6ff);
+    color: #2563eb;
+    border: 1px solid #bfdbfe;
+}
+.bav-legend-swatch.available {
+    background: linear-gradient(135deg, #dcfce7, #f0fdf4);
+    color: #16a34a;
+    border: 1px solid #bbf7d0;
+}
+.bav-legend-swatch.unavailable {
+    background: linear-gradient(135deg, #fee2e2, #fef2f2);
+    color: #dc2626;
+    border: 1px solid #fecaca;
+}
+.bav-legend-item span { color: #475569; }
 
-    /* Statut: Indisponible */
-    .availability-slot.unavailable {
-        background: #fee2e2;
-        color: #991b1b;
-        border-bottom-color: #fecaca;
-    }
+/* -- Empty state ---------------------------------------------- */
+.bav-empty {
+    background: #fff;
+    border: 1.5px dashed #cbd5e1;
+    border-radius: 16px;
+    padding: 3rem 1.5rem;
+    text-align: center;
+}
+.bav-empty-icon {
+    width: 64px; height: 64px;
+    margin: 0 auto 1rem;
+    border-radius: 50%;
+    background: #f8fafc;
+    color: #94a3b8;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.5rem;
+}
+.bav-empty h3 { font-size: 1.1rem; font-weight: 700; color: #0f172a; margin: 0 0 .35rem; }
+.bav-empty p { font-size: .88rem; color: #64748b; margin: 0; }
 
-    .availability-slot.unavailable i {
-        color: #dc2626;
-        font-size: 0.65rem;
-        opacity: 0.6;
-    }
+/* -- Toast notif --------------------------------------------- */
+.bav-toast {
+    position: fixed;
+    top: 20px; right: 20px;
+    padding: .75rem 1.1rem;
+    border-radius: 12px;
+    color: #fff; font-weight: 600; font-size: .88rem;
+    box-shadow: 0 10px 30px rgba(0,0,0,.18);
+    z-index: 9999;
+    transform: translateX(120%);
+    transition: transform .3s ease;
+    display: flex; align-items: center; gap: .55rem;
+}
+.bav-toast.show { transform: translateX(0); }
+.bav-toast.success { background: linear-gradient(135deg, #10b981, #059669); }
+.bav-toast.danger { background: linear-gradient(135deg, #dc2626, #b91c1c); }
+.bav-toast.warning { background: linear-gradient(135deg, #f59e0b, #d97706); }
+.bav-toast.info { background: linear-gradient(135deg, #0453cb, #3b7ddb); }
 
-    /* Hover */
-    .availability-slot:hover {
-        filter: brightness(0.95);
-        box-shadow: inset 0 0 0 2px rgba(0,0,0,0.08);
-    }
-
-    /* Cellule modifiée (en mode édition) */
-    .availability-slot.modified {
-        position: relative;
-        box-shadow: inset 0 0 0 2px #f59e0b;
-    }
-
-    .availability-slot.modified::after {
-        content: '';
-        position: absolute;
-        top: 3px;
-        right: 3px;
-        width: 6px;
-        height: 6px;
-        background: #f59e0b;
-        border-radius: 50%;
-    }
-
-    /* Zebra striping léger pour les rangées */
-    .availability-grid > .availability-time-slot:nth-of-type(odd),
-    .availability-grid > .availability-slot:nth-child(14n+9),
-    .availability-grid > .availability-slot:nth-child(14n+10),
-    .availability-grid > .availability-slot:nth-child(14n+11),
-    .availability-grid > .availability-slot:nth-child(14n+12),
-    .availability-grid > .availability-slot:nth-child(14n+13),
-    .availability-grid > .availability-slot:nth-child(14n+14) {
-        /* Subtle zebra via slightly different border */
-    }
-
-    /* =============================================
-       LÉGENDE
-       ============================================= */
-    .availability-legend {
-        display: flex;
-        justify-content: center;
-        gap: 20px;
-        margin-top: 12px;
-        flex-wrap: wrap;
-    }
-
-    .legend-item {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 0.8rem;
-        font-weight: 500;
-        color: #475569;
-    }
-
-    .legend-color {
-        width: 20px;
-        height: 20px;
-        border-radius: 6px;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-size: 0.65rem;
-    }
-
-    /* =============================================
-       STATS BADGES
-       ============================================= */
-    .availability-stats {
-        display: flex;
-        gap: 10px;
-        margin-bottom: 14px;
-        flex-wrap: wrap;
-    }
-
-    .stat-mini {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        font-size: 0.82rem;
-        padding: 6px 12px;
-        border-radius: 8px;
-        font-weight: 500;
-    }
-
-    .stat-mini.stat-preferred {
-        background: #eff6ff;
-        color: #1d4ed8;
-        border: 1px solid #bfdbfe;
-    }
-
-    .stat-mini.stat-available {
-        background: #f0fdf4;
-        color: #15803d;
-        border: 1px solid #bbf7d0;
-    }
-
-    .stat-mini.stat-unavailable {
-        background: #fef2f2;
-        color: #991b1b;
-        border: 1px solid #fecaca;
-    }
-
-    .stat-mini .stat-value {
-        font-weight: 700;
-        font-size: 0.95rem;
-    }
-
-    /* =============================================
-       BLOC ENSEIGNANT
-       ============================================= */
-    .bulk-enseignant-block {
-        background: #ffffff;
-        padding: 20px;
-    }
-
-    .bulk-enseignant-block .availability-actions {
-        display: flex;
-        gap: 8px;
-        margin-bottom: 14px;
-        flex-wrap: wrap;
-    }
-
-    .btn-edit-availability,
-    .btn-save-availability,
-    .btn-cancel-availability {
-        border: none;
-        padding: 8px 16px;
-        border-radius: 8px;
-        font-size: 0.85rem;
-        font-weight: 600;
-        cursor: pointer;
-        transition: all 0.2s ease;
-        display: flex;
-        align-items: center;
-        gap: 6px;
-    }
-
-    .btn-edit-availability {
-        background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-        color: white;
-        box-shadow: 0 2px 4px rgba(37, 99, 235, 0.3);
-    }
-
-    .btn-edit-availability:hover {
-        box-shadow: 0 4px 8px rgba(37, 99, 235, 0.4);
-        transform: translateY(-1px);
-    }
-
-    .btn-save-availability {
-        background: linear-gradient(135deg, #22c55e 0%, #16a34a 100%);
-        color: white;
-        box-shadow: 0 2px 4px rgba(22, 163, 74, 0.3);
-    }
-
-    .btn-save-availability:hover {
-        box-shadow: 0 4px 8px rgba(22, 163, 74, 0.4);
-        transform: translateY(-1px);
-    }
-
-    .btn-cancel-availability {
-        background: #f1f5f9;
-        color: #475569;
-        border: 1px solid #e2e8f0;
-    }
-
-    .btn-cancel-availability:hover {
-        background: #fee2e2;
-        color: #dc2626;
-        border-color: #fecaca;
-    }
-
-    /* =============================================
-       RESPONSIVE
-       ============================================= */
-    @media (max-width: 768px) {
-        .availability-grid {
-            grid-template-columns: 52px repeat(7, 1fr);
-            padding: 8px;
-            font-size: 0.65rem;
-        }
-
-        .availability-day-header {
-            padding: 6px 2px;
-            font-size: 0.68rem;
-        }
-
-        .availability-time-slot {
-            font-size: 0.65rem;
-            padding: 0 2px;
-        }
-
-        .availability-slot {
-            min-height: 32px;
-            font-size: 0.6rem;
-            padding: 2px 1px;
-        }
-
-        .availability-slot .slot-label {
-            display: none;
-        }
-
-        .availability-stats {
-            gap: 6px;
-        }
-
-        .stat-mini {
-            font-size: 0.75rem;
-            padding: 4px 8px;
-        }
-    }
-
-    @media (max-width: 480px) {
-        .availability-grid {
-            grid-template-columns: 44px repeat(7, 1fr);
-        }
-
-        .availability-slot {
-            min-height: 28px;
-        }
-    }
+/* -- Responsive ---------------------------------------------- */
+@media (max-width: 768px) {
+    .bav-grid { grid-template-columns: 56px repeat(7, 1fr); }
+    .bav-grid-day-header { font-size: .62rem; padding: .45rem .15rem; }
+    .bav-grid-time { font-size: .68rem; }
+    .bav-grid-cell { min-height: 34px; font-size: .58rem; }
+    .bav-grid-cell .bav-slot-label { display: none; }
+    .bav-stats { grid-template-columns: 1fr 1fr; }
+    .bav-stat-value { font-size: 1.2rem; }
+    .bav-item-body { padding: 1rem; }
+}
+@media (max-width: 480px) {
+    .bav-grid { grid-template-columns: 44px repeat(7, 1fr); }
+    .bav-grid-cell { min-height: 30px; }
+    .bav-stats { grid-template-columns: 1fr; }
+}
 </style>
 @endsection
 
 @section('content')
-<div class="dashboard-acasi">
-    <div class="main-content">
-        <!-- Header -->
-        <div class="bulk-availability-header">
-            <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
-                <div>
-                    <h1><i class="fas fa-calendar-check me-2"></i>Modification rapide des disponibilités</h1>
-                    <p>Modifiez les disponibilités de plusieurs enseignants en une seule page.</p>
-                </div>
-                <div>
-                    <a href="{{ route('esbtp.enseignants.index') }}" class="btn btn-light">
-                        <i class="fas fa-arrow-left me-2"></i>Retour à la liste
-                    </a>
-                </div>
+<div class="bav-hero">
+    <div class="bav-hero-inner">
+        <div class="bav-hero-icon"><i class="fas fa-calendar-check"></i></div>
+        <div class="bav-hero-text">
+            <h1 class="bav-hero-title">Disponibilités — modification rapide</h1>
+            <p class="bav-hero-sub"><i class="fas fa-info-circle" style="margin-right:4px;"></i> Modifiez les créneaux de plusieurs enseignants depuis une seule page.</p>
+            <div class="bav-hero-pills">
+                <span class="bav-hero-pill"><i class="fas fa-users"></i> {{ $enseignants->count() }} enseignant{{ $enseignants->count() > 1 ? 's' : '' }}</span>
+                <span class="bav-hero-pill"><i class="fas fa-mouse-pointer"></i> Cliquez sur un créneau pour cycler les statuts</span>
             </div>
         </div>
+        <div class="bav-hero-btns">
+            <a href="{{ route('esbtp.enseignants.index') }}" class="bav-hero-btn">
+                <i class="fas fa-arrow-left"></i> Retour à la liste
+            </a>
+        </div>
+    </div>
+</div>
 
+<div class="dashboard-acasi">
+    <div class="main-content">
         @if(session('success'))
             <div class="alert alert-success alert-dismissible fade show" role="alert">
                 <i class="fas fa-check-circle me-2"></i>{{ session('success') }}
@@ -470,117 +473,88 @@
             </div>
         @endif
 
-        <!-- Accordéon des enseignants -->
-        <div class="accordion" id="bulkAvailabilityAccordion">
-            @forelse($enseignantsData as $data)
-                @php
-                    $enseignant = $data['enseignant'];
-                    $collapseId = 'collapse-enseignant-' . $enseignant->id;
-                    $headingId = 'heading-enseignant-' . $enseignant->id;
-                @endphp
-                <div class="accordion-item mb-3" id="enseignant-block-{{ $enseignant->id }}">
-                    <h2 class="accordion-header" id="{{ $headingId }}">
-                        <div class="main-card-header d-flex flex-wrap justify-content-between align-items-center gap-3">
-                            <div>
-                                <div class="main-card-title">
-                                    <i class="fas fa-user-tie"></i>
-                                    {{ $enseignant->user->name ?? 'Enseignant #' . $enseignant->id }}
-                                </div>
-                                <div class="text-muted small">
-                                    {{ $enseignant->specialization ?? 'Spécialisation non définie' }}
-                                    · Matricule: {{ $enseignant->matricule ?? 'N/A' }}
-                                </div>
-                            </div>
-                            <div class="d-flex align-items-center gap-2">
-                                <span class="badge bg-{{ $enseignant->status === 'active' ? 'success' : 'secondary' }}">
-                                    {{ $enseignant->status === 'active' ? 'Actif' : 'Inactif' }}
-                                </span>
-                                <a href="{{ route('esbtp.enseignants.show', ['enseignant' => $enseignant->id]) }}"
-                                   class="btn btn-sm btn-outline-primary" target="_blank">
-                                    <i class="fas fa-external-link-alt me-1"></i>Voir
-                                </a>
-                                <button class="btn btn-sm btn-outline-secondary accordion-toggle"
-                                        type="button" data-bs-toggle="collapse"
-                                        data-bs-target="#{{ $collapseId }}" aria-expanded="true">
-                                    <i class="fas fa-chevron-down accordion-toggle-icon"></i>
-                                </button>
-                            </div>
-                        </div>
-                    </h2>
-                    <div id="{{ $collapseId }}" class="accordion-collapse collapse show"
-                         aria-labelledby="{{ $headingId }}">
-                        <div class="accordion-body p-0">
-                            @include('esbtp.enseignants.partials.availability-block', $data)
+        @forelse($enseignantsData as $data)
+            @php
+                $enseignant = $data['enseignant'];
+                $collapseId = 'bav-collapse-' . $enseignant->id;
+                $name = $enseignant->user->name ?? ('Enseignant #' . $enseignant->id);
+                $initials = collect(explode(' ', trim($name)))
+                    ->filter()
+                    ->take(2)
+                    ->map(fn($w) => mb_strtoupper(mb_substr($w, 0, 1)))
+                    ->implode('');
+                $isActive = ($enseignant->status === 'active');
+            @endphp
+            <div class="bav-item" id="bav-item-{{ $enseignant->id }}" data-enseignant-id="{{ $enseignant->id }}">
+                <div class="bav-item-header">
+                    <div class="bav-avatar">{{ $initials ?: 'NN' }}</div>
+                    <div class="bav-item-info">
+                        <h3 class="bav-item-name">{{ $name }}</h3>
+                        <div class="bav-item-meta">
+                            <span><i class="fas fa-star" style="color:#f59e0b;font-size:.7rem"></i> {{ $enseignant->specialization ?? 'Spécialisation non définie' }}</span>
+                            <span class="bav-item-meta-sep">·</span>
+                            <span><i class="fas fa-id-badge" style="color:#94a3b8;font-size:.7rem"></i> {{ $enseignant->matricule ?? 'N/A' }}</span>
                         </div>
                     </div>
+                    <div class="bav-item-actions">
+                        <span class="bav-status-pill {{ $isActive ? 'is-active' : 'is-inactive' }}">
+                            <span class="dot"></span> {{ $isActive ? 'Actif' : 'Inactif' }}
+                        </span>
+                        <a href="{{ route('esbtp.enseignants.show', ['enseignant' => $enseignant->id]) }}"
+                           class="bav-btn-link" target="_blank" rel="noopener">
+                            <i class="fas fa-external-link-alt"></i> Voir
+                        </a>
+                        <button class="bav-toggle-chevron"
+                                type="button" data-bs-toggle="collapse"
+                                data-bs-target="#{{ $collapseId }}"
+                                aria-expanded="true" aria-controls="{{ $collapseId }}">
+                            <i class="fas fa-chevron-down"></i>
+                        </button>
+                    </div>
                 </div>
-            @empty
-                <div class="alert alert-warning">
-                    <i class="fas fa-exclamation-triangle me-2"></i>
-                    Aucun enseignant sélectionné.
+
+                <div id="{{ $collapseId }}" class="collapse show">
+                    <div class="bav-item-body">
+                        @include('esbtp.enseignants.partials.availability-block', $data)
+                    </div>
                 </div>
-            @endforelse
-        </div>
+            </div>
+        @empty
+            <div class="bav-empty">
+                <div class="bav-empty-icon"><i class="fas fa-users-slash"></i></div>
+                <h3>Aucun enseignant sélectionné</h3>
+                <p>Retournez à la liste et sélectionnez les enseignants à modifier.</p>
+            </div>
+        @endforelse
     </div>
 </div>
 
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-    // Gérer le toggle des accordéons
-    document.querySelectorAll('.accordion-toggle').forEach(function(btn) {
-        btn.addEventListener('click', function() {
-            const icon = this.querySelector('.accordion-toggle-icon');
-            icon.style.transform = icon.style.transform === 'rotate(180deg)' ? '' : 'rotate(180deg)';
-        });
-    });
-});
+function showNotification(message, type = 'info') {
+    const t = document.createElement('div');
+    t.className = 'bav-toast ' + type;
+    const iconMap = { success: 'fa-check-circle', danger: 'fa-exclamation-circle', warning: 'fa-exclamation-triangle', info: 'fa-info-circle' };
+    t.innerHTML = '<i class="fas ' + (iconMap[type] || 'fa-info-circle') + '"></i><span>' + message + '</span>';
+    document.body.appendChild(t);
+    requestAnimationFrame(() => t.classList.add('show'));
+    setTimeout(() => {
+        t.classList.remove('show');
+        setTimeout(() => t.remove(), 300);
+    }, 3500);
+}
 
-// Fonction pour rafraîchir un bloc enseignant via AJAX
 async function refreshBlock(enseignantId) {
     try {
         const response = await fetch(`{{ url('/esbtp/enseignants') }}/${enseignantId}/availability-section`, {
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest'
-            }
+            headers: { 'X-Requested-With': 'XMLHttpRequest' }
         });
-        if (!response.ok) {
-            throw new Error('Erreur lors du rafraîchissement');
-        }
+        if (!response.ok) throw new Error('Erreur lors du rafraîchissement');
         const payload = await response.json();
-        const container = document.querySelector(`#enseignant-block-${enseignantId} .accordion-body`);
-        if (container && payload.html) {
-            container.innerHTML = payload.html;
-        }
+        const container = document.querySelector(`#bav-item-${enseignantId} .bav-item-body`);
+        if (container && payload.html) container.innerHTML = payload.html;
     } catch (error) {
         console.error('Erreur refresh:', error);
     }
-}
-
-// Notification toast
-function showNotification(message, type) {
-    const notification = document.createElement('div');
-    notification.style.cssText = `
-        position: fixed;
-        top: 20px;
-        right: 20px;
-        background: ${type === 'success' ? '#10b981' : type === 'danger' ? '#ef4444' : type === 'warning' ? '#f59e0b' : '#3b82f6'};
-        color: white;
-        padding: 12px 20px;
-        border-radius: 8px;
-        box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-        z-index: 9999;
-        font-weight: 500;
-        transform: translateX(100%);
-        transition: transform 0.3s ease;
-    `;
-    notification.textContent = message;
-    document.body.appendChild(notification);
-
-    setTimeout(() => { notification.style.transform = 'translateX(0)'; }, 100);
-    setTimeout(() => {
-        notification.style.transform = 'translateX(100%)';
-        setTimeout(() => { document.body.removeChild(notification); }, 300);
-    }, 4000);
 }
 </script>
 @endsection

--- a/resources/views/esbtp/enseignants/partials/availability-block.blade.php
+++ b/resources/views/esbtp/enseignants/partials/availability-block.blade.php
@@ -1,63 +1,72 @@
-<div class="bulk-enseignant-block" data-enseignant-id="{{ $enseignant->id }}">
-    <!-- Stats rapides -->
-    <div class="availability-stats">
-        <div class="stat-mini stat-preferred">
-            <i class="fas fa-star"></i>
-            <span>Préféré: <span class="stat-value">{{ $stats['preferred'] }}</span></span>
+<div data-enseignant-id="{{ $enseignant->id }}">
+    <div class="bav-edit-banner">
+        <i class="fas fa-edit"></i>
+        <span>Mode édition actif. Cliquez sur un créneau pour cycler entre <strong>Indisponible → Disponible → Préféré</strong>.</span>
+    </div>
+
+    <div class="bav-stats">
+        <div class="bav-stat bav-stat--preferred">
+            <div class="bav-stat-icon"><i class="fas fa-star"></i></div>
+            <div class="bav-stat-content">
+                <div class="bav-stat-value">{{ $stats['preferred'] }}</div>
+                <div class="bav-stat-label">Préférés</div>
+            </div>
         </div>
-        <div class="stat-mini stat-available">
-            <i class="fas fa-check-circle"></i>
-            <span>Disponible: <span class="stat-value">{{ $stats['available'] }}</span></span>
+        <div class="bav-stat bav-stat--available">
+            <div class="bav-stat-icon"><i class="fas fa-check-circle"></i></div>
+            <div class="bav-stat-content">
+                <div class="bav-stat-value">{{ $stats['available'] }}</div>
+                <div class="bav-stat-label">Disponibles</div>
+            </div>
         </div>
-        <div class="stat-mini stat-unavailable">
-            <i class="fas fa-times-circle"></i>
-            <span>Indisponible: <span class="stat-value">{{ $stats['unavailable'] }}</span></span>
+        <div class="bav-stat bav-stat--unavailable">
+            <div class="bav-stat-icon"><i class="fas fa-times-circle"></i></div>
+            <div class="bav-stat-content">
+                <div class="bav-stat-value">{{ $stats['unavailable'] }}</div>
+                <div class="bav-stat-label">Indisponibles</div>
+            </div>
         </div>
     </div>
 
-    <!-- Actions -->
-    <div class="availability-actions">
-        <button type="button" class="btn-edit-availability" onclick="toggleEditMode({{ $enseignant->id }})">
-            <i class="fas fa-edit me-1"></i>
+    <div class="bav-actions">
+        <button type="button" class="bav-btn bav-btn--edit" onclick="toggleEditMode({{ $enseignant->id }})">
+            <i class="fas fa-edit"></i>
             <span class="edit-text">Modifier</span>
         </button>
-        <button type="button" class="btn-save-availability" onclick="saveAvailability({{ $enseignant->id }})" style="display: none;">
-            <i class="fas fa-save me-1"></i>
-            Sauvegarder
+        <button type="button" class="bav-btn bav-btn--save" onclick="saveAvailability({{ $enseignant->id }})" style="display: none;">
+            <i class="fas fa-save"></i>
+            <span>Sauvegarder</span>
         </button>
-        <button type="button" class="btn-cancel-availability" onclick="cancelEditMode({{ $enseignant->id }})" style="display: none;">
-            <i class="fas fa-times me-1"></i>
-            Annuler
+        <button type="button" class="bav-btn bav-btn--cancel" onclick="cancelEditMode({{ $enseignant->id }})" style="display: none;">
+            <i class="fas fa-times"></i>
+            <span>Annuler</span>
         </button>
     </div>
 
-    <!-- Grille de disponibilité -->
-    <div class="availability-grid" id="availability-grid-{{ $enseignant->id }}">
-        <!-- En-têtes -->
-        <div class="availability-time-header">Horaires</div>
+    <div class="bav-grid" id="bav-grid-{{ $enseignant->id }}">
+        <div class="bav-grid-time-header">Horaires</div>
         @foreach($joursNoms as $dayKey => $dayName)
-            <div class="availability-day-header">{{ substr($dayName, 0, 3) }}</div>
+            <div class="bav-grid-day-header">{{ substr($dayName, 0, 3) }}</div>
         @endforeach
 
-        <!-- Créneaux horaires -->
         @foreach($hours as $index => $hour)
-            <div class="availability-time-slot">{{ sprintf('%02d:00', $hour) }}</div>
+            <div class="bav-grid-time">{{ sprintf('%02d:00', $hour) }}</div>
             @foreach($days as $dayIndex => $day)
                 @php
                     $status = $availability[$day][$index] ?? 'unavailable';
                 @endphp
-                <div class="availability-slot {{ $status }}"
+                <div class="bav-grid-cell {{ $status }}"
                      id="slot-{{ $enseignant->id }}-{{ $index }}-{{ $dayIndex }}"
                      data-enseignant-id="{{ $enseignant->id }}"
                      data-day="{{ $dayIndex }}"
                      data-hour="{{ $hour }}"
                      data-time-index="{{ $index }}"
                      data-original-status="{{ $status }}"
-                     title="{{ $joursNoms[$day] }} {{ sprintf('%02d:00', $hour) }} - {{ ucfirst($status) }}">
+                     title="{{ $joursNoms[$day] }} {{ sprintf('%02d:00', $hour) }} — {{ ucfirst($status) }}">
                     @if($status === 'preferred')
-                        <i class="fas fa-star"></i><span class="slot-label">Préf.</span>
+                        <i class="fas fa-star"></i><span class="bav-slot-label">Préf.</span>
                     @elseif($status === 'available')
-                        <i class="fas fa-check"></i><span class="slot-label">Dispo</span>
+                        <i class="fas fa-check"></i><span class="bav-slot-label">Dispo</span>
                     @else
                         <i class="fas fa-minus"></i>
                     @endif
@@ -66,24 +75,17 @@
         @endforeach
     </div>
 
-    <!-- Légende -->
-    <div class="availability-legend">
-        <div class="legend-item">
-            <div class="legend-color" style="background: #dbeafe; color: #2563eb; border: 1px solid #bfdbfe;">
-                <i class="fas fa-star"></i>
-            </div>
+    <div class="bav-legend">
+        <div class="bav-legend-item">
+            <div class="bav-legend-swatch preferred"><i class="fas fa-star"></i></div>
             <span>Préféré</span>
         </div>
-        <div class="legend-item">
-            <div class="legend-color" style="background: #dcfce7; color: #16a34a; border: 1px solid #bbf7d0;">
-                <i class="fas fa-check"></i>
-            </div>
+        <div class="bav-legend-item">
+            <div class="bav-legend-swatch available"><i class="fas fa-check"></i></div>
             <span>Disponible</span>
         </div>
-        <div class="legend-item">
-            <div class="legend-color" style="background: #fee2e2; color: #dc2626; border: 1px solid #fecaca;">
-                <i class="fas fa-minus"></i>
-            </div>
+        <div class="bav-legend-item">
+            <div class="bav-legend-swatch unavailable"><i class="fas fa-minus"></i></div>
             <span>Indisponible</span>
         </div>
     </div>
@@ -92,9 +94,7 @@
 <script>
 (function() {
     const enseignantId = {{ $enseignant->id }};
-    const blockId = `enseignant-block-${enseignantId}`;
 
-    // Initialiser les données pour cet enseignant
     if (!window.editModes) window.editModes = {};
     if (!window.originalData) window.originalData = {};
     if (!window.modifiedSlots) window.modifiedSlots = {};
@@ -103,56 +103,47 @@
     window.originalData[enseignantId] = {};
     window.modifiedSlots[enseignantId] = new Set();
 
-    // Fonctions d'édition
     window.toggleEditMode = function(id) {
         window.editModes[id] = !window.editModes[id];
-        const block = document.querySelector(`[data-enseignant-id="${id}"]`);
-        const slots = block.querySelectorAll('.availability-slot');
-        const editBtn = block.querySelector('.btn-edit-availability');
-        const saveBtn = block.querySelector('.btn-save-availability');
-        const cancelBtn = block.querySelector('.btn-cancel-availability');
+        const item = document.getElementById('bav-item-' + id);
+        const slots = item.querySelectorAll('.bav-grid-cell');
+        const editBtn = item.querySelector('.bav-btn--edit');
+        const saveBtn = item.querySelector('.bav-btn--save');
+        const cancelBtn = item.querySelector('.bav-btn--cancel');
 
         if (window.editModes[id]) {
-            // Activer le mode édition
+            item.classList.add('bav-edit-active');
             slots.forEach(slot => {
-                slot.style.cursor = 'pointer';
                 slot.onclick = () => toggleSlotStatus(id, slot);
                 window.originalData[id][slot.id] = slot.dataset.originalStatus;
             });
-
             editBtn.style.display = 'none';
-            saveBtn.style.display = 'flex';
-            cancelBtn.style.display = 'flex';
-            block.style.background = 'linear-gradient(135deg, #fefce8, #fef9c3)';
-
-            showNotification('Mode édition activé. Cliquez sur les créneaux pour modifier.', 'info');
+            saveBtn.style.display = 'inline-flex';
+            cancelBtn.style.display = 'inline-flex';
+            showNotification('Mode édition activé', 'info');
         } else {
-            // Désactiver le mode édition
-            slots.forEach(slot => {
-                slot.style.cursor = 'default';
-                slot.onclick = null;
-            });
-
-            editBtn.style.display = 'flex';
+            item.classList.remove('bav-edit-active');
+            slots.forEach(slot => { slot.onclick = null; });
+            editBtn.style.display = 'inline-flex';
             saveBtn.style.display = 'none';
             cancelBtn.style.display = 'none';
-            block.style.background = '#ffffff';
         }
     };
 
     window.toggleSlotStatus = function(id, slot) {
         if (!window.editModes[id]) return;
-
         const statuses = ['unavailable', 'available', 'preferred'];
-        const icons = ['<i class="fas fa-minus"></i>', '<i class="fas fa-check"></i><span class="slot-label">Dispo</span>', '<i class="fas fa-star"></i><span class="slot-label">Préf.</span>'];
+        const icons = [
+            '<i class="fas fa-minus"></i>',
+            '<i class="fas fa-check"></i><span class="bav-slot-label">Dispo</span>',
+            '<i class="fas fa-star"></i><span class="bav-slot-label">Préf.</span>',
+        ];
         const currentClasses = Array.from(slot.classList);
-        let currentStatus = statuses.find(status => currentClasses.includes(status)) || 'unavailable';
-
-        const currentIndex = statuses.indexOf(currentStatus);
-        const nextIndex = (currentIndex + 1) % statuses.length;
+        let currentStatus = statuses.find(s => currentClasses.includes(s)) || 'unavailable';
+        const nextIndex = (statuses.indexOf(currentStatus) + 1) % statuses.length;
         const nextStatus = statuses[nextIndex];
 
-        statuses.forEach(status => slot.classList.remove(status));
+        statuses.forEach(s => slot.classList.remove(s));
         slot.classList.add(nextStatus);
         slot.innerHTML = icons[nextIndex];
 
@@ -164,28 +155,25 @@
             window.modifiedSlots[id].delete(slot.id);
         }
 
-        // Mettre à jour le tooltip
         const joursNoms = ['Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi', 'Dimanche'];
         const statusNames = { unavailable: 'Indisponible', available: 'Disponible', preferred: 'Préféré' };
-        const dayIndex = parseInt(slot.dataset.day);
-        const hour = slot.dataset.hour;
-        slot.title = `${joursNoms[dayIndex]} ${hour}:00 - ${statusNames[nextStatus]}`;
+        slot.title = `${joursNoms[parseInt(slot.dataset.day)]} ${slot.dataset.hour}:00 — ${statusNames[nextStatus]}`;
     };
 
     window.cancelEditMode = function(id) {
-        const icons = { unavailable: '<i class="fas fa-minus"></i>', available: '<i class="fas fa-check"></i><span class="slot-label">Dispo</span>', preferred: '<i class="fas fa-star"></i><span class="slot-label">Préf.</span>' };
-
+        const icons = {
+            unavailable: '<i class="fas fa-minus"></i>',
+            available: '<i class="fas fa-check"></i><span class="bav-slot-label">Dispo</span>',
+            preferred: '<i class="fas fa-star"></i><span class="bav-slot-label">Préf.</span>',
+        };
         window.modifiedSlots[id].forEach(slotId => {
             const slot = document.getElementById(slotId);
             const originalStatus = window.originalData[id][slotId];
-            const statuses = ['unavailable', 'available', 'preferred'];
-
-            statuses.forEach(status => slot.classList.remove(status));
+            ['unavailable', 'available', 'preferred'].forEach(s => slot.classList.remove(s));
             slot.classList.add(originalStatus);
             slot.innerHTML = icons[originalStatus];
             slot.classList.remove('modified');
         });
-
         window.modifiedSlots[id].clear();
         toggleEditMode(id);
         showNotification('Modifications annulées', 'warning');
@@ -196,22 +184,17 @@
             showNotification('Aucune modification à sauvegarder', 'warning');
             return;
         }
-
         const changedSlots = [];
         window.modifiedSlots[id].forEach(slotId => {
             const slot = document.getElementById(slotId);
             const statuses = ['unavailable', 'available', 'preferred'];
-            const currentStatus = statuses.find(status => slot.classList.contains(status));
-
-            const timeIndex = parseInt(slot.dataset.timeIndex);
-            const startHour = 8 + timeIndex;
-            const endHour = startHour + 1;
-
+            const currentStatus = statuses.find(s => slot.classList.contains(s));
+            const startHour = 8 + parseInt(slot.dataset.timeIndex);
             changedSlots.push({
                 day: parseInt(slot.dataset.day),
                 startTime: String(startHour).padStart(2, '0') + ':00',
-                endTime: String(endHour).padStart(2, '0') + ':00',
-                status: currentStatus
+                endTime: String(startHour + 1).padStart(2, '0') + ':00',
+                status: currentStatus,
             });
         });
 
@@ -219,37 +202,30 @@
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
-                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content')
+                'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
             },
-            body: JSON.stringify({ changes: changedSlots })
+            body: JSON.stringify({ changes: changedSlots }),
         })
-        .then(response => response.json())
+        .then(r => r.json())
         .then(data => {
             if (data.success) {
-                showNotification('Disponibilités mises à jour !', 'success');
-
-                // Mettre à jour les données originales
+                showNotification('Disponibilités mises à jour', 'success');
                 window.modifiedSlots[id].forEach(slotId => {
                     const slot = document.getElementById(slotId);
                     const statuses = ['unavailable', 'available', 'preferred'];
-                    const currentStatus = statuses.find(status => slot.classList.contains(status));
+                    const currentStatus = statuses.find(s => slot.classList.contains(s));
                     window.originalData[id][slotId] = currentStatus;
                     slot.dataset.originalStatus = currentStatus;
                     slot.classList.remove('modified');
                 });
-
                 window.modifiedSlots[id].clear();
                 toggleEditMode(id);
-
-                // Rafraîchir le bloc pour mettre à jour les stats
                 refreshBlock(id);
             } else {
-                showNotification('Erreur: ' + (data.message || 'Erreur inconnue'), 'danger');
+                showNotification('Erreur : ' + (data.message || 'Erreur inconnue'), 'danger');
             }
         })
-        .catch(error => {
-            showNotification('Erreur de connexion: ' + error.message, 'danger');
-        });
+        .catch(error => showNotification('Erreur de connexion : ' + error.message, 'danger'));
     };
 })();
 </script>


### PR DESCRIPTION
## Résumé

Refonte premium complète de `/esbtp/enseignants/bulk-availability` — chaque item enseignant et chaque sous-élément (stats, actions, grille, légende) repensés, pas seulement le header.

## Couleurs sémantiques préservées

Comme demandé : **vert (disponible) / bleu KLASSCI (préféré) / rouge (indisponible)** — c'est de la sémantique de statut, pas de la décoration.

## Avant → Après

**Hero**
- Gradient bleu simple → Gradient KLASSCI 3-couleurs (#0a3d8f → #0453cb → #3b7ddb) + icône glass 52px + 2 pills info contextuelles

**Item enseignant (chaque card)**
- Header bandeau plat → Avatar gradient KLASSCI 44px avec initiales, nom premium, meta avec icônes discrètes, status pill (vert/gris), bouton Voir outline, chevron toggle premium
- Stats badges discrets → 3 stat cards 12px radius avec icône colorée 38px + valeur 1.4rem + label uppercase
- Boutons plats → Boutons gradient (bleu Modifier / vert Sauver) + outline (Annuler), hover translate + shadow
- Grille calendrier basique → Cellules gradient subtil par statut, hover scale en mode edit, modified state outline orange + dot
- Légende inline → Légende dans card grise avec swatches gradient

**UX**
- Bannière mode-édition jaune visible uniquement en edit
- Toast premium gradient avec slide-in
- Mode édition active une bordure bleue 2px sur l'item entier (`bav-edit-active`)

## Implémentation

- Namespace CSS `.bav-*` dédié (évite conflits)
- 2 fichiers : `bulk-availability.blade.php` + `partials/availability-block.blade.php`
- JS conservé fonctionnellement (toggleEditMode / saveAvailability / refreshBlock)
- Empty state premium pour cas 0 enseignant sélectionné
- Responsive 768px + 480px (stats 1-col mobile, grille compactée)

## Verification

- [x] `php artisan view:cache` compile sans erreur
- [x] CSS namespace 100% .bav-* — pas de fuite
- [x] JS callbacks préservés (mêmes routes update-availability + availability-section)
- [x] Couleurs sémantiques préservées (vert/bleu/rouge)