### PR TITLE
fix(notes): hotfix critique calculs moyenne (JS + BulletinService)

### DIFF
--- a/app/Console/Commands/NotesAuditDivergence.php
+++ b/app/Console/Commands/NotesAuditDivergence.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ESBTPNote;
+use App\Models\ESBTPResultat;
+use App\Services\BulletinService;
+use Illuminate\Console\Command;
+
+/**
+ * Audite les divergences entre les moyennes par matière persistées dans
+ * `esbtp_resultats` et celles recalculées avec la nouvelle logique
+ * (normalisation par barème + exclusion des absences) introduite en mai 2026.
+ *
+ * Usage typique post-déploiement du hotfix calcul de moyenne :
+ *   php artisan notes:audit-divergence --dry-run
+ *   php artisan notes:audit-divergence --classe=12 --export-csv=storage/audit.csv
+ *
+ * NB : ne modifie aucune donnée. Le recompute viendra dans une PR ultérieure.
+ */
+class NotesAuditDivergence extends Command
+{
+    /** Seuil au-delà duquel un écart est considéré significatif. */
+    private const SIGNIFICANT_GAP = 0.5;
+
+    protected $signature = 'notes:audit-divergence
+        {--tenant=all : Code du tenant à auditer (réservé pour usage cross-tenant futur, ignoré ici).}
+        {--classe= : Limiter l\'audit à une classe (ID).}
+        {--dry-run : Mode lecture seule (par défaut, ne modifie rien — flag conservé pour clarté).}
+        {--export-csv= : Chemin du fichier CSV où exporter le rapport complet (optionnel).}';
+
+    protected $description = 'Détecte les bulletins/résultats matière dont la moyenne persistée diverge de la moyenne recalculée (post-fix barème).';
+
+    public function handle(BulletinService $bulletinService): int
+    {
+        $classeId = $this->option('classe');
+        $exportCsvPath = $this->option('export-csv');
+        $tenant = $this->option('tenant');
+
+        if ($tenant && $tenant !== 'all') {
+            $this->warn("Note : --tenant={$tenant} est ignoré dans cette version (audit single-tenant uniquement).");
+        }
+
+        $this->info('Audit de divergence des moyennes — démarrage...');
+        if ($classeId) {
+            $this->line("Filtre actif : classe_id = {$classeId}");
+        }
+
+        // Eager-load anti N+1 — colonnes minimales pour réduire la mémoire sur gros volumes.
+        $query = ESBTPResultat::query()
+            ->with([
+                'etudiant:id,nom,prenoms,matricule',
+                'matiere:id,name',
+                'classe:id,name',
+            ]);
+
+        if ($classeId) {
+            $query->where('classe_id', $classeId);
+        }
+
+        $total = (clone $query)->count();
+        if ($total === 0) {
+            $this->warn('Aucun résultat à auditer.');
+
+            return self::SUCCESS;
+        }
+
+        $this->line("{$total} résultat(s) à auditer.");
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        $rows = [];
+        $significantGaps = 0;
+        $maxGap = 0.0;
+
+        $query->chunkById(500, function ($chunk) use (&$rows, &$significantGaps, &$maxGap, $bulletinService, $bar) {
+            foreach ($chunk as $resultat) {
+                $bar->advance();
+
+                // Si la moyenne provient d'une saisie 100 % manuelle (aucune note rattachée),
+                // on ne peut pas recalculer — on saute pour éviter de signaler des faux positifs.
+                $notes = ESBTPNote::query()
+                    ->where('etudiant_id', $resultat->etudiant_id)
+                    ->where(function ($q) use ($resultat) {
+                        $q->where('matiere_id', $resultat->matiere_id)
+                            ->orWhereHas('evaluation', function ($sub) use ($resultat) {
+                                $sub->where('matiere_id', $resultat->matiere_id);
+                            });
+                    })
+                    ->whereHas('evaluation', function ($q) use ($resultat) {
+                        $q->where('annee_universitaire_id', $resultat->annee_universitaire_id)
+                            ->where('periode', $resultat->periode)
+                            ->where('status', '!=', 'cancelled');
+                    })
+                    ->with('evaluation:id,coefficient,bareme')
+                    ->get();
+
+                if ($notes->isEmpty()) {
+                    continue;  // résultat manuel — pas auditable
+                }
+
+                $notesData = $notes->map(function ($note) {
+                    return [
+                        'note' => $note->note,
+                        'coefficient' => $note->evaluation->coefficient ?? 1,
+                        'bareme' => ($note->evaluation->bareme ?? 0) > 0 ? $note->evaluation->bareme : 20,
+                        'is_absent' => (bool) $note->is_absent,
+                    ];
+                })->all();
+
+                $recalculee = $bulletinService->computeMoyenneFromNotesData($notesData);
+                $persistee = (float) $resultat->moyenne;
+                $ecart = round(abs($recalculee - $persistee), 2);
+
+                if ($ecart > 0) {
+                    if ($ecart > $maxGap) {
+                        $maxGap = $ecart;
+                    }
+                    if ($ecart > self::SIGNIFICANT_GAP) {
+                        $significantGaps++;
+                    }
+
+                    $etudiant = $resultat->etudiant;
+                    $rows[] = [
+                        'etudiant' => $etudiant ? trim(($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '')) . ' (' . ($etudiant->matricule ?? '?') . ')' : '?',
+                        'classe' => $resultat->classe->name ?? '?',
+                        'matiere' => $resultat->matiere->name ?? '?',
+                        'periode' => $resultat->periode,
+                        'persistee' => number_format($persistee, 2),
+                        'recalculee' => number_format($recalculee, 2),
+                        'ecart' => number_format($ecart, 2),
+                        '_significant' => $ecart > self::SIGNIFICANT_GAP,
+                    ];
+                }
+            }
+        });
+
+        $bar->finish();
+        $this->newLine(2);
+
+        if (empty($rows)) {
+            $this->info('Aucune divergence détectée. Toutes les moyennes persistées sont cohérentes.');
+
+            return self::SUCCESS;
+        }
+
+        // Affichage console — coloration rouge sur les écarts significatifs.
+        $tableRows = array_map(function ($row) {
+            $marker = $row['_significant'] ? '<fg=red>' . $row['ecart'] . '</>' : $row['ecart'];
+
+            return [
+                $row['etudiant'],
+                $row['classe'],
+                $row['matiere'],
+                $row['periode'],
+                $row['persistee'],
+                $row['recalculee'],
+                $marker,
+            ];
+        }, $rows);
+
+        $this->table(
+            ['Étudiant', 'Classe', 'Matière', 'Période', 'Moy. persistée', 'Moy. recalculée', 'Écart'],
+            array_slice($tableRows, 0, 50)  // limite affichage console à 50, le CSV contient tout
+        );
+
+        if (count($rows) > 50) {
+            $this->line('... (' . (count($rows) - 50) . ' lignes supplémentaires non affichées — utilisez --export-csv pour le rapport complet)');
+        }
+
+        // Export CSV optionnel.
+        if ($exportCsvPath) {
+            $this->exportCsv($exportCsvPath, $rows);
+            $this->info("Rapport CSV exporté : {$exportCsvPath}");
+        }
+
+        // Résumé final.
+        $this->newLine();
+        $this->info(sprintf(
+            '%d résultat(s) audité(s), %d divergence(s) totale(s), %d significative(s) (> %.2f), écart max %.2f.',
+            $total,
+            count($rows),
+            $significantGaps,
+            self::SIGNIFICANT_GAP,
+            $maxGap
+        ));
+
+        if ($significantGaps > 0) {
+            $this->warn('Des écarts significatifs détectés. Le recompute des moyennes persistées sera traité dans une PR séparée.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Export CSV — encoding UTF-8 + BOM pour Excel-friendly.
+     */
+    private function exportCsv(string $path, array $rows): void
+    {
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        $handle = fopen($path, 'w');
+        // BOM UTF-8 pour Excel
+        fwrite($handle, "\xEF\xBB\xBF");
+
+        fputcsv($handle, ['Étudiant', 'Classe', 'Matière', 'Période', 'Moyenne persistée', 'Moyenne recalculée', 'Écart absolu', 'Significatif (> 0.5)']);
+
+        foreach ($rows as $row) {
+            fputcsv($handle, [
+                $row['etudiant'],
+                $row['classe'],
+                $row['matiere'],
+                $row['periode'],
+                $row['persistee'],
+                $row['recalculee'],
+                $row['ecart'],
+                $row['_significant'] ? 'OUI' : 'non',
+            ]);
+        }
+
+        fclose($handle);
+    }
+}

--- a/app/Services/BulletinService.php
+++ b/app/Services/BulletinService.php
@@ -106,9 +106,13 @@ class BulletinService
                     ];
                 }
 
+                // BUG FIX : on capture aussi `bareme` et `is_absent` pour permettre la normalisation /20
+                // et l'exclusion des absences dans le calcul de moyenne par matière (cf. computeMoyenneFromNotesData).
                 $resultatsParMatiere[$matiereId]->notes[] = [
                     'note' => $note->note,
                     'coefficient' => $note->evaluation->coefficient,
+                    'bareme' => $note->evaluation->bareme ?: 20,
+                    'is_absent' => (bool) $note->is_absent,
                 ];
 
                 // Utiliser uniquement les professeurs configurés
@@ -117,16 +121,10 @@ class BulletinService
         }
 
         // Calculer les moyennes pondérées pour chaque matière (automatiques)
+        // BUG FIX : on normalise CHAQUE note par son barème avant pondération.
+        // Avant : note brute (15/30 + 10/20)/2 = 12.5 au lieu de (10 + 10)/2 = 10.
         foreach ($resultatsParMatiere as $matiereId => $resultat) {
-            $totalPoints = 0;
-            $totalCoeffs = 0;
-
-            foreach ($resultat->notes as $noteData) {
-                $totalPoints += $noteData['note'] * $noteData['coefficient'];
-                $totalCoeffs += $noteData['coefficient'];
-            }
-
-            $resultat->moyenne = $totalCoeffs > 0 ? $totalPoints / $totalCoeffs : 0;
+            $resultat->moyenne = $this->computeMoyenneFromNotesData($resultat->notes);
             $resultat->appreciation = $this->getAppreciation($resultat->moyenne);
         }
 
@@ -481,6 +479,50 @@ class BulletinService
                 ]
             );
         }
+    }
+
+    /**
+     * Calcule la moyenne pondérée d'une matière à partir d'un tableau de notes brutes.
+     *
+     * Algorithme officiel KLASSCI (mai 2026) :
+     *  1. Exclure les notes marquées absentes (is_absent = true).
+     *  2. Ignorer les notes dont le barème est invalide (<= 0) — garde-fou silencieux.
+     *  3. Normaliser chaque note sur 20 : (note / barème) * 20.
+     *  4. Pondérer par le coefficient de l'évaluation, faire la moyenne arithmétique pondérée.
+     *  5. Arrondir à 2 décimales (cohérence avec l'affichage UI).
+     *
+     * Pure function : aucun accès DB, aucun side-effect → testable unitairement.
+     *
+     * @param array<int, array{note: float|int|string, coefficient: float|int, bareme?: float|int|null, is_absent?: bool}> $notes
+     */
+    public function computeMoyenneFromNotesData(array $notes): float
+    {
+        $totalPoints = 0.0;
+        $totalCoeffs = 0.0;
+
+        foreach ($notes as $noteData) {
+            if (! empty($noteData['is_absent'])) {
+                continue;
+            }
+
+            $bareme = (float) ($noteData['bareme'] ?? 20);
+            if ($bareme <= 0) {
+                continue;
+            }
+
+            $coefficient = (float) ($noteData['coefficient'] ?? 1);
+            $noteValue = is_numeric($noteData['note'] ?? null) ? (float) $noteData['note'] : 0.0;
+            $normalized = ($noteValue / $bareme) * 20;
+
+            $totalPoints += $normalized * $coefficient;
+            $totalCoeffs += $coefficient;
+        }
+
+        if ($totalCoeffs <= 0) {
+            return 0.0;
+        }
+
+        return round($totalPoints / $totalCoeffs, 2);
     }
 
     /**

--- a/resources/views/esbtp/notes/index.blade.php
+++ b/resources/views/esbtp/notes/index.blade.php
@@ -1113,15 +1113,24 @@ function calculateStudentAverage(studentId) {
 
     noteInputs.each(function() {
         const evalId = $(this).data('eval-id');
-        const noteValue = parseFloat($(this).val()) || 0;
         const isAbsent = $(`#absent-${studentId}-${evalId}`).is(':checked');
+        const rawValue = $(this).val();
         const params = getEvalParams(evalId);
 
-        if (!isAbsent && !isNaN(noteValue) && noteValue > 0) {
-            const normalizedNote = (noteValue / params.bareme) * 20;
-            totalPoints += normalizedNote * params.coefficient;
-            totalCoefficients += params.coefficient;
-            hasNotes = true;
+        // Garde-fou : barème invalide → ignorer (évite division par 0)
+        if (!params.bareme || params.bareme <= 0) return;
+
+        // BUG FIX : on traite la note 0 légitime (ex: 0/20) comme valide.
+        // Avant : `noteValue > 0` excluait silencieusement 0 → moyenne fausse (10 et 0 → 10 au lieu de 5).
+        // Aligné sur calculateClassAverages() pour cohérence des deux algos.
+        if (!isAbsent && rawValue !== '') {
+            const noteValue = parseFloat(rawValue);
+            if (!isNaN(noteValue)) {
+                const normalizedNote = (noteValue / params.bareme) * 20;
+                totalPoints += normalizedNote * params.coefficient;
+                totalCoefficients += params.coefficient;
+                hasNotes = true;
+            }
         }
     });
 

--- a/tests/Unit/Services/BulletinServiceCalculTest.php
+++ b/tests/Unit/Services/BulletinServiceCalculTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\BulletinService;
+use App\Services\ESBTP\ESBTPAbsenceService;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests unitaires purs (sans DB) pour la logique de calcul de moyenne par matière
+ * dans BulletinService::computeMoyenneFromNotesData().
+ *
+ * Couvre les 2 bugs critiques fixés en mai 2026 :
+ *  - JS excluait les notes 0 légitimes (10 et 0 → 10 au lieu de 5)
+ *  - Bulletin ne normalisait pas par barème (15/30 + 10/20 → 12.5 au lieu de 10)
+ *
+ * Pas de DB, pas de Eloquent : on teste uniquement la pure function.
+ */
+class BulletinServiceCalculTest extends TestCase
+{
+    private BulletinService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Mockery sur le seul collaborateur du constructeur — la fonction testée
+        // ne touche à rien de DB-dépendant donc les méthodes du mock ne sont jamais appelées.
+        $absenceService = Mockery::mock(ESBTPAbsenceService::class);
+        $this->service = new BulletinService($absenceService);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /**
+     * BUG #1 reproduit : 2 notes 10/20 et 0/20 → moyenne attendue 5 (pas 10).
+     */
+    public function test_it_includes_zero_grade_in_average(): void
+    {
+        $notes = [
+            ['note' => 10, 'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],
+            ['note' => 0,  'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],
+        ];
+
+        $this->assertSame(5.0, $this->service->computeMoyenneFromNotesData($notes));
+    }
+
+    /**
+     * BUG #2 reproduit : note 15/30 + note 10/20 → moyenne attendue 10
+     * (15/30*20 = 10, 10/20*20 = 10, moyenne = 10).
+     */
+    public function test_it_normalizes_grades_by_bareme(): void
+    {
+        $notes = [
+            ['note' => 15, 'coefficient' => 1, 'bareme' => 30, 'is_absent' => false],
+            ['note' => 10, 'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],
+        ];
+
+        $this->assertSame(10.0, $this->service->computeMoyenneFromNotesData($notes));
+    }
+
+    /**
+     * Une absence ne doit JAMAIS être comptée comme un 0 — l'évaluation est exclue.
+     * 1 note 10/20 + 1 absence → moyenne = 10.
+     */
+    public function test_it_excludes_absent_grades(): void
+    {
+        $notes = [
+            ['note' => 10, 'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],
+            ['note' => 0,  'coefficient' => 1, 'bareme' => 20, 'is_absent' => true],
+        ];
+
+        $this->assertSame(10.0, $this->service->computeMoyenneFromNotesData($notes));
+    }
+
+    /**
+     * Coefficients respectés : 10 (coef 2) + 20 (coef 1) → (20 + 20) / 3 ≈ 13.33.
+     */
+    public function test_it_applies_coefficient_correctly(): void
+    {
+        $notes = [
+            ['note' => 10, 'coefficient' => 2, 'bareme' => 20, 'is_absent' => false],
+            ['note' => 20, 'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],
+        ];
+
+        $this->assertSame(13.33, $this->service->computeMoyenneFromNotesData($notes));
+    }
+
+    /**
+     * Aucune note → 0 (pas d'exception, pas de division par 0).
+     */
+    public function test_it_handles_empty_notes_returns_zero(): void
+    {
+        $this->assertSame(0.0, $this->service->computeMoyenneFromNotesData([]));
+    }
+
+    /**
+     * Garde-fou : barème 0 ou négatif → la note est silencieusement ignorée
+     * (ne crash pas, ne divise pas par 0).
+     */
+    public function test_it_handles_invalid_bareme_skips_note(): void
+    {
+        $notes = [
+            ['note' => 10, 'coefficient' => 1, 'bareme' => 0,  'is_absent' => false],  // ignoré
+            ['note' => 15, 'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],  // compté → 15
+        ];
+
+        $this->assertSame(15.0, $this->service->computeMoyenneFromNotesData($notes));
+    }
+
+    /**
+     * Une note pleine (30/30) doit donner 20 après normalisation, pas un débordement.
+     */
+    public function test_it_caps_bareme_normalization_correctly(): void
+    {
+        $notes = [
+            ['note' => 30, 'coefficient' => 1, 'bareme' => 30, 'is_absent' => false],
+        ];
+
+        $this->assertSame(20.0, $this->service->computeMoyenneFromNotesData($notes));
+    }
+
+    /**
+     * Arrondi à 2 décimales : (10/3) * 20 ≈ 66.66... mais on cherche un cas réaliste.
+     * Avec note 10 (coef 1) + note 20 (coef 2) + note 0 (coef 0) on aurait soucis.
+     * Cas concret : 3 notes égales 10 mais pondération particulière → résultat /3 arrondi.
+     * Ici : 5 (coef 1) + 10 (coef 1) + 5 (coef 1) → 20/3 = 6.666... → arrondi 6.67.
+     */
+    public function test_it_rounds_to_two_decimals(): void
+    {
+        $notes = [
+            ['note' => 5,  'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],
+            ['note' => 10, 'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],
+            ['note' => 5,  'coefficient' => 1, 'bareme' => 20, 'is_absent' => false],
+        ];
+
+        $this->assertSame(6.67, $this->service->computeMoyenneFromNotesData($notes));
+    }
+
+    /**
+     * Bonus : robustesse aux clés manquantes — `bareme` absent → défaut 20,
+     * `is_absent` absent → défaut false, `coefficient` absent → défaut 1.
+     */
+    public function test_it_uses_default_values_when_keys_missing(): void
+    {
+        $notes = [
+            ['note' => 12],  // bareme défaut 20, coef défaut 1, non absent
+            ['note' => 8],
+        ];
+
+        $this->assertSame(10.0, $this->service->computeMoyenneFromNotesData($notes));
+    }
+}


### PR DESCRIPTION
## Bugs corrigés

Une enseignante a remonté : « quand on saisit deux notes 10 et 0, la moyenne affichée est 10 au lieu de 5 ». Audit fait, deux bugs critiques confirmés.

### Bug #1 — JS exclut les notes 0 légitimes
**Fichier** : `resources/views/esbtp/notes/index.blade.php` (`calculateStudentAverage()`)

`noteValue > 0` rejetait à la fois les cellules vides ET les notes 0 légitimes (ex: une vraie note de 0/20). La fonction sœur `calculateClassAverages()` du même fichier utilisait déjà le bon filtre (`rawValue !== ''`) → divergence des deux algos. **Aligné** sur le bon comportement + garde-fou contre les barèmes invalides (≤ 0).

### Bug #2 — BulletinService ne normalise pas par barème
**Fichier** : `app/Services/BulletinService.php` (`genererDonneesBulletin()`)

La moyenne par matière était calculée en multipliant directement la note brute par le coefficient (`note × coef`), sans normaliser sur 20. Conséquence : un étudiant avec 15/30 + 10/20 voyait 12.5 sur son bulletin officiel au lieu de la vraie moyenne 10.

**Refactor** :
- Capture de `bareme` et `is_absent` dans la structure `notes` envoyée au calcul
- Nouvelle méthode pure `computeMoyenneFromNotesData(array $notes): float` qui :
  - exclut les notes marquées absentes
  - ignore les barèmes invalides (≤ 0) — garde-fou silencieux
  - normalise chaque note sur 20 : `(note / bareme) * 20`
  - pondère par coefficient et arrondit à 2 décimales
- Méthode pure (sans accès DB) → testable unitairement

## Tests

`tests/Unit/Services/BulletinServiceCalculTest.php` — **9 tests, 9 assertions, tous passent** (PHPUnit pur, pas de DB requise via Mockery).

```
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.
.........                                                           9 / 9 (100%)
OK (9 tests, 9 assertions)
```

Couvre :
- Inclusion notes 0 légitimes (bug #1 reproduit)
- Normalisation par barème (bug #2 reproduit : 15/30 + 10/20 → 10)
- Exclusion absences (10 + absence → 10, pas 5)
- Coefficients respectés (10 coef 2 + 20 coef 1 → 13.33)
- Garde-fous : tableau vide → 0, barème invalide → ignoré silencieusement
- Cap normalisation : 30/30 → 20
- Arrondi 2 décimales : 5+10+5 (coef 1) → 6.67
- Valeurs par défaut quand clés absentes (`bareme` → 20, `coefficient` → 1, `is_absent` → false)

## Audit data

Nouvelle commande : `php artisan notes:audit-divergence [--classe=ID] [--export-csv=path.csv] [--dry-run]`

- **Lecture seule** — ne modifie aucune donnée
- Recalcule chaque `ESBTPResultat` avec la nouvelle logique et signale les écarts
- Anti N+1 (eager-load `etudiant:id,nom,prenoms,matricule`, `matiere:id,name`, `classe:id,name`)
- `chunkById(500)` pour gros volumes
- Écarts > 0.5 affichés en rouge dans la console
- Export CSV optionnel avec BOM UTF-8 (Excel-friendly)
- Sortie résumée : nombre d'écarts totaux + significatifs + écart max

**Run sur tenant local** : 2 vraies divergences détectées (écart max 5.00 sur étudiant `12047923AB`, prouvant que le fix corrige des bugs réels).

## Migration data

**Aucune dans cette PR.** La commande d'audit est en lecture seule. Le recompute des moyennes persistées en `esbtp_resultats` viendra dans la PR #2 (système d'observer notes), avec un job dédié pour traiter les bulletins existants.

## Comm tenant

Effet immédiat sur la **prochaine** génération de bulletin pour tout tenant. Les moyennes déjà persistées en `esbtp_resultats` restent fausses tant que le recompute n'est pas joué. À communiquer aux écoles :
- Si un bulletin est régénéré (preview ou PDF), il sera correct.
- Les bulletins déjà persistés peuvent encore contenir l'ancienne valeur — utiliser la commande `notes:audit-divergence` pour faire l'inventaire avant la migration data (PR #2).

## Boundary check (intentionally NOT touched)

- ❌ Design CSS modal (PR #4)
- ❌ Raccourcis clavier / autosave localStorage (PR #3)
- ❌ Validations FormRequest backend (PR #5)
- ❌ Système d'observer notes / recompute job (PR #2)
- ❌ NoteCalculationService partagé (PR #6)
- ❌ Système LMD (`ESBTPLMDNoteController`)