### PR TITLE
fix(emploi-temps): dropdown clipping (index) + KPI pointer-events (show)

### DIFF
--- a/resources/views/esbtp/emploi-temps/index.blade.php
+++ b/resources/views/esbtp/emploi-temps/index.blade.php
@@ -1287,7 +1287,7 @@
         border: 1px solid #e2e8f0;
         border-radius: 14px;
         margin-bottom: .85rem;
-        overflow: hidden;
+        /* overflow visible pour ne pas clipper le dropdown kebab */
         box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
         transition: box-shadow .2s ease, transform .2s ease, border-color .2s ease;
     }
@@ -1300,7 +1300,11 @@
         width: 4px;
         flex-shrink: 0;
         display: block;
+        border-radius: 14px 0 0 14px;
     }
+    /* Dropdown kebab dans la card doit s'afficher au-dessus des cards voisines */
+    .et-card .dropdown-menu.show { z-index: 1060; }
+    .et-card:has(.dropdown-menu.show) { z-index: 5; }
     .et-card__inner {
         flex: 1;
         padding: 1rem 1.1rem;

--- a/resources/views/esbtp/emploi-temps/show.blade.php
+++ b/resources/views/esbtp/emploi-temps/show.blade.php
@@ -102,7 +102,7 @@
         flex-wrap: wrap;
         align-items: flex-start;
         position: relative;
-        z-index: 3;
+        z-index: 10;
     }
     .ets-btn {
         display: inline-flex;
@@ -159,15 +159,17 @@
         margin: .3rem 0;
     }
 
-    /* KPIs dans hero */
+    /* KPIs dans hero — pointer-events:none pour ne pas bloquer les boutons en hover */
     .ets-kpis {
         display: flex;
         gap: .65rem;
         margin-top: 1.2rem;
         flex-wrap: wrap;
         position: relative;
-        z-index: 2;
+        z-index: 1;
+        pointer-events: none;
     }
+    .ets-kpis .ets-kpi { pointer-events: auto; }
     .ets-kpi {
         flex: 1;
         min-width: 160px;


### PR DESCRIPTION
## Bugs

**Index** () : dropdown kebab des cards clippé par `overflow:hidden` de `.et-card`.
**Show** (`#infos`) : KPIs interceptaient les events souris, le curseur ne devenait plus pointer sur les boutons d'action.

## Fix

- `.et-card` : retire `overflow:hidden` ; le stripe gauche conserve l'arrondi via `border-radius: 14px 0 0 14px` ; `z-index: 1060` sur `dropdown-menu.show` + 5 sur la card avec dropdown ouvert pour passer au-dessus.
- `.ets-kpis` : `pointer-events: none` (les KPIs sont décoratifs), restauré sur les enfants `.ets-kpi`. `.ets-hero-actions` z-index 3 → 10.