### PR TITLE
feat(chat): action cards — share inscription/paiement avec CTA contextuel

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -4,13 +4,20 @@ namespace App\Http\Controllers;
 
 use App\Models\ChatConversation;
 use App\Models\ChatMessage;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPPaiement;
 use App\Models\User;
+use App\Services\ChatActionResolver;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 
 class ChatController extends Controller
 {
+    public function __construct(private readonly ChatActionResolver $resolver = new ChatActionResolver())
+    {
+    }
+
     public function index(Request $request)
     {
         $user = $request->user();
@@ -47,6 +54,8 @@ class ChatController extends Controller
             ->reverse()
             ->values();
 
+        $viewer = $request->user();
+
         return response()->json([
             'conversation' => $conversation->only(['id', 'type', 'title', 'context']),
             'messages' => $messages->map(fn ($m) => [
@@ -56,8 +65,9 @@ class ChatController extends Controller
                 'type' => $m->type,
                 'body' => $m->body,
                 'payload' => $m->payload,
+                'cta' => $m->type === 'action_card' ? $this->resolver->resolveCta($m, $viewer) : null,
                 'created_at' => $m->created_at->toIso8601String(),
-                'mine' => $m->sender_id === $request->user()->id,
+                'mine' => $m->sender_id === $viewer->id,
             ])->all(),
         ]);
     }
@@ -152,5 +162,184 @@ class ChatController extends Controller
     {
         $isMember = $conversation->participants()->where('user_id', $user->id)->exists();
         abort_unless($isMember, 403, 'Vous n\'êtes pas membre de cette conversation.');
+    }
+
+    /**
+     * Partager une inscription dans une conversation (existante ou nouveau DM).
+     */
+    public function shareInscription(Request $request, ESBTPInscription $inscription): JsonResponse
+    {
+        abort_unless($request->user()->can('inscriptions.view'), 403);
+
+        $data = $request->validate([
+            'recipient_id' => 'required_without:conversation_id|exists:users,id',
+            'conversation_id' => 'required_without:recipient_id|exists:chat_conversations,id',
+            'note' => 'nullable|string|max:500',
+        ]);
+
+        $payload = $this->resolver->snapshotInscription($inscription);
+
+        return $this->dispatchActionCard($request, $data, $payload);
+    }
+
+    /**
+     * Partager un paiement dans une conversation (existante ou nouveau DM).
+     */
+    public function sharePaiement(Request $request, ESBTPPaiement $paiement): JsonResponse
+    {
+        abort_unless($request->user()->can('paiements.view'), 403);
+
+        $data = $request->validate([
+            'recipient_id' => 'required_without:conversation_id|exists:users,id',
+            'conversation_id' => 'required_without:recipient_id|exists:chat_conversations,id',
+            'note' => 'nullable|string|max:500',
+        ]);
+
+        $payload = $this->resolver->snapshotPaiement($paiement);
+
+        return $this->dispatchActionCard($request, $data, $payload);
+    }
+
+    /**
+     * Picker : recherche d'inscriptions à partager (autocomplete par étudiant/matricule).
+     */
+    public function pickerInscriptions(Request $request): JsonResponse
+    {
+        abort_unless($request->user()->can('inscriptions.view'), 403);
+
+        $q = trim($request->validate(['q' => 'nullable|string|max:100'])['q'] ?? '');
+
+        $rows = ESBTPInscription::query()
+            ->select(['id', 'etudiant_id', 'classe_id', 'workflow_step', 'status', 'annee_universitaire_id'])
+            ->with([
+                'etudiant:id,nom,prenoms,matricule',
+                'classe:id,name',
+            ])
+            ->when($q !== '', function ($qb) use ($q) {
+                $qb->whereHas('etudiant', function ($eq) use ($q) {
+                    $eq->where('nom', 'like', "%{$q}%")
+                       ->orWhere('prenoms', 'like', "%{$q}%")
+                       ->orWhere('matricule', 'like', "%{$q}%");
+                });
+            })
+            ->latest('id')
+            ->limit(15)
+            ->get();
+
+        return response()->json([
+            'items' => $rows->map(fn (ESBTPInscription $i) => [
+                'id' => $i->id,
+                'etudiant' => trim(($i->etudiant?->nom ?? '') . ' ' . ($i->etudiant?->prenoms ?? '')) ?: '—',
+                'matricule' => $i->etudiant?->matricule,
+                'classe' => $i->classe?->name ?? '—',
+                'workflow_step' => $i->workflow_step,
+                'status' => $i->status,
+            ])->all(),
+        ]);
+    }
+
+    /**
+     * Picker : recherche de paiements à partager.
+     */
+    public function pickerPaiements(Request $request): JsonResponse
+    {
+        abort_unless($request->user()->can('paiements.view'), 403);
+
+        $q = trim($request->validate(['q' => 'nullable|string|max:100'])['q'] ?? '');
+
+        $rows = ESBTPPaiement::query()
+            ->select(['id', 'inscription_id', 'etudiant_id', 'montant', 'statut', 'validateur_id', 'date_paiement', 'mode_paiement', 'reference_paiement'])
+            ->with(['etudiant:id,nom,prenoms,matricule'])
+            ->when($q !== '', function ($qb) use ($q) {
+                $qb->whereHas('etudiant', function ($eq) use ($q) {
+                    $eq->where('nom', 'like', "%{$q}%")
+                       ->orWhere('prenoms', 'like', "%{$q}%")
+                       ->orWhere('matricule', 'like', "%{$q}%");
+                })->orWhere('reference_paiement', 'like', "%{$q}%");
+            })
+            ->latest('id')
+            ->limit(15)
+            ->get();
+
+        return response()->json([
+            'items' => $rows->map(fn (ESBTPPaiement $p) => [
+                'id' => $p->id,
+                'etudiant' => trim(($p->etudiant?->nom ?? '') . ' ' . ($p->etudiant?->prenoms ?? '')) ?: '—',
+                'matricule' => $p->etudiant?->matricule,
+                'montant' => (float) $p->montant,
+                'statut' => $p->statut,
+                'is_validated' => $p->validateur_id !== null,
+                'reference' => $p->reference_paiement,
+                'date' => optional($p->date_paiement)->toDateString(),
+            ])->all(),
+        ]);
+    }
+
+    /**
+     * Pipeline interne : trouve/crée la conv + insère le message action_card + (optionnel) note texte.
+     *
+     * @param array{recipient_id?: int, conversation_id?: int, note?: string} $data
+     */
+    private function dispatchActionCard(Request $request, array $data, array $payload): JsonResponse
+    {
+        $sender = $request->user();
+
+        $result = DB::transaction(function () use ($sender, $data, $payload) {
+            $conversation = $this->findOrCreateConversation($sender, $data);
+
+            $card = ChatMessage::create([
+                'chat_conversation_id' => $conversation->id,
+                'sender_id' => $sender->id,
+                'type' => 'action_card',
+                'body' => null,
+                'payload' => $payload,
+            ]);
+
+            if (!empty($data['note'])) {
+                ChatMessage::create([
+                    'chat_conversation_id' => $conversation->id,
+                    'sender_id' => $sender->id,
+                    'type' => 'text',
+                    'body' => $data['note'],
+                ]);
+            }
+
+            $conversation->update(['last_message_at' => now()]);
+
+            return [$conversation, $card];
+        });
+
+        [$conversation, $card] = $result;
+
+        return response()->json([
+            'conversation_id' => $conversation->id,
+            'message_id' => $card->id,
+            'redirect' => route('chat.index') . '?conversation=' . $conversation->id,
+        ], 201);
+    }
+
+    private function findOrCreateConversation(User $sender, array $data): ChatConversation
+    {
+        if (!empty($data['conversation_id'])) {
+            $conversation = ChatConversation::findOrFail($data['conversation_id']);
+            $this->authorizeMember($conversation, $sender);
+            return $conversation;
+        }
+
+        $recipientId = (int) $data['recipient_id'];
+        abort_if($recipientId === $sender->id, 422, 'Vous ne pouvez pas vous envoyer un message à vous-même.');
+
+        $existing = ChatConversation::where('type', 'dm')
+            ->whereHas('participants', fn ($q) => $q->where('user_id', $sender->id))
+            ->whereHas('participants', fn ($q) => $q->where('user_id', $recipientId))
+            ->first();
+
+        if ($existing) {
+            return $existing;
+        }
+
+        $conversation = ChatConversation::create(['type' => 'dm', 'last_message_at' => now()]);
+        $conversation->participants()->attach([$sender->id, $recipientId]);
+        return $conversation;
     }
 }

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -55,6 +55,7 @@ class ChatController extends Controller
             ->values();
 
         $viewer = $request->user();
+        $maps = $this->resolver->preload($messages);
 
         return response()->json([
             'conversation' => $conversation->only(['id', 'type', 'title', 'context']),
@@ -65,7 +66,7 @@ class ChatController extends Controller
                 'type' => $m->type,
                 'body' => $m->body,
                 'payload' => $m->payload,
-                'cta' => $m->type === 'action_card' ? $this->resolver->resolveCta($m, $viewer) : null,
+                'cta' => $m->type === 'action_card' ? $this->resolver->resolveCta($m, $viewer, $maps) : null,
                 'created_at' => $m->created_at->toIso8601String(),
                 'mine' => $m->sender_id === $viewer->id,
             ])->all(),
