### PR TITLE
fix(emploi-temps): card hovered passait au-dessus du dropdown ouvert

### DIFF
--- a/resources/views/esbtp/emploi-temps/index.blade.php
+++ b/resources/views/esbtp/emploi-temps/index.blade.php
@@ -1302,9 +1302,12 @@
         display: block;
         border-radius: 14px 0 0 14px;
     }
-    /* Dropdown kebab dans la card doit s'afficher au-dessus des cards voisines */
-    .et-card .dropdown-menu.show { z-index: 1060; }
-    .et-card:has(.dropdown-menu.show) { z-index: 5; }
+    /* Dropdown kebab Alpine (.et-card__menu-pop) doit passer au-dessus des cards
+       voisines hovered — celles-ci créent un nouveau stacking context via transform.
+       On bumpe le z-index de la card parent quand le menu Alpine est ouvert. */
+    .et-card { z-index: 1; }
+    .et-card:has(.et-card__menu--open) { z-index: 50; }
+    .et-card__menu-pop { z-index: 1060; }
     .et-card__inner {
         flex: 1;
         padding: 1rem 1.1rem;

--- a/resources/views/esbtp/emploi-temps/partials/cards-compact.blade.php
+++ b/resources/views/esbtp/emploi-temps/partials/cards-compact.blade.php
@@ -110,7 +110,7 @@
                     Ouvrir<i class="fas fa-arrow-right"></i>
                 </a>
                 @if($canEdit || $canDelete)
-                    <div class="et-card__menu" x-data="{ open: false }" @click.outside="open = false">
+                    <div class="et-card__menu" x-data="{ open: false }" @click.outside="open = false" :class="{ 'et-card__menu--open': open }">
                         <button type="button"
                                 class="et-row__btn"
                                 @click="open = !open"

--- a/resources/views/esbtp/emploi-temps/partials/cards.blade.php
+++ b/resources/views/esbtp/emploi-temps/partials/cards.blade.php
@@ -170,7 +170,7 @@
                     <i class="fas fa-arrow-right"></i>
                 </a>
                 @if($canEdit || $canDelete)
-                    <div class="et-card__menu" x-data="{ open: false }" @click.outside="open = false">
+                    <div class="et-card__menu" x-data="{ open: false }" @click.outside="open = false" :class="{ 'et-card__menu--open': open }">
                         <button type="button"
                                 class="et-card-btn et-card-btn--icon"
                                 @click="open = !open"


### PR DESCRIPTION
Card du dessous hovered (transform translateY) creait un stacking context au-dessus du dropdown Alpine de la card precedente. Bumper z-index parent a 50 via classe \.et-card__menu--open ajoutee par Alpine :class.