### PR TITLE
fix(notes): validations backend + throttling + transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ Le format suit librement [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/
 - **Exports PDF + Excel du journal d'audit** — formats premium (PDF via `<x-pdf-document>`, Excel avec colonnes formatées). Throttle 5/min sur exports, 100/min sur consultation.
 - **Index DB sur `audits`** — ajout de 3 indexes (`created_at`, `event`, `tags`) pour temps de réponse stables au-delà de 10 000 enregistrements.
 
+### Sécurité
+
+- **Throttling sur les endpoints notes** — 30 requêtes/min sur la saisie unitaire (`/esbtp/notes/save-ajax`), 10 req/min sur les saisies en masse (`/esbtp/notes/save-ajax-bulk` et `/esbtp/notes/store-batch`), 60 req/min sur les endpoints AJAX de lecture (étudiants par classe, évaluations par classe/matière). Évite les abus, scripts d'enumeration et erreurs en boucle.
+- **Validation backend stricte pour les notes** — refacto en `StoreNoteRequest` + `StoreBulkNotesRequest` (Form Requests) avec autorisation centralisée (permissions `notes.create` / `notes.edit` / `notes.manage_own`), nouvelle règle `App\Rules\NoteRespectsBareme` qui rejette toute note dépassant le barème de l'évaluation, plafond strict de 500 notes par batch, borne haute défensive à 100, validation `commentaire` ≤ 500 caractères, coercion robuste de `is_absent` (boolean au lieu de string). Garde-fou anti division par zéro : barème de l'évaluation rejeté s'il est ≤ 0.
+- **Validation barème + coefficient sur les évaluations** — `bareme` strictement > 0 (entre 0.1 et 100), `coefficient` borné entre 0.1 et 10 (déjà strict en création, désormais aussi en modification), `duree_minutes` borné entre 1 et 480 minutes (8h max). Empêche la création d'évaluations qui casseraient ensuite le calcul de moyenne.
+- **Filtre `workflow_step = etudiant_cree` sur la liste des étudiants pour saisie de notes** — la modal de saisie via `/esbtp/notes`, les pages de saisie rapide (web + PDF vierges) ainsi que les pages détail/PDF d'une évaluation (`ESBTPEvaluationController`) n'affichent plus les étudiants en pré-inscription / prospect. Évite la création accidentelle de notes orphelines pour des étudiants qui ne sont pas encore officiellement inscrits.
+
+### Améliorations
+
+- **Transaction DB sur la saisie de note unitaire** — `saveNoteAjax` est désormais wrappé dans `DB::transaction(...)` (le bulk l'avait déjà). Garantit l'atomicité face aux Observer / triggers de recalcul de moyennes en cascade. Les notifications d'absence sont envoyées après le commit (évite les rollbacks en cascade en cas d'échec d'envoi).
+
 ### Corrections
 
 - **CRITIQUE — calcul de moyenne dans la saisie de notes** (`/esbtp/notes`) — la moyenne par étudiant affichée côté UI excluait silencieusement les notes 0 légitimes. Une enseignante saisissait 10 et 0 et voyait 10 au lieu de 5. Cause : la fonction JS `calculateStudentAverage()` filtrait `noteValue > 0` au lieu de `rawValue !== ''`, ce qui rejetait à la fois les cellules vides ET les notes 0. La fonction sœur `calculateClassAverages()` du même fichier utilisait le bon filtre, ce qui créait une divergence entre la moyenne par étudiant (fausse) et la moyenne par évaluation (correcte). Algo aligné sur le bon filtre + ajout d'un garde-fou contre les barèmes invalides (≤ 0).

--- a/app/Http/Controllers/ESBTPClasseController.php
+++ b/app/Http/Controllers/ESBTPClasseController.php
@@ -1244,6 +1244,7 @@ class ESBTPClasseController extends Controller
                 ->inscriptions()
                 ->with(["etudiant"])
                 ->where("status", "active")
+                ->where("workflow_step", "etudiant_cree")
                 ->where("annee_universitaire_id", $anneeCourante->id)
                 ->get()
                 ->map(function ($inscription) {

--- a/app/Http/Controllers/ESBTPEvaluationController.php
+++ b/app/Http/Controllers/ESBTPEvaluationController.php
@@ -339,18 +339,20 @@ class ESBTPEvaluationController extends Controller
             'colonnes_table' => \Schema::getColumnListing('esbtp_evaluations'),
         ]);
 
+        // Garde-fou critique : bareme strictement > 0 (sinon division par zéro
+        // dans ESBTPNote::getNoteVingtAttribute), coefficient strictement borné.
         $validator = \Validator::make($request->all(), [
             'titre' => 'required|string|max:255',
-            'description' => 'nullable|string',
-            'type' => 'required|string|in:devoir,examen,projet,tp,controle,quiz',
+            'description' => 'nullable|string|max:1000',
+            'type' => 'required|string|in:devoir,examen,projet,tp,controle,quiz,oral,cc',
             'date_evaluation' => 'required|date',
             'heure_debut' => 'required|date_format:H:i',
             'heure_fin' => 'required|date_format:H:i|after:heure_debut',
             'classe_id' => 'required|exists:esbtp_classes,id',
             'matiere_id' => 'required|exists:esbtp_matieres,id',
-'bareme' => 'required|numeric|min:0',
+            'bareme' => 'required|numeric|min:0.1|max:100',
             'coefficient' => 'required|numeric|min:0.1|max:10',
-            'duree_minutes' => 'nullable|integer|min:0',
+            'duree_minutes' => 'nullable|integer|min:1|max:480',
             'is_published' => 'nullable|boolean',
             'periode' => 'required|in:1,2,3,4,5,6,7,8,9,10,semestre1,semestre2,semestre3,semestre4,semestre5,semestre6,semestre7,semestre8,semestre9,semestre10,Semestre 1,Semestre 2,Semestre 3,Semestre 4,Semestre 5,Semestre 6,Semestre 7,Semestre 8,Semestre 9,Semestre 10',
         ], [
@@ -363,11 +365,14 @@ class ESBTPEvaluationController extends Controller
             'classe_id.exists' => 'La classe sélectionnée n\'existe pas',
             'matiere_id.required' => 'La matière est obligatoire',
             'matiere_id.exists' => 'La matière sélectionnée n\'existe pas',
-'bareme.required' => 'Le barème est obligatoire',
+            'bareme.required' => 'Le barème est obligatoire',
+            'bareme.min' => 'Le barème doit être strictement supérieur à zéro.',
+            'bareme.max' => 'Le barème ne peut pas dépasser 100.',
             'coefficient.required' => 'Le coefficient de l\'évaluation est obligatoire',
             'coefficient.numeric' => 'Le coefficient doit être un nombre',
-            'coefficient.min' => 'Le coefficient doit être supérieur à 0',
+            'coefficient.min' => 'Le coefficient doit être strictement supérieur à zéro.',
             'coefficient.max' => 'Le coefficient ne peut pas dépasser 10',
+            'duree_minutes.max' => 'La durée ne peut pas dépasser 480 minutes (8h).',
         ]);
 
         if ($validator->fails()) {
@@ -614,17 +619,20 @@ $evaluation = new ESBTPEvaluation;
         ]);
 
         try {
+            // Garde-fou critique : bareme strictement > 0 (sinon division par zéro
+            // dans ESBTPNote::getNoteVingtAttribute), coefficient strictement borné.
             $request->validate([
                 'titre' => 'required|string|max:255',
-                'description' => 'nullable|string',
-                'type' => 'required|in:devoir,examen,projet,tp,controle,quiz',
+                'description' => 'nullable|string|max:1000',
+                'type' => 'required|in:devoir,examen,projet,tp,controle,quiz,oral,cc',
                 'date_evaluation' => 'required|date',
                 'heure_debut' => 'required|date_format:H:i',
                 'heure_fin' => 'required|date_format:H:i|after:heure_debut',
                 'classe_id' => 'required|exists:esbtp_classes,id',
                 'matiere_id' => 'required|exists:esbtp_matieres,id',
-                'bareme' => 'required|numeric|min:0',
-                'duree_minutes' => 'nullable|integer|min:0',
+                'bareme' => 'required|numeric|min:0.1|max:100',
+                'coefficient' => 'nullable|numeric|min:0.1|max:10',
+                'duree_minutes' => 'nullable|integer|min:1|max:480',
                 'periode' => 'required|in:1,2,3,4,5,6,7,8,9,10,semestre1,semestre2,semestre3,semestre4,semestre5,semestre6,semestre7,semestre8,semestre9,semestre10,Semestre 1,Semestre 2,Semestre 3,Semestre 4,Semestre 5,Semestre 6,Semestre 7,Semestre 8,Semestre 9,Semestre 10',
             ], [
                 'titre.required' => 'Le titre est obligatoire',
@@ -633,6 +641,11 @@ $evaluation = new ESBTPEvaluation;
                 'classe_id.required' => 'La classe est obligatoire',
                 'matiere_id.required' => 'La matière est obligatoire',
                 'bareme.required' => 'Le barème est obligatoire',
+                'bareme.min' => 'Le barème doit être strictement supérieur à zéro.',
+                'bareme.max' => 'Le barème ne peut pas dépasser 100.',
+                'coefficient.min' => 'Le coefficient doit être strictement supérieur à zéro.',
+                'coefficient.max' => 'Le coefficient ne peut pas dépasser 10.',
+                'duree_minutes.max' => 'La durée ne peut pas dépasser 480 minutes (8h).',
             ]);
         } catch (\Illuminate\Validation\ValidationException $e) {
             \Log::error('❌ ESBTPEvaluation UPDATE - Erreur de validation', [

--- a/app/Http/Controllers/ESBTPEvaluationController.php
+++ b/app/Http/Controllers/ESBTPEvaluationController.php
@@ -555,9 +555,11 @@ $evaluation = new ESBTPEvaluation;
         $anneeCourante = ESBTPAnneeUniversitaire::where('is_current', true)->first();
 
         // Récupérer tous les étudiants avec inscriptions actives sur l'année courante
+        // ET workflow_step = etudiant_cree (exclut les pré-inscriptions / prospects).
         $etudiantsAnneeCourante = ESBTPEtudiant::whereHas('inscriptions', function ($query) use ($evaluation, $anneeCourante) {
             $query->where('classe_id', $evaluation->classe_id)
-                ->where('status', 'active');
+                ->where('status', 'active')
+                ->where('workflow_step', 'etudiant_cree');
             if ($anneeCourante) {
                 $query->where('annee_universitaire_id', $anneeCourante->id);
             }
@@ -1124,7 +1126,8 @@ $evaluation->titre = $request->titre;
 
         $etudiants = ESBTPEtudiant::whereHas('inscriptions', function ($query) use ($evaluation, $anneeCourante) {
             $query->where('classe_id', $evaluation->classe_id)
-                ->where('status', 'active');
+                ->where('status', 'active')
+                ->where('workflow_step', 'etudiant_cree');
             if ($anneeCourante) {
                 $query->where('annee_universitaire_id', $anneeCourante->id);
             }

--- a/app/Http/Controllers/ESBTPNoteController.php
+++ b/app/Http/Controllers/ESBTPNoteController.php
@@ -15,6 +15,8 @@ use App\Models\ESBTPNiveauEtude;
 use App\Models\ESBTPNote;
 use App\Models\ESBTPSeanceCours;
 use App\Models\ESBTPTeacher;
+use App\Http\Requests\Notes\StoreBulkNotesRequest;
+use App\Http\Requests\Notes\StoreNoteRequest;
 use App\Models\User;
 use App\Services\NoteCalculationService;
 use App\Services\NotesImportService;
@@ -547,26 +549,16 @@ class ESBTPNoteController extends Controller
     /**
      * Sauvegarde (création ou mise à jour) d'une note via AJAX depuis notes.index.
      * Retourne toujours du JSON. Utilise un UPSERT pour éviter le "already exists".
+     *
+     * Validation déléguée à StoreNoteRequest :
+     *   - permissions notes.create / notes.edit / notes.manage_own
+     *   - exists evaluation_id / etudiant_id
+     *   - note ≤ barème via la rule NoteRespectsBareme
      */
-    public function saveNoteAjax(Request $request)
+    public function saveNoteAjax(StoreNoteRequest $request)
     {
         try {
-            $validator = \Validator::make($request->all(), [
-                'etudiant_id'   => 'required|exists:esbtp_etudiants,id',
-                'evaluation_id' => 'required|exists:esbtp_evaluations,id',
-                'note'          => 'nullable|numeric|min:0',
-                'is_absent'     => 'nullable|string',
-            ]);
-
-            if ($validator->fails()) {
-                return response()->json([
-                    'success' => false,
-                    'message' => $validator->errors()->first(),
-                    'errors'  => $validator->errors()->toArray(),
-                ], 422);
-            }
-
-            $evaluation = ESBTPEvaluation::findOrFail($request->evaluation_id);
+            $evaluation = ESBTPEvaluation::findOrFail($request->input('evaluation_id'));
 
             if (! $evaluation->is_published) {
                 return response()->json([
@@ -575,8 +567,8 @@ class ESBTPNoteController extends Controller
                 ], 422);
             }
 
-            $existingNote = ESBTPNote::where('etudiant_id', $request->etudiant_id)
-                ->where('evaluation_id', $request->evaluation_id)
+            $existingNote = ESBTPNote::where('etudiant_id', $request->input('etudiant_id'))
+                ->where('evaluation_id', $request->input('evaluation_id'))
                 ->first();
 
             if ($existingNote && ! Auth::user()->can('notes.edit')) {
@@ -586,14 +578,21 @@ class ESBTPNoteController extends Controller
                 ], 403);
             }
 
-            $result = $this->processNoteEntry($evaluation, $existingNote, [
-                'etudiant_id'   => $request->etudiant_id,
-                'evaluation_id' => $request->evaluation_id,
-                'note'          => $request->note,
-                'is_absent'     => $request->is_absent,
-                'commentaire'   => $request->commentaire,
-            ]);
+            // Transaction explicite : la création/modification d'une note
+            // déclenche un Observer (recalcul moyennes) qui peut écrire en
+            // cascade. On garde l'atomicité pour éviter les états partiels.
+            $result = DB::transaction(function () use ($evaluation, $existingNote, $request) {
+                return $this->processNoteEntry($evaluation, $existingNote, [
+                    'etudiant_id'   => $request->input('etudiant_id'),
+                    'evaluation_id' => $request->input('evaluation_id'),
+                    'note'          => $request->input('note'),
+                    'is_absent'     => $request->boolean('is_absent'),
+                    'commentaire'   => $request->input('commentaire'),
+                ]);
+            });
 
+            // La notification est envoyée APRÈS commit pour éviter qu'un échec
+            // d'envoi ne rollback la note enregistrée.
             if ($result['is_new_absent']) {
                 $this->sendAbsenceNotificationForNote($result['note'], $evaluation);
             }
@@ -607,45 +606,40 @@ class ESBTPNoteController extends Controller
             ]);
 
         } catch (\Exception $e) {
-            \Log::error('saveNoteAjax error: ' . $e->getMessage());
+            \Log::error('saveNoteAjax error: ' . $e->getMessage(), [
+                'evaluation_id' => $request->input('evaluation_id'),
+                'etudiant_id' => $request->input('etudiant_id'),
+                'user_id' => Auth::id(),
+            ]);
+
             return response()->json([
                 'success' => false,
-                'message' => 'Erreur serveur : ' . $e->getMessage(),
+                'message' => 'Erreur serveur lors de l\'enregistrement de la note.',
             ], 500);
         }
     }
 
     /**
      * Sauvegarde en masse des notes (une seule requête HTTP au lieu d'une par étudiant).
+     *
+     * Validation déléguée à StoreBulkNotesRequest :
+     *   - permissions notes.create / notes.edit / notes.manage_own
+     *   - max 500 notes par batch (anti-abus)
+     *   - exists evaluation_id / etudiant_id sur chaque entrée
      */
-    public function saveNotesAjaxBulk(Request $request)
+    public function saveNotesAjaxBulk(StoreBulkNotesRequest $request)
     {
-        $validator = \Validator::make($request->all(), [
-            'notes'                 => 'required|array|min:1',
-            'notes.*.etudiant_id'   => 'required|integer',
-            'notes.*.evaluation_id' => 'required|integer',
-            'notes.*.note'          => 'nullable|numeric|min:0',
-            'notes.*.is_absent'     => 'nullable|string',
-        ]);
-
-        if ($validator->fails()) {
-            return response()->json([
-                'success' => false,
-                'message' => $validator->errors()->first(),
-                'errors'  => $validator->errors()->toArray(),
-            ], 422);
-        }
-
         $errors = 0;
         $saved  = 0;
+        $notes = $request->input('notes', []);
 
         DB::beginTransaction();
         try {
-            $evalIds = collect($request->notes)->pluck('evaluation_id')->unique();
+            $evalIds = collect($notes)->pluck('evaluation_id')->unique();
             $evaluations = ESBTPEvaluation::whereIn('id', $evalIds)->get()->keyBy('id');
 
             // Requête tuple-based IN avec cast int pour éviter injection SQL
-            $pairs = collect($request->notes)
+            $pairs = collect($notes)
                 ->map(fn($e) => '(' . (int) $e['etudiant_id'] . ', ' . (int) $e['evaluation_id'] . ')')
                 ->implode(',');
             $existingNotes = $pairs
@@ -656,11 +650,23 @@ class ESBTPNoteController extends Controller
             $canEdit = Auth::user()->can('notes.edit');
             $pendingNotifications = [];
 
-            foreach ($request->notes as $entry) {
+            foreach ($notes as $entry) {
                 $evaluation = $evaluations->get($entry['evaluation_id']);
                 if (! $evaluation || ! $evaluation->is_published) {
                     $errors++;
                     continue;
+                }
+
+                // Garde-fou cohérence note ≤ barème (défense en profondeur,
+                // déjà couvert pour les saisies unitaires par NoteRespectsBareme).
+                $rawNote = $entry['note'] ?? null;
+                $isAbsent = (bool) ($entry['is_absent'] ?? false);
+                if (! $isAbsent && $rawNote !== null && $rawNote !== '') {
+                    $bareme = (float) $evaluation->bareme;
+                    if ($bareme <= 0 || (float) $rawNote > $bareme) {
+                        $errors++;
+                        continue;
+                    }
                 }
 
                 $key  = $entry['etudiant_id'] . '_' . $entry['evaluation_id'];
@@ -690,18 +696,21 @@ class ESBTPNoteController extends Controller
                 'success' => $errors === 0,
                 'saved'   => $saved,
                 'errors'  => $errors,
-                'total'   => count($request->notes),
+                'total'   => count($notes),
                 'message' => $errors === 0
                     ? "{$saved} note(s) enregistrée(s) avec succès."
                     : "{$saved} enregistrée(s), {$errors} erreur(s).",
             ]);
         } catch (\Exception $e) {
             DB::rollBack();
-            \Log::error('saveNotesAjaxBulk error: ' . $e->getMessage());
+            \Log::error('saveNotesAjaxBulk error: ' . $e->getMessage(), [
+                'user_id' => Auth::id(),
+                'count' => count($notes),
+            ]);
 
             return response()->json([
                 'success' => false,
-                'message' => 'Erreur serveur : ' . $e->getMessage(),
+                'message' => 'Erreur serveur lors de l\'enregistrement des notes.',
             ], 500);
         }
     }
@@ -786,9 +795,11 @@ class ESBTPNoteController extends Controller
         $anneeCourante = ESBTPAnneeUniversitaire::where('is_current', true)->first();
 
         // Récupérer uniquement les étudiants avec inscriptions actives sur l'année courante
+        // ET workflow_step = etudiant_cree (exclut les pré-inscriptions / prospects).
         $etudiants = ESBTPEtudiant::whereHas('inscriptions', function ($query) use ($evaluation, $anneeCourante) {
             $query->where('classe_id', $evaluation->classe_id)
-                ->where('status', 'active');
+                ->where('status', 'active')
+                ->where('workflow_step', 'etudiant_cree');
             if ($anneeCourante) {
                 $query->where('annee_universitaire_id', $anneeCourante->id);
             }
@@ -837,7 +848,8 @@ class ESBTPNoteController extends Controller
 
         $etudiants = ESBTPEtudiant::whereHas('inscriptions', function ($query) use ($evaluation, $anneeCourante) {
             $query->where('classe_id', $evaluation->classe_id)
-                ->where('status', 'active');
+                ->where('status', 'active')
+                ->where('workflow_step', 'etudiant_cree');
             if ($anneeCourante) {
                 $query->where('annee_universitaire_id', $anneeCourante->id);
             }
@@ -894,7 +906,8 @@ class ESBTPNoteController extends Controller
 
         $etudiants = ESBTPEtudiant::whereHas('inscriptions', function ($query) use ($classe, $anneeCourante) {
             $query->where('classe_id', $classe->id)
-                ->where('status', 'active');
+                ->where('status', 'active')
+                ->where('workflow_step', 'etudiant_cree');
             if ($anneeCourante) {
                 $query->where('annee_universitaire_id', $anneeCourante->id);
             }

--- a/app/Http/Requests/Evaluations/StoreEvaluationRequest.php
+++ b/app/Http/Requests/Evaluations/StoreEvaluationRequest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Requests\Evaluations;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validation pour la création d'une évaluation.
+ *
+ * Garde-fous critiques : bareme >= 0.1 (pas de division par zéro),
+ * coefficient strictement borné [0.1, 10].
+ */
+class StoreEvaluationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        if (! $user) {
+            return false;
+        }
+
+        return $user->can('evaluations.create') || $user->can('evaluations.edit');
+    }
+
+    public function rules(): array
+    {
+        // On accepte un superset des types historiques pour ne pas casser les
+        // formulaires existants ; la liste reste fermée (pas d'arbitraire).
+        $allowedTypes = ['examen', 'devoir', 'tp', 'projet', 'oral', 'controle', 'quiz', 'cc'];
+
+        // Les périodes acceptées historiquement sont à la fois numériques et
+        // sous forme `semestreN`. On garde les deux formats pour rétrocompat.
+        $allowedPeriodes = [
+            '1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
+            'semestre1', 'semestre2', 'semestre3', 'semestre4', 'semestre5',
+            'semestre6', 'semestre7', 'semestre8', 'semestre9', 'semestre10',
+            'Semestre 1', 'Semestre 2', 'Semestre 3', 'Semestre 4', 'Semestre 5',
+            'Semestre 6', 'Semestre 7', 'Semestre 8', 'Semestre 9', 'Semestre 10',
+        ];
+
+        return [
+            'titre' => ['required', 'string', 'max:255'],
+            'description' => ['nullable', 'string', 'max:1000'],
+            'classe_id' => ['required', 'integer', 'exists:esbtp_classes,id'],
+            'matiere_id' => ['required', 'integer', 'exists:esbtp_matieres,id'],
+            'type' => ['required', 'string', 'in:'.implode(',', $allowedTypes)],
+            'date_evaluation' => ['required', 'date'],
+            'heure_debut' => ['required', 'date_format:H:i'],
+            'heure_fin' => ['required', 'date_format:H:i', 'after:heure_debut'],
+            // Garde-fous critiques : bareme strictement > 0 (sinon division par
+            // zéro dans getNoteVingtAttribute), borné à 100.
+            'bareme' => ['required', 'numeric', 'min:0.1', 'max:100'],
+            'coefficient' => ['required', 'numeric', 'min:0.1', 'max:10'],
+            'duree_minutes' => ['nullable', 'integer', 'min:1', 'max:480'],
+            'is_published' => ['nullable', 'boolean'],
+            'periode' => ['required', 'in:'.implode(',', $allowedPeriodes)],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'titre.required' => 'Le titre est obligatoire.',
+            'type.required' => "Le type d'évaluation est obligatoire.",
+            'type.in' => "Le type d'évaluation est invalide.",
+            'date_evaluation.required' => 'La date est obligatoire.',
+            'date_evaluation.date' => 'Le format de la date est invalide.',
+            'heure_debut.required' => "L'heure de début est obligatoire.",
+            'heure_fin.required' => "L'heure de fin est obligatoire.",
+            'heure_fin.after' => "L'heure de fin doit être postérieure à l'heure de début.",
+            'classe_id.required' => 'La classe est obligatoire.',
+            'classe_id.exists' => "La classe sélectionnée n'existe pas.",
+            'matiere_id.required' => 'La matière est obligatoire.',
+            'matiere_id.exists' => "La matière sélectionnée n'existe pas.",
+            'bareme.required' => 'Le barème est obligatoire.',
+            'bareme.min' => 'Le barème doit être strictement supérieur à zéro.',
+            'bareme.max' => 'Le barème ne peut pas dépasser 100.',
+            'coefficient.required' => "Le coefficient de l'évaluation est obligatoire.",
+            'coefficient.numeric' => 'Le coefficient doit être un nombre.',
+            'coefficient.min' => 'Le coefficient doit être strictement supérieur à zéro.',
+            'coefficient.max' => 'Le coefficient ne peut pas dépasser 10.',
+            'duree_minutes.min' => 'La durée doit être supérieure à zéro.',
+            'duree_minutes.max' => 'La durée ne peut pas dépasser 480 minutes (8h).',
+        ];
+    }
+}

--- a/app/Http/Requests/Notes/StoreBulkNotesRequest.php
+++ b/app/Http/Requests/Notes/StoreBulkNotesRequest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Http\Requests\Notes;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+/**
+ * Validation pour la sauvegarde en masse des notes (AJAX).
+ *
+ * Couvre saveNotesAjaxBulk (POST /esbtp/notes/save-ajax-bulk).
+ */
+class StoreBulkNotesRequest extends FormRequest
+{
+    /**
+     * Plafond strict pour éviter les abus volumétriques.
+     */
+    public const MAX_NOTES_PER_BATCH = 500;
+
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        if (! $user) {
+            return false;
+        }
+
+        return $user->can('notes.create') || $user->can('notes.edit') || $user->can('notes.manage_own');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'classe_id' => ['nullable', 'integer', 'exists:esbtp_classes,id'],
+            'matiere_id' => ['nullable', 'integer', 'exists:esbtp_matieres,id'],
+            'notes' => ['required', 'array', 'min:1', 'max:'.self::MAX_NOTES_PER_BATCH],
+            'notes.*.evaluation_id' => ['required', 'integer', 'exists:esbtp_evaluations,id'],
+            'notes.*.etudiant_id' => ['required', 'integer', 'exists:esbtp_etudiants,id'],
+            // Borne haute défense en profondeur — la cohérence note/barème
+            // est ensuite vérifiée dans le service via processNoteEntry.
+            'notes.*.note' => ['nullable', 'numeric', 'min:0', 'max:100'],
+            'notes.*.is_absent' => ['nullable', 'boolean'],
+            'notes.*.commentaire' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'notes.required' => 'Aucune note à enregistrer.',
+            'notes.array' => 'Le format des notes est invalide.',
+            'notes.min' => 'Au moins une note doit être fournie.',
+            'notes.max' => 'Vous ne pouvez pas enregistrer plus de '.self::MAX_NOTES_PER_BATCH.' notes en une seule requête.',
+            'notes.*.evaluation_id.required' => "L'évaluation est obligatoire pour chaque note.",
+            'notes.*.evaluation_id.exists' => "Une évaluation référencée n'existe pas.",
+            'notes.*.etudiant_id.required' => "L'étudiant est obligatoire pour chaque note.",
+            'notes.*.etudiant_id.exists' => "Un étudiant référencé n'existe pas.",
+            'notes.*.note.numeric' => 'La note doit être un nombre.',
+            'notes.*.note.min' => 'La note ne peut pas être négative.',
+            'notes.*.note.max' => 'La note dépasse la borne maximale autorisée (100).',
+        ];
+    }
+
+    /**
+     * Coerce is_absent en booléen sur chaque entrée — l'UI envoie souvent
+     * "on" / "1" / "true" pour les checkboxes.
+     */
+    protected function prepareForValidation(): void
+    {
+        $notes = $this->input('notes');
+        if (! is_array($notes)) {
+            return;
+        }
+
+        foreach ($notes as $key => $entry) {
+            if (isset($entry['is_absent'])) {
+                $notes[$key]['is_absent'] = filter_var(
+                    $entry['is_absent'],
+                    FILTER_VALIDATE_BOOLEAN,
+                    FILTER_NULL_ON_FAILURE
+                ) ?? false;
+            }
+        }
+
+        $this->merge(['notes' => $notes]);
+    }
+
+    /**
+     * Toujours retourner du JSON (les endpoints AJAX consomment cette structure).
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'success' => false,
+                'message' => $validator->errors()->first(),
+                'errors' => $validator->errors()->toArray(),
+            ], 422)
+        );
+    }
+}

--- a/app/Http/Requests/Notes/StoreNoteRequest.php
+++ b/app/Http/Requests/Notes/StoreNoteRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Requests\Notes;
+
+use App\Rules\NoteRespectsBareme;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+/**
+ * Validation pour la sauvegarde d'une note unitaire (AJAX).
+ *
+ * Couvre saveNoteAjax (POST /esbtp/notes/save-ajax).
+ */
+class StoreNoteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        if (! $user) {
+            return false;
+        }
+
+        return $user->can('notes.create') || $user->can('notes.edit') || $user->can('notes.manage_own');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'evaluation_id' => ['required', 'integer', 'exists:esbtp_evaluations,id'],
+            'etudiant_id' => ['required', 'integer', 'exists:esbtp_etudiants,id'],
+            'note' => [
+                'nullable',
+                'numeric',
+                'min:0',
+                new NoteRespectsBareme($this->input('evaluation_id')),
+            ],
+            'is_absent' => ['nullable', 'boolean'],
+            'commentaire' => ['nullable', 'string', 'max:500'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'evaluation_id.required' => "L'évaluation est obligatoire.",
+            'evaluation_id.exists' => "L'évaluation sélectionnée n'existe pas.",
+            'etudiant_id.required' => "L'étudiant est obligatoire.",
+            'etudiant_id.exists' => "L'étudiant sélectionné n'existe pas.",
+            'note.numeric' => 'La note doit être un nombre.',
+            'note.min' => 'La note ne peut pas être négative.',
+            'commentaire.max' => 'Le commentaire ne peut pas dépasser 500 caractères.',
+        ];
+    }
+
+    /**
+     * Coerce is_absent en booléen — l'UI peut envoyer "on", "1", "true".
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('is_absent')) {
+            $raw = $this->input('is_absent');
+            $this->merge([
+                'is_absent' => filter_var($raw, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false,
+            ]);
+        }
+    }
+
+    /**
+     * Toujours retourner du JSON (les endpoints AJAX consomment cette structure).
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        throw new HttpResponseException(
+            response()->json([
+                'success' => false,
+                'message' => $validator->errors()->first(),
+                'errors' => $validator->errors()->toArray(),
+            ], 422)
+        );
+    }
+}

--- a/app/Rules/NoteRespectsBareme.php
+++ b/app/Rules/NoteRespectsBareme.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Rules;
+
+use App\Models\ESBTPEvaluation;
+use Illuminate\Contracts\Validation\Rule;
+
+/**
+ * Vérifie qu'une note ne dépasse pas le barème de l'évaluation,
+ * et que l'évaluation a un barème valide (> 0).
+ *
+ * Usage:
+ *   'note' => ['nullable', 'numeric', new NoteRespectsBareme($evaluationId)]
+ *
+ * Note Laravel 9 : on utilise le contrat `Rule` (passes/message) car
+ * `ValidationRule` n'existe qu'à partir de Laravel 10.
+ */
+class NoteRespectsBareme implements Rule
+{
+    private string $errorMessage = 'La note dépasse le barème de l\'évaluation.';
+
+    /**
+     * @param  mixed  $evaluationId  ID brut depuis la requête (string, int, null).
+     */
+    public function __construct(private mixed $evaluationId) {}
+
+    public function passes($attribute, $value): bool
+    {
+        // Si la note est null/vide, on laisse passer (gestion par les autres rules : nullable, etc.)
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        if (! is_numeric($value)) {
+            // Déléguer à la règle 'numeric'
+            return true;
+        }
+
+        $evaluationId = $this->evaluationId;
+        if ($evaluationId === null || $evaluationId === '' || ! is_numeric($evaluationId)) {
+            $this->errorMessage = "L'évaluation associée est introuvable.";
+
+            return false;
+        }
+
+        $evaluation = ESBTPEvaluation::query()->find((int) $evaluationId);
+        if (! $evaluation) {
+            $this->errorMessage = "L'évaluation associée est introuvable.";
+
+            return false;
+        }
+
+        $bareme = (float) $evaluation->bareme;
+        if ($bareme <= 0) {
+            $this->errorMessage = "Le barème de l'évaluation est invalide ({$bareme}). Corrigez le barème avant de saisir des notes.";
+
+            return false;
+        }
+
+        if ((float) $value > $bareme) {
+            $this->errorMessage = "La note ({$value}) dépasse le barème de l'évaluation ({$bareme}).";
+
+            return false;
+        }
+
+        return true;
+    }
+
+    public function message(): string
+    {
+        return $this->errorMessage;
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1067,9 +1067,13 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
 
             // Routes API utilisées par les formulaires
 
-            // Routes pour les notes
-            Route::post('notes/save-ajax', [ESBTPNoteController::class, 'saveNoteAjax'])->name('notes.save-ajax');
-            Route::post('notes/save-ajax-bulk', [ESBTPNoteController::class, 'saveNotesAjaxBulk'])->name('notes.save-ajax-bulk');
+            // Routes pour les notes — throttle anti-abus (saisie unitaire 30/min, bulk 10/min).
+            Route::post('notes/save-ajax', [ESBTPNoteController::class, 'saveNoteAjax'])
+                ->middleware('throttle:30,1')
+                ->name('notes.save-ajax');
+            Route::post('notes/save-ajax-bulk', [ESBTPNoteController::class, 'saveNotesAjaxBulk'])
+                ->middleware('throttle:10,1')
+                ->name('notes.save-ajax-bulk');
 
             // PR #7 — Excel import/export bidirectionnel + preview impact bulletin
             Route::get('notes/export-excel', [ESBTPNoteController::class, 'exportExcel'])
@@ -1095,7 +1099,9 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
                     'destroy' => 'esbtp.notes.destroy',
                 ])
                 ->middleware(['permission:notes.view|notes.create|notes.edit|notes.delete']);
-            Route::get('evaluations/{evaluation}/saisie-rapide', [ESBTPNoteController::class, 'saisieRapide'])->name('notes.saisie-rapide');
+            Route::get('evaluations/{evaluation}/saisie-rapide', [ESBTPNoteController::class, 'saisieRapide'])
+                ->middleware('throttle:60,1')
+                ->name('notes.saisie-rapide');
             Route::get('evaluations/{evaluation}/saisie-rapide/pdf', [ESBTPNoteController::class, 'saisieRapidePDF'])->name('notes.saisie-rapide.pdf');
             Route::get('evaluations/{evaluation}/saisie-rapide/pdf/preview', [ESBTPNoteController::class, 'saisieRapidePDFPreview'])
                 ->name('notes.saisie-rapide.pdf-preview')
@@ -1104,7 +1110,9 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             Route::get('classes/{classe}/notes/saisie-rapide/pdf/preview', [ESBTPNoteController::class, 'saisieRapideBlankPDFPreview'])
                 ->name('notes.saisie-rapide-blank.pdf-preview')
                 ->middleware('throttle:60,1');
-            Route::post('notes/store-batch', [ESBTPNoteController::class, 'enregistrerSaisieRapide'])->name('notes.store-batch');
+            Route::post('notes/store-batch', [ESBTPNoteController::class, 'enregistrerSaisieRapide'])
+                ->middleware('throttle:10,1')
+                ->name('notes.store-batch');
         });
 
         // Espace étudiant - routes accessibles pour les étudiants
@@ -2115,10 +2123,12 @@ Route::middleware(['auth', 'permission:admin.access'])->prefix('esbtp')->name('e
             ->middleware('permission:notes.delete');
         // saisie-rapide already defined in enseignant|coordinateur group (line 1347)
         
-        // API routes for new notes system
+        // API routes for new notes system — throttle généreux 60/min (lecture seule).
         Route::get('/api/evaluations/by-class-matiere/{classId}/{matiereId}', [\App\Http\Controllers\ESBTPEvaluationController::class, 'byClassMatiere'])
+            ->middleware('throttle:60,1')
             ->name('evaluations.by-class-matiere');
         Route::get('/api/classes/{classe}/students', [\App\Http\Controllers\ESBTPClasseController::class, 'students'])
+            ->middleware('throttle:60,1')
             ->name('classes.students');
     });
 

--- a/tests/Feature/Notes/NoteValidationTest.php
+++ b/tests/Feature/Notes/NoteValidationTest.php
@@ -1,0 +1,293 @@
+<?php
+
+namespace Tests\Feature\Notes;
+
+use App\Http\Requests\Notes\StoreBulkNotesRequest;
+use App\Http\Requests\Notes\StoreNoteRequest;
+use App\Rules\NoteRespectsBareme;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+/**
+ * Tests des validations strictes sur les endpoints notes.
+ *
+ * Ces tests visent les couches qui peuvent être testées sans accès DB
+ * (Custom Rules, FormRequests via Validator manuel, registration des routes).
+ * Les tests d'intégration (route + DB + permissions) requièrent une DB
+ * tenant configurée et sont laissés à la CI / staging.
+ */
+class NoteValidationTest extends TestCase
+{
+    /**
+     * Provide the rule set from StoreNoteRequest without DB-touching custom rules.
+     * Laisse tomber NoteRespectsBareme (testé séparément).
+     */
+    private function storeNoteRulesWithoutBareme(): array
+    {
+        $rules = (new StoreNoteRequest)->rules();
+
+        // Retire la rule custom NoteRespectsBareme pour les tests qui ne
+        // veulent pas toucher la DB (existence évaluation).
+        $rules['note'] = array_values(array_filter(
+            $rules['note'],
+            fn ($r) => ! ($r instanceof NoteRespectsBareme)
+        ));
+
+        // Idem pour exists:* qui touche la DB
+        $rules['evaluation_id'] = ['required', 'integer'];
+        $rules['etudiant_id'] = ['required', 'integer'];
+
+        return $rules;
+    }
+
+    private function storeBulkRulesWithoutDb(): array
+    {
+        $rules = (new StoreBulkNotesRequest)->rules();
+        $rules['classe_id'] = ['nullable', 'integer'];
+        $rules['matiere_id'] = ['nullable', 'integer'];
+        $rules['notes.*.evaluation_id'] = ['required', 'integer'];
+        $rules['notes.*.etudiant_id'] = ['required', 'integer'];
+
+        return $rules;
+    }
+
+    /**
+     * Test 1 — La validation rejette une note négative (single).
+     */
+    public function test_it_rejects_negative_note(): void
+    {
+        $validator = Validator::make([
+            'evaluation_id' => 1,
+            'etudiant_id' => 1,
+            'note' => -2,
+        ], $this->storeNoteRulesWithoutBareme());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('note', $validator->errors()->toArray());
+    }
+
+    /**
+     * Test 2 — La validation rejette une note non numérique (single).
+     */
+    public function test_it_rejects_non_numeric_note(): void
+    {
+        $validator = Validator::make([
+            'evaluation_id' => 1,
+            'etudiant_id' => 1,
+            'note' => 'not-a-number',
+        ], $this->storeNoteRulesWithoutBareme());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('note', $validator->errors()->toArray());
+    }
+
+    /**
+     * Test 3 — La validation accepte une note absente / nullable.
+     */
+    public function test_it_accepts_null_note_for_absent_student(): void
+    {
+        $validator = Validator::make([
+            'evaluation_id' => 1,
+            'etudiant_id' => 1,
+            'note' => null,
+            'is_absent' => true,
+        ], $this->storeNoteRulesWithoutBareme());
+
+        $this->assertFalse($validator->fails());
+    }
+
+    /**
+     * Test 4 — La validation rejette un commentaire trop long (>500 chars).
+     */
+    public function test_it_rejects_oversize_comment(): void
+    {
+        $validator = Validator::make([
+            'evaluation_id' => 1,
+            'etudiant_id' => 1,
+            'note' => 12,
+            'commentaire' => str_repeat('x', 501),
+        ], $this->storeNoteRulesWithoutBareme());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('commentaire', $validator->errors()->toArray());
+    }
+
+    /**
+     * Test 5 — La validation bulk rejette plus de 500 notes par requête.
+     */
+    public function test_it_rejects_bulk_exceeding_max_batch(): void
+    {
+        $notes = [];
+        for ($i = 1; $i <= StoreBulkNotesRequest::MAX_NOTES_PER_BATCH + 1; $i++) {
+            $notes[] = ['evaluation_id' => 1, 'etudiant_id' => $i, 'note' => 12];
+        }
+
+        $validator = Validator::make(['notes' => $notes], $this->storeBulkRulesWithoutDb());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('notes', $validator->errors()->toArray());
+    }
+
+    /**
+     * Test 6 — La validation bulk rejette un tableau notes vide.
+     */
+    public function test_it_rejects_bulk_with_empty_notes_array(): void
+    {
+        $validator = Validator::make(['notes' => []], $this->storeBulkRulesWithoutDb());
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('notes', $validator->errors()->toArray());
+    }
+
+    /**
+     * Test 7 — La validation bulk rejette une note > 100 (borne haute).
+     */
+    public function test_it_rejects_bulk_note_exceeding_upper_bound(): void
+    {
+        $validator = Validator::make([
+            'notes' => [
+                ['evaluation_id' => 1, 'etudiant_id' => 1, 'note' => 250],
+            ],
+        ], $this->storeBulkRulesWithoutDb());
+
+        $this->assertTrue($validator->fails());
+        $errors = $validator->errors()->toArray();
+        $this->assertArrayHasKey('notes.0.note', $errors);
+    }
+
+    /**
+     * Test 8 — La validation bulk accepte un payload valide.
+     */
+    public function test_it_accepts_valid_bulk_payload(): void
+    {
+        $validator = Validator::make([
+            'classe_id' => 1,
+            'matiere_id' => 2,
+            'notes' => [
+                ['evaluation_id' => 1, 'etudiant_id' => 1, 'note' => 12.5, 'is_absent' => false],
+                ['evaluation_id' => 1, 'etudiant_id' => 2, 'note' => null, 'is_absent' => true],
+            ],
+        ], $this->storeBulkRulesWithoutDb());
+
+        $this->assertFalse($validator->fails(), 'Payload should pass: '.$validator->errors()->first());
+    }
+
+    /**
+     * Test 9 — Les routes critiques sont throttlées.
+     *
+     * Vérifie que les routes notes.save-ajax (30/min) / save-ajax-bulk (10/min) /
+     * store-batch (10/min) sont bien enregistrées avec leur middleware throttle.
+     */
+    public function test_it_registers_throttle_middleware_on_critical_routes(): void
+    {
+        $expectations = [
+            'esbtp.notes.save-ajax' => 'throttle:30,1',
+            'esbtp.notes.save-ajax-bulk' => 'throttle:10,1',
+            'esbtp.notes.store-batch' => 'throttle:10,1',
+        ];
+
+        foreach ($expectations as $routeName => $expectedMiddleware) {
+            $route = Route::getRoutes()->getByName($routeName);
+
+            $this->assertNotNull($route, "Route {$routeName} should be registered");
+            $this->assertContains(
+                $expectedMiddleware,
+                $route->gatherMiddleware(),
+                "Route {$routeName} should have middleware {$expectedMiddleware}"
+            );
+        }
+    }
+
+    /**
+     * Test 10 — L'évaluation StoreEvaluationRequest valide la borne min sur barème.
+     *
+     * Garde-fou critique : un barème à 0 causerait une division par zéro
+     * dans ESBTPNote::getNoteVingtAttribute.
+     */
+    public function test_it_rejects_evaluation_with_zero_bareme(): void
+    {
+        $rules = (new \App\Http\Requests\Evaluations\StoreEvaluationRequest)->rules();
+
+        // Strip exists:* / les règles qui touchent la DB
+        $rules['classe_id'] = ['required', 'integer'];
+        $rules['matiere_id'] = ['required', 'integer'];
+
+        $validator = Validator::make([
+            'titre' => 'Examen test',
+            'classe_id' => 1,
+            'matiere_id' => 1,
+            'type' => 'examen',
+            'date_evaluation' => '2026-05-15',
+            'heure_debut' => '08:00',
+            'heure_fin' => '10:00',
+            'bareme' => 0,
+            'coefficient' => 1,
+            'periode' => 'semestre1',
+        ], $rules);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('bareme', $validator->errors()->toArray());
+    }
+
+    /**
+     * Test 11 — L'évaluation StoreEvaluationRequest valide la borne max sur coefficient.
+     */
+    public function test_it_rejects_evaluation_with_excessive_coefficient(): void
+    {
+        $rules = (new \App\Http\Requests\Evaluations\StoreEvaluationRequest)->rules();
+        $rules['classe_id'] = ['required', 'integer'];
+        $rules['matiere_id'] = ['required', 'integer'];
+
+        $validator = Validator::make([
+            'titre' => 'Examen test',
+            'classe_id' => 1,
+            'matiere_id' => 1,
+            'type' => 'examen',
+            'date_evaluation' => '2026-05-15',
+            'heure_debut' => '08:00',
+            'heure_fin' => '10:00',
+            'bareme' => 20,
+            'coefficient' => 50,
+            'periode' => 'semestre1',
+        ], $rules);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('coefficient', $validator->errors()->toArray());
+    }
+
+    /**
+     * Test 12 — Le custom Rule NoteRespectsBareme rejette une note > barème.
+     *
+     * On utilise un evaluation_id null pour tester sans DB :
+     * la rule fail immédiatement avec "introuvable".
+     */
+    public function test_note_respects_bareme_rule_fails_when_evaluation_id_invalid(): void
+    {
+        $rule = new NoteRespectsBareme(null);
+
+        $this->assertFalse($rule->passes('note', 15));
+        $this->assertStringContainsString('introuvable', $rule->message());
+    }
+
+    /**
+     * Test 13 — Le custom Rule passe quand value est null.
+     */
+    public function test_note_respects_bareme_rule_passes_for_null_value(): void
+    {
+        $rule = new NoteRespectsBareme(1);
+
+        $this->assertTrue($rule->passes('note', null), 'Null value should pass (gérée par nullable)');
+    }
+
+    /**
+     * Test 14 — Le custom Rule passe quand value est non numérique
+     * (déléguée à la règle 'numeric').
+     */
+    public function test_note_respects_bareme_rule_passes_for_non_numeric(): void
+    {
+        $rule = new NoteRespectsBareme(1);
+
+        $this->assertTrue($rule->passes('note', 'abc'), 'Non-numeric value should pass (géré par numeric)');
+    }
+}


### PR DESCRIPTION
## Summary

PR #5 — Sécurisation backend des endpoints de saisie de notes (validations strictes, throttling anti-abus, transaction DB).

L'audit pré-PR avait identifié 4 trous :
1. Aucun throttling sur `save-ajax` / `save-ajax-bulk` (rule `exports-pdf-excel.md` exige throttle).
2. Validation incomplète : `note > bareme` accepté, `bareme = 0` accepté (division par zéro), pas de vérif `evaluation_id` cohérent.
3. `saveNoteAjax` (single) sans transaction DB (le bulk en avait une).
4. Filtre `workflow_step = etudiant_cree` absent → étudiants en pré-inscription dans la liste de saisie → notes orphelines possibles.

Tous fixés.

## Changes

### FormRequests stricts (3 nouveaux)
- `App\Http\Requests\Notes\StoreNoteRequest` — autorisation centralisée, custom rule `NoteRespectsBareme`, commentaire ≤ 500 chars, coercion `is_absent` boolean, retour JSON sur failedValidation.
- `App\Http\Requests\Notes\StoreBulkNotesRequest` — max 500 notes par batch (constante `MAX_NOTES_PER_BATCH`), borne haute défensive note ≤ 100, validation array.* sur chaque entrée.
- `App\Http\Requests\Evaluations\StoreEvaluationRequest` — pour future migration. Le store/update inline du `ESBTPEvaluationController` a été tightened en parallèle (`bareme min:0.1 max:100`, `coefficient min:0.1 max:10`, `duree_minutes min:1 max:480`).

### Custom Rule
- `App\Rules\NoteRespectsBareme` — vérifie note ≤ barème, rejette barème ≤ 0 (anti division par zéro), gracieusement passe sur null/non-numeric (délégué aux autres rules).

### Refacto controller
- `saveNoteAjax(StoreNoteRequest $request)` — wrappé dans `DB::transaction(...)`. Notifications absence dispatched **après commit** pour éviter rollback en cascade.
- `saveNotesAjaxBulk(StoreBulkNotesRequest $request)` — garde-fou cohérence note ≤ barème appliqué défense en profondeur.
- Logs serveur : retrait des `$e->getMessage()` bruts dans les réponses 500 (info-leak), conservés en `\Log::error` avec contexte (user_id, evaluation_id, etudiant_id).

### Filtre workflow_step = etudiant_cree
Appliqué partout où une liste d'étudiants est chargée pour saisie/affichage de notes :
- `ESBTPNoteController::saisieRapide` (page web saisie rapide)
- `ESBTPNoteController::buildSaisieRapidePdf` (PDF avec notes)
- `ESBTPNoteController::buildSaisieRapideBlankPdf` (PDF vierge classe)
- `ESBTPClasseController::students` (endpoint AJAX `/api/classes/{classe}/students` utilisé par la modal saisie sur `/esbtp/notes`)

### Throttling
| Route | Throttle | Type |
|---|---|---|
| POST /esbtp/notes/save-ajax | 30/min | écriture unitaire |
| POST /esbtp/notes/save-ajax-bulk | 10/min | écriture batch |
| POST /esbtp/notes/store-batch | 10/min | écriture batch (saisie rapide) |
| GET /esbtp/evaluations/{id}/saisie-rapide | 60/min | lecture |
| GET /api/evaluations/by-class-matiere | 60/min | lecture (modal saisie) |
| GET /api/classes/{classe}/students | 60/min | lecture (modal saisie) |

### CHANGELOG
- Sécurité : 4 entrées (throttling, validation backend, validation evaluation, filtre workflow_step).
- Améliorations : 1 entrée (transaction DB sur saveNoteAjax).

## Test plan

14 tests Pest dans `tests/Feature/Notes/NoteValidationTest.php` — **tous PASS** :

- [x] `it_rejects_negative_note` — note < 0 rejetée
- [x] `it_rejects_non_numeric_note` — note "abc" rejetée
- [x] `it_accepts_null_note_for_absent_student` — note null + is_absent OK
- [x] `it_rejects_oversize_comment` — commentaire > 500 chars rejeté
- [x] `it_rejects_bulk_exceeding_max_batch` — bulk avec 501 notes rejeté
- [x] `it_rejects_bulk_with_empty_notes_array` — bulk vide rejeté
- [x] `it_rejects_bulk_note_exceeding_upper_bound` — note > 100 rejetée
- [x] `it_accepts_valid_bulk_payload` — payload valide passe
- [x] `it_registers_throttle_middleware_on_critical_routes` — throttle 30/10/10 enregistré
- [x] `it_rejects_evaluation_with_zero_bareme` — bareme = 0 rejeté
- [x] `it_rejects_evaluation_with_excessive_coefficient` — coef = 50 rejeté
- [x] `note_respects_bareme_rule_fails_when_evaluation_id_invalid` — eval introuvable
- [x] `note_respects_bareme_rule_passes_for_null_value` — null OK (nullable)
- [x] `note_respects_bareme_rule_passes_for_non_numeric` — "abc" OK (numeric handle)

```
Tests:  14 passed
Time:   1.03s
```

## Notes

- Pas de test d'intégration full DB car les factories `ESBTPInscription` / `ESBTPEtudiant` / `ESBTPClasse` n'existent pas dans le repo (vérifié via `php artisan tinker`). Les tests d'intégration HTTP avec `actingAs()` + permissions Spatie + throttle reset nécessitent ce scaffolding qu'on laisse à une PR dédiée à la suite de tests.
- Boundary respectée : aucune modification au calcul moyenne (PR #1), Observer (PR #2), CSS/Blade UI (PR #4), LMD, ou aux migrations.
- Throttle Laravel cache la limite par route + IP (RateLimiter par défaut). Pour reset en test : `RateLimiter::clear($key)`.