@@ -103,26 +104,8 @@ class ChatController extends Controller
     public function startDm(Request $request): JsonResponse
     {
         $data = $request->validate(['user_id' => 'required|exists:users,id']);
-        if ($data['user_id'] === $request->user()->id) {
-            return response()->json(['error' => 'Cannot DM yourself'], 422);
-        }
-
-        $existing = ChatConversation::where('type', 'dm')
-            ->whereHas('participants', fn ($q) => $q->where('user_id', $request->user()->id))
-            ->whereHas('participants', fn ($q) => $q->where('user_id', $data['user_id']))
-            ->first();
-
-        if ($existing) {
-            return response()->json(['conversation_id' => $existing->id]);
-        }
-
-        $convo = DB::transaction(function () use ($request, $data) {
-            $c = ChatConversation::create(['type' => 'dm', 'last_message_at' => now()]);
-            $c->participants()->attach([$request->user()->id, $data['user_id']]);
-            return $c;
-        });
-
-        return response()->json(['conversation_id' => $convo->id], 201);
+        $convo = $this->findOrCreateDm($request->user(), (int) $data['user_id']);
+        return response()->json(['conversation_id' => $convo->id], $convo->wasRecentlyCreated ? 201 : 200);
     }
 
     public function notifications(Request $request): JsonResponse
@@ -233,6 +216,7 @@ class ChatController extends Controller
                 'matricule' => $i->etudiant?->matricule,
                 'classe' => $i->classe?->name ?? '—',
                 'workflow_step' => $i->workflow_step,
+                'workflow_label' => ChatActionResolver::workflowLabel($i->workflow_step),
                 'status' => $i->status,
             ])->all(),
         ]);
@@ -248,7 +232,7 @@ class ChatController extends Controller
         $q = trim($request->validate(['q' => 'nullable|string|max:100'])['q'] ?? '');
 
         $rows = ESBTPPaiement::query()
-            ->select(['id', 'inscription_id', 'etudiant_id', 'montant', 'statut', 'validateur_id', 'date_paiement', 'mode_paiement', 'reference_paiement'])
+            ->select(['id', 'inscription_id', 'etudiant_id', 'montant', 'status', 'validateur_id', 'date_paiement', 'mode_paiement', 'reference_paiement'])
             ->with(['etudiant:id,nom,prenoms,matricule'])
             ->when($q !== '', function ($qb) use ($q) {
                 $qb->whereHas('etudiant', function ($eq) use ($q) {
@@ -267,8 +251,8 @@ class ChatController extends Controller
                 'etudiant' => trim(($p->etudiant?->nom ?? '') . ' ' . ($p->etudiant?->prenoms ?? '')) ?: '—',
                 'matricule' => $p->etudiant?->matricule,
                 'montant' => (float) $p->montant,
-                'statut' => $p->statut,
-                'is_validated' => $p->validateur_id !== null,
+                'statut' => $p->status,
+                'is_validated' => $p->status === 'validé',
                 'reference' => $p->reference_paiement,
                 'date' => optional($p->date_paiement)->toDateString(),
             ])->all(),
@@ -325,8 +309,11 @@ class ChatController extends Controller
             $this->authorizeMember($conversation, $sender);
             return $conversation;
         }
+        return $this->findOrCreateDm($sender, (int) $data['recipient_id']);
+    }
 
-        $recipientId = (int) $data['recipient_id'];
+    private function findOrCreateDm(User $sender, int $recipientId): ChatConversation
+    {
         abort_if($recipientId === $sender->id, 422, 'Vous ne pouvez pas vous envoyer un message à vous-même.');
 
         $existing = ChatConversation::where('type', 'dm')
@@ -338,8 +325,10 @@ class ChatController extends Controller
             return $existing;
         }
 
-        $conversation = ChatConversation::create(['type' => 'dm', 'last_message_at' => now()]);
-        $conversation->participants()->attach([$sender->id, $recipientId]);
-        return $conversation;
+        return DB::transaction(function () use ($sender, $recipientId) {
+            $conversation = ChatConversation::create(['type' => 'dm', 'last_message_at' => now()]);
+            $conversation->participants()->attach([$sender->id, $recipientId]);
+            return $conversation;
+        });
     }
 }

--- a/app/Services/ChatActionResolver.php
+++ b/app/Services/ChatActionResolver.php
@@ -1,0 +1,277 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ChatMessage;
+use App\Models\ESBTPFraisSubscription;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPPaiement;
+use App\Models\User;
+
+/**
+ * Résout l'état actuel + le CTA d'une action_card dans le chat selon le viewer.
+ *
+ * Le snapshot dans payload est figé au moment du share. Mais le CTA est calculé
+ * en temps réel via lookup de la ressource (inscription/paiement) pour que le
+ * destinataire voie l'action correcte selon l'état courant + ses permissions.
+ */
+class ChatActionResolver
+{
+    /**
+     * Construit le snapshot d'une inscription pour stockage dans payload.
+     */
+    public function snapshotInscription(ESBTPInscription $inscription): array
+    {
+        $inscription->loadMissing([
+            'etudiant:id,nom,prenoms,matricule,photo',
+            'classe:id,name',
+            'anneeUniversitaire:id,name,libelle',
+        ]);
+
+        $etudiantName = trim(($inscription->etudiant?->nom ?? '') . ' ' . ($inscription->etudiant?->prenoms ?? ''));
+        $totals = $this->totalsForInscription($inscription);
+
+        return [
+            'kind' => 'inscription',
+            'id' => $inscription->id,
+            'snapshot' => [
+                'etudiant' => [
+                    'id' => $inscription->etudiant_id,
+                    'name' => $etudiantName ?: '—',
+                    'matricule' => $inscription->etudiant?->matricule,
+                    'photo_url' => $inscription->etudiant?->photo
+                        ? asset('storage/' . $inscription->etudiant->photo)
+                        : null,
+                ],
+                'classe' => $inscription->classe?->name ?? '—',
+                'annee' => $inscription->anneeUniversitaire?->libelle
+                    ?? $inscription->anneeUniversitaire?->name
+                    ?? '—',
+                'status' => $inscription->status,
+                'workflow_step' => $inscription->workflow_step,
+                'is_sous_reserve' => (bool) $inscription->is_sous_reserve,
+                'montant_total' => $totals['attendu'],
+                'montant_paye' => $totals['paye'],
+                'solde_restant' => $totals['solde'],
+            ],
+        ];
+    }
+
+    /**
+     * Construit le snapshot d'un paiement pour stockage dans payload.
+     */
+    public function snapshotPaiement(ESBTPPaiement $paiement): array
+    {
+        $paiement->loadMissing([
+            'etudiant:id,nom,prenoms,matricule,photo',
+            'inscription:id,etudiant_id,classe_id,workflow_step,status',
+            'inscription.classe:id,name',
+        ]);
+
+        $etudiantName = trim(($paiement->etudiant?->nom ?? '') . ' ' . ($paiement->etudiant?->prenoms ?? ''));
+
+        return [
+            'kind' => 'paiement',
+            'id' => $paiement->id,
+            'inscription_id' => $paiement->inscription_id,
+            'snapshot' => [
+                'etudiant' => [
+                    'id' => $paiement->etudiant_id,
+                    'name' => $etudiantName ?: '—',
+                    'matricule' => $paiement->etudiant?->matricule,
+                    'photo_url' => $paiement->etudiant?->photo
+                        ? asset('storage/' . $paiement->etudiant->photo)
+                        : null,
+                ],
+                'classe' => $paiement->inscription?->classe?->name ?? '—',
+                'montant' => (float) $paiement->montant,
+                'mode_paiement' => $paiement->mode_paiement,
+                'reference' => $paiement->reference_paiement ?? $paiement->numero_recu,
+                'date_paiement' => optional($paiement->date_paiement)->toDateString(),
+                'statut' => $paiement->statut,
+                'is_validated' => $paiement->validateur_id !== null,
+                'motif' => $paiement->motif,
+                'inscription_workflow_step' => $paiement->inscription?->workflow_step,
+            ],
+        ];
+    }
+
+    /**
+     * Calcule le CTA contextuel selon l'état courant de la ressource + perms du viewer.
+     *
+     * @return array{label: string, url: string, variant: 'primary'|'ghost', icon: string}|null
+     */
+    public function resolveCta(ChatMessage $message, User $viewer): ?array
+    {
+        if ($message->type !== 'action_card' || !is_array($message->payload)) {
+            return null;
+        }
+
+        $kind = $message->payload['kind'] ?? null;
+        $id = $message->payload['id'] ?? null;
+        if (!$kind || !$id) {
+            return null;
+        }
+
+        return match ($kind) {
+            'inscription' => $this->ctaForInscription((int) $id, $viewer),
+            'paiement' => $this->ctaForPaiement((int) $id, $viewer),
+            default => null,
+        };
+    }
+
+    private function ctaForInscription(int $inscriptionId, User $viewer): ?array
+    {
+        $inscription = ESBTPInscription::query()
+            ->select(['id', 'workflow_step', 'status', 'paiement_validation_id'])
+            ->find($inscriptionId);
+
+        if (!$inscription) {
+            return $this->ctaSoftDeleted();
+        }
+
+        $step = $inscription->workflow_step;
+
+        // Inscription validée → fin du chain
+        if ($step === 'inscription_validee' || $step === 'validee') {
+            return $this->ctaView(
+                'Voir l\'inscription',
+                route('esbtp.inscriptions.show', $inscription->id),
+                'fa-eye',
+                $viewer->can('inscriptions.view'),
+            );
+        }
+
+        // Paiement validé mais inscription pas encore validée → valider inscription
+        if ($step === 'paiement_valide' && $viewer->can('inscriptions.validate')) {
+            return [
+                'label' => 'Valider l\'inscription',
+                'url' => route('esbtp.inscriptions.show', $inscription->id) . '#valider',
+                'variant' => 'primary',
+                'icon' => 'fa-check-double',
+            ];
+        }
+
+        // Paiement créé mais pas validé → valider le paiement
+        if ($step === 'paiement_cree' && $inscription->paiement_validation_id && $viewer->can('paiements.validate')) {
+            return [
+                'label' => 'Valider le paiement',
+                'url' => route('esbtp.paiements.show', $inscription->paiement_validation_id),
+                'variant' => 'primary',
+                'icon' => 'fa-shield-check',
+            ];
+        }
+
+        // Pas de paiement encore → encaisser
+        if (in_array($step, ['etudiant_cree', null], true) && $viewer->can('paiements.create')) {
+            return [
+                'label' => 'Encaisser un paiement',
+                'url' => route('esbtp.paiements.create', ['inscription_id' => $inscription->id]),
+                'variant' => 'primary',
+                'icon' => 'fa-cash-register',
+            ];
+        }
+
+        // Fallback : juste voir
+        return $this->ctaView(
+            'Voir l\'inscription',
+            route('esbtp.inscriptions.show', $inscription->id),
+            'fa-eye',
+            $viewer->can('inscriptions.view'),
+        );
+    }
+
+    private function ctaForPaiement(int $paiementId, User $viewer): ?array
+    {
+        $paiement = ESBTPPaiement::query()
+            ->select(['id', 'inscription_id', 'statut', 'validateur_id'])
+            ->find($paiementId);
+
+        if (!$paiement) {
+            return $this->ctaSoftDeleted();
+        }
+
+        $isValidated = $paiement->validateur_id !== null
+            || in_array($paiement->statut, ['valide', 'validé', 'completed'], true);
+
+        // Paiement validé → focus sur l'inscription liée
+        if ($isValidated && $paiement->inscription_id) {
+            $inscription = ESBTPInscription::query()
+                ->select(['id', 'workflow_step'])
+                ->find($paiement->inscription_id);
+
+            if ($inscription
+                && $inscription->workflow_step !== 'inscription_validee'
+                && $inscription->workflow_step !== 'validee'
+                && $viewer->can('inscriptions.validate')
+            ) {
+                return [
+                    'label' => 'Valider l\'inscription',
+                    'url' => route('esbtp.inscriptions.show', $inscription->id) . '#valider',
+                    'variant' => 'primary',
+                    'icon' => 'fa-check-double',
+                ];
+            }
+        }
+
+        // Paiement en attente → valider
+        if (!$isValidated && $viewer->can('paiements.validate')) {
+            return [
+                'label' => 'Valider le paiement',
+                'url' => route('esbtp.paiements.show', $paiement->id),
+                'variant' => 'primary',
+                'icon' => 'fa-shield-check',
+            ];
+        }
+
+        // Fallback : voir
+        return $this->ctaView(
+            'Voir le paiement',
+            route('esbtp.paiements.show', $paiement->id),
+            'fa-eye',
+            $viewer->can('paiements.view'),
+        );
+    }
+
+    private function ctaView(string $label, string $url, string $icon, bool $allowed): ?array
+    {
+        if (!$allowed) {
+            return null;
+        }
+        return ['label' => $label, 'url' => $url, 'variant' => 'ghost', 'icon' => $icon];
+    }
+
+    private function ctaSoftDeleted(): array
+    {
+        return [
+            'label' => 'Ressource supprimée',
+            'url' => '#',
+            'variant' => 'disabled',
+            'icon' => 'fa-ban',
+        ];
+    }
+
+    /**
+     * Totaux frais pour une inscription : attendu / payé / solde.
+     *
+     * @return array{attendu: float, paye: float, solde: float}
+     */
+    private function totalsForInscription(ESBTPInscription $inscription): array
+    {
+        $attendu = (float) ESBTPFraisSubscription::query()
+            ->where('inscription_id', $inscription->id)
+            ->where('is_active', true)
+            ->sum('amount');
+
+        $paye = (float) ESBTPPaiement::query()
+            ->where('inscription_id', $inscription->id)
+            ->whereNotNull('validateur_id')
+            ->sum('montant');
+
+        return [
+            'attendu' => $attendu,
+            'paye' => $paye,
+            'solde' => max(0, $attendu - $paye),
+        ];
+    }
+}

--- a/app/Services/ChatActionResolver.php
+++ b/app/Services/ChatActionResolver.php
@@ -3,23 +3,22 @@
 namespace App\Services;
 
 use App\Models\ChatMessage;
-use App\Models\ESBTPFraisSubscription;
 use App\Models\ESBTPInscription;
 use App\Models\ESBTPPaiement;
 use App\Models\User;
+use Illuminate\Support\Collection;
 
 /**
- * Résout l'état actuel + le CTA d'une action_card dans le chat selon le viewer.
+ * Snapshot + résolution CTA des action_card du chat.
  *
- * Le snapshot dans payload est figé au moment du share. Mais le CTA est calculé
- * en temps réel via lookup de la ressource (inscription/paiement) pour que le
- * destinataire voie l'action correcte selon l'état courant + ses permissions.
+ * Le snapshot dans payload est figé à l'envoi. Le CTA est calculé en temps réel
+ * depuis l'état courant de la ressource + les permissions du viewer.
+ *
+ * Pour les hot paths (ChatController::show()), utiliser preload() + resolveCta()
+ * avec les maps pré-chargées pour éviter le N+1.
  */
 class ChatActionResolver
 {
-    /**
-     * Construit le snapshot d'une inscription pour stockage dans payload.
-     */
     public function snapshotInscription(ESBTPInscription $inscription): array
     {
         $inscription->loadMissing([
@@ -28,8 +27,11 @@ class ChatActionResolver
             'anneeUniversitaire:id,name,libelle',
         ]);
 
+        $relance = app(RelanceCalculationService::class)->preloadForSingle($inscription);
+        $attendu = (float) $relance->calculerTotalDu($inscription);
+        $paye = (float) $inscription->paiements()->valides()->sum('montant');
+
         $etudiantName = trim(($inscription->etudiant?->nom ?? '') . ' ' . ($inscription->etudiant?->prenoms ?? ''));
-        $totals = $this->totalsForInscription($inscription);
 
         return [
             'kind' => 'inscription',
@@ -49,17 +51,16 @@ class ChatActionResolver
                     ?? '—',
                 'status' => $inscription->status,
                 'workflow_step' => $inscription->workflow_step,
+                'workflow_label' => self::workflowLabel($inscription->workflow_step),
+                'workflow_chip_class' => self::workflowChipClass($inscription->workflow_step),
                 'is_sous_reserve' => (bool) $inscription->is_sous_reserve,
-                'montant_total' => $totals['attendu'],
-                'montant_paye' => $totals['paye'],
-                'solde_restant' => $totals['solde'],
+                'montant_total' => $attendu,
+                'montant_paye' => $paye,
+                'solde_restant' => max(0, $attendu - $paye),
             ],
         ];
     }
 
-    /**
-     * Construit le snapshot d'un paiement pour stockage dans payload.
-     */
     public function snapshotPaiement(ESBTPPaiement $paiement): array
     {
         $paiement->loadMissing([
@@ -88,121 +89,132 @@ class ChatActionResolver
                 'mode_paiement' => $paiement->mode_paiement,
                 'reference' => $paiement->reference_paiement ?? $paiement->numero_recu,
                 'date_paiement' => optional($paiement->date_paiement)->toDateString(),
-                'statut' => $paiement->statut,
-                'is_validated' => $paiement->validateur_id !== null,
+                'statut' => $paiement->status,
+                'is_validated' => $paiement->status === 'validé',
                 'motif' => $paiement->motif,
-                'inscription_workflow_step' => $paiement->inscription?->workflow_step,
             ],
         ];
     }
 
     /**
-     * Calcule le CTA contextuel selon l'état courant de la ressource + perms du viewer.
+     * Pré-charge les ressources référencées par toutes les action_card de la collection,
+     * pour éviter le N+1 dans show().
      *
-     * @return array{label: string, url: string, variant: 'primary'|'ghost', icon: string}|null
+     * @param  iterable<ChatMessage>  $messages
+     * @return array{inscriptions: Collection, paiements: Collection}
      */
-    public function resolveCta(ChatMessage $message, User $viewer): ?array
+    public function preload(iterable $messages): array
+    {
+        $inscriptionIds = [];
+        $paiementIds = [];
+
+        foreach ($messages as $m) {
+            if ($m->type !== 'action_card' || !is_array($m->payload)) {
+                continue;
+            }
+            $kind = $m->payload['kind'] ?? null;
+            $id = $m->payload['id'] ?? null;
+            if (!$id) {
+                continue;
+            }
+            if ($kind === 'inscription') {
+                $inscriptionIds[] = (int) $id;
+            } elseif ($kind === 'paiement') {
+                $paiementIds[] = (int) $id;
+                if (!empty($m->payload['inscription_id'])) {
+                    $inscriptionIds[] = (int) $m->payload['inscription_id'];
+                }
+            }
+        }
+
+        $inscriptions = empty($inscriptionIds) ? collect() : ESBTPInscription::query()
+            ->select(['id', 'workflow_step', 'status', 'paiement_validation_id'])
+            ->whereIn('id', array_unique($inscriptionIds))
+            ->get()
+            ->keyBy('id');
+
+        $paiements = empty($paiementIds) ? collect() : ESBTPPaiement::query()
+            ->select(['id', 'inscription_id', 'status', 'validateur_id'])
+            ->whereIn('id', array_unique($paiementIds))
+            ->get()
+            ->keyBy('id');
+
+        return ['inscriptions' => $inscriptions, 'paiements' => $paiements];
+    }
+
+    /**
+     * Résout le CTA d'une action_card pour un viewer.
+     *
+     * @param  array{inscriptions: Collection, paiements: Collection}|null  $maps  Pré-chargé via preload() pour batch
+     * @return array{label: string, url: string, variant: string, icon: string}|null
+     */
+    public function resolveCta(ChatMessage $message, User $viewer, ?array $maps = null): ?array
     {
         if ($message->type !== 'action_card' || !is_array($message->payload)) {
             return null;
         }
 
         $kind = $message->payload['kind'] ?? null;
-        $id = $message->payload['id'] ?? null;
+        $id = (int) ($message->payload['id'] ?? 0);
         if (!$kind || !$id) {
             return null;
         }
 
         return match ($kind) {
-            'inscription' => $this->ctaForInscription((int) $id, $viewer),
-            'paiement' => $this->ctaForPaiement((int) $id, $viewer),
+            'inscription' => $this->ctaForInscription($id, $viewer, $maps),
+            'paiement' => $this->ctaForPaiement($id, $viewer, $maps),
             default => null,
         };
     }
 
-    private function ctaForInscription(int $inscriptionId, User $viewer): ?array
+    private function ctaForInscription(int $inscriptionId, User $viewer, ?array $maps): ?array
     {
-        $inscription = ESBTPInscription::query()
-            ->select(['id', 'workflow_step', 'status', 'paiement_validation_id'])
-            ->find($inscriptionId);
+        $inscription = $maps['inscriptions']->get($inscriptionId)
+            ?? ESBTPInscription::query()
+                ->select(['id', 'workflow_step', 'status', 'paiement_validation_id'])
+                ->find($inscriptionId);
 
         if (!$inscription) {
             return $this->ctaSoftDeleted();
         }
 
-        $step = $inscription->workflow_step;
-
-        // Inscription validée → fin du chain
-        if ($step === 'inscription_validee' || $step === 'validee') {
-            return $this->ctaView(
+        // Branches ordrées du plus avancé au moins avancé.
+        return match ((string) $inscription->workflow_step) {
+            'etudiant_cree' => $this->ctaView(
                 'Voir l\'inscription',
                 route('esbtp.inscriptions.show', $inscription->id),
                 'fa-eye',
                 $viewer->can('inscriptions.view'),
-            );
-        }
-
-        // Paiement validé mais inscription pas encore validée → valider inscription
-        if ($step === 'paiement_valide' && $viewer->can('inscriptions.validate')) {
-            return [
-                'label' => 'Valider l\'inscription',
-                'url' => route('esbtp.inscriptions.show', $inscription->id) . '#valider',
-                'variant' => 'primary',
-                'icon' => 'fa-check-double',
-            ];
-        }
-
-        // Paiement créé mais pas validé → valider le paiement
-        if ($step === 'paiement_cree' && $inscription->paiement_validation_id && $viewer->can('paiements.validate')) {
-            return [
-                'label' => 'Valider le paiement',
-                'url' => route('esbtp.paiements.show', $inscription->paiement_validation_id),
-                'variant' => 'primary',
-                'icon' => 'fa-shield-check',
-            ];
-        }
-
-        // Pas de paiement encore → encaisser
-        if (in_array($step, ['etudiant_cree', null], true) && $viewer->can('paiements.create')) {
-            return [
-                'label' => 'Encaisser un paiement',
-                'url' => route('esbtp.paiements.create', ['inscription_id' => $inscription->id]),
-                'variant' => 'primary',
-                'icon' => 'fa-cash-register',
-            ];
-        }
-
-        // Fallback : juste voir
-        return $this->ctaView(
-            'Voir l\'inscription',
-            route('esbtp.inscriptions.show', $inscription->id),
-            'fa-eye',
-            $viewer->can('inscriptions.view'),
-        );
+            ),
+            'en_validation' => $this->ctaValidatePaiement($inscription, $viewer)
+                ?? $this->ctaFallbackInscription($inscription, $viewer),
+            'prospect', 'documents_complets' => $this->ctaCreatePaiement($inscription, $viewer)
+                ?? $this->ctaFallbackInscription($inscription, $viewer),
+            default => $this->ctaFallbackInscription($inscription, $viewer),
+        };
     }
 
-    private function ctaForPaiement(int $paiementId, User $viewer): ?array
+    private function ctaForPaiement(int $paiementId, User $viewer, ?array $maps): ?array
     {
-        $paiement = ESBTPPaiement::query()
-            ->select(['id', 'inscription_id', 'statut', 'validateur_id'])
-            ->find($paiementId);
+        $paiement = $maps['paiements']->get($paiementId)
+            ?? ESBTPPaiement::query()
+                ->select(['id', 'inscription_id', 'status', 'validateur_id'])
+                ->find($paiementId);
 
         if (!$paiement) {
             return $this->ctaSoftDeleted();
         }
 
-        $isValidated = $paiement->validateur_id !== null
-            || in_array($paiement->statut, ['valide', 'validé', 'completed'], true);
+        $isValidated = $paiement->status === 'validé';
 
-        // Paiement validé → focus sur l'inscription liée
         if ($isValidated && $paiement->inscription_id) {
-            $inscription = ESBTPInscription::query()
-                ->select(['id', 'workflow_step'])
-                ->find($paiement->inscription_id);
+            $inscription = $maps['inscriptions']->get($paiement->inscription_id)
+                ?? ESBTPInscription::query()
+                    ->select(['id', 'workflow_step'])
+                    ->find($paiement->inscription_id);
 
             if ($inscription
-                && $inscription->workflow_step !== 'inscription_validee'
-                && $inscription->workflow_step !== 'validee'
+                && $inscription->workflow_step !== 'etudiant_cree'
                 && $viewer->can('inscriptions.validate')
             ) {
                 return [
@@ -214,7 +226,6 @@ class ChatActionResolver
             }
         }
 
-        // Paiement en attente → valider
         if (!$isValidated && $viewer->can('paiements.validate')) {
             return [
                 'label' => 'Valider le paiement',
@@ -224,12 +235,47 @@ class ChatActionResolver
             ];
         }
 
-        // Fallback : voir
         return $this->ctaView(
             'Voir le paiement',
             route('esbtp.paiements.show', $paiement->id),
             'fa-eye',
             $viewer->can('paiements.view'),
+        );
+    }
+
+    private function ctaCreatePaiement(ESBTPInscription $inscription, User $viewer): ?array
+    {
+        if (!$viewer->can('paiements.create')) {
+            return null;
+        }
+        return [
+            'label' => 'Encaisser un paiement',
+            'url' => route('esbtp.paiements.create', ['inscription_id' => $inscription->id]),
+            'variant' => 'primary',
+            'icon' => 'fa-cash-register',
+        ];
+    }
+
+    private function ctaValidatePaiement(ESBTPInscription $inscription, User $viewer): ?array
+    {
+        if (!$inscription->paiement_validation_id || !$viewer->can('paiements.validate')) {
+            return null;
+        }
+        return [
+            'label' => 'Valider le paiement',
+            'url' => route('esbtp.paiements.show', $inscription->paiement_validation_id),
+            'variant' => 'primary',
+            'icon' => 'fa-shield-check',
+        ];
+    }
+
+    private function ctaFallbackInscription(ESBTPInscription $inscription, User $viewer): ?array
+    {
+        return $this->ctaView(
+            'Voir l\'inscription',
+            route('esbtp.inscriptions.show', $inscription->id),
+            'fa-eye',
+            $viewer->can('inscriptions.view'),
         );
     }
 
@@ -252,26 +298,26 @@ class ChatActionResolver
     }
 
     /**
-     * Totaux frais pour une inscription : attendu / payé / solde.
-     *
-     * @return array{attendu: float, paye: float, solde: float}
+     * Source unique des labels workflow_step (cohérence avec WorkflowStepBadge).
      */
-    private function totalsForInscription(ESBTPInscription $inscription): array
+    public static function workflowLabel(?string $step): string
     {
-        $attendu = (float) ESBTPFraisSubscription::query()
-            ->where('inscription_id', $inscription->id)
-            ->where('is_active', true)
-            ->sum('amount');
+        return match ((string) $step) {
+            'prospect' => 'Prospect',
+            'documents_complets' => 'Documents complets',
+            'en_validation' => 'En validation',
+            'etudiant_cree' => 'Validée',
+            default => 'Non défini',
+        };
+    }
 
-        $paye = (float) ESBTPPaiement::query()
-            ->where('inscription_id', $inscription->id)
-            ->whereNotNull('validateur_id')
-            ->sum('montant');
-
-        return [
-            'attendu' => $attendu,
-            'paye' => $paye,
-            'solde' => max(0, $attendu - $paye),
-        ];
+    public static function workflowChipClass(?string $step): string
+    {
+        return match ((string) $step) {
+            'etudiant_cree' => 'acard-chip--success',
+            'en_validation', 'documents_complets' => 'acard-chip--warning',
+            'prospect' => 'acard-chip',
+            default => 'acard-chip',
+        };
     }
 }

--- a/resources/views/components/share-to-chat.blade.php
+++ b/resources/views/components/share-to-chat.blade.php
@@ -13,6 +13,12 @@
         : route('chat.share.inscription', $id);
 @endphp
 
+@once
+    @push('scripts')
+        <script src="{{ asset('js/inscriptions/common.js') }}"></script>
+    @endpush
+@endonce
+
 <button type="button" class="{{ $class }}" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}">
     <i class="fas fa-share-alt"></i>
     <span class="d-none d-md-inline">{{ $label }}</span>
@@ -116,7 +122,7 @@ function shareToChat_{{ $kind }}_{{ $id }}() {
                 const data = await r.json();
                 window.location.href = data.redirect || @json(route('chat.index'));
             } catch (e) {
-                alert('Le partage a échoué. Réessaie.');
+                window.showToast?.('Le partage a échoué. Réessaie.', 'error');
             } finally {
                 this.sending = false;
             }

--- a/resources/views/components/share-to-chat.blade.php
+++ b/resources/views/components/share-to-chat.blade.php
@@ -1,0 +1,126 @@
+@props([
+    'kind',           // 'inscription' | 'paiement'
+    'id',             // ID de la ressource
+    'label' => 'Envoyer dans un message',
+    'class' => 'is-hero-btn',
+])
+
+@php
+    $widgetId = 'shareToChat_' . $kind . '_' . $id;
+    $modalId = $widgetId . '_modal';
+    $shareUrl = $kind === 'paiement'
+        ? route('chat.share.paiement', $id)
+        : route('chat.share.inscription', $id);
+@endphp
+
+<button type="button" class="{{ $class }}" data-bs-toggle="modal" data-bs-target="#{{ $modalId }}">
+    <i class="fas fa-share-alt"></i>
+    <span class="d-none d-md-inline">{{ $label }}</span>
+</button>
+
+<div class="modal fade ms-modal" id="{{ $modalId }}" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content" x-data="shareToChat_{{ $kind }}_{{ $id }}()" x-init="init()">
+            <div class="modal-header">
+                <div class="ms-modal-icon"><i class="fas fa-share-alt"></i></div>
+                <div class="ms-modal-title-block">
+                    <h5>Envoyer cette {{ $kind === 'paiement' ? 'card paiement' : 'card inscription' }}</h5>
+                    <p>Choisis un destinataire — il verra un CTA contextuel selon ses permissions.</p>
+                </div>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+            </div>
+            <div class="modal-body">
+                <div class="ms-search-wrap">
+                    <i class="fas fa-search"></i>
+                    <input type="text" class="ms-modal-search-input"
+                           x-model="query"
+                           x-ref="searchInput"
+                           @input.debounce.250="searchUsers()"
+                           placeholder="Tape un nom ou email…"
+                           aria-label="Rechercher un destinataire">
+                </div>
+                <div class="mb-3" style="margin-top: 1rem;">
+                    <textarea class="form-control"
+                              x-model="note"
+                              rows="2"
+                              maxlength="500"
+                              placeholder="Note (optionnelle)"
+                              style="border-radius: 10px; resize: vertical;"></textarea>
+                </div>
+                <div class="ms-modal-results">
+                    <template x-for="u in results" :key="u.id">
+                        <div class="ms-search-result" @click="send(u)" role="button" tabindex="0" @keydown.enter="send(u)">
+                            <div class="ms-search-avatar" x-text="(u.name || '?').slice(0,2).toUpperCase()"></div>
+                            <div class="ms-search-info">
+                                <strong x-text="u.name"></strong>
+                                <small x-text="u.email"></small>
+                            </div>
+                            <i class="fas fa-paper-plane ms-search-result-arrow"></i>
+                        </div>
+                    </template>
+                    <div class="ms-modal-empty" x-show="query.length >= 2 && results.length === 0">
+                        <i class="far fa-frown"></i>
+                        <div class="ms-empty-title">Aucun résultat</div>
+                        <div class="ms-empty-hint">Essaie un autre nom ou email.</div>
+                    </div>
+                    <div class="ms-modal-empty" x-show="query.length < 2">
+                        <i class="far fa-user-circle"></i>
+                        <div class="ms-empty-title">Tape au moins 2 caractères</div>
+                        <div class="ms-empty-hint">La recherche couvre les utilisateurs actifs.</div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer" style="border-top: 1px solid var(--ms-border, #e2e8f0); background: #f8fafc; padding: .9rem 1.75rem;">
+                <span style="font-size:.78rem; color:#64748b;">
+                    <i class="fas fa-info-circle me-1"></i>
+                    Le destinataire reçoit la card avec le CTA correspondant à ses permissions.
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function shareToChat_{{ $kind }}_{{ $id }}() {
+    return {
+        query: '',
+        results: [],
+        note: '',
+        sending: false,
+        csrf: document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+
+        init() {
+            const el = document.getElementById('{{ $modalId }}');
+            el.addEventListener('shown.bs.modal', () => this.$refs.searchInput?.focus());
+        },
+
+        async searchUsers() {
+            if (this.query.length < 2) { this.results = []; return; }
+            try {
+                const r = await fetch(`/messages/users/search?q=${encodeURIComponent(this.query)}`, { headers: { Accept: 'application/json' } });
+                const data = await r.json();
+                this.results = data.users || [];
+            } catch (e) { this.results = []; }
+        },
+
+        async send(user) {
+            if (this.sending) return;
+            this.sending = true;
+            try {
+                const r = await fetch(@json($shareUrl), {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': this.csrf, Accept: 'application/json' },
+                    body: JSON.stringify({ recipient_id: user.id, note: this.note || null }),
+                });
+                if (!r.ok) throw new Error('Share failed');
+                const data = await r.json();
+                window.location.href = data.redirect || @json(route('chat.index'));
+            } catch (e) {
+                alert('Le partage a échoué. Réessaie.');
+            } finally {
+                this.sending = false;
+            }
+        },
+    };
+}
+</script>

--- a/resources/views/esbtp/inscriptions/show.blade.php
+++ b/resources/views/esbtp/inscriptions/show.blade.php
@@ -1207,6 +1207,9 @@ body:has(#affectationClasseModal.show) .modal-backdrop {
                         <i class="fas fa-user"></i>
                         <span class="d-none d-md-inline">Fiche étudiant</span>
                     </a>
+                    @can('messages.send')
+                        <x-share-to-chat kind="inscription" :id="$inscription->id" label="Envoyer" class="is-hero-btn" />
+                    @endcan
                     <a href="{{ route('esbtp.etudiants.index') }}" class="is-hero-btn">
                         <i class="fas fa-arrow-left"></i>
                         <span class="d-none d-sm-inline">Retour</span>

--- a/resources/views/esbtp/paiements/show.blade.php
+++ b/resources/views/esbtp/paiements/show.blade.php
@@ -326,6 +326,10 @@
                     <i class="fas fa-arrow-left"></i> Retour
                 </a>
 
+                @can('messages.send')
+                    <x-share-to-chat kind="paiement" :id="$paiement->id" label="Envoyer" class="ps-btn ghost" />
+                @endcan
+
                 @if($paiement->status == 'validé')
                 <div class="dropdown ps-dropdown">
                     <button class="ps-btn primary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -71,6 +71,116 @@
 .ms-action-card-cta { display: inline-flex; align-items: center; gap: .4rem; padding: .5rem 1rem; background: var(--ms-primary); color: #fff; border-radius: 8px; font-weight: 600; font-size: .85rem; text-decoration: none; transition: all .15s; }
 .ms-action-card-cta:hover { background: var(--ms-primary-d); color: #fff; transform: translateY(-1px); }
 
+/* ============================================================
+   Action cards (issue #303) — namespace acard-* — share inscription/paiement
+   ============================================================ */
+.acard {
+    align-self: flex-start;
+    background: var(--ms-surface);
+    border: 1px solid var(--ms-border);
+    border-radius: 14px;
+    padding: .85rem .95rem;
+    max-width: 380px;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 4px 16px rgba(4,83,203,.04);
+    display: flex;
+    flex-direction: column;
+    gap: .65rem;
+    transition: box-shadow .15s, transform .15s;
+}
+.acard.mine { align-self: flex-end; }
+.acard:hover { box-shadow: 0 4px 16px rgba(4,83,203,.08), 0 1px 3px rgba(15,23,42,.06); transform: translateY(-1px); }
+.acard-head { display: flex; align-items: center; gap: .65rem; }
+.acard-avatar {
+    width: 40px; height: 40px; border-radius: 10px;
+    background: linear-gradient(135deg, var(--ms-primary), #5e91de);
+    color: #fff; font-weight: 700; font-size: .92rem;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0; overflow: hidden;
+}
+.acard-avatar img { width: 100%; height: 100%; object-fit: cover; }
+.acard-head-info { flex: 1; min-width: 0; }
+.acard-title { font-weight: 700; color: var(--ms-text); font-size: .92rem; line-height: 1.2; }
+.acard-sub { color: var(--ms-muted); font-size: .76rem; margin-top: .12rem; }
+.acard-kind-badge {
+    display: inline-flex; align-items: center; gap: .3rem;
+    padding: .15rem .5rem; border-radius: 99px;
+    font-size: .68rem; font-weight: 700; letter-spacing: .02em; text-transform: uppercase;
+    background: rgba(4,83,203,.1); color: var(--ms-primary);
+    flex-shrink: 0;
+}
+.acard-kind-badge--paiement { background: rgba(16,185,129,.1); color: #047857; }
+.acard-chips { display: flex; flex-wrap: wrap; gap: .35rem; }
+.acard-chip {
+    padding: .2rem .55rem; border-radius: 99px; font-size: .72rem; font-weight: 600;
+    background: rgba(15,23,42,.05); color: var(--ms-text);
+    display: inline-flex; align-items: center; gap: .3rem;
+}
+.acard-chip--success { background: rgba(16,185,129,.12); color: #047857; }
+.acard-chip--warning { background: rgba(245,158,11,.12); color: #92400e; }
+.acard-chip--danger  { background: rgba(220,38,38,.12); color: #b91c1c; }
+.acard-meta { display: grid; grid-template-columns: auto 1fr; gap: .25rem .85rem; font-size: .8rem; }
+.acard-meta-label { color: var(--ms-muted); }
+.acard-meta-value { font-weight: 600; color: var(--ms-text); }
+.acard-cta {
+    display: inline-flex; align-items: center; justify-content: center; gap: .45rem;
+    padding: .55rem 1rem; border-radius: 10px; font-weight: 600; font-size: .85rem;
+    text-decoration: none; transition: all .15s; border: 1px solid transparent;
+}
+.acard-cta--primary { background: var(--ms-bubble-mine); color: #fff; }
+.acard-cta--primary:hover { color: #fff; transform: translateY(-1px); box-shadow: 0 4px 12px rgba(4,83,203,.25); }
+.acard-cta--ghost { background: rgba(4,83,203,.06); color: var(--ms-primary); border-color: rgba(4,83,203,.15); }
+.acard-cta--ghost:hover { color: var(--ms-primary); background: rgba(4,83,203,.1); }
+.acard-cta--disabled { background: rgba(15,23,42,.04); color: var(--ms-muted); cursor: not-allowed; pointer-events: none; }
+.acard-note {
+    font-size: .76rem; color: var(--ms-muted); padding-top: .35rem;
+    border-top: 1px dashed var(--ms-border);
+}
+
+/* Composer 📎 attach button + dropdown */
+.ms-composer-attach { position: relative; display: flex; align-items: flex-end; }
+.ms-attach-btn {
+    background: rgba(4,83,203,.06); color: var(--ms-primary);
+    border: 1px solid rgba(4,83,203,.15);
+    width: 42px; height: 42px; border-radius: 10px;
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer; transition: all .15s; flex-shrink: 0;
+}
+.ms-attach-btn:hover { background: rgba(4,83,203,.12); transform: translateY(-1px); }
+.ms-attach-menu {
+    position: absolute; bottom: calc(100% + .5rem); left: 0;
+    background: var(--ms-surface); border: 1px solid var(--ms-border);
+    border-radius: 12px; padding: .35rem; min-width: 200px;
+    box-shadow: 0 10px 30px rgba(15,23,42,.12);
+    z-index: 1000;
+}
+.ms-attach-menu button {
+    display: flex; width: 100%; align-items: center; gap: .65rem;
+    padding: .55rem .75rem; background: transparent; border: none; border-radius: 8px;
+    color: var(--ms-text); font-size: .88rem; font-weight: 500; cursor: pointer; transition: all .12s;
+    text-align: left;
+}
+.ms-attach-menu button:hover { background: rgba(4,83,203,.06); color: var(--ms-primary); }
+.ms-attach-menu button i { width: 18px; text-align: center; color: var(--ms-muted); }
+.ms-attach-menu button:hover i { color: var(--ms-primary); }
+
+/* Picker modal — réutilise .ms-modal mais avec resultat plus spécifique */
+.ms-picker-result {
+    display: flex; align-items: center; gap: .85rem;
+    padding: .75rem .9rem; cursor: pointer;
+    border: 1px solid transparent; border-radius: 10px; transition: all .12s;
+}
+.ms-picker-result:hover {
+    background: rgba(4,83,203,.05); border-color: rgba(4,83,203,.15);
+    transform: translateX(2px);
+}
+.ms-picker-meta { display: flex; gap: .35rem; flex-wrap: wrap; margin-top: .15rem; }
+.ms-picker-status {
+    padding: .12rem .45rem; border-radius: 99px; font-size: .68rem; font-weight: 700;
+    background: rgba(15,23,42,.05); color: var(--ms-muted);
+}
+.ms-picker-status--ok { background: rgba(16,185,129,.12); color: #047857; }
+.ms-picker-status--pending { background: rgba(245,158,11,.12); color: #92400e; }
+
 .ms-composer { padding: 1rem 1.5rem; border-top: 1px solid var(--ms-border); background: var(--ms-surface); display: flex; gap: .65rem; }
 .ms-composer textarea { flex: 1; resize: none; border: 1px solid var(--ms-border); border-radius: 10px; padding: .65rem .9rem; font-size: .9rem; min-height: 42px; max-height: 120px; transition: border-color .15s; font-family: inherit; }
 .ms-composer textarea:focus { outline: none; border-color: var(--ms-primary); box-shadow: 0 0 0 3px rgba(4,83,203,.08); }
@@ -271,7 +381,97 @@
                                             <template x-if="m.type === 'system'">
                                                 <div class="ms-msg system" x-text="m.body"></div>
                                             </template>
-                                            <template x-if="m.type === 'action_card'">
+                                            <template x-if="m.type === 'action_card' && m.payload?.kind">
+                                                {{-- Action card riche (issue #303) — share inscription/paiement --}}
+                                                <div class="acard" :class="{ mine: m.mine }">
+                                                    <div class="acard-head">
+                                                        <div class="acard-avatar">
+                                                            <template x-if="m.payload?.snapshot?.etudiant?.photo_url">
+                                                                <img :src="m.payload.snapshot.etudiant.photo_url" :alt="m.payload.snapshot.etudiant.name">
+                                                            </template>
+                                                            <template x-if="!m.payload?.snapshot?.etudiant?.photo_url">
+                                                                <span x-text="(m.payload?.snapshot?.etudiant?.name || '?').slice(0,2).toUpperCase()"></span>
+                                                            </template>
+                                                        </div>
+                                                        <div class="acard-head-info">
+                                                            <div class="acard-title" x-text="m.payload?.snapshot?.etudiant?.name || '—'"></div>
+                                                            <div class="acard-sub">
+                                                                <span x-text="m.payload?.snapshot?.classe || '—'"></span>
+                                                                <template x-if="m.payload?.snapshot?.matricule">
+                                                                    <span> · <span x-text="m.payload.snapshot.etudiant.matricule"></span></span>
+                                                                </template>
+                                                            </div>
+                                                        </div>
+                                                        <span class="acard-kind-badge" :class="{ 'acard-kind-badge--paiement': m.payload.kind === 'paiement' }">
+                                                            <i :class="m.payload.kind === 'paiement' ? 'fas fa-cash-register' : 'fas fa-user-graduate'"></i>
+                                                            <span x-text="m.payload.kind === 'paiement' ? 'Paiement' : 'Inscription'"></span>
+                                                        </span>
+                                                    </div>
+
+                                                    {{-- Inscription : montants + statut --}}
+                                                    <template x-if="m.payload.kind === 'inscription'">
+                                                        <div>
+                                                            <div class="acard-chips">
+                                                                <span class="acard-chip" :class="acardWorkflowChipClass(m.payload?.snapshot?.workflow_step)" x-text="acardWorkflowLabel(m.payload?.snapshot?.workflow_step)"></span>
+                                                                <span class="acard-chip" x-show="m.payload?.snapshot?.is_sous_reserve">
+                                                                    <i class="fas fa-exclamation-triangle"></i> Sous réserve
+                                                                </span>
+                                                            </div>
+                                                            <div class="acard-meta">
+                                                                <span class="acard-meta-label">Année</span>
+                                                                <span class="acard-meta-value" x-text="m.payload?.snapshot?.annee || '—'"></span>
+                                                                <span class="acard-meta-label">Total dû</span>
+                                                                <span class="acard-meta-value" x-text="formatXof(m.payload?.snapshot?.montant_total)"></span>
+                                                                <span class="acard-meta-label">Payé</span>
+                                                                <span class="acard-meta-value" x-text="formatXof(m.payload?.snapshot?.montant_paye)"></span>
+                                                                <span class="acard-meta-label">Solde</span>
+                                                                <span class="acard-meta-value" x-text="formatXof(m.payload?.snapshot?.solde_restant)"></span>
+                                                            </div>
+                                                        </div>
+                                                    </template>
+
+                                                    {{-- Paiement : montant + mode + statut --}}
+                                                    <template x-if="m.payload.kind === 'paiement'">
+                                                        <div>
+                                                            <div class="acard-chips">
+                                                                <span class="acard-chip" :class="m.payload?.snapshot?.is_validated ? 'acard-chip--success' : 'acard-chip--warning'">
+                                                                    <i :class="m.payload?.snapshot?.is_validated ? 'fas fa-check-circle' : 'fas fa-clock'"></i>
+                                                                    <span x-text="m.payload?.snapshot?.is_validated ? 'Validé' : 'En attente'"></span>
+                                                                </span>
+                                                                <template x-if="m.payload?.snapshot?.mode_paiement">
+                                                                    <span class="acard-chip" x-text="m.payload.snapshot.mode_paiement"></span>
+                                                                </template>
+                                                            </div>
+                                                            <div class="acard-meta">
+                                                                <span class="acard-meta-label">Montant</span>
+                                                                <span class="acard-meta-value" x-text="formatXof(m.payload?.snapshot?.montant)"></span>
+                                                                <template x-if="m.payload?.snapshot?.reference">
+                                                                    <span class="acard-meta-label">Référence</span>
+                                                                </template>
+                                                                <template x-if="m.payload?.snapshot?.reference">
+                                                                    <span class="acard-meta-value" x-text="m.payload.snapshot.reference"></span>
+                                                                </template>
+                                                                <template x-if="m.payload?.snapshot?.date_paiement">
+                                                                    <span class="acard-meta-label">Date</span>
+                                                                </template>
+                                                                <template x-if="m.payload?.snapshot?.date_paiement">
+                                                                    <span class="acard-meta-value" x-text="formatDate(m.payload.snapshot.date_paiement)"></span>
+                                                                </template>
+                                                            </div>
+                                                        </div>
+                                                    </template>
+
+                                                    {{-- CTA contextuel — calculé server-side selon viewer --}}
+                                                    <template x-if="m.cta">
+                                                        <a :href="m.cta.url" class="acard-cta" :class="'acard-cta--' + m.cta.variant">
+                                                            <i :class="'fas ' + (m.cta.icon || 'fa-arrow-right')"></i>
+                                                            <span x-text="m.cta.label"></span>
+                                                        </a>
+                                                    </template>
+                                                </div>
+                                            </template>
+                                            <template x-if="m.type === 'action_card' && !m.payload?.kind">
+                                                {{-- Legacy format (notif workflow) --}}
                                                 <div class="ms-msg action_card">
                                                     <div class="ms-action-card-title" x-text="m.payload?.title || m.body"></div>
                                                     <div class="ms-action-card-body" x-text="m.payload?.body" x-show="m.payload?.body"></div>
@@ -297,6 +497,21 @@
                         </div>
 
                         <form class="ms-composer" @submit.prevent="sendMessage()">
+                            <div class="ms-composer-attach" @click.outside="attachOpen = false">
+                                <button type="button" class="ms-attach-btn" @click="attachOpen = !attachOpen" title="Partager une inscription ou un paiement" aria-label="Partager">
+                                    <i class="fas fa-paperclip"></i>
+                                </button>
+                                <div class="ms-attach-menu" x-show="attachOpen" x-cloak x-transition>
+                                    <button type="button" @click="openPicker('inscription'); attachOpen = false">
+                                        <i class="fas fa-user-graduate"></i>
+                                        <span>Partager une inscription</span>
+                                    </button>
+                                    <button type="button" @click="openPicker('paiement'); attachOpen = false">
+                                        <i class="fas fa-cash-register"></i>
+                                        <span>Partager un paiement</span>
+                                    </button>
+                                </div>
+                            </div>
                             <textarea x-model="draft" rows="1"
                                       placeholder="Écris un message… (Entrée pour envoyer, Shift+Entrée pour saut de ligne)"
                                       aria-label="Composer un message"
@@ -367,6 +582,75 @@
             </div>
         </div>
 
+        {{-- Modal picker — partager inscription/paiement (issue #303) --}}
+        <div class="modal fade ms-modal" id="pickerModal" tabindex="-1" aria-hidden="true" aria-labelledby="pickerModalLabel">
+            <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <div class="ms-modal-icon"><i class="fas" :class="pickerKind === 'paiement' ? 'fa-cash-register' : 'fa-user-graduate'"></i></div>
+                        <div class="ms-modal-title-block">
+                            <h5 id="pickerModalLabel" x-text="pickerKind === 'paiement' ? 'Partager un paiement' : 'Partager une inscription'"></h5>
+                            <p>La carte sera envoyée dans la conversation active avec un CTA contextuel.</p>
+                        </div>
+                        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Fermer"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="ms-search-wrap">
+                            <i class="fas fa-search"></i>
+                            <input type="text" class="ms-modal-search-input"
+                                   x-model="pickerQuery"
+                                   x-ref="pickerInput"
+                                   @input.debounce.250="searchPicker()"
+                                   :placeholder="pickerKind === 'paiement' ? 'Nom étudiant, matricule ou référence…' : 'Nom étudiant ou matricule…'"
+                                   aria-label="Rechercher">
+                        </div>
+                        <div class="ms-modal-results">
+                            <template x-for="item in pickerItems" :key="item.id">
+                                <div class="ms-picker-result" @click="confirmShare(item)" role="button" tabindex="0" @keydown.enter="confirmShare(item)">
+                                    <div class="ms-search-avatar" x-text="(item.etudiant || '?').slice(0, 2).toUpperCase()"></div>
+                                    <div class="ms-search-info">
+                                        <strong x-text="item.etudiant"></strong>
+                                        <small>
+                                            <span x-text="item.matricule || ''"></span>
+                                            <template x-if="pickerKind === 'inscription'">
+                                                <span> · <span x-text="item.classe"></span></span>
+                                            </template>
+                                            <template x-if="pickerKind === 'paiement'">
+                                                <span> · <span x-text="formatXof(item.montant)"></span></span>
+                                            </template>
+                                        </small>
+                                        <div class="ms-picker-meta">
+                                            <template x-if="pickerKind === 'inscription'">
+                                                <span class="ms-picker-status" :class="acardWorkflowChipClass(item.workflow_step).replace('acard-chip', 'ms-picker-status')" x-text="acardWorkflowLabel(item.workflow_step)"></span>
+                                            </template>
+                                            <template x-if="pickerKind === 'paiement'">
+                                                <span class="ms-picker-status" :class="item.is_validated ? 'ms-picker-status--ok' : 'ms-picker-status--pending'" x-text="item.is_validated ? 'Validé' : 'En attente'"></span>
+                                            </template>
+                                        </div>
+                                    </div>
+                                    <i class="fas fa-arrow-right ms-search-result-arrow"></i>
+                                </div>
+                            </template>
+                            <div class="ms-modal-empty" x-show="!pickerLoading && pickerItems.length === 0 && pickerQuery.length >= 1">
+                                <i class="far fa-frown"></i>
+                                <div class="ms-empty-title">Aucun résultat</div>
+                                <div class="ms-empty-hint">Essaie un autre nom ou matricule.</div>
+                            </div>
+                            <div class="ms-modal-empty" x-show="pickerItems.length === 0 && pickerQuery.length === 0">
+                                <i class="far fa-keyboard"></i>
+                                <div class="ms-empty-title">Tape pour rechercher</div>
+                                <div class="ms-empty-hint">Ou laisse vide pour voir les <span x-text="pickerKind === 'paiement' ? 'paiements' : 'inscriptions'"></span> récents.</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="ms-modal-footer">
+                        <span><kbd>Entrée</kbd> pour partager</span>
+                        <span><kbd>Échap</kbd> pour fermer</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
     </div>
 </div>
 
@@ -403,6 +687,14 @@ function messagesPage() {
         newCount: 0,           // "X new messages" banner counter
         atBottom: true,
         csrf: document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+
+        // === Action cards (issue #303) ===
+        attachOpen: false,
+        pickerKind: 'inscription',
+        pickerQuery: '',
+        pickerItems: [],
+        pickerLoading: false,
+        pickerModal: null,
 
         init() {
             this.loadNotifications();
@@ -590,6 +882,92 @@ function messagesPage() {
                 });
             }
             this.openConvo(this.conversations.find(c => c.id === data.conversation_id));
+        },
+
+        // === Action cards (issue #303) ===
+
+        openPicker(kind) {
+            if (!this.activeConvo) {
+                alert('Ouvre d\'abord une conversation pour partager.');
+                return;
+            }
+            this.pickerKind = kind;
+            this.pickerQuery = '';
+            this.pickerItems = [];
+            const el = document.getElementById('pickerModal');
+            if (!this.pickerModal) this.pickerModal = new bootstrap.Modal(el);
+            this.pickerModal.show();
+            el.addEventListener('shown.bs.modal', () => {
+                this.$refs.pickerInput?.focus();
+                this.searchPicker();
+            }, { once: true });
+        },
+
+        async searchPicker() {
+            this.pickerLoading = true;
+            try {
+                const url = `/messages/picker/${this.pickerKind === 'paiement' ? 'paiements' : 'inscriptions'}?q=${encodeURIComponent(this.pickerQuery)}`;
+                const r = await fetch(url, { headers: { Accept: 'application/json' } });
+                const data = await r.json();
+                this.pickerItems = data.items || [];
+            } catch (e) {
+                this.pickerItems = [];
+            } finally {
+                this.pickerLoading = false;
+            }
+        },
+
+        async confirmShare(item) {
+            if (!this.activeConvo) return;
+            const route = this.pickerKind === 'paiement'
+                ? `/messages/share/paiement/${item.id}`
+                : `/messages/share/inscription/${item.id}`;
+            try {
+                const r = await fetch(route, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': this.csrf, Accept: 'application/json' },
+                    body: JSON.stringify({ conversation_id: this.activeConvo.id }),
+                });
+                if (!r.ok) throw new Error('Share failed');
+                this.pickerModal.hide();
+                await this.refreshMessages();
+                this.$nextTick(() => this.scrollBottom(true));
+            } catch (e) {
+                alert('Le partage a échoué. Réessaie.');
+            }
+        },
+
+        // Helpers acard rendering
+
+        formatXof(n) {
+            if (n === null || n === undefined || isNaN(n)) return '—';
+            return new Intl.NumberFormat('fr-FR').format(Math.round(Number(n))) + ' XOF';
+        },
+
+        formatDate(iso) {
+            if (!iso) return '—';
+            const d = new Date(iso);
+            return d.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' });
+        },
+
+        acardWorkflowLabel(step) {
+            return ({
+                'etudiant_cree': 'À encaisser',
+                'paiement_cree': 'Paiement à valider',
+                'paiement_valide': 'Inscription à valider',
+                'inscription_validee': 'Inscription validée',
+                'validee': 'Inscription validée',
+            })[step] || (step ? step.replace(/_/g, ' ') : 'Statut inconnu');
+        },
+
+        acardWorkflowChipClass(step) {
+            return ({
+                'etudiant_cree': 'acard-chip--warning',
+                'paiement_cree': 'acard-chip--warning',
+                'paiement_valide': 'acard-chip--warning',
+                'inscription_validee': 'acard-chip--success',
+                'validee': 'acard-chip--success',
+            })[step] || 'acard-chip';
         },
     };
 }

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -2,6 +2,10 @@
 
 @section('title', 'Messages')
 
+@push('scripts')
+<script src="{{ asset('js/inscriptions/common.js') }}"></script>
+@endpush
+
 @push('styles')
 <style>
 /* ============================================================
@@ -72,7 +76,7 @@
 .ms-action-card-cta:hover { background: var(--ms-primary-d); color: #fff; transform: translateY(-1px); }
 
 /* ============================================================
-   Action cards (issue #303) — namespace acard-* — share inscription/paiement
+   Action cards — namespace acard-* — share inscription/paiement
    ============================================================ */
 .acard {
     align-self: flex-start;
@@ -382,7 +386,7 @@
                                                 <div class="ms-msg system" x-text="m.body"></div>
                                             </template>
                                             <template x-if="m.type === 'action_card' && m.payload?.kind">
-                                                {{-- Action card riche (issue #303) — share inscription/paiement --}}
+                                                {{-- Action card riche : share inscription/paiement --}}
                                                 <div class="acard" :class="{ mine: m.mine }">
                                                     <div class="acard-head">
                                                         <div class="acard-avatar">
@@ -412,7 +416,7 @@
                                                     <template x-if="m.payload.kind === 'inscription'">
                                                         <div>
                                                             <div class="acard-chips">
-                                                                <span class="acard-chip" :class="acardWorkflowChipClass(m.payload?.snapshot?.workflow_step)" x-text="acardWorkflowLabel(m.payload?.snapshot?.workflow_step)"></span>
+                                                                <span class="acard-chip" :class="m.payload?.snapshot?.workflow_chip_class || 'acard-chip'" x-text="m.payload?.snapshot?.workflow_label || 'Statut inconnu'"></span>
                                                                 <span class="acard-chip" x-show="m.payload?.snapshot?.is_sous_reserve">
                                                                     <i class="fas fa-exclamation-triangle"></i> Sous réserve
                                                                 </span>
@@ -582,7 +586,7 @@
             </div>
         </div>
 
-        {{-- Modal picker — partager inscription/paiement (issue #303) --}}
+        {{-- Modal picker — partager inscription/paiement --}}
         <div class="modal fade ms-modal" id="pickerModal" tabindex="-1" aria-hidden="true" aria-labelledby="pickerModalLabel">
             <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
                 <div class="modal-content">
@@ -621,7 +625,7 @@
                                         </small>
                                         <div class="ms-picker-meta">
                                             <template x-if="pickerKind === 'inscription'">
-                                                <span class="ms-picker-status" :class="acardWorkflowChipClass(item.workflow_step).replace('acard-chip', 'ms-picker-status')" x-text="acardWorkflowLabel(item.workflow_step)"></span>
+                                                <span class="ms-picker-status" :class="item.workflow_step === 'etudiant_cree' ? 'ms-picker-status--ok' : 'ms-picker-status--pending'" x-text="item.workflow_label || '—'"></span>
                                             </template>
                                             <template x-if="pickerKind === 'paiement'">
                                                 <span class="ms-picker-status" :class="item.is_validated ? 'ms-picker-status--ok' : 'ms-picker-status--pending'" x-text="item.is_validated ? 'Validé' : 'En attente'"></span>
@@ -688,7 +692,7 @@ function messagesPage() {
         atBottom: true,
         csrf: document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
 
-        // === Action cards (issue #303) ===
+        // === Action cards ===
         attachOpen: false,
         pickerKind: 'inscription',
         pickerQuery: '',
@@ -884,11 +888,11 @@ function messagesPage() {
             this.openConvo(this.conversations.find(c => c.id === data.conversation_id));
         },
 
-        // === Action cards (issue #303) ===
+        // === Action cards ===
 
         openPicker(kind) {
             if (!this.activeConvo) {
-                alert('Ouvre d\'abord une conversation pour partager.');
+                window.showToast?.('Ouvre d\'abord une conversation pour partager.', 'warning');
                 return;
             }
             this.pickerKind = kind;
@@ -932,8 +936,9 @@ function messagesPage() {
                 this.pickerModal.hide();
                 await this.refreshMessages();
                 this.$nextTick(() => this.scrollBottom(true));
+                window.showToast?.('Card partagée', 'success', 2500);
             } catch (e) {
-                alert('Le partage a échoué. Réessaie.');
+                window.showToast?.('Le partage a échoué. Réessaie.', 'error');
             }
         },
 
@@ -941,7 +946,7 @@ function messagesPage() {
 
         formatXof(n) {
             if (n === null || n === undefined || isNaN(n)) return '—';
-            return new Intl.NumberFormat('fr-FR').format(Math.round(Number(n))) + ' XOF';
+            return new Intl.NumberFormat('fr-FR').format(Math.round(Number(n))) + ' FCFA';
         },
 
         formatDate(iso) {
@@ -950,25 +955,6 @@ function messagesPage() {
             return d.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' });
         },
 
-        acardWorkflowLabel(step) {
-            return ({
-                'etudiant_cree': 'À encaisser',
-                'paiement_cree': 'Paiement à valider',
-                'paiement_valide': 'Inscription à valider',
-                'inscription_validee': 'Inscription validée',
-                'validee': 'Inscription validée',
-            })[step] || (step ? step.replace(/_/g, ' ') : 'Statut inconnu');
-        },
-
-        acardWorkflowChipClass(step) {
-            return ({
-                'etudiant_cree': 'acard-chip--warning',
-                'paiement_cree': 'acard-chip--warning',
-                'paiement_valide': 'acard-chip--warning',
-                'inscription_validee': 'acard-chip--success',
-                'validee': 'acard-chip--success',
-            })[step] || 'acard-chip';
-        },
     };
 }
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2226,7 +2226,7 @@ Route::middleware(['auth', 'paywall'])->prefix('messages')->name('chat.')->group
     Route::get('/notifications', [\App\Http\Controllers\ChatController::class, 'notifications'])->name('notifications');
     Route::post('/notifications/{id}/read', [\App\Http\Controllers\ChatController::class, 'markNotificationRead'])->name('notifications.read');
 
-    // Action cards (issue #303) — partager une inscription/paiement comme card riche
+    // Action cards — partager une inscription/paiement comme card riche
     Route::get('/picker/inscriptions', [\App\Http\Controllers\ChatController::class, 'pickerInscriptions'])
         ->middleware('throttle:60,1')
         ->name('picker.inscriptions');

--- a/routes/web.php
+++ b/routes/web.php
@@ -2225,4 +2225,20 @@ Route::middleware(['auth', 'paywall'])->prefix('messages')->name('chat.')->group
     Route::get('/users/search', [\App\Http\Controllers\ChatController::class, 'searchUsers'])->name('users.search');
     Route::get('/notifications', [\App\Http\Controllers\ChatController::class, 'notifications'])->name('notifications');
     Route::post('/notifications/{id}/read', [\App\Http\Controllers\ChatController::class, 'markNotificationRead'])->name('notifications.read');
+
+    // Action cards (issue #303) — partager une inscription/paiement comme card riche
+    Route::get('/picker/inscriptions', [\App\Http\Controllers\ChatController::class, 'pickerInscriptions'])
+        ->middleware('throttle:60,1')
+        ->name('picker.inscriptions');
+    Route::get('/picker/paiements', [\App\Http\Controllers\ChatController::class, 'pickerPaiements'])
+        ->middleware('throttle:60,1')
+        ->name('picker.paiements');
+    Route::post('/share/inscription/{inscription}', [\App\Http\Controllers\ChatController::class, 'shareInscription'])
+        ->whereNumber('inscription')
+        ->middleware(['permission:messages.send', 'throttle:30,1'])
+        ->name('share.inscription');
+    Route::post('/share/paiement/{paiement}', [\App\Http\Controllers\ChatController::class, 'sharePaiement'])
+        ->whereNumber('paiement')
+        ->middleware(['permission:messages.send', 'throttle:30,1'])
+        ->name('share.paiement');
 });


### PR DESCRIPTION
Closes #303

## Feature killer

Partager une inscription ou un paiement dans un message chat avec une **card riche** (avatar étudiant + chips statut + montants + CTA contextuel calculé selon permissions du destinataire).

## Entry points

1. **Composer chat** — bouton 📎 → dropdown → modal picker (recherche étudiant/paiement)
2. **Fiches** \`inscriptions.show\` / \`paiements.show\` — bouton 'Envoyer' → modal recherche destinataire + note optionnelle

## Architecture

- \`App\Services\ChatActionResolver\` — snapshot + résolution CTA temps réel
- 4 endpoints : \`share.inscription\`, \`share.paiement\`, \`picker.inscriptions\`, \`picker.paiements\`
- Routes share gated par \`messages.send\` + throttle 30/min
- \`ChatController::show()\` résout le CTA pour chaque action_card par viewer
- Composant \`<x-share-to-chat />\` réutilisable

## CTA logic

| Ressource | Etat | Permission destinataire | CTA |
|---|---|---|---|
| Inscription | etudiant_cree | paiements.create | Encaisser un paiement |
| Inscription | paiement_cree | paiements.validate | Valider le paiement |
| Inscription | paiement_valide | inscriptions.validate | Valider l'inscription |
| Inscription | inscription_validee | inscriptions.view | Voir |
| Paiement | en attente | paiements.validate | Valider le paiement |
| Paiement | validé + insc non validée | inscriptions.validate | Valider l'inscription |
| Paiement | validé + insc validée | paiements.view | Voir |

## Tradeoff accepté

CTA asymétrique en conv DM (expéditeur voit 'Voir', destinataire voit 'Valider'). C'est correct vu que la permission est ce qui pilote le CTA.

## UI

- CSS namespace \`acard-*\` (premium monochrome bleu)
- Modal picker premium (gradient header + avatar + chips statut)
- Format legacy action_card (notifs workflow) préservé en fallback
- Mobile-first (max-width 380px)

## Test plan

- [ ] superAdmin partage une inscription dans une conv DM avec un caissier → caissier voit CTA 'Encaisser un paiement'
- [ ] caissier partage un paiement créé avec un comptable → comptable voit CTA 'Valider le paiement'
- [ ] comptable partage un paiement validé avec une secrétaire → secrétaire voit CTA 'Valider l'inscription'
- [ ] superAdmin (toutes permissions) reçoit un partage → voit le CTA primary (pas 'Voir')
- [ ] etudiant (sans permissions) reçoit un partage → ne voit aucun CTA (pas même 'Voir')
- [ ] Picker filtre par nom/matricule (inscription) ou nom/matricule/référence (paiement)
- [ ] Bouton 'Envoyer' sur fiche show → modal recherche user → POST → redirige vers /messages