### PR TITLE
fix(emploi-temps): card hovered toujours au-dessus du dropdown — fix robuste

### DIFF
--- a/resources/views/esbtp/emploi-temps/index.blade.php
+++ b/resources/views/esbtp/emploi-temps/index.blade.php
@@ -1302,12 +1302,16 @@
         display: block;
         border-radius: 14px 0 0 14px;
     }
-    /* Dropdown kebab Alpine (.et-card__menu-pop) doit passer au-dessus des cards
-       voisines hovered — celles-ci créent un nouveau stacking context via transform.
-       On bumpe le z-index de la card parent quand le menu Alpine est ouvert. */
+    /* Stacking fix : la card hovered crée un nouveau stacking context via transform,
+       ce qui peut la placer au-dessus du dropdown Alpine d'une autre card.
+       Solution :
+       1. Bump z-index de la card avec menu ouvert (1000)
+       2. Désactiver le transform sur TOUTE card hovered tant qu'un dropdown est ouvert
+          ailleurs (supprime le stacking context concurrent). */
     .et-card { z-index: 1; }
-    .et-card:has(.et-card__menu--open) { z-index: 50; }
+    .et-card:has(.et-card__menu--open) { z-index: 1000; }
     .et-card__menu-pop { z-index: 1060; }
+    body:has(.et-card__menu--open) .et-card:hover { transform: none; }
     .et-card__inner {
         flex: 1;
         padding: 1rem 1.1rem;


### PR DESCRIPTION
Le z-index seul ne suffit pas : transform:translateY cree un stacking context concurrent. Fix combine : bump z-index a 1000 + desactive transform sur cards hovered quand un dropdown est ouvert ailleurs (body:has).