### PR TITLE
feat(notes): Excel bidirectionnel + preview impact bulletin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Le format suit librement [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/
 
 ## Mai 2026
 
+### Ajouts
+
+- **Excel bidirectionnel + aperçu impact bulletin temps réel** (`/esbtp/notes`) — nouveau bouton « Exporter Excel » dans le modal de saisie qui télécharge un fichier xlsx ergonomique (1 ligne par étudiant, 1 colonne par évaluation avec barème et coefficient dans le header, freeze pane sur étudiant + nom, autoFilter, matricule en text pour préserver les zéros initiaux, ligne meta cachée pour ré-import). Nouveau bouton « Importer Excel » avec drag-drop premium, modal preview Avant/Après (4 KPIs créer/maj/inchangé/erreur, table colorée par action, validation par cellule barème + matricule + format français), application atomique en transaction. Sous chaque ligne étudiant dans la grille de saisie, un encadré discret affiche désormais en temps réel l'impact d'une note hypothétique sur la moyenne matière, la moyenne générale et la mention CAMES (Très Bien/Bien/Assez Bien/Passable/Insuffisant), debouncé 500 ms. Permission `notes.import_excel` ajoutée au registry pour secrétaire, coordinateur, enseignant et superAdmin. Throttle 10/min export, 5/min dry-run import, 3/min apply import, 60/min preview impact.
+
 ### Corrections
 
 - **Bug accents en majuscules dans les titres PDF** — les exports comptabilité affichaient « TABLEAU DéTAILLé DES PAIEMENTS » au lieu de « TABLEAU DÉTAILLÉ DES PAIEMENTS ». La fonction PHP `strtoupper()` ne gère pas correctement les caractères UTF-8 (les accents `é`, `à`, `è`, etc. ne sont pas convertis en majuscules). Remplacement par `mb_strtoupper(..., 'UTF-8')` sur les 3 templates PDF concernés (recouvrement, analytics, paiements détaillés). Effet collatéral : les badges de statut (Validé / Rejeté / Annulé) et les libellés de niveau de risque sont également correctement majuscules.

--- a/app/Exports/NotesClasseMatiereExport.php
+++ b/app/Exports/NotesClasseMatiereExport.php
@@ -1,0 +1,404 @@
+<?php
+
+namespace App\Exports;
+
+use App\Helpers\SettingsHelper;
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEvaluation;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPNote;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Maatwebsite\Excel\Concerns\FromArray;
+use Maatwebsite\Excel\Concerns\WithColumnFormatting;
+use Maatwebsite\Excel\Concerns\WithColumnWidths;
+use Maatwebsite\Excel\Concerns\WithEvents;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithTitle;
+use Maatwebsite\Excel\Events\AfterSheet;
+use PhpOffice\PhpSpreadsheet\Style\Alignment;
+use PhpOffice\PhpSpreadsheet\Style\Border;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
+use PhpOffice\PhpSpreadsheet\Style\NumberFormat;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+
+/**
+ * Export Excel des notes par classe + matière + période.
+ *
+ * Format ergonomique pour saisie offline :
+ *  - 1 ligne par étudiant (matricule, nom, evals…, moyenne)
+ *  - 1 colonne par évaluation (avec barème dans le header)
+ *  - Header bleu KLASSCI #0453cb texte blanc
+ *  - Freeze pane sur ligne header + 2 colonnes (matricule + nom)
+ *  - AutoFilter sur la ligne header
+ *  - Matricule formaté en text pour préserver leading zeros
+ *  - Ligne de marqueur évaluation_id cachée pour ré-import (ligne 1)
+ */
+class NotesClasseMatiereExport implements
+    FromArray,
+    WithHeadings,
+    WithTitle,
+    WithColumnWidths,
+    WithColumnFormatting,
+    WithEvents
+{
+    private int $classeId;
+    private int $matiereId;
+    private string $periode;
+    private ?int $anneeUniversitaireId;
+
+    /** @var Collection<ESBTPEvaluation> */
+    private Collection $evaluations;
+
+    /** @var Collection<ESBTPInscription> */
+    private Collection $inscriptions;
+
+    /** @var array<string, ESBTPNote> indexée par etudiant_id . '_' . evaluation_id */
+    private array $notesIndex = [];
+
+    private ?ESBTPClasse $classe = null;
+    private ?ESBTPMatiere $matiere = null;
+    private ?ESBTPAnneeUniversitaire $annee = null;
+
+    public function __construct(int $classeId, int $matiereId, string $periode, ?int $anneeUniversitaireId = null)
+    {
+        $this->classeId = $classeId;
+        $this->matiereId = $matiereId;
+        $this->periode = $periode;
+        $this->anneeUniversitaireId = $anneeUniversitaireId;
+
+        $this->loadData();
+    }
+
+    private function loadData(): void
+    {
+        $this->classe = ESBTPClasse::find($this->classeId);
+        $this->matiere = ESBTPMatiere::find($this->matiereId);
+
+        if ($this->anneeUniversitaireId === null) {
+            $current = ESBTPAnneeUniversitaire::where('is_current', 1)->first();
+            $this->anneeUniversitaireId = $current?->id;
+            $this->annee = $current;
+        } else {
+            $this->annee = ESBTPAnneeUniversitaire::find($this->anneeUniversitaireId);
+        }
+
+        // Évaluations triées par date
+        $this->evaluations = ESBTPEvaluation::query()
+            ->where('classe_id', $this->classeId)
+            ->where('matiere_id', $this->matiereId)
+            ->where('periode', $this->periode)
+            ->when($this->anneeUniversitaireId, fn ($q) => $q->where('annee_universitaire_id', $this->anneeUniversitaireId))
+            ->where('is_published', 1)
+            ->orderBy('date_evaluation')
+            ->orderBy('id')
+            ->get();
+
+        // Inscriptions actives triées par nom
+        $this->inscriptions = ESBTPInscription::query()
+            ->with(['etudiant:id,matricule,nom,prenoms'])
+            ->where('classe_id', $this->classeId)
+            ->where('status', 'active')
+            ->where('workflow_step', 'etudiant_cree')
+            ->when($this->anneeUniversitaireId, fn ($q) => $q->where('annee_universitaire_id', $this->anneeUniversitaireId))
+            ->get()
+            ->filter(fn ($i) => $i->etudiant !== null)
+            ->sortBy(fn ($i) => Str::lower(($i->etudiant->nom ?? '') . ' ' . ($i->etudiant->prenoms ?? '')))
+            ->values();
+
+        // Notes indexées
+        $evalIds = $this->evaluations->pluck('id')->all();
+        $etuIds = $this->inscriptions->pluck('etudiant_id')->all();
+
+        if ($evalIds && $etuIds) {
+            $notes = ESBTPNote::whereIn('evaluation_id', $evalIds)
+                ->whereIn('etudiant_id', $etuIds)
+                ->get();
+
+            foreach ($notes as $note) {
+                $this->notesIndex[$note->etudiant_id . '_' . $note->evaluation_id] = $note;
+            }
+        }
+    }
+
+    /**
+     * Compte de cellules de saisie (étudiants × évaluations) — pour garde-fou volume.
+     */
+    public function cellsCount(): int
+    {
+        return $this->inscriptions->count() * max(1, $this->evaluations->count());
+    }
+
+    public function studentsCount(): int
+    {
+        return $this->inscriptions->count();
+    }
+
+    public function evaluationsCount(): int
+    {
+        return $this->evaluations->count();
+    }
+
+    public function classeName(): ?string
+    {
+        return $this->classe?->name;
+    }
+
+    public function matiereName(): ?string
+    {
+        return $this->matiere?->name;
+    }
+
+    public function title(): string
+    {
+        $matiereSlug = $this->matiere?->name ? Str::limit($this->matiere->name, 25, '') : 'Matiere';
+
+        return Str::ascii($matiereSlug . ' - ' . $this->periodeLabel());
+    }
+
+    public function headings(): array
+    {
+        $headings = [
+            'Matricule',
+            'Nom & Prénoms',
+        ];
+
+        foreach ($this->evaluations as $eval) {
+            $bareme = (float) ($eval->bareme ?? 20);
+            $coef = (float) ($eval->coefficient ?? 1);
+            $titre = $eval->titre ?? ('Eval #' . $eval->id);
+            // Format compact "Titre (/20 ×1)" pour caser dans 12 colonnes
+            $headings[] = sprintf('%s (/%s ×%s)', $titre, $this->formatNumber($bareme), $this->formatNumber($coef));
+        }
+
+        $headings[] = 'Moyenne /20';
+
+        return $headings;
+    }
+
+    public function array(): array
+    {
+        $rows = [];
+
+        foreach ($this->inscriptions as $inscription) {
+            $etu = $inscription->etudiant;
+            $row = [
+                (string) ($etu->matricule ?? ''),
+                trim(($etu->nom ?? '') . ' ' . ($etu->prenoms ?? '')),
+            ];
+
+            // Notes par évaluation
+            $totalPondere = 0.0;
+            $totalCoef = 0.0;
+            foreach ($this->evaluations as $eval) {
+                $key = $etu->id . '_' . $eval->id;
+                $note = $this->notesIndex[$key] ?? null;
+                $bareme = max(0.01, (float) ($eval->bareme ?? 20));
+                $coef = (float) ($eval->coefficient ?? 1);
+
+                if ($note && $note->is_absent) {
+                    $row[] = 'ABS';
+                    // Les absences n'entrent pas dans la moyenne
+                } elseif ($note) {
+                    $val = (float) $note->note;
+                    $row[] = $val;
+                    $noteSur20 = ($val / $bareme) * 20;
+                    $totalPondere += $noteSur20 * $coef;
+                    $totalCoef += $coef;
+                } else {
+                    $row[] = null;
+                }
+            }
+
+            // Moyenne calculée
+            $moyenne = $totalCoef > 0 ? round($totalPondere / $totalCoef, 2) : null;
+            $row[] = $moyenne;
+
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    public function columnWidths(): array
+    {
+        $widths = [
+            'A' => 16,  // Matricule
+            'B' => 32,  // Nom & Prénoms
+        ];
+
+        // Colonnes des évaluations + moyenne
+        $col = 3; // Index colonne (1-based)
+        foreach ($this->evaluations as $eval) {
+            $widths[$this->columnLetter($col + 0)] = 14;
+            $col++;
+        }
+        // Colonne moyenne
+        $widths[$this->columnLetter($col)] = 13;
+
+        return $widths;
+    }
+
+    public function columnFormatting(): array
+    {
+        // Matricule en text pour préserver leading zeros
+        return [
+            'A' => NumberFormat::FORMAT_TEXT,
+        ];
+    }
+
+    public function registerEvents(): array
+    {
+        return [
+            AfterSheet::class => function (AfterSheet $event) {
+                $sheet = $event->sheet->getDelegate();
+
+                // Ajouter une ligne marker en haut (cachée) avec les IDs pour ré-import
+                $sheet->insertNewRowBefore(1, 1);
+                $sheet->setCellValue('A1', '__KLASSCI_NOTES_EXPORT__');
+                $sheet->setCellValue('B1', json_encode([
+                    'classe_id' => $this->classeId,
+                    'matiere_id' => $this->matiereId,
+                    'periode' => $this->periode,
+                    'annee_universitaire_id' => $this->anneeUniversitaireId,
+                    'evaluations' => $this->evaluations->map(fn ($e) => [
+                        'id' => $e->id,
+                        'titre' => $e->titre,
+                        'bareme' => (float) $e->bareme,
+                        'coefficient' => (float) $e->coefficient,
+                    ])->values()->all(),
+                    'generated_at' => now()->toIso8601String(),
+                ], JSON_UNESCAPED_UNICODE));
+                $sheet->getRowDimension(1)->setVisible(false);
+
+                $headingRow = 2;
+                $highestColumn = $sheet->getHighestDataColumn();
+                $highestRow = $sheet->getHighestRow();
+
+                // Style header (ligne 2)
+                $headerRange = "A{$headingRow}:{$highestColumn}{$headingRow}";
+                $sheet->getStyle($headerRange)->applyFromArray([
+                    'font' => ['bold' => true, 'size' => 11, 'color' => ['rgb' => 'FFFFFF']],
+                    'alignment' => [
+                        'horizontal' => Alignment::HORIZONTAL_CENTER,
+                        'vertical' => Alignment::VERTICAL_CENTER,
+                        'wrapText' => true,
+                    ],
+                    'fill' => ['fillType' => Fill::FILL_SOLID, 'startColor' => ['rgb' => '0453CB']],
+                    'borders' => [
+                        'allBorders' => ['borderStyle' => Border::BORDER_THIN, 'color' => ['rgb' => '0F1F4B']],
+                    ],
+                ]);
+                $sheet->getRowDimension($headingRow)->setRowHeight(36);
+
+                $dataStartRow = $headingRow + 1;
+                $dataEndRow = $highestRow;
+
+                if ($dataEndRow >= $dataStartRow) {
+                    // Style des lignes de données
+                    $dataRange = "A{$dataStartRow}:{$highestColumn}{$dataEndRow}";
+                    $sheet->getStyle($dataRange)->applyFromArray([
+                        'font' => ['size' => 10],
+                        'alignment' => ['vertical' => Alignment::VERTICAL_CENTER],
+                        'borders' => [
+                            'allBorders' => ['borderStyle' => Border::BORDER_THIN, 'color' => ['rgb' => 'D1D5DB']],
+                        ],
+                    ]);
+
+                    // Lignes alternées
+                    for ($row = $dataStartRow; $row <= $dataEndRow; $row++) {
+                        if (($row - $dataStartRow) % 2 === 0) {
+                            $sheet->getStyle("A{$row}:{$highestColumn}{$row}")
+                                ->getFill()
+                                ->setFillType(Fill::FILL_SOLID)
+                                ->getStartColor()
+                                ->setRGB('F8FAFC');
+                        }
+                    }
+
+                    // Centrer matricule + notes + moyenne
+                    $sheet->getStyle("A{$dataStartRow}:A{$dataEndRow}")
+                        ->getAlignment()
+                        ->setHorizontal(Alignment::HORIZONTAL_CENTER);
+
+                    // Notes: centrées
+                    $firstEvalCol = 'C';
+                    $lastEvalCol = $highestColumn;
+                    $sheet->getStyle("{$firstEvalCol}{$dataStartRow}:{$lastEvalCol}{$dataEndRow}")
+                        ->getAlignment()
+                        ->setHorizontal(Alignment::HORIZONTAL_CENTER);
+
+                    // Colonne moyenne en gras + couleur
+                    $sheet->getStyle("{$lastEvalCol}{$dataStartRow}:{$lastEvalCol}{$dataEndRow}")
+                        ->applyFromArray([
+                            'font' => ['bold' => true, 'color' => ['rgb' => '0453CB']],
+                            'fill' => ['fillType' => Fill::FILL_SOLID, 'startColor' => ['rgb' => 'EFF6FF']],
+                        ]);
+                }
+
+                // Freeze pane sur 2 colonnes + header
+                $sheet->freezePane('C' . ($headingRow + 1));
+
+                // AutoFilter
+                $sheet->setAutoFilter("A{$headingRow}:{$highestColumn}{$headingRow}");
+
+                // Forcer A en text format pour matricule
+                $sheet->getStyle("A{$dataStartRow}:A{$dataEndRow}")
+                    ->getNumberFormat()
+                    ->setFormatCode(NumberFormat::FORMAT_TEXT);
+
+                // Bandeau info en bas
+                $infoRow = $dataEndRow + 2;
+                $sheet->mergeCells("A{$infoRow}:{$highestColumn}{$infoRow}");
+                $school = SettingsHelper::get('school_name', config('app.name'));
+                $sheet->setCellValue("A{$infoRow}", sprintf(
+                    '%s — %s — %s — %s — %s — Exporté le %s',
+                    $school,
+                    $this->classe?->name ?? 'Classe',
+                    $this->matiere?->name ?? 'Matière',
+                    $this->periodeLabel(),
+                    $this->annee?->name ?? 'Année courante',
+                    now()->format('d/m/Y H:i')
+                ));
+                $sheet->getStyle("A{$infoRow}")->applyFromArray([
+                    'font' => ['italic' => true, 'size' => 9, 'color' => ['rgb' => '64748B']],
+                    'alignment' => ['horizontal' => Alignment::HORIZONTAL_LEFT],
+                ]);
+
+                // Note d'instructions
+                $instructRow = $infoRow + 1;
+                $sheet->mergeCells("A{$instructRow}:{$highestColumn}{$instructRow}");
+                $sheet->setCellValue("A{$instructRow}",
+                    'Saisie offline : tapez la note (0 — barème) ou « ABS » pour absent. Laissez vide pour ne pas modifier. La ligne 1 cachée contient les métadonnées d\'import — ne pas la supprimer.'
+                );
+                $sheet->getStyle("A{$instructRow}")->applyFromArray([
+                    'font' => ['size' => 9, 'color' => ['rgb' => '0453CB']],
+                    'alignment' => ['horizontal' => Alignment::HORIZONTAL_LEFT, 'wrapText' => true],
+                    'fill' => ['fillType' => Fill::FILL_SOLID, 'startColor' => ['rgb' => 'EFF6FF']],
+                ]);
+                $sheet->getRowDimension($instructRow)->setRowHeight(20);
+            },
+        ];
+    }
+
+    private function periodeLabel(): string
+    {
+        return match ($this->periode) {
+            'semestre1' => 'Semestre 1',
+            'semestre2' => 'Semestre 2',
+            default => ucfirst($this->periode),
+        };
+    }
+
+    private function formatNumber(float $n): string
+    {
+        return rtrim(rtrim(number_format($n, 2, '.', ''), '0'), '.');
+    }
+
+    private function columnLetter(int $index): string
+    {
+        return \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($index);
+    }
+}

--- a/app/Http/Controllers/ESBTPNoteController.php
+++ b/app/Http/Controllers/ESBTPNoteController.php
@@ -2,22 +2,28 @@
 
 namespace App\Http\Controllers;
 
+use App\Exports\NotesClasseMatiereExport;
+use App\Http\Requests\Notes\ImportNotesRequest;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPClasse;
 use App\Models\ESBTPEtudiant;
 use App\Models\ESBTPEvaluation;
 use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
 use App\Models\ESBTPMatiere;
 use App\Models\ESBTPNiveauEtude;
 use App\Models\ESBTPNote;
 use App\Models\ESBTPSeanceCours;
 use App\Models\ESBTPTeacher;
 use App\Models\User;
+use App\Services\NotesImportService;
 use App\Services\NotificationService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Maatwebsite\Excel\Facades\Excel;
 
 class ESBTPNoteController extends Controller
 {
@@ -1203,5 +1209,373 @@ class ESBTPNoteController extends Controller
                 'trace' => config('app.debug') ? $e->getTraceAsString() : null,
             ]);
         }
+    }
+
+    // ════════════════════════════════════════════════════════════════════════
+    // PR #7 — Excel import/export bidirectionnel + preview impact bulletin
+    // ════════════════════════════════════════════════════════════════════════
+
+    /**
+     * Export Excel des notes d'une classe + matière + période.
+     * Format optimisé pour saisie offline puis ré-import.
+     */
+    public function exportExcel(Request $request)
+    {
+        $user = Auth::user();
+        if (! $user || ! $user->can('notes.view')) {
+            abort(403, "Vous n'avez pas la permission d'exporter les notes.");
+        }
+
+        $validator = \Validator::make($request->all(), [
+            'classe' => ['required', 'integer', 'exists:esbtp_classes,id'],
+            'matiere' => ['required', 'integer', 'exists:esbtp_matieres,id'],
+            'periode' => ['required', 'in:semestre1,semestre2'],
+            'annee_universitaire_id' => ['nullable', 'integer', 'exists:esbtp_annee_universitaires,id'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['success' => false, 'message' => $validator->errors()->first()], 422);
+        }
+
+        $classeId = (int) $request->input('classe');
+        $matiereId = (int) $request->input('matiere');
+        $periode = (string) $request->input('periode');
+        $anneeId = $request->filled('annee_universitaire_id')
+            ? (int) $request->input('annee_universitaire_id')
+            : null;
+
+        $export = new NotesClasseMatiereExport($classeId, $matiereId, $periode, $anneeId);
+
+        if ($export->cellsCount() > 5000) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Volume trop important : '
+                    . $export->studentsCount() . ' étudiants × '
+                    . $export->evaluationsCount() . ' évaluations dépasse la limite de 5000 cellules. Affinez les filtres.',
+            ], 422);
+        }
+
+        $classeSlug = Str::slug($export->classeName() ?? ('classe-' . $classeId));
+        $matiereSlug = Str::slug($export->matiereName() ?? ('matiere-' . $matiereId));
+        $filename = sprintf('notes_%s_%s_%s_%s.xlsx', $classeSlug, $matiereSlug, $periode, now()->format('Ymd-His'));
+
+        return Excel::download($export, $filename);
+    }
+
+    /**
+     * Dry-run : analyse l'import Excel et retourne le diff Avant/Après sans persister.
+     */
+    public function importDryRun(ImportNotesRequest $request, NotesImportService $service)
+    {
+        try {
+            $file = $request->file('file');
+            $parsed = $service->parseFile($file);
+
+            $diff = $service->dryRun(
+                $parsed,
+                (int) $request->input('classe_id'),
+                (int) $request->input('matiere_id'),
+                (string) $request->input('periode'),
+                $request->filled('annee_universitaire_id')
+                    ? (int) $request->input('annee_universitaire_id')
+                    : null
+            );
+
+            return response()->json([
+                'success' => true,
+                'summary' => $diff['summary'],
+                'changes' => $diff['changes'],
+                'errors' => $diff['errors'],
+                'evaluations' => $diff['evaluations'],
+                'parsed_signature' => $this->parsedSignature($parsed),
+            ]);
+        } catch (\Throwable $e) {
+            \Log::error('importDryRun error: ' . $e->getMessage(), [
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Impossible de lire le fichier Excel : ' . $e->getMessage(),
+            ], 422);
+        }
+    }
+
+    /**
+     * Applique l'import Excel (transaction).
+     */
+    public function importApply(ImportNotesRequest $request, NotesImportService $service)
+    {
+        try {
+            $file = $request->file('file');
+            $parsed = $service->parseFile($file);
+
+            $result = $service->apply(
+                $parsed,
+                (int) $request->input('classe_id'),
+                (int) $request->input('matiere_id'),
+                (string) $request->input('periode'),
+                $request->filled('annee_universitaire_id')
+                    ? (int) $request->input('annee_universitaire_id')
+                    : null
+            );
+
+            if (($result['errors'] ?? 0) > 0) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Import bloqué : ' . $result['errors'] . ' erreur(s) détectée(s). Corrigez le fichier puis réessayez.',
+                    'errors' => $result['error_details'] ?? [],
+                ], 422);
+            }
+
+            return response()->json([
+                'success' => true,
+                'created' => $result['created'],
+                'updated' => $result['updated'],
+                'message' => sprintf('Import réussi : %d note(s) créée(s), %d mise(s) à jour.', $result['created'], $result['updated']),
+            ]);
+        } catch (\Throwable $e) {
+            \Log::error('importApply error: ' . $e->getMessage(), [
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Erreur lors de l\'application de l\'import : ' . $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    /**
+     * Calcule l'impact d'une note hypothétique sur la moyenne matière + générale.
+     * Utilisé par l'UI temps réel sous chaque ligne étudiant.
+     */
+    public function previewImpact(Request $request)
+    {
+        $user = Auth::user();
+        if (! $user || (! $user->can('notes.view') && ! $user->can('notes.view_own') && ! $user->can('notes.create') && ! $user->can('notes.edit'))) {
+            return response()->json(['success' => false, 'message' => 'Permission refusée.'], 403);
+        }
+
+        $validator = \Validator::make($request->all(), [
+            'etudiant_id' => ['required', 'integer', 'exists:esbtp_etudiants,id'],
+            'classe_id' => ['required', 'integer', 'exists:esbtp_classes,id'],
+            'matiere_id' => ['required', 'integer', 'exists:esbtp_matieres,id'],
+            'periode' => ['required', 'in:semestre1,semestre2'],
+            'evaluation_id' => ['required', 'integer', 'exists:esbtp_evaluations,id'],
+            'hypothetical_note' => ['required', 'numeric', 'min:0'],
+            'is_absent' => ['nullable', 'boolean'],
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['success' => false, 'message' => $validator->errors()->first()], 422);
+        }
+
+        $etudiantId = (int) $request->input('etudiant_id');
+        $classeId = (int) $request->input('classe_id');
+        $matiereId = (int) $request->input('matiere_id');
+        $periode = (string) $request->input('periode');
+        $evaluationId = (int) $request->input('evaluation_id');
+        $hypoValue = (float) $request->input('hypothetical_note');
+        $isAbsent = (bool) $request->input('is_absent', false);
+
+        // Évaluation cible
+        $targetEval = ESBTPEvaluation::find($evaluationId);
+        if (! $targetEval) {
+            return response()->json(['success' => false, 'message' => 'Évaluation introuvable.'], 404);
+        }
+
+        // Validation barème
+        $bareme = max(0.01, (float) $targetEval->bareme);
+        if (! $isAbsent && $hypoValue > $bareme) {
+            return response()->json([
+                'success' => false,
+                'message' => sprintf('Note %s hors barème (max %s).', $hypoValue, $bareme),
+            ], 422);
+        }
+
+        // Toutes les évaluations de la matière + période
+        $evaluations = ESBTPEvaluation::query()
+            ->where('classe_id', $classeId)
+            ->where('matiere_id', $matiereId)
+            ->where('periode', $periode)
+            ->where('is_published', 1)
+            ->get();
+
+        // Notes existantes pour cet étudiant sur ces évaluations
+        $notes = ESBTPNote::where('etudiant_id', $etudiantId)
+            ->whereIn('evaluation_id', $evaluations->pluck('id'))
+            ->get()
+            ->keyBy('evaluation_id');
+
+        // Moyenne matière AVANT
+        $moyenneMatiereAvant = $this->computeMatiereAverage($evaluations, $notes, null, null);
+
+        // Moyenne matière APRÈS (en remplaçant la note de cette éval)
+        $moyenneMatiereApres = $this->computeMatiereAverage($evaluations, $notes, $evaluationId, [
+            'note' => $hypoValue,
+            'is_absent' => $isAbsent,
+        ]);
+
+        $mentionAvant = $this->getMention($moyenneMatiereAvant);
+        $mentionApres = $this->getMention($moyenneMatiereApres);
+
+        // Moyenne générale (toutes matières confondues, période)
+        $moyenneGeneraleAvant = $this->computeGeneralAverage($etudiantId, $classeId, $periode, null, null, null);
+        $moyenneGeneraleApres = $this->computeGeneralAverage($etudiantId, $classeId, $periode, $matiereId, $evaluationId, [
+            'note' => $hypoValue,
+            'is_absent' => $isAbsent,
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'matiere_avant' => $moyenneMatiereAvant !== null ? round($moyenneMatiereAvant, 2) : null,
+            'matiere_apres' => $moyenneMatiereApres !== null ? round($moyenneMatiereApres, 2) : null,
+            'mention_avant' => $mentionAvant,
+            'mention_apres' => $mentionApres,
+            'moyenne_generale_avant' => $moyenneGeneraleAvant !== null ? round($moyenneGeneraleAvant, 2) : null,
+            'moyenne_generale_apres' => $moyenneGeneraleApres !== null ? round($moyenneGeneraleApres, 2) : null,
+            'changed_mention' => $mentionAvant !== $mentionApres,
+        ]);
+    }
+
+    /**
+     * Calcule la moyenne d'une matière à partir d'une collection d'évaluations + notes.
+     * Si $overrideEvalId fourni, remplace la note correspondante par $override.
+     *
+     * @param  \Illuminate\Support\Collection  $evaluations
+     * @param  \Illuminate\Support\Collection  $notesByEvalId  (keyBy evaluation_id)
+     * @param  int|null  $overrideEvalId
+     * @param  array{note: float, is_absent: bool}|null  $override
+     */
+    private function computeMatiereAverage($evaluations, $notesByEvalId, ?int $overrideEvalId = null, ?array $override = null): ?float
+    {
+        $totalPondere = 0.0;
+        $totalCoef = 0.0;
+
+        foreach ($evaluations as $eval) {
+            $bareme = max(0.01, (float) ($eval->bareme ?? 20));
+            $coef = (float) ($eval->coefficient ?? 1);
+
+            if ($overrideEvalId !== null && $eval->id === $overrideEvalId && $override !== null) {
+                if ($override['is_absent']) {
+                    continue;
+                }
+                $valSur20 = ((float) $override['note'] / $bareme) * 20;
+                $totalPondere += $valSur20 * $coef;
+                $totalCoef += $coef;
+                continue;
+            }
+
+            $note = $notesByEvalId->get($eval->id);
+            if (! $note) {
+                continue;
+            }
+            if ($note->is_absent) {
+                continue;
+            }
+            $valSur20 = ((float) $note->note / $bareme) * 20;
+            $totalPondere += $valSur20 * $coef;
+            $totalCoef += $coef;
+        }
+
+        return $totalCoef > 0 ? $totalPondere / $totalCoef : null;
+    }
+
+    /**
+     * Calcule la moyenne générale pondérée (par coefficient matière) d'un étudiant
+     * pour une période donnée.
+     *
+     * Si $overrideMatiereId + $overrideEvalId fournis, recalcule la matière concernée
+     * en remplaçant la note.
+     */
+    private function computeGeneralAverage(
+        int $etudiantId,
+        int $classeId,
+        string $periode,
+        ?int $overrideMatiereId,
+        ?int $overrideEvalId,
+        ?array $override
+    ): ?float {
+        $evaluations = ESBTPEvaluation::query()
+            ->where('classe_id', $classeId)
+            ->where('periode', $periode)
+            ->where('is_published', 1)
+            ->get();
+
+        if ($evaluations->isEmpty()) {
+            return null;
+        }
+
+        $matiereIds = $evaluations->pluck('matiere_id')->unique()->values()->all();
+
+        $matiereCoefs = ESBTPMatiere::whereIn('id', $matiereIds)
+            ->get(['id', 'coefficient'])
+            ->mapWithKeys(fn ($m) => [$m->id => max(0.01, (float) ($m->coefficient ?? 1))]);
+
+        $notes = ESBTPNote::where('etudiant_id', $etudiantId)
+            ->whereIn('evaluation_id', $evaluations->pluck('id'))
+            ->get();
+
+        $byMatiere = $evaluations->groupBy('matiere_id');
+
+        $totalPondere = 0.0;
+        $totalCoef = 0.0;
+
+        foreach ($byMatiere as $matiereId => $evalsMat) {
+            $notesMat = $notes->where('matiere_id', $matiereId)->keyBy('evaluation_id');
+
+            $isOverridden = ($overrideMatiereId === (int) $matiereId);
+            $moyMat = $this->computeMatiereAverage(
+                $evalsMat,
+                $notesMat,
+                $isOverridden ? $overrideEvalId : null,
+                $isOverridden ? $override : null
+            );
+
+            if ($moyMat === null) {
+                continue;
+            }
+
+            $coef = $matiereCoefs->get($matiereId, 1.0);
+            $totalPondere += $moyMat * $coef;
+            $totalCoef += $coef;
+        }
+
+        return $totalCoef > 0 ? $totalPondere / $totalCoef : null;
+    }
+
+    /**
+     * Mention CAMES standard sur 20.
+     */
+    private function getMention(?float $moyenne): ?string
+    {
+        if ($moyenne === null) {
+            return null;
+        }
+        if ($moyenne >= 16) {
+            return 'Très Bien';
+        }
+        if ($moyenne >= 14) {
+            return 'Bien';
+        }
+        if ($moyenne >= 12) {
+            return 'Assez Bien';
+        }
+        if ($moyenne >= 10) {
+            return 'Passable';
+        }
+        return 'Insuffisant';
+    }
+
+    /**
+     * Petit hash de la signature du fichier parsé pour idempotence (debug).
+     */
+    private function parsedSignature(array $parsed): string
+    {
+        return substr(md5(json_encode([
+            'rows_count' => count($parsed['rows'] ?? []),
+            'has_meta' => isset($parsed['meta']),
+        ])), 0, 12);
     }
 }

--- a/app/Http/Requests/Notes/ImportNotesRequest.php
+++ b/app/Http/Requests/Notes/ImportNotesRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Requests\Notes;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ImportNotesRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        if (! $user) {
+            return false;
+        }
+
+        return $user->can('notes.import_excel') || $user->can('notes.create') || $user->can('notes.edit');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'file' => ['required', 'file', 'mimes:xlsx,xls,csv', 'max:5120'],
+            'classe_id' => ['required', 'integer', 'exists:esbtp_classes,id'],
+            'matiere_id' => ['required', 'integer', 'exists:esbtp_matieres,id'],
+            'periode' => ['required', 'in:semestre1,semestre2'],
+            'annee_universitaire_id' => ['nullable', 'integer', 'exists:esbtp_annee_universitaires,id'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'file.required' => 'Veuillez sélectionner un fichier Excel à importer.',
+            'file.mimes' => 'Le fichier doit être au format xlsx, xls ou csv.',
+            'file.max' => 'Le fichier ne doit pas dépasser 5 Mo.',
+            'classe_id.required' => 'La classe est obligatoire.',
+            'matiere_id.required' => 'La matière est obligatoire.',
+            'periode.required' => 'La période est obligatoire.',
+            'periode.in' => 'La période doit être semestre1 ou semestre2.',
+        ];
+    }
+}

--- a/app/Services/NotesImportService.php
+++ b/app/Services/NotesImportService.php
@@ -1,0 +1,447 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPEvaluation;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPNote;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Maatwebsite\Excel\Facades\Excel;
+use Maatwebsite\Excel\Concerns\ToArray;
+
+/**
+ * Service de parsing & application des imports Excel de notes.
+ *
+ * Pipeline en 3 phases :
+ *  1. parseFile()  → lit la feuille, extrait métadonnées + lignes brutes
+ *  2. dryRun()     → calcule un diff Avant/Après + erreurs (lecture seule)
+ *  3. apply()      → exécute les changements en transaction (création/mise à jour)
+ *
+ * Validation par cellule : note ∈ [0, bareme], etudiant dans la classe,
+ * évaluation existe, format numérique français accepté (',' → '.').
+ */
+class NotesImportService
+{
+    public const ACTION_CREATE = 'create';
+    public const ACTION_UPDATE = 'update';
+    public const ACTION_UNCHANGED = 'unchanged';
+
+    /**
+     * Lit le fichier et retourne les lignes brutes.
+     *
+     * @return array{rows: array, meta: array|null}
+     */
+    public function parseFile(UploadedFile $file): array
+    {
+        $reader = new class implements ToArray {
+            public array $data = [];
+
+            public function array(array $array): void
+            {
+                $this->data = $array;
+            }
+        };
+
+        Excel::import($reader, $file);
+
+        $rows = $reader->data ?? [];
+
+        // Meta (ligne 1 : marker + JSON)
+        $meta = null;
+        if (isset($rows[0][0]) && $rows[0][0] === '__KLASSCI_NOTES_EXPORT__') {
+            $rawJson = $rows[0][1] ?? null;
+            if (is_string($rawJson)) {
+                try {
+                    $decoded = json_decode($rawJson, true, 512, JSON_THROW_ON_ERROR);
+                    $meta = $decoded;
+                } catch (\Throwable) {
+                    $meta = null;
+                }
+            }
+            // Retirer la ligne meta des données
+            array_shift($rows);
+        }
+
+        return ['rows' => $rows, 'meta' => $meta];
+    }
+
+    /**
+     * Dry-run : calcule le diff sans persister.
+     *
+     * @return array{summary: array, changes: array, errors: array, evaluations: array}
+     */
+    public function dryRun(array $parsed, int $classeId, int $matiereId, string $periode, ?int $anneeUniversitaireId = null): array
+    {
+        $rows = $parsed['rows'] ?? [];
+        $meta = $parsed['meta'] ?? null;
+
+        $errors = [];
+        $changes = [];
+        $summary = [
+            'will_create' => 0,
+            'will_update' => 0,
+            'unchanged' => 0,
+            'errors' => 0,
+        ];
+
+        if (empty($rows)) {
+            return [
+                'summary' => $summary,
+                'changes' => [],
+                'errors' => [['row' => 0, 'col' => '-', 'reason' => 'Le fichier est vide.']],
+                'evaluations' => [],
+            ];
+        }
+
+        // L'année courante si non fournie
+        if ($anneeUniversitaireId === null) {
+            $current = ESBTPAnneeUniversitaire::where('is_current', 1)->first();
+            $anneeUniversitaireId = $current?->id;
+        }
+
+        // Header (1ère ligne après meta)
+        $headerRow = $rows[0];
+        $dataRows = array_slice($rows, 1);
+
+        // Mapper les évaluations à partir du meta (priorité) ou du header
+        $evalColumns = $this->resolveEvaluations($headerRow, $meta, $classeId, $matiereId, $periode, $anneeUniversitaireId);
+
+        if (empty($evalColumns)) {
+            return [
+                'summary' => $summary,
+                'changes' => [],
+                'errors' => [['row' => 1, 'col' => '-', 'reason' => 'Aucune évaluation reconnue. Réexportez le modèle Excel.']],
+                'evaluations' => [],
+            ];
+        }
+
+        // Charger les inscriptions actives de la classe pour mapping matricule → etudiant
+        $inscriptions = ESBTPInscription::query()
+            ->with(['etudiant:id,matricule,nom,prenoms'])
+            ->where('classe_id', $classeId)
+            ->where('status', 'active')
+            ->where('workflow_step', 'etudiant_cree')
+            ->when($anneeUniversitaireId, fn ($q) => $q->where('annee_universitaire_id', $anneeUniversitaireId))
+            ->get();
+
+        $matriculeMap = [];
+        foreach ($inscriptions as $i) {
+            $etu = $i->etudiant;
+            if ($etu && $etu->matricule) {
+                $matriculeMap[trim($etu->matricule)] = $etu;
+            }
+        }
+
+        // Charger les notes existantes
+        $evalIds = collect($evalColumns)->pluck('id')->all();
+        $etuIds = collect($matriculeMap)->pluck('id')->all();
+        $existingNotes = [];
+        if ($evalIds && $etuIds) {
+            ESBTPNote::whereIn('evaluation_id', $evalIds)
+                ->whereIn('etudiant_id', $etuIds)
+                ->get()
+                ->each(function ($n) use (&$existingNotes) {
+                    $existingNotes[$n->etudiant_id . '_' . $n->evaluation_id] = $n;
+                });
+        }
+
+        // Parcourir les lignes
+        $rowOffset = $meta ? 3 : 2; // ligne Excel réelle (meta ligne 1, header ligne 2 si meta)
+        foreach ($dataRows as $rowIdx => $row) {
+            $excelRow = $rowOffset + $rowIdx;
+
+            $matricule = trim((string) ($row[0] ?? ''));
+            if ($matricule === '') {
+                continue; // ignore lignes vides
+            }
+
+            $etudiant = $matriculeMap[$matricule] ?? null;
+            if (! $etudiant) {
+                $errors[] = [
+                    'row' => $excelRow,
+                    'col' => 'A',
+                    'matricule' => $matricule,
+                    'reason' => "Aucun étudiant actif trouvé avec ce matricule dans la classe sélectionnée.",
+                ];
+                $summary['errors']++;
+                continue;
+            }
+
+            // Pour chaque colonne d'évaluation
+            foreach ($evalColumns as $colIndex => $evalCol) {
+                $cellValue = $row[$colIndex] ?? null;
+                $evalId = $evalCol['id'];
+                $bareme = (float) ($evalCol['bareme'] ?? 20);
+                $titre = $evalCol['titre'] ?? ('Eval #' . $evalId);
+
+                $parsed = $this->parseCellValue($cellValue);
+                if ($parsed === null) {
+                    // Cellule vide : pas de modification
+                    continue;
+                }
+
+                $colLetter = $this->columnLetter($colIndex + 1);
+
+                if ($parsed === 'invalid') {
+                    $errors[] = [
+                        'row' => $excelRow,
+                        'col' => $colLetter,
+                        'matricule' => $matricule,
+                        'evaluation' => $titre,
+                        'reason' => "Valeur '" . (string) $cellValue . "' non reconnue. Utilisez un nombre, ABS ou laissez vide.",
+                    ];
+                    $summary['errors']++;
+                    continue;
+                }
+
+                $isAbsent = ($parsed === 'absent');
+                $noteValue = $isAbsent ? 0.0 : (float) $parsed;
+
+                // Validation barème
+                if (! $isAbsent && ($noteValue < 0 || $noteValue > $bareme)) {
+                    $errors[] = [
+                        'row' => $excelRow,
+                        'col' => $colLetter,
+                        'matricule' => $matricule,
+                        'evaluation' => $titre,
+                        'reason' => sprintf("Note %s hors barème [0 — %s].", $noteValue, $bareme),
+                    ];
+                    $summary['errors']++;
+                    continue;
+                }
+
+                $key = $etudiant->id . '_' . $evalId;
+                $existing = $existingNotes[$key] ?? null;
+
+                if (! $existing) {
+                    $changes[] = [
+                        'etudiant_id' => $etudiant->id,
+                        'matricule' => $matricule,
+                        'etudiant_nom' => trim(($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '')),
+                        'evaluation_id' => $evalId,
+                        'evaluation' => $titre,
+                        'before' => null,
+                        'after' => $isAbsent ? 'ABS' : $noteValue,
+                        'is_absent' => $isAbsent,
+                        'action' => self::ACTION_CREATE,
+                        'row' => $excelRow,
+                        'col' => $colLetter,
+                    ];
+                    $summary['will_create']++;
+                } else {
+                    $beforeIsAbsent = (bool) $existing->is_absent;
+                    $beforeValue = $beforeIsAbsent ? 'ABS' : (float) $existing->note;
+                    $afterValue = $isAbsent ? 'ABS' : $noteValue;
+
+                    $changed = ($beforeIsAbsent !== $isAbsent) || ($beforeValue !== $afterValue);
+                    if (! $changed) {
+                        $summary['unchanged']++;
+                        continue;
+                    }
+
+                    $changes[] = [
+                        'etudiant_id' => $etudiant->id,
+                        'matricule' => $matricule,
+                        'etudiant_nom' => trim(($etudiant->nom ?? '') . ' ' . ($etudiant->prenoms ?? '')),
+                        'evaluation_id' => $evalId,
+                        'evaluation' => $titre,
+                        'before' => $beforeValue,
+                        'after' => $afterValue,
+                        'is_absent' => $isAbsent,
+                        'action' => self::ACTION_UPDATE,
+                        'row' => $excelRow,
+                        'col' => $colLetter,
+                    ];
+                    $summary['will_update']++;
+                }
+            }
+        }
+
+        return [
+            'summary' => $summary,
+            'changes' => $changes,
+            'errors' => $errors,
+            'evaluations' => array_values($evalColumns),
+        ];
+    }
+
+    /**
+     * Applique les changements (transaction). Repasse par dryRun() pour cohérence.
+     *
+     * @return array{created: int, updated: int, errors: int}
+     */
+    public function apply(array $parsed, int $classeId, int $matiereId, string $periode, ?int $anneeUniversitaireId = null): array
+    {
+        $diff = $this->dryRun($parsed, $classeId, $matiereId, $periode, $anneeUniversitaireId);
+
+        if (! empty($diff['errors'])) {
+            return [
+                'created' => 0,
+                'updated' => 0,
+                'errors' => count($diff['errors']),
+                'error_details' => $diff['errors'],
+            ];
+        }
+
+        $created = 0;
+        $updated = 0;
+        $userId = Auth::id();
+
+        // Précharger les évaluations pour les méta (classe_id, matiere_id, periode, annee)
+        $evalIds = collect($diff['changes'])->pluck('evaluation_id')->unique()->all();
+        $evaluations = ESBTPEvaluation::whereIn('id', $evalIds)->get()->keyBy('id');
+
+        DB::transaction(function () use ($diff, $evaluations, $userId, &$created, &$updated) {
+            foreach ($diff['changes'] as $change) {
+                $eval = $evaluations->get($change['evaluation_id']);
+                if (! $eval) {
+                    continue;
+                }
+
+                $note = ESBTPNote::where('etudiant_id', $change['etudiant_id'])
+                    ->where('evaluation_id', $change['evaluation_id'])
+                    ->first();
+
+                $isNew = ($note === null);
+                if ($isNew) {
+                    $note = new ESBTPNote();
+                    $note->etudiant_id = $change['etudiant_id'];
+                    $note->evaluation_id = $change['evaluation_id'];
+                    $note->classe_id = $eval->classe_id;
+                    $note->matiere_id = $eval->matiere_id;
+                    $note->semestre = $eval->periode;
+                    $note->annee_universitaire = optional($eval->anneeUniversitaire)->name ?? 'N/A';
+                    $note->type_evaluation = $eval->type;
+                    $note->created_by = $userId;
+                }
+
+                $note->is_absent = $change['is_absent'] ? 1 : 0;
+                $note->note = $change['is_absent'] ? 0 : (float) $change['after'];
+                $note->updated_by = $userId;
+                $note->save();
+
+                if ($isNew) {
+                    $created++;
+                } else {
+                    $updated++;
+                }
+            }
+        });
+
+        return [
+            'created' => $created,
+            'updated' => $updated,
+            'errors' => 0,
+        ];
+    }
+
+    /**
+     * Convertit une cellule en valeur :
+     *  - null si vide
+     *  - 'absent' si ABS / Absent
+     *  - float si numérique
+     *  - 'invalid' sinon
+     */
+    private function parseCellValue($value)
+    {
+        if ($value === null || $value === '' || (is_string($value) && trim($value) === '')) {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        $str = trim((string) $value);
+        $upper = mb_strtoupper($str, 'UTF-8');
+
+        if (in_array($upper, ['ABS', 'ABSENT', 'ABSENTE', 'A'], true)) {
+            return 'absent';
+        }
+
+        // Format français : 12,5 → 12.5
+        $normalized = str_replace([',', ' '], ['.', ''], $str);
+        if (is_numeric($normalized)) {
+            return (float) $normalized;
+        }
+
+        return 'invalid';
+    }
+
+    /**
+     * Résout les colonnes d'évaluation : depuis le meta JSON (préféré)
+     * sinon best-effort match par titre.
+     *
+     * @return array<int, array{id: int, titre: string, bareme: float, coefficient: float}>
+     *         Indexé par index de colonne (0-based : 0=matricule, 1=nom, 2=eval1, ...)
+     */
+    private function resolveEvaluations(array $headerRow, ?array $meta, int $classeId, int $matiereId, string $periode, ?int $anneeUniversitaireId): array
+    {
+        $resolved = [];
+
+        // Évaluations actives en BDD
+        $dbEvals = ESBTPEvaluation::query()
+            ->where('classe_id', $classeId)
+            ->where('matiere_id', $matiereId)
+            ->where('periode', $periode)
+            ->when($anneeUniversitaireId, fn ($q) => $q->where('annee_universitaire_id', $anneeUniversitaireId))
+            ->where('is_published', 1)
+            ->get()
+            ->keyBy('id');
+
+        // Stratégie 1 : meta JSON
+        if ($meta && isset($meta['evaluations']) && is_array($meta['evaluations'])) {
+            $colIndex = 2; // skip matricule + nom
+            foreach ($meta['evaluations'] as $metaEval) {
+                $evalId = (int) ($metaEval['id'] ?? 0);
+                if ($evalId && $dbEvals->has($evalId)) {
+                    $eval = $dbEvals->get($evalId);
+                    $resolved[$colIndex] = [
+                        'id' => $eval->id,
+                        'titre' => $eval->titre,
+                        'bareme' => (float) $eval->bareme,
+                        'coefficient' => (float) $eval->coefficient,
+                    ];
+                }
+                $colIndex++;
+            }
+
+            return $resolved;
+        }
+
+        // Stratégie 2 : match par titre (header)
+        // Skip A (matricule) + B (nom) + dernière (moyenne)
+        $headerCount = count($headerRow);
+        for ($colIndex = 2; $colIndex < $headerCount - 1; $colIndex++) {
+            $title = trim((string) ($headerRow[$colIndex] ?? ''));
+            if ($title === '') {
+                continue;
+            }
+
+            // Extraire le titre brut (avant " (/")
+            $rawTitle = preg_replace('/\s*\(.*\)\s*$/', '', $title);
+
+            $match = $dbEvals->first(fn ($e) => Str::lower(trim($e->titre)) === Str::lower($rawTitle));
+            if ($match) {
+                $resolved[$colIndex] = [
+                    'id' => $match->id,
+                    'titre' => $match->titre,
+                    'bareme' => (float) $match->bareme,
+                    'coefficient' => (float) $match->coefficient,
+                ];
+            }
+        }
+
+        return $resolved;
+    }
+
+    private function columnLetter(int $index): string
+    {
+        return \PhpOffice\PhpSpreadsheet\Cell\Coordinate::stringFromColumnIndex($index);
+    }
+}

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -446,6 +446,12 @@ return [
             'icon' => 'fa-cog',
             'aliases' => ['manage_own_notes'],
         ],
+        'notes.import_excel' => [
+            'label' => 'Importer des notes depuis un fichier Excel',
+            'group' => 'Notes & Évaluations',
+            'icon' => 'fa-file-import',
+            'aliases' => [],
+        ],
 
         // ===== Évaluations =====
         'evaluations.view' => [
@@ -1143,7 +1149,7 @@ return [
             'filieres.view', 'filieres.create', 'filieres.edit',
             'niveaux.view', 'niveaux.create', 'niveaux.edit',
             'matieres.view',
-            'notes.view', 'evaluations.view', 'exams.view',
+            'notes.view', 'notes.create', 'notes.edit', 'notes.import_excel', 'evaluations.view', 'exams.view',
             'bulletins.view', 'bulletins.generate', 'bulletins.configure',
             'attendances.view', 'attendances.create', 'attendances.edit', 'attendances.delete',
             'attendances.generate_codes',
@@ -1214,7 +1220,7 @@ return [
             'classes.view',
             'filieres.view', 'niveaux.view',
             'matieres.view', 'matieres.create', 'matieres.edit',
-            'notes.view', 'notes.create',
+            'notes.view', 'notes.create', 'notes.import_excel',
             'evaluations.view', 'evaluations.create', 'evaluations.edit',
             'exams.view',
             'bulletins.view', 'bulletins.generate', 'bulletins.edit',
@@ -1241,7 +1247,7 @@ return [
             'admin.access', 'dashboard.view',
             'students.view_own',
             'classes.view',
-            'notes.view', 'notes.view_own', 'notes.create', 'notes.edit', 'notes.manage_own',
+            'notes.view', 'notes.view_own', 'notes.create', 'notes.edit', 'notes.manage_own', 'notes.import_excel',
             'evaluations.view', 'evaluations.create', 'evaluations.edit',
             'bulletins.view',
             'attendances.view', 'attendances.create', 'attendances.edit',

--- a/database/factories/ESBTPAnneeUniversitaireFactory.php
+++ b/database/factories/ESBTPAnneeUniversitaireFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ESBTPAnneeUniversitaireFactory extends Factory
+{
+    protected $model = ESBTPAnneeUniversitaire::class;
+
+    public function definition(): array
+    {
+        $year = $this->faker->numberBetween(2020, 2030);
+
+        return [
+            'name' => $year . '-' . ($year + 1),
+            'start_date' => $year . '-09-01',
+            'end_date' => ($year + 1) . '-07-31',
+            'is_current' => false,
+            'is_active' => true,
+            'description' => $this->faker->optional()->sentence(),
+        ];
+    }
+}

--- a/database/factories/ESBTPClasseFactory.php
+++ b/database/factories/ESBTPClasseFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPNiveauEtude;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ESBTPClasseFactory extends Factory
+{
+    protected $model = ESBTPClasse::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => 'Classe ' . $this->faker->unique()->numberBetween(1, 99999),
+            'code' => 'CL' . $this->faker->unique()->numberBetween(1000, 99999),
+            'filiere_id' => ESBTPFiliere::factory(),
+            'niveau_etude_id' => ESBTPNiveauEtude::factory(),
+            'annee_universitaire_id' => ESBTPAnneeUniversitaire::factory(),
+            'places_totales' => 50,
+            'places_occupees' => 0,
+            'description' => $this->faker->sentence(),
+            'is_active' => true,
+            'systeme_academique' => 'BTS',
+        ];
+    }
+}

--- a/database/factories/ESBTPEtudiantFactory.php
+++ b/database/factories/ESBTPEtudiantFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ESBTPEtudiant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ESBTPEtudiantFactory extends Factory
+{
+    protected $model = ESBTPEtudiant::class;
+
+    public function definition(): array
+    {
+        return [
+            'matricule' => 'MAT' . $this->faker->unique()->numberBetween(10000, 9999999),
+            'nom' => $this->faker->lastName(),
+            'prenoms' => $this->faker->firstName(),
+            'sexe' => $this->faker->randomElement(['M', 'F']),
+            'date_naissance' => $this->faker->date('Y-m-d', '-18 years'),
+            'lieu_naissance' => $this->faker->city(),
+            'nationalite' => 'Ivoirienne',
+            'adresse' => $this->faker->address(),
+            'telephone' => '+225' . $this->faker->numerify('##########'),
+            'email' => $this->faker->unique()->safeEmail(),
+            'statut' => 'actif',
+        ];
+    }
+}

--- a/database/factories/ESBTPFiliereFactory.php
+++ b/database/factories/ESBTPFiliereFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ESBTPFiliere;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ESBTPFiliereFactory extends Factory
+{
+    protected $model = ESBTPFiliere::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->randomElement(['BTP', 'Comptabilité', 'Informatique', 'Marketing', 'Logistique']);
+
+        return [
+            'name' => $name . ' ' . $this->faker->numberBetween(1, 999),
+            'code' => strtoupper(substr($name, 0, 3)) . $this->faker->unique()->numberBetween(100, 9999),
+            'description' => $this->faker->sentence(),
+            'is_active' => true,
+            'is_tronc_commun' => false,
+        ];
+    }
+}

--- a/database/factories/ESBTPInscriptionFactory.php
+++ b/database/factories/ESBTPInscriptionFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPInscription;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ESBTPInscriptionFactory extends Factory
+{
+    protected $model = ESBTPInscription::class;
+
+    public function definition(): array
+    {
+        return [
+            'etudiant_id' => ESBTPEtudiant::factory(),
+            'classe_id' => ESBTPClasse::factory(),
+            'annee_universitaire_id' => ESBTPAnneeUniversitaire::factory(),
+            'date_inscription' => now()->subDays($this->faker->numberBetween(1, 365)),
+            'type_inscription' => 'nouvelle',
+            'status' => 'active',
+            'workflow_step' => 'etudiant_cree',
+            'is_sous_reserve' => false,
+            'affectation_status' => 'affecté',
+            'comptabilite_activee' => false,
+        ];
+    }
+}

--- a/database/factories/ESBTPMatiereFactory.php
+++ b/database/factories/ESBTPMatiereFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ESBTPMatiere;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ESBTPMatiereFactory extends Factory
+{
+    protected $model = ESBTPMatiere::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->randomElement(['Mathématiques', 'Français', 'Anglais', 'Comptabilité', 'Informatique', 'Économie']);
+
+        return [
+            'name' => $name,
+            'code' => strtoupper(substr($name, 0, 3)) . $this->faker->unique()->numberBetween(100, 9999),
+            'description' => $this->faker->sentence(),
+            'coefficient' => $this->faker->randomElement([1, 2, 3]),
+            'heures_cm' => 20,
+            'heures_td' => 10,
+            'heures_tp' => 0,
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/ESBTPNiveauEtudeFactory.php
+++ b/database/factories/ESBTPNiveauEtudeFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ESBTPNiveauEtude;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ESBTPNiveauEtudeFactory extends Factory
+{
+    protected $model = ESBTPNiveauEtude::class;
+
+    public function definition(): array
+    {
+        $year = $this->faker->numberBetween(1, 3);
+
+        return [
+            'name' => 'BTS ' . $year,
+            'libelle' => 'BTS Année ' . $year,
+            'code' => 'BTS' . $year . $this->faker->unique()->randomNumber(4),
+            'type' => 'BTS',
+            'year' => $year,
+            'description' => 'Niveau BTS ' . $year,
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -16,6 +16,7 @@ class UserFactory extends Factory
     {
         return [
             'name' => $this->faker->name(),
+            'username' => $this->faker->unique()->userName() . Str::random(4),
             'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password

--- a/public/css/notes-management.css
+++ b/public/css/notes-management.css
@@ -1345,3 +1345,422 @@
         min-width: 150px;
     }
 }
+
+/* ══════════════════════════════════════════════════════════
+   PR #7 — Excel Import/Export + Preview Impact (namespace nm-)
+   ══════════════════════════════════════════════════════════ */
+
+/* ── Boutons modal footer (Export Excel + Import Excel) ── */
+.nm-modal-footer .nm-btn-export,
+.nm-modal-footer .nm-btn-import {
+    border-radius: 7px;
+    font-weight: 600;
+    font-size: 0.82rem;
+    padding: 0.4rem 0.85rem;
+    border: 1px solid transparent;
+    background: #fff;
+    transition: all 0.15s ease;
+}
+.nm-modal-footer .nm-btn-export {
+    color: #047857;
+    border-color: #10b981;
+    background: rgba(16, 185, 129, 0.06);
+}
+.nm-modal-footer .nm-btn-export:hover:not(:disabled):not(.disabled) {
+    background: #10b981;
+    color: #fff;
+}
+.nm-modal-footer .nm-btn-import {
+    color: #0453cb;
+    border-color: #0453cb;
+    background: rgba(4, 83, 203, 0.06);
+}
+.nm-modal-footer .nm-btn-import:hover:not(:disabled):not(.disabled) {
+    background: #0453cb;
+    color: #fff;
+}
+.nm-modal-footer .nm-btn-export:disabled,
+.nm-modal-footer .nm-btn-import:disabled,
+.nm-modal-footer .nm-btn-export.disabled,
+.nm-modal-footer .nm-btn-import.disabled {
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+/* ── Modal Import — Header gradient ───────────────────── */
+#nm-import-preview-modal .modal-content {
+    border-radius: 14px;
+    overflow: hidden;
+    border: none;
+}
+.nm-import-modal-header {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 50%, #3b7ddb 100%);
+    color: #fff;
+    padding: 1.1rem 1.5rem;
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+}
+.nm-import-modal-header .modal-title {
+    font-weight: 700;
+    font-size: 1.05rem;
+}
+.nm-import-context {
+    color: rgba(255,255,255,0.78);
+    font-size: 0.82rem;
+    margin: 0;
+}
+
+/* ── Drop zone ─────────────────────────────────────────── */
+.nm-import-dropzone {
+    border: 2px dashed #cbd5e1;
+    border-radius: 14px;
+    padding: 2.5rem 1.5rem;
+    text-align: center;
+    background: #f8fafc;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+.nm-import-dropzone:hover,
+.nm-import-dropzone.is-dragover {
+    border-color: #0453cb;
+    background: rgba(4, 83, 203, 0.04);
+    transform: translateY(-1px);
+}
+.nm-import-dropzone-icon {
+    font-size: 2.6rem;
+    color: #0453cb;
+    margin-bottom: 0.6rem;
+    display: flex;
+    justify-content: center;
+}
+.nm-import-dropzone-icon i {
+    background: linear-gradient(135deg, #0453cb, #5e91de);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+.nm-import-dropzone-title {
+    font-weight: 700;
+    color: #1e293b;
+    font-size: 1.05rem;
+    margin-bottom: 0.25rem;
+}
+.nm-import-dropzone-sub {
+    color: #64748b;
+    font-size: 0.88rem;
+    margin-bottom: 0.6rem;
+}
+.nm-import-dropzone-formats {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    background: rgba(4, 83, 203, 0.08);
+    color: #0453cb;
+    font-size: 0.74rem;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+/* ── Loading state ─────────────────────────────────────── */
+.nm-import-loading {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: #64748b;
+}
+
+/* ── Preview file pill ─────────────────────────────────── */
+.nm-import-file-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 0.8rem;
+    background: #eff6ff;
+    border: 1px solid #bfdbfe;
+    color: #0453cb;
+    font-weight: 600;
+    font-size: 0.82rem;
+    border-radius: 999px;
+    margin-bottom: 1rem;
+}
+.nm-import-file-pill i {
+    color: #047857;
+}
+.nm-import-file-clear {
+    border: none;
+    background: transparent;
+    color: #94a3b8;
+    cursor: pointer;
+    padding: 0.1rem 0.3rem;
+    border-radius: 4px;
+    transition: all 0.15s ease;
+}
+.nm-import-file-clear:hover {
+    background: rgba(220, 38, 38, 0.1);
+    color: #dc2626;
+}
+
+/* ── KPIs (4 cards) ────────────────────────────────────── */
+.nm-import-kpis {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0.6rem;
+    margin-bottom: 1rem;
+}
+.nm-import-kpi {
+    padding: 0.7rem;
+    border-radius: 10px;
+    border: 1px solid #e2e8f0;
+    background: #fff;
+    text-align: center;
+}
+.nm-import-kpi-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1;
+}
+.nm-import-kpi-label {
+    font-size: 0.72rem;
+    color: #64748b;
+    margin-top: 0.3rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+}
+.nm-import-kpi-create {
+    border-color: rgba(16, 185, 129, 0.3);
+    background: rgba(16, 185, 129, 0.04);
+}
+.nm-import-kpi-create .nm-import-kpi-value { color: #10b981; }
+.nm-import-kpi-update {
+    border-color: rgba(245, 158, 11, 0.3);
+    background: rgba(245, 158, 11, 0.04);
+}
+.nm-import-kpi-update .nm-import-kpi-value { color: #f59e0b; }
+.nm-import-kpi-unchanged {
+    border-color: #e2e8f0;
+    background: #f8fafc;
+}
+.nm-import-kpi-unchanged .nm-import-kpi-value { color: #64748b; }
+.nm-import-kpi-error {
+    border-color: rgba(220, 38, 38, 0.3);
+    background: rgba(220, 38, 38, 0.04);
+}
+.nm-import-kpi-error .nm-import-kpi-value { color: #dc2626; }
+
+/* ── Errors block ─────────────────────────────────────── */
+.nm-import-errors {
+    border-radius: 10px;
+    border: 1px solid rgba(220, 38, 38, 0.3);
+    background: rgba(220, 38, 38, 0.04);
+    margin-bottom: 1rem;
+    overflow: hidden;
+}
+.nm-import-errors-header {
+    padding: 0.55rem 0.85rem;
+    background: rgba(220, 38, 38, 0.1);
+    color: #b91c1c;
+    font-weight: 700;
+    font-size: 0.82rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.nm-import-errors-body {
+    max-height: 180px;
+    overflow-y: auto;
+    padding: 0.5rem 0.85rem;
+    font-size: 0.78rem;
+    color: #7f1d1d;
+}
+.nm-import-error-item {
+    padding: 0.3rem 0;
+    border-bottom: 1px dotted rgba(220, 38, 38, 0.2);
+}
+.nm-import-error-item:last-child { border-bottom: none; }
+.nm-import-error-item .err-cell {
+    background: rgba(220, 38, 38, 0.15);
+    color: #b91c1c;
+    padding: 0.05rem 0.4rem;
+    border-radius: 4px;
+    font-family: monospace;
+    font-weight: 700;
+    font-size: 0.74rem;
+}
+
+/* ── Changes table ─────────────────────────────────────── */
+.nm-import-changes-header {
+    font-weight: 700;
+    font-size: 0.88rem;
+    color: #1e293b;
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.nm-import-changes-header i { color: #0453cb; }
+.nm-import-table-wrap {
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    overflow: hidden;
+    max-height: 380px;
+    overflow-y: auto;
+}
+.nm-import-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.82rem;
+}
+.nm-import-table thead th {
+    background: #f1f5f9;
+    color: #475569;
+    font-weight: 700;
+    text-align: left;
+    padding: 0.55rem 0.75rem;
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    position: sticky;
+    top: 0;
+    z-index: 2;
+}
+.nm-import-table tbody td {
+    padding: 0.45rem 0.75rem;
+    border-top: 1px solid #f1f5f9;
+    color: #1e293b;
+}
+.nm-import-table tbody tr.row-create td {
+    background: rgba(16, 185, 129, 0.04);
+    border-left: 3px solid #10b981;
+}
+.nm-import-table tbody tr.row-update td {
+    background: rgba(245, 158, 11, 0.04);
+    border-left: 3px solid #f59e0b;
+}
+.nm-import-table .cell-before {
+    color: #64748b;
+    text-decoration: line-through;
+    text-decoration-color: #cbd5e1;
+}
+.nm-import-table .cell-after {
+    color: #0f172a;
+    font-weight: 700;
+}
+.nm-import-table .cell-after-abs {
+    color: #f59e0b;
+    font-weight: 700;
+}
+.nm-import-table .badge-action-create {
+    background: rgba(16, 185, 129, 0.15);
+    color: #047857;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+.nm-import-table .badge-action-update {
+    background: rgba(245, 158, 11, 0.15);
+    color: #b45309;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+/* ── Modal footer + confirm button ────────────────────── */
+.nm-import-modal-footer {
+    background: #fff;
+    border-top: 1px solid #e8edf5;
+    padding: 0.75rem 1.25rem;
+}
+.nm-btn-confirm-import {
+    background: linear-gradient(135deg, #0453cb, #3b7ddb);
+    color: #fff;
+    border: none;
+    font-weight: 600;
+    font-size: 0.85rem;
+    padding: 0.5rem 1.1rem;
+    border-radius: 8px;
+    transition: all 0.15s ease;
+}
+.nm-btn-confirm-import:hover:not(:disabled) {
+    background: linear-gradient(135deg, #033a8e, #0453cb);
+    color: #fff;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(4, 83, 203, 0.3);
+}
+.nm-btn-confirm-import:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* ── Preview impact (sous-row dans la grille notes) ──── */
+.nm-impact-row {
+    background: #fafbfc;
+}
+.nm-impact-row td {
+    padding: 0.45rem 0.85rem !important;
+    border-top: 1px dotted #e2e8f0 !important;
+    font-size: 0.78rem;
+    color: #475569;
+}
+.nm-impact-content {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+    align-items: center;
+}
+.nm-impact-block {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.3rem;
+}
+.nm-impact-label {
+    color: #94a3b8;
+    font-weight: 500;
+    font-size: 0.74rem;
+}
+.nm-impact-value-old {
+    color: #94a3b8;
+    text-decoration: line-through;
+    font-weight: 600;
+}
+.nm-impact-arrow {
+    color: #0453cb;
+    margin: 0 0.15rem;
+}
+.nm-impact-value-new {
+    color: #0453cb;
+    font-weight: 700;
+}
+.nm-impact-mention {
+    padding: 0.1rem 0.45rem;
+    background: rgba(4, 83, 203, 0.1);
+    color: #0453cb;
+    border-radius: 4px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    margin-left: 0.25rem;
+}
+.nm-impact-mention-up {
+    background: rgba(16, 185, 129, 0.12);
+    color: #047857;
+}
+.nm-impact-mention-down {
+    background: rgba(245, 158, 11, 0.12);
+    color: #b45309;
+}
+.nm-impact-loading {
+    color: #94a3b8;
+    font-style: italic;
+}
+
+@media (max-width: 768px) {
+    .nm-import-kpis {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .nm-import-table {
+        font-size: 0.74rem;
+    }
+}

--- a/resources/views/esbtp/notes/index.blade.php
+++ b/resources/views/esbtp/notes/index.blade.php
@@ -1461,5 +1461,468 @@ function showYearChangeInfo() {
         $(modalEl).modal('show');
     }
 }
+
+// ════════════════════════════════════════════════════════════════════════
+// PR #7 — Excel Export/Import + Preview Impact (JS)
+// ════════════════════════════════════════════════════════════════════════
+
+const PR7 = {
+    routes: {
+        exportExcel: '{{ route("esbtp.notes.export-excel") }}',
+        @can('notes.import_excel')
+        importDryRun: '{{ route("esbtp.notes.import.dry-run") }}',
+        importApply:  '{{ route("esbtp.notes.import.apply") }}',
+        @endcan
+        previewImpact: '{{ route("esbtp.notes.preview-impact") }}',
+    },
+    csrf: '{{ csrf_token() }}',
+    selectedFile: null,
+    impactDebounceTimers: {},
+    impactCache: {},
+};
+
+// ── Activer/désactiver les boutons Export/Import selon classe + matière + période ──
+function pr7UpdateButtons() {
+    const periodeFilter = $('#periodeFilter').val();
+    const validPeriode = (periodeFilter === 'semestre1' || periodeFilter === 'semestre2');
+    const ready = currentClassId && currentMatiereId && validPeriode;
+
+    const exportBtn = document.getElementById('exportExcelBtn');
+    if (exportBtn) {
+        exportBtn.disabled = !ready;
+        exportBtn.classList.toggle('disabled', !ready);
+        if (ready) {
+            exportBtn.title = `Exporter les notes — ${currentClassname || ''} (${periodeFilter})`;
+        } else {
+            exportBtn.title = 'Sélectionnez classe, matière et période (semestre 1 ou 2)';
+        }
+    }
+
+    const importBtn = document.getElementById('openImportModalBtn');
+    if (importBtn) {
+        importBtn.disabled = !ready;
+        importBtn.classList.toggle('disabled', !ready);
+    }
+}
+
+$(document).on('change', '#matiereSelect, #periodeFilter', pr7UpdateButtons);
+$(document).on('click', '.class-card, .nm-class-card, .class-select-btn, .nm-card-action', function() {
+    setTimeout(pr7UpdateButtons, 50);
+});
+
+// ── Bouton Export Excel ──
+$(document).on('click', '#exportExcelBtn:not(:disabled):not(.disabled)', function() {
+    const periode = $('#periodeFilter').val();
+    if (!currentClassId || !currentMatiereId || !(periode === 'semestre1' || periode === 'semestre2')) {
+        return;
+    }
+    const url = PR7.routes.exportExcel
+        + '?classe=' + encodeURIComponent(currentClassId)
+        + '&matiere=' + encodeURIComponent(currentMatiereId)
+        + '&periode=' + encodeURIComponent(periode);
+    window.open(url, '_blank');
+});
+
+@can('notes.import_excel')
+// ── Ouvrir modal import ──
+$(document).on('click', '#openImportModalBtn:not(:disabled):not(.disabled)', function() {
+    const periode = $('#periodeFilter').val();
+    if (!currentClassId || !currentMatiereId || !(periode === 'semestre1' || periode === 'semestre2')) {
+        return;
+    }
+    pr7ResetImportModal();
+    document.getElementById('nm-import-context').textContent =
+        `${currentClassname || 'Classe'} — ${currentMatiereName || 'Matière'} — ${periode === 'semestre1' ? 'Semestre 1' : 'Semestre 2'}`;
+    const modalEl = document.getElementById('nm-import-preview-modal');
+    if (window.bootstrap && window.bootstrap.Modal) {
+        new window.bootstrap.Modal(modalEl).show();
+    } else {
+        $(modalEl).modal('show');
+    }
+});
+
+function pr7ResetImportModal() {
+    PR7.selectedFile = null;
+    const fileInput = document.getElementById('nm-import-file-input');
+    if (fileInput) fileInput.value = '';
+    document.getElementById('nm-import-dropzone').style.display = '';
+    document.getElementById('nm-import-loading').style.display = 'none';
+    document.getElementById('nm-import-preview').style.display = 'none';
+    document.getElementById('nm-import-errors').style.display = 'none';
+    const confirmBtn = document.getElementById('nm-import-confirm-btn');
+    if (confirmBtn) confirmBtn.disabled = true;
+}
+
+// Drop zone handlers
+$(document).on('click', '#nm-import-dropzone', function() {
+    document.getElementById('nm-import-file-input').click();
+});
+
+$(document).on('dragover', '#nm-import-dropzone', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    $(this).addClass('is-dragover');
+});
+
+$(document).on('dragleave drop', '#nm-import-dropzone', function(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    $(this).removeClass('is-dragover');
+});
+
+$(document).on('drop', '#nm-import-dropzone', function(e) {
+    const files = e.originalEvent.dataTransfer && e.originalEvent.dataTransfer.files;
+    if (files && files.length > 0) {
+        pr7HandleFile(files[0]);
+    }
+});
+
+$(document).on('change', '#nm-import-file-input', function(e) {
+    const file = e.target.files && e.target.files[0];
+    if (file) pr7HandleFile(file);
+});
+
+$(document).on('click', '#nm-import-file-clear', function() {
+    pr7ResetImportModal();
+});
+
+function pr7HandleFile(file) {
+    if (!file) return;
+
+    // Validation basique côté client
+    const validExt = /\.(xlsx|xls|csv)$/i;
+    if (!validExt.test(file.name)) {
+        alert('Format invalide. Utilisez xlsx, xls ou csv.');
+        return;
+    }
+    if (file.size > 5 * 1024 * 1024) {
+        alert('Fichier trop volumineux (max 5 Mo).');
+        return;
+    }
+
+    PR7.selectedFile = file;
+    document.getElementById('nm-import-filename').textContent = file.name;
+
+    // Show loading
+    document.getElementById('nm-import-dropzone').style.display = 'none';
+    document.getElementById('nm-import-loading').style.display = '';
+    document.getElementById('nm-import-preview').style.display = 'none';
+
+    // Send dry-run
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('classe_id', currentClassId);
+    formData.append('matiere_id', currentMatiereId);
+    formData.append('periode', $('#periodeFilter').val());
+
+    fetch(PR7.routes.importDryRun, {
+        method: 'POST',
+        body: formData,
+        headers: {
+            'X-CSRF-TOKEN': PR7.csrf,
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+        credentials: 'same-origin',
+    })
+        .then(r => r.json().then(data => ({ ok: r.ok, data })))
+        .then(({ ok, data }) => {
+            document.getElementById('nm-import-loading').style.display = 'none';
+            if (!ok || !data.success) {
+                pr7ShowError(data.message || 'Erreur lors de l\'analyse du fichier.');
+                return;
+            }
+            pr7RenderPreview(data);
+        })
+        .catch(err => {
+            console.error(err);
+            document.getElementById('nm-import-loading').style.display = 'none';
+            pr7ShowError('Erreur réseau. Vérifiez votre connexion.');
+        });
+}
+
+function pr7ShowError(message) {
+    document.getElementById('nm-import-dropzone').style.display = '';
+    alert(message);
+}
+
+function pr7RenderPreview(data) {
+    document.getElementById('nm-import-preview').style.display = '';
+
+    const summary = data.summary || {};
+    document.getElementById('nm-import-kpi-create').textContent = summary.will_create || 0;
+    document.getElementById('nm-import-kpi-update').textContent = summary.will_update || 0;
+    document.getElementById('nm-import-kpi-unchanged').textContent = summary.unchanged || 0;
+    document.getElementById('nm-import-kpi-error').textContent = summary.errors || 0;
+
+    // Errors
+    const errors = data.errors || [];
+    const errBox = document.getElementById('nm-import-errors');
+    const errList = document.getElementById('nm-import-errors-list');
+    if (errors.length > 0) {
+        errBox.style.display = '';
+        errList.innerHTML = errors.map(e => `
+            <div class="nm-import-error-item">
+                <span class="err-cell">L${e.row || '?'}${e.col || ''}</span>
+                ${e.matricule ? `<strong>${pr7Escape(e.matricule)}</strong>` : ''}
+                ${e.evaluation ? ` — <em>${pr7Escape(e.evaluation)}</em>` : ''}
+                — ${pr7Escape(e.reason || '')}
+            </div>
+        `).join('');
+    } else {
+        errBox.style.display = 'none';
+    }
+
+    // Changes table
+    const changes = data.changes || [];
+    document.getElementById('nm-import-changes-count').textContent = changes.length;
+    const body = document.getElementById('nm-import-changes-body');
+    if (changes.length === 0) {
+        body.innerHTML = '<tr><td colspan="6" class="text-center text-muted py-3">Aucun changement détecté</td></tr>';
+    } else {
+        body.innerHTML = changes.slice(0, 500).map(c => {
+            const beforeDisp = (c.before === null || c.before === undefined) ? '<em style="color:#94a3b8;">—</em>' : pr7Escape(String(c.before));
+            const afterDisp = (c.after === 'ABS' || c.is_absent)
+                ? '<span class="cell-after-abs">ABS</span>'
+                : `<span class="cell-after">${pr7Escape(String(c.after))}</span>`;
+            return `
+                <tr class="row-${c.action}">
+                    <td>L${c.row || '?'}</td>
+                    <td><strong>${pr7Escape(c.matricule || '')}</strong> — ${pr7Escape(c.etudiant_nom || '')}</td>
+                    <td>${pr7Escape(c.evaluation || '')}</td>
+                    <td><span class="cell-before">${beforeDisp}</span></td>
+                    <td>${afterDisp}</td>
+                    <td><span class="badge-action-${c.action}">${c.action === 'create' ? 'Créer' : 'Mettre à jour'}</span></td>
+                </tr>
+            `;
+        }).join('');
+        if (changes.length > 500) {
+            body.innerHTML += `<tr><td colspan="6" class="text-center text-muted py-2"><em>… ${changes.length - 500} autres changements masqués pour l'affichage. Tous seront appliqués.</em></td></tr>`;
+        }
+    }
+
+    // Confirm button : enabled seulement si pas d'erreurs ET au moins 1 change
+    const confirmBtn = document.getElementById('nm-import-confirm-btn');
+    confirmBtn.disabled = (errors.length > 0) || (changes.length === 0);
+}
+
+// Confirm import → apply
+$(document).on('click', '#nm-import-confirm-btn:not(:disabled)', function() {
+    if (!PR7.selectedFile) return;
+
+    const btn = this;
+    const spinner = document.getElementById('nm-import-confirm-spinner');
+    const icon = document.getElementById('nm-import-confirm-icon');
+    btn.disabled = true;
+    if (spinner) spinner.classList.remove('d-none');
+    if (icon) icon.classList.add('d-none');
+
+    const formData = new FormData();
+    formData.append('file', PR7.selectedFile);
+    formData.append('classe_id', currentClassId);
+    formData.append('matiere_id', currentMatiereId);
+    formData.append('periode', $('#periodeFilter').val());
+
+    fetch(PR7.routes.importApply, {
+        method: 'POST',
+        body: formData,
+        headers: {
+            'X-CSRF-TOKEN': PR7.csrf,
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+        credentials: 'same-origin',
+    })
+        .then(r => r.json().then(data => ({ ok: r.ok, data })))
+        .then(({ ok, data }) => {
+            btn.disabled = false;
+            if (spinner) spinner.classList.add('d-none');
+            if (icon) icon.classList.remove('d-none');
+
+            if (!ok || !data.success) {
+                alert(data.message || 'Erreur lors de l\'application de l\'import.');
+                return;
+            }
+
+            // Toast + close + reload notes grid
+            pr7Toast(data.message || 'Import réussi.', 'success');
+            const modalEl = document.getElementById('nm-import-preview-modal');
+            const modal = window.bootstrap ? window.bootstrap.Modal.getInstance(modalEl) : null;
+            if (modal) modal.hide(); else $(modalEl).modal('hide');
+
+            // Recharge la grille
+            if (typeof loadEvaluationsAndNotes === 'function' && currentClassId && currentMatiereId) {
+                loadEvaluationsAndNotes();
+            }
+        })
+        .catch(err => {
+            console.error(err);
+            btn.disabled = false;
+            if (spinner) spinner.classList.add('d-none');
+            if (icon) icon.classList.remove('d-none');
+            alert('Erreur réseau lors de l\'application de l\'import.');
+        });
+});
+
+function pr7Toast(message, type) {
+    type = type || 'success';
+    if (window.iiToast && typeof window.iiToast === 'function') {
+        window.iiToast(message, type);
+        return;
+    }
+    // Fallback simple
+    const t = document.createElement('div');
+    t.style.cssText = 'position:fixed;bottom:20px;right:20px;background:#10b981;color:#fff;padding:0.8rem 1.2rem;border-radius:8px;box-shadow:0 4px 12px rgba(0,0,0,0.15);z-index:9999;font-weight:600;';
+    if (type === 'error') t.style.background = '#dc2626';
+    t.textContent = message;
+    document.body.appendChild(t);
+    setTimeout(() => t.remove(), 4000);
+}
+
+@endcan
+
+function pr7Escape(str) {
+    const div = document.createElement('div');
+    div.textContent = String(str);
+    return div.innerHTML;
+}
+
+// ── Preview impact (debounced 500ms après dernière frappe) ──
+$(document).on('focus input', '.note-input', function() {
+    const $input = $(this);
+    const studentId = parseInt($input.data('student-id'));
+    const evalId = parseInt($input.data('eval-id'));
+    const noteValue = $input.val();
+    const isAbsent = $input.is(':disabled');
+
+    if (!studentId || !evalId) return;
+
+    const periode = $('#periodeFilter').val();
+    if (!(periode === 'semestre1' || periode === 'semestre2')) {
+        // Pas de période semestre claire : on ne peut pas calculer
+        return;
+    }
+
+    // Debounce per-input
+    const key = studentId + '_' + evalId;
+    if (PR7.impactDebounceTimers[key]) {
+        clearTimeout(PR7.impactDebounceTimers[key]);
+    }
+
+    // Show "calcul en cours" placeholder immédiatement
+    pr7ShowImpactLoading(studentId, evalId);
+
+    PR7.impactDebounceTimers[key] = setTimeout(() => {
+        pr7FetchImpact(studentId, evalId, noteValue, isAbsent, periode);
+    }, 500);
+});
+
+$(document).on('blur', '.note-input', function() {
+    // Ne pas masquer la row impact au blur (pour la voir après save)
+});
+
+function pr7ShowImpactLoading(studentId, evalId) {
+    const $studentRow = $('.note-input[data-student-id="' + studentId + '"]').first().closest('tr');
+    if ($studentRow.length === 0) return;
+
+    let $impactRow = $studentRow.next('.nm-impact-row[data-impact-student="' + studentId + '"]');
+    if ($impactRow.length === 0) {
+        $impactRow = $('<tr class="nm-impact-row" data-impact-student="' + studentId + '"><td colspan="100"><span class="nm-impact-loading"><i class="fas fa-spinner fa-spin me-1"></i>Calcul en cours…</span></td></tr>');
+        $studentRow.after($impactRow);
+    } else {
+        $impactRow.find('td').html('<span class="nm-impact-loading"><i class="fas fa-spinner fa-spin me-1"></i>Calcul en cours…</span>');
+    }
+}
+
+function pr7FetchImpact(studentId, evalId, noteValue, isAbsent, periode) {
+    if (!currentClassId || !currentMatiereId) return;
+
+    const numNote = noteValue === '' || noteValue === null ? null : parseFloat(noteValue);
+    if (!isAbsent && (numNote === null || isNaN(numNote))) {
+        // Cellule vide : retire la row impact
+        const $studentRow = $('.note-input[data-student-id="' + studentId + '"]').first().closest('tr');
+        $studentRow.next('.nm-impact-row').remove();
+        return;
+    }
+
+    const formData = new FormData();
+    formData.append('etudiant_id', studentId);
+    formData.append('classe_id', currentClassId);
+    formData.append('matiere_id', currentMatiereId);
+    formData.append('periode', periode);
+    formData.append('evaluation_id', evalId);
+    formData.append('hypothetical_note', isAbsent ? 0 : numNote);
+    formData.append('is_absent', isAbsent ? 1 : 0);
+
+    fetch(PR7.routes.previewImpact, {
+        method: 'POST',
+        body: formData,
+        headers: {
+            'X-CSRF-TOKEN': PR7.csrf,
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+        },
+        credentials: 'same-origin',
+    })
+        .then(r => r.json())
+        .then(data => {
+            if (!data.success) return;
+            pr7RenderImpact(studentId, data);
+        })
+        .catch(() => {
+            // Silencieux : preview est best-effort
+        });
+}
+
+function pr7RenderImpact(studentId, data) {
+    const $studentRow = $('.note-input[data-student-id="' + studentId + '"]').first().closest('tr');
+    if ($studentRow.length === 0) return;
+
+    let $impactRow = $studentRow.next('.nm-impact-row[data-impact-student="' + studentId + '"]');
+    if ($impactRow.length === 0) {
+        $impactRow = $('<tr class="nm-impact-row" data-impact-student="' + studentId + '"><td colspan="100"></td></tr>');
+        $studentRow.after($impactRow);
+    }
+
+    // Récup nom étudiant
+    const studentName = $studentRow.find('.nm-student-fullname').text().trim() || 'Étudiant';
+
+    // Format display values
+    const matAv = data.matiere_avant !== null ? data.matiere_avant.toFixed(2) : '—';
+    const matAp = data.matiere_apres !== null ? data.matiere_apres.toFixed(2) : '—';
+    const genAv = data.moyenne_generale_avant !== null ? data.moyenne_generale_avant.toFixed(2) : '—';
+    const genAp = data.moyenne_generale_apres !== null ? data.moyenne_generale_apres.toFixed(2) : '—';
+
+    let mentionPart = '';
+    if (data.mention_avant && data.mention_apres) {
+        if (data.changed_mention) {
+            const direction = (data.matiere_apres || 0) > (data.matiere_avant || 0) ? 'up' : 'down';
+            mentionPart = `<span class="nm-impact-mention nm-impact-mention-${direction}">${pr7Escape(data.mention_avant)} → ${pr7Escape(data.mention_apres)}</span>`;
+        } else {
+            mentionPart = `<span class="nm-impact-mention">${pr7Escape(data.mention_apres)}</span>`;
+        }
+    }
+
+    const html = `
+        <div class="nm-impact-content">
+            <span><strong>${pr7Escape(studentName)}</strong></span>
+            <div class="nm-impact-block">
+                <span class="nm-impact-label">moyenne matière</span>
+                <span class="nm-impact-value-old">${matAv}</span>
+                <i class="fas fa-arrow-right nm-impact-arrow"></i>
+                <span class="nm-impact-value-new">${matAp}</span>
+                ${mentionPart}
+            </div>
+            <div class="nm-impact-block">
+                <span class="nm-impact-label">moyenne générale</span>
+                <span class="nm-impact-value-old">${genAv}</span>
+                <i class="fas fa-arrow-right nm-impact-arrow"></i>
+                <span class="nm-impact-value-new">${genAp}</span>
+            </div>
+        </div>
+    `;
+    $impactRow.find('td').html(html);
+}
+
 </script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -1070,6 +1070,20 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             // Routes pour les notes
             Route::post('notes/save-ajax', [ESBTPNoteController::class, 'saveNoteAjax'])->name('notes.save-ajax');
             Route::post('notes/save-ajax-bulk', [ESBTPNoteController::class, 'saveNotesAjaxBulk'])->name('notes.save-ajax-bulk');
+
+            // PR #7 — Excel import/export bidirectionnel + preview impact bulletin
+            Route::get('notes/export-excel', [ESBTPNoteController::class, 'exportExcel'])
+                ->middleware('throttle:10,1')
+                ->name('notes.export-excel');
+            Route::post('notes/import/dry-run', [ESBTPNoteController::class, 'importDryRun'])
+                ->middleware('throttle:5,1')
+                ->name('notes.import.dry-run');
+            Route::post('notes/import/apply', [ESBTPNoteController::class, 'importApply'])
+                ->middleware('throttle:3,1')
+                ->name('notes.import.apply');
+            Route::post('notes/preview-impact', [ESBTPNoteController::class, 'previewImpact'])
+                ->middleware('throttle:60,1')
+                ->name('notes.preview-impact');
             Route::resource('notes', \App\Http\Controllers\ESBTPNoteController::class)
                 ->names([
                     'index' => 'esbtp.notes.index',

--- a/tests/Feature/Notes/NotesExcelExportTest.php
+++ b/tests/Feature/Notes/NotesExcelExportTest.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tests\Feature\Notes;
+
+use App\Exports\NotesClasseMatiereExport;
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPEvaluation;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPNote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Maatwebsite\Excel\Facades\Excel;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class NotesExcelExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Permissions
+        Permission::findOrCreate('notes.view', 'web');
+        Permission::findOrCreate('module.notes_evaluations.access', 'web');
+        Permission::findOrCreate('admin.access', 'web');
+    }
+
+    private function authUser(): User
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('notes.view');
+        $user->givePermissionTo('module.notes_evaluations.access');
+        $user->givePermissionTo('admin.access');
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    private function buildContext(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create(['is_current' => 1]);
+        $classe = ESBTPClasse::factory()->create();
+        $matiere = ESBTPMatiere::factory()->create();
+
+        $eval1 = ESBTPEvaluation::factory()->create([
+            'classe_id' => $classe->id,
+            'matiere_id' => $matiere->id,
+            'periode' => 'semestre1',
+            'annee_universitaire_id' => $annee->id,
+            'is_published' => 1,
+            'bareme' => 20,
+            'coefficient' => 1,
+            'titre' => 'Devoir 1',
+        ]);
+
+        $eval2 = ESBTPEvaluation::factory()->create([
+            'classe_id' => $classe->id,
+            'matiere_id' => $matiere->id,
+            'periode' => 'semestre1',
+            'annee_universitaire_id' => $annee->id,
+            'is_published' => 1,
+            'bareme' => 30,
+            'coefficient' => 2,
+            'titre' => 'Examen 1',
+        ]);
+
+        return compact('annee', 'classe', 'matiere', 'eval1', 'eval2');
+    }
+
+    private function makeStudent(int $classeId, int $anneeId, string $matricule = 'STU001'): ESBTPEtudiant
+    {
+        $etudiant = ESBTPEtudiant::factory()->create([
+            'matricule' => $matricule,
+            'nom' => 'NOM',
+            'prenoms' => 'Prenom',
+        ]);
+        ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'classe_id' => $classeId,
+            'annee_universitaire_id' => $anneeId,
+            'status' => 'active',
+            'workflow_step' => 'etudiant_cree',
+        ]);
+
+        return $etudiant;
+    }
+
+    public function test_it_exports_classe_matiere_to_excel(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $student = $this->makeStudent($ctx['classe']->id, $ctx['annee']->id);
+
+        ESBTPNote::create([
+            'evaluation_id' => $ctx['eval1']->id,
+            'etudiant_id' => $student->id,
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'semestre' => 'semestre1',
+            'annee_universitaire' => $ctx['annee']->name,
+            'note' => 15,
+            'is_absent' => 0,
+        ]);
+
+        Excel::fake();
+
+        $response = $this->get(route('esbtp.notes.export-excel', [
+            'classe' => $ctx['classe']->id,
+            'matiere' => $ctx['matiere']->id,
+            'periode' => 'semestre1',
+        ]));
+
+        $response->assertOk();
+        Excel::assertDownloaded('/^notes_/');
+    }
+
+    public function test_it_includes_correct_headers_with_bareme(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $this->makeStudent($ctx['classe']->id, $ctx['annee']->id);
+
+        $export = new NotesClasseMatiereExport(
+            $ctx['classe']->id,
+            $ctx['matiere']->id,
+            'semestre1',
+            $ctx['annee']->id
+        );
+
+        $headings = $export->headings();
+        $this->assertSame('Matricule', $headings[0]);
+        $this->assertSame('Nom & Prénoms', $headings[1]);
+        $this->assertStringContainsString('/20', $headings[2]);  // eval1
+        $this->assertStringContainsString('/30', $headings[3]);  // eval2 bareme 30
+        $this->assertStringContainsString('×2', $headings[3]);   // eval2 coef 2
+        $this->assertSame('Moyenne /20', end($headings));
+    }
+
+    public function test_it_returns_422_when_volume_exceeds_5000_cells(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+
+        // 1 évaluation existe déjà via buildContext (eval1 + eval2 = 2 évals)
+        // Pour dépasser 5000 cellules, créer 2501 étudiants → 2501×2 = 5002
+        for ($i = 0; $i < 2501; $i++) {
+            $this->makeStudent($ctx['classe']->id, $ctx['annee']->id, 'BULK' . $i);
+        }
+
+        $response = $this->get(route('esbtp.notes.export-excel', [
+            'classe' => $ctx['classe']->id,
+            'matiere' => $ctx['matiere']->id,
+            'periode' => 'semestre1',
+        ]));
+
+        $response->assertStatus(422);
+        $response->assertJsonFragment(['success' => false]);
+    }
+
+    public function test_it_throttles_export_at_10_per_minute(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $this->makeStudent($ctx['classe']->id, $ctx['annee']->id);
+
+        Excel::fake();
+
+        // 10 requêtes OK
+        for ($i = 0; $i < 10; $i++) {
+            $r = $this->get(route('esbtp.notes.export-excel', [
+                'classe' => $ctx['classe']->id,
+                'matiere' => $ctx['matiere']->id,
+                'periode' => 'semestre1',
+            ]));
+            $this->assertContains($r->status(), [200, 429], "Iteration {$i}: status was {$r->status()}");
+        }
+
+        // 11ème devrait être 429
+        $r11 = $this->get(route('esbtp.notes.export-excel', [
+            'classe' => $ctx['classe']->id,
+            'matiere' => $ctx['matiere']->id,
+            'periode' => 'semestre1',
+        ]));
+
+        $this->assertSame(429, $r11->status(), 'La 11ème requête devrait être throttle 429.');
+    }
+}

--- a/tests/Feature/Notes/NotesExcelImportTest.php
+++ b/tests/Feature/Notes/NotesExcelImportTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Tests\Feature\Notes;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPEvaluation;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPNote;
+use App\Models\User;
+use App\Services\NotesImportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Maatwebsite\Excel\Facades\Excel;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx as XlsxWriter;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class NotesExcelImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Permission::findOrCreate('notes.view', 'web');
+        Permission::findOrCreate('notes.create', 'web');
+        Permission::findOrCreate('notes.edit', 'web');
+        Permission::findOrCreate('notes.import_excel', 'web');
+        Permission::findOrCreate('module.notes_evaluations.access', 'web');
+        Permission::findOrCreate('admin.access', 'web');
+    }
+
+    private function authUser(array $perms = ['notes.view', 'notes.create', 'notes.edit', 'notes.import_excel']): User
+    {
+        $user = User::factory()->create();
+        foreach (array_merge($perms, ['module.notes_evaluations.access', 'admin.access']) as $p) {
+            $user->givePermissionTo($p);
+        }
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    private function buildContext(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create(['is_current' => 1]);
+        $classe = ESBTPClasse::factory()->create();
+        $matiere = ESBTPMatiere::factory()->create();
+        $eval = ESBTPEvaluation::factory()->create([
+            'classe_id' => $classe->id,
+            'matiere_id' => $matiere->id,
+            'periode' => 'semestre1',
+            'annee_universitaire_id' => $annee->id,
+            'is_published' => 1,
+            'bareme' => 20,
+            'coefficient' => 1,
+            'titre' => 'Devoir 1',
+        ]);
+
+        return compact('annee', 'classe', 'matiere', 'eval');
+    }
+
+    private function makeInscription(int $classeId, int $anneeId, string $matricule = 'STU001'): ESBTPEtudiant
+    {
+        $etudiant = ESBTPEtudiant::factory()->create([
+            'matricule' => $matricule,
+            'nom' => 'KOFFI',
+            'prenoms' => 'Marie',
+        ]);
+        ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'classe_id' => $classeId,
+            'annee_universitaire_id' => $anneeId,
+            'status' => 'active',
+            'workflow_step' => 'etudiant_cree',
+        ]);
+
+        return $etudiant;
+    }
+
+    /**
+     * Build une UploadedFile xlsx avec meta + 1 row note.
+     */
+    private function buildExcelFile(array $ctx, string $matricule, $noteValue): UploadedFile
+    {
+        $spreadsheet = new Spreadsheet();
+        $sheet = $spreadsheet->getActiveSheet();
+
+        // Ligne 1 : meta
+        $sheet->setCellValue('A1', '__KLASSCI_NOTES_EXPORT__');
+        $sheet->setCellValue('B1', json_encode([
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'periode' => 'semestre1',
+            'annee_universitaire_id' => $ctx['annee']->id,
+            'evaluations' => [[
+                'id' => $ctx['eval']->id,
+                'titre' => $ctx['eval']->titre,
+                'bareme' => 20,
+                'coefficient' => 1,
+            ]],
+            'generated_at' => now()->toIso8601String(),
+        ]));
+
+        // Ligne 2 : header
+        $sheet->setCellValue('A2', 'Matricule');
+        $sheet->setCellValue('B2', 'Nom & Prénoms');
+        $sheet->setCellValue('C2', 'Devoir 1 (/20 ×1)');
+        $sheet->setCellValue('D2', 'Moyenne /20');
+
+        // Ligne 3 : data
+        $sheet->setCellValueExplicit('A3', $matricule, \PhpOffice\PhpSpreadsheet\Cell\DataType::TYPE_STRING);
+        $sheet->setCellValue('B3', 'KOFFI Marie');
+        $sheet->setCellValue('C3', $noteValue);
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'notes_imp_') . '.xlsx';
+        $writer = new XlsxWriter($spreadsheet);
+        $writer->save($tmpPath);
+
+        return new UploadedFile($tmpPath, 'notes_test.xlsx', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', null, true);
+    }
+
+    public function test_it_parses_valid_excel_file(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $this->makeInscription($ctx['classe']->id, $ctx['annee']->id, 'STU001');
+
+        $file = $this->buildExcelFile($ctx, 'STU001', 15);
+
+        $service = app(NotesImportService::class);
+        $parsed = $service->parseFile($file);
+
+        $this->assertArrayHasKey('rows', $parsed);
+        $this->assertArrayHasKey('meta', $parsed);
+        $this->assertNotNull($parsed['meta']);
+        $this->assertSame($ctx['classe']->id, $parsed['meta']['classe_id']);
+    }
+
+    public function test_dry_run_returns_diff(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $this->makeInscription($ctx['classe']->id, $ctx['annee']->id, 'STU001');
+
+        $file = $this->buildExcelFile($ctx, 'STU001', 15);
+
+        $service = app(NotesImportService::class);
+        $parsed = $service->parseFile($file);
+        $diff = $service->dryRun($parsed, $ctx['classe']->id, $ctx['matiere']->id, 'semestre1', $ctx['annee']->id);
+
+        $this->assertSame(1, $diff['summary']['will_create']);
+        $this->assertSame(0, $diff['summary']['will_update']);
+        $this->assertSame(0, $diff['summary']['errors']);
+        $this->assertCount(1, $diff['changes']);
+        $this->assertSame('create', $diff['changes'][0]['action']);
+        $this->assertSame(15.0, (float) $diff['changes'][0]['after']);
+    }
+
+    public function test_apply_persists_changes_atomically(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $student = $this->makeInscription($ctx['classe']->id, $ctx['annee']->id, 'STU001');
+
+        $file = $this->buildExcelFile($ctx, 'STU001', 17.5);
+
+        $service = app(NotesImportService::class);
+        $parsed = $service->parseFile($file);
+        $result = $service->apply($parsed, $ctx['classe']->id, $ctx['matiere']->id, 'semestre1', $ctx['annee']->id);
+
+        $this->assertSame(1, $result['created']);
+        $this->assertSame(0, $result['updated']);
+        $this->assertSame(0, $result['errors']);
+
+        $this->assertDatabaseHas('esbtp_notes', [
+            'etudiant_id' => $student->id,
+            'evaluation_id' => $ctx['eval']->id,
+            'note' => 17.5,
+            'is_absent' => 0,
+        ]);
+    }
+
+    public function test_it_rejects_notes_exceeding_bareme_during_import(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $this->makeInscription($ctx['classe']->id, $ctx['annee']->id, 'STU001');
+
+        $file = $this->buildExcelFile($ctx, 'STU001', 25); // Bareme 20 → 25 hors barème
+
+        $service = app(NotesImportService::class);
+        $parsed = $service->parseFile($file);
+        $diff = $service->dryRun($parsed, $ctx['classe']->id, $ctx['matiere']->id, 'semestre1', $ctx['annee']->id);
+
+        $this->assertSame(0, $diff['summary']['will_create']);
+        $this->assertSame(1, $diff['summary']['errors']);
+        $this->assertStringContainsString('hors barème', $diff['errors'][0]['reason']);
+    }
+
+    public function test_it_throttles_import_dry_run_at_5_per_minute(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $this->makeInscription($ctx['classe']->id, $ctx['annee']->id, 'STU001');
+
+        // Fire 5 fast (each request needs a fresh file)
+        for ($i = 0; $i < 5; $i++) {
+            $file = $this->buildExcelFile($ctx, 'STU001', 10 + $i);
+            $r = $this->postJson(route('esbtp.notes.import.dry-run'), [
+                'file' => $file,
+                'classe_id' => $ctx['classe']->id,
+                'matiere_id' => $ctx['matiere']->id,
+                'periode' => 'semestre1',
+            ]);
+            $this->assertContains($r->status(), [200, 422, 429], "Iteration {$i}: status was {$r->status()}");
+        }
+
+        // 6th = throttle
+        $file6 = $this->buildExcelFile($ctx, 'STU001', 12);
+        $r6 = $this->postJson(route('esbtp.notes.import.dry-run'), [
+            'file' => $file6,
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'periode' => 'semestre1',
+        ]);
+
+        $this->assertSame(429, $r6->status(), 'La 6ème requête doit être throttled.');
+    }
+
+    public function test_it_supports_absent_marker(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $student = $this->makeInscription($ctx['classe']->id, $ctx['annee']->id, 'STU001');
+
+        $file = $this->buildExcelFile($ctx, 'STU001', 'ABS');
+
+        $service = app(NotesImportService::class);
+        $parsed = $service->parseFile($file);
+        $result = $service->apply($parsed, $ctx['classe']->id, $ctx['matiere']->id, 'semestre1', $ctx['annee']->id);
+
+        $this->assertSame(1, $result['created']);
+        $this->assertDatabaseHas('esbtp_notes', [
+            'etudiant_id' => $student->id,
+            'evaluation_id' => $ctx['eval']->id,
+            'is_absent' => 1,
+        ]);
+    }
+
+    public function test_it_accepts_french_decimal_format(): void
+    {
+        $this->authUser();
+        $ctx = $this->buildContext();
+        $student = $this->makeInscription($ctx['classe']->id, $ctx['annee']->id, 'STU001');
+
+        $file = $this->buildExcelFile($ctx, 'STU001', '12,5');
+
+        $service = app(NotesImportService::class);
+        $parsed = $service->parseFile($file);
+        $result = $service->apply($parsed, $ctx['classe']->id, $ctx['matiere']->id, 'semestre1', $ctx['annee']->id);
+
+        $this->assertSame(1, $result['created']);
+        $this->assertDatabaseHas('esbtp_notes', [
+            'etudiant_id' => $student->id,
+            'evaluation_id' => $ctx['eval']->id,
+            'note' => 12.5,
+        ]);
+    }
+}

--- a/tests/Feature/Notes/PreviewImpactTest.php
+++ b/tests/Feature/Notes/PreviewImpactTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace Tests\Feature\Notes;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPEvaluation;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPNote;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+class PreviewImpactTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Permission::findOrCreate('notes.view', 'web');
+        Permission::findOrCreate('notes.create', 'web');
+        Permission::findOrCreate('notes.edit', 'web');
+        Permission::findOrCreate('module.notes_evaluations.access', 'web');
+        Permission::findOrCreate('admin.access', 'web');
+    }
+
+    private function authUser(): User
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('notes.view');
+        $user->givePermissionTo('notes.create');
+        $user->givePermissionTo('notes.edit');
+        $user->givePermissionTo('module.notes_evaluations.access');
+        $user->givePermissionTo('admin.access');
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    private function makeContext(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create(['is_current' => 1]);
+        $classe = ESBTPClasse::factory()->create();
+        $matiere = ESBTPMatiere::factory()->create(['coefficient' => 2]);
+
+        $eval1 = ESBTPEvaluation::factory()->create([
+            'classe_id' => $classe->id,
+            'matiere_id' => $matiere->id,
+            'periode' => 'semestre1',
+            'annee_universitaire_id' => $annee->id,
+            'is_published' => 1,
+            'bareme' => 20,
+            'coefficient' => 1,
+            'titre' => 'Devoir 1',
+        ]);
+        $eval2 = ESBTPEvaluation::factory()->create([
+            'classe_id' => $classe->id,
+            'matiere_id' => $matiere->id,
+            'periode' => 'semestre1',
+            'annee_universitaire_id' => $annee->id,
+            'is_published' => 1,
+            'bareme' => 20,
+            'coefficient' => 1,
+            'titre' => 'Examen 1',
+        ]);
+
+        $etudiant = ESBTPEtudiant::factory()->create([
+            'matricule' => 'STU001',
+            'nom' => 'KOFFI',
+            'prenoms' => 'Marie',
+        ]);
+        ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'classe_id' => $classe->id,
+            'annee_universitaire_id' => $annee->id,
+            'status' => 'active',
+            'workflow_step' => 'etudiant_cree',
+        ]);
+
+        return compact('annee', 'classe', 'matiere', 'eval1', 'eval2', 'etudiant');
+    }
+
+    public function test_it_returns_avant_apres_for_matiere(): void
+    {
+        $this->authUser();
+        $ctx = $this->makeContext();
+
+        // Note actuelle eval1 = 12, eval2 = 14 → moyenne 13
+        ESBTPNote::create([
+            'evaluation_id' => $ctx['eval1']->id,
+            'etudiant_id' => $ctx['etudiant']->id,
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'semestre' => 'semestre1',
+            'annee_universitaire' => $ctx['annee']->name,
+            'note' => 12,
+            'is_absent' => 0,
+        ]);
+        ESBTPNote::create([
+            'evaluation_id' => $ctx['eval2']->id,
+            'etudiant_id' => $ctx['etudiant']->id,
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'semestre' => 'semestre1',
+            'annee_universitaire' => $ctx['annee']->name,
+            'note' => 14,
+            'is_absent' => 0,
+        ]);
+
+        // On simule changer eval1 de 12 → 18
+        $response = $this->postJson(route('esbtp.notes.preview-impact'), [
+            'etudiant_id' => $ctx['etudiant']->id,
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'periode' => 'semestre1',
+            'evaluation_id' => $ctx['eval1']->id,
+            'hypothetical_note' => 18,
+        ]);
+
+        $response->assertOk();
+        $response->assertJson([
+            'success' => true,
+            'matiere_avant' => 13.0,  // (12+14)/2
+            'matiere_apres' => 16.0,  // (18+14)/2
+        ]);
+    }
+
+    public function test_it_calculates_mention_change(): void
+    {
+        $this->authUser();
+        $ctx = $this->makeContext();
+
+        // Moyenne actuelle = 12.5 (Assez Bien)
+        ESBTPNote::create([
+            'evaluation_id' => $ctx['eval1']->id,
+            'etudiant_id' => $ctx['etudiant']->id,
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'semestre' => 'semestre1',
+            'annee_universitaire' => $ctx['annee']->name,
+            'note' => 12.5,
+            'is_absent' => 0,
+        ]);
+
+        // Hypothétique : si eval1 devient 11 → moyenne 11 (Passable)
+        $response = $this->postJson(route('esbtp.notes.preview-impact'), [
+            'etudiant_id' => $ctx['etudiant']->id,
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'periode' => 'semestre1',
+            'evaluation_id' => $ctx['eval1']->id,
+            'hypothetical_note' => 11,
+        ]);
+
+        $response->assertOk();
+        $data = $response->json();
+        $this->assertSame('Assez Bien', $data['mention_avant']);
+        $this->assertSame('Passable', $data['mention_apres']);
+        $this->assertTrue($data['changed_mention']);
+    }
+
+    public function test_it_handles_first_note_no_existing_average(): void
+    {
+        $this->authUser();
+        $ctx = $this->makeContext();
+
+        // Aucune note existante
+        $response = $this->postJson(route('esbtp.notes.preview-impact'), [
+            'etudiant_id' => $ctx['etudiant']->id,
+            'classe_id' => $ctx['classe']->id,
+            'matiere_id' => $ctx['matiere']->id,
+            'periode' => 'semestre1',
+            'evaluation_id' => $ctx['eval1']->id,
+            'hypothetical_note' => 15,
+        ]);
+
+        $response->assertOk();
+        $data = $response->json();
+        $this->assertNull($data['matiere_avant']);
+        $this->assertSame(15.0, (float) $data['matiere_apres']);
+    }
+}


### PR DESCRIPTION
PR #7 — Productivité enseignants africains : Excel offline + preview pédagogique temps réel.

## Summary

- **Export Excel** d'une classe + matière + période (1 ligne/étudiant, 1 colonne/évaluation avec barème + coefficient dans le header, freeze pane, autoFilter, matricule en text format, ligne meta cachée pour ré-import lossless)
- **Import Excel** avec drag-drop + modal preview Avant/Après premium (4 KPIs colorés, table par ligne avec badges create/update, validation par cellule barème + matricule + format français + marqueur ABS), application atomique
- **Preview impact bulletin temps réel** : sous chaque ligne étudiant, encadré discret affichant la nouvelle moyenne matière + générale + changement de mention CAMES, debounced 500ms
- Permission notes.import_excel ajoutée pour secrétaire / coordinateur / enseignant / superAdmin
- Throttle : 10/min export, 5/min dry-run, 3/min apply, 60/min preview

## Files

**New**
- app/Exports/NotesClasseMatiereExport.php — export xlsx avec styles KLASSCI
- app/Services/NotesImportService.php — pipeline parseFile/dryRun/apply
- app/Http/Requests/Notes/ImportNotesRequest.php — FormRequest avec authorize
- tests/Feature/Notes/{NotesExcelExportTest,NotesExcelImportTest,PreviewImpactTest}.php
- 7 factories ESBTP* + UserFactory.username

**Modified**
- app/Http/Controllers/ESBTPNoteController.php — 4 méthodes (exportExcel, importDryRun, importApply, previewImpact) + helpers
- routes/web.php — 4 routes throttlées
- config/permissions.php — permission notes.import_excel + role_defaults
- resources/views/esbtp/notes/index.blade.php — boutons + modal preview + JS PR7
- public/css/notes-management.css — styles namespace nm-* (export/import/impact)
- CHANGELOG.md + miroir klassci-landing FR/EN

## Test plan

- [ ] Export xlsx fonctionnel (header bleu, freeze pane, matricule preserve zéros, autoFilter, ligne meta)
- [ ] Modal import drag-drop premium, validation par cellule (note > barème → erreur)
- [ ] Format français 12,5 reconnu, marqueur ABS reconnu
- [ ] Apply atomique en transaction, toast succès, grille rechargée
- [ ] Preview impact temps réel sous étudiant (moyennes + mention)
- [ ] Throttle (11ème export = 429, 6ème dry-run = 429)
- [ ] Garde-fou volume (>5000 cellules = 422)

## Boundaries respectées

- Pas de modif Observer/Job (PR #2), validations backend (PR #5), calcul moyenne JS (PR #1), raccourcis clavier (PR #3), LMD
- Namespace CSS nm-* strictement préservé