### PR TITLE
refactor(student): rename /mes-messages → /mes-annonces (sémantique annonces)

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -220,7 +220,7 @@ class ChatController extends Controller
 
         // Issue #315 : isolation étudiants — on n'expose pas les comptes étudiants
         // dans le picker du chat staff. Les étudiants ne peuvent pas recevoir de DM
-        // (ils consultent leurs annonces via /esbtp/mes-messages). On exclut donc
+        // (ils consultent leurs annonces via /esbtp/mes-annonces). On exclut donc
         // explicitement les users qui ont le rôle `etudiant` ET on conserve les
         // checks existants (auto-exclu, actifs).
         $users = User::query()

--- a/app/Http/Controllers/ESBTPAnnonceController.php
+++ b/app/Http/Controllers/ESBTPAnnonceController.php
@@ -375,13 +375,13 @@ class ESBTPAnnonceController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function studentMessages()
+    public function studentAnnonces()
     {
         $user = Auth::user();
         $etudiant = ESBTPEtudiant::where('user_id', $user->id)->first();
 
-        // Si l'utilisateur n'est pas un étudiant (superAdmin, secrétaire, etc.),
-        // afficher toutes les annonces publiées au lieu de crasher en 404
+        // Si l'utilisateur n'est pas un étudiant (superAdmin pour preview),
+        // afficher toutes les annonces publiées avec stats représentatives.
         if (!$etudiant) {
             $messages = ESBTPAnnonce::where('is_published', true)
                 ->where('date_publication', '<=', now())
@@ -392,7 +392,6 @@ class ESBTPAnnonceController extends Controller
                 ->orderBy('created_at', 'desc')
                 ->paginate(10);
 
-            // Hydratation cohérente pour la vue (is_read toujours présent)
             foreach ($messages as $message) {
                 $message->is_read = true;
                 $message->read_at = null;
@@ -412,7 +411,7 @@ class ESBTPAnnonceController extends Controller
                     : 0,
             ];
 
-            return view('esbtp.annonces.student-messages', compact('messages', 'stats', 'etudiant'));
+            return view('esbtp.annonces.student-annonces', compact('messages', 'stats', 'etudiant'));
         }
 
         // Récupérer la classe de l'année universitaire en cours
@@ -516,7 +515,7 @@ class ESBTPAnnonceController extends Controller
             'urgent' => $urgentCount,
         ];
 
-        return view('esbtp.annonces.student-messages', compact('messages', 'stats', 'etudiant'));
+        return view('esbtp.annonces.student-annonces', compact('messages', 'stats', 'etudiant'));
     }
 
     /**

--- a/app/Http/Controllers/NavbarController.php
+++ b/app/Http/Controllers/NavbarController.php
@@ -340,7 +340,7 @@ class NavbarController extends Controller
                         'sender' => $annonce->createdBy ? explode(' ', $annonce->createdBy->name)[0].' '.(explode(' ', $annonce->createdBy->name)[1] ?? '') : 'Administration',
                         'time' => $annonce->created_at->diffForHumans(),
                         'read' => $annonce->created_at->lt(now()->subDay()), // Marquer comme lu si plus de 24h
-                        'url' => route('esbtp.mes-messages.index'),
+                        'url' => route('esbtp.mes-annonces.index'),
                         'avatar' => null,
                     ];
                 });

--- a/app/Services/NotificationService.php
+++ b/app/Services/NotificationService.php
@@ -584,7 +584,7 @@ class NotificationService
 
             $title = "Nouvelle annonce: " . $annonce->titre;
             $message = substr($annonce->contenu, 0, 150) . (strlen($annonce->contenu) > 150 ? '...' : '');
-            $link = route('esbtp.mes-messages.index');
+            $link = route('esbtp.mes-annonces.index');
 
             $notifiedCount = 0;
             foreach ($etudiants as $etudiant) {

--- a/resources/views/esbtp/annonces/student-annonces.blade.php
+++ b/resources/views/esbtp/annonces/student-annonces.blade.php
@@ -1,13 +1,13 @@
 @extends('layouts.app')
 
-@section('title', 'Mes Messages')
+@section('title', 'Mes Annonces')
 
 @push('styles')
 <link rel="stylesheet" href="{{ asset('css/dashboard-moderne.css') }}">
 <style>
 /* ══════════════════════════════════════════════
-   Mes Messages — Premium Redesign
-   Prefix: mm- (mes-messages)
+   Mes Annonces — Premium Redesign
+   Prefix: mm- (mes annonces / messaging)
    ══════════════════════════════════════════════ */
 
 .mm-page {
@@ -615,11 +615,11 @@
         <div class="mm-hero-top">
             <div class="mm-hero-left">
                 <div class="mm-hero-icon" aria-hidden="true">
-                    <i class="fas fa-envelope-open-text"></i>
+                    <i class="fas fa-bullhorn"></i>
                 </div>
                 <div class="mm-hero-info">
-                    <h1>Mes Messages</h1>
-                    <p>Consultez vos annonces et notifications de l'établissement.</p>
+                    <h1>Mes Annonces</h1>
+                    <p>Consultez les annonces et communications de votre établissement.</p>
                 </div>
             </div>
 
@@ -904,8 +904,8 @@
     'use strict';
 
     const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content || '';
-    const markReadUrlBase = @json(rtrim(route('esbtp.mes-messages.read', ['id' => '__ID__']), '/'));
-    const markAllReadUrl  = @json(route('esbtp.mes-messages.mark-all-read'));
+    const markReadUrlBase = @json(rtrim(route('esbtp.mes-annonces.read', ['id' => '__ID__']), '/'));
+    const markAllReadUrl  = @json(route('esbtp.mes-annonces.mark-all-read'));
 
     function showFeedback(message, type) {
         if (typeof window.showToast === 'function') {
@@ -1004,7 +1004,7 @@
         .catch(err => {
             showFeedback('Impossible de marquer le message comme lu', 'error');
             // eslint-disable-next-line no-console
-            console.error('mes-messages markAsRead', err);
+            console.error('mes-annonces markAsRead', err);
         });
     }
 
@@ -1062,7 +1062,7 @@
                     allBtn.disabled = false;
                     showFeedback('Impossible de marquer tous les messages comme lus', 'error');
                     // eslint-disable-next-line no-console
-                    console.error('mes-messages markAllRead', err);
+                    console.error('mes-annonces markAllRead', err);
                 });
             });
         }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1934,7 +1934,7 @@
                     @endcan
 
                     {{-- Chat interactif (issue #298) — réservé staff (permission messages.send).
-                         Les étudiants consultent leurs annonces via /esbtp/mes-messages
+                         Les étudiants consultent leurs annonces via /esbtp/mes-annonces
                          (section « Communication » plus bas, gated @can('identity.student')). --}}
                     @can('messages.send')
                     <div class="menu-item">
@@ -1954,15 +1954,15 @@
                     </div>
                     @endcan
 
-                    <!-- Messages Section -->
+                    {{-- Section Communication étudiant : annonces + notifications --}}
                     @can('identity.student')
                         <div class="menu-category">Communication</div>
 
-                        <!-- Messages -->
+                        {{-- Annonces reçues (broadcast admin → étudiant). --}}
                         <div class="menu-item">
-                            <a href="{{ route('esbtp.mes-messages.index') }}" class="menu-link {{ Request::routeIs('esbtp.mes-messages.*') ? 'active' : '' }}">
-                                <div class="menu-icon"><i class="fas fa-envelope"></i></div>
-                                <div class="menu-text">Messages étudiant</div>
+                            <a href="{{ route('esbtp.mes-annonces.index') }}" class="menu-link {{ Request::routeIs('esbtp.mes-annonces.*') ? 'active' : '' }}">
+                                <div class="menu-icon"><i class="fas fa-bullhorn"></i></div>
+                                <div class="menu-text">Mes annonces</div>
                             </a>
                         </div>
 
@@ -2338,9 +2338,9 @@
                                 <li><hr class="dropdown-divider"></li>
                                 <li>
                                     @can('identity.student')
-                                        <a class="dropdown-item text-center view-all" href="{{ route('esbtp.mes-messages.index') }}">
-                                            <i class="fas fa-envelope-open me-1"></i>
-                                            Voir tous les messages
+                                        <a class="dropdown-item text-center view-all" href="{{ route('esbtp.mes-annonces.index') }}">
+                                            <i class="fas fa-bullhorn me-1"></i>
+                                            Voir toutes les annonces
                                         </a>
                                     @else
                                         <a class="dropdown-item text-center view-all" href="{{ route('esbtp.annonces.index') }}">
@@ -2435,11 +2435,11 @@
                                                 </div>
                                                 <span class="quick-action-text">Mon emploi du temps</span>
                                             </a>
-                                            <a href="{{ route('esbtp.mes-messages.index') }}" class="quick-action-item">
+                                            <a href="{{ route('esbtp.mes-annonces.index') }}" class="quick-action-item">
                                                 <div class="quick-action-icon" style="background: linear-gradient(135deg, #0453cb, #5e91de); color: white;">
-                                                    <i class="fas fa-envelope"></i>
+                                                    <i class="fas fa-bullhorn"></i>
                                                 </div>
-                                                <span class="quick-action-text">Mes messages</span>
+                                                <span class="quick-action-text">Mes annonces</span>
                                             </a>
                                         @else
                                             <div class="dropdown-empty">

--- a/resources/views/layouts/appESBTPYAKRO.blade.php
+++ b/resources/views/layouts/appESBTPYAKRO.blade.php
@@ -616,9 +616,9 @@
                     </a>
                 </li>
                 <li class="nav-item">
-                    <a href="{{ route('esbtp.mes-messages.index') }}" class="nav-link {{ request()->routeIs('esbtp.mes-messages.index') ? 'active' : '' }}">
-                        <i class="fas fa-inbox nav-icon"></i>
-                        <span>Mes messages</span>
+                    <a href="{{ route('esbtp.mes-annonces.index') }}" class="nav-link {{ request()->routeIs('esbtp.mes-annonces.*') ? 'active' : '' }}">
+                        <i class="fas fa-bullhorn nav-icon"></i>
+                        <span>Mes annonces</span>
                     </a>
                 </li>
                 @endrole

--- a/routes/web.php
+++ b/routes/web.php
@@ -1175,18 +1175,22 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
             Route::get('/notifications/unread-count', [ESBTPNotificationController::class, 'getUnreadCount'])
                 ->name('notifications.unreadCount');
 
-            // Routes pour les messages des étudiants (annonces consultables).
-            // Issue #315 : gate explicite sur `annonces.view` pour cohérence avec
-            // le reste des routes étudiant. Le rôle `etudiant` a déjà la permission.
-            Route::get('/mes-messages', [ESBTPAnnonceController::class, 'studentMessages'])
-                ->name('mes-messages.index')
+            // Routes annonces étudiantes (consultation des ESBTPAnnonce reçues).
+            // Sémantique : un étudiant ne reçoit pas de "messages" personnels mais des
+            // ANNONCES (broadcast admin → étudiant). D'où le naming `mes-annonces`.
+            // Gate `annonces.view` cohérent avec le reste des routes étudiant.
+            Route::get('/mes-annonces', [ESBTPAnnonceController::class, 'studentAnnonces'])
+                ->name('mes-annonces.index')
                 ->middleware('permission:annonces.view');
-            Route::post('/mes-messages/{id}/read', [ESBTPAnnonceController::class, 'markAsRead'])
-                ->name('mes-messages.read')
+            Route::post('/mes-annonces/{id}/read', [ESBTPAnnonceController::class, 'markAsRead'])
+                ->name('mes-annonces.read')
                 ->middleware('permission:annonces.view');
-            Route::post('/mes-messages/mark-all-read', [ESBTPAnnonceController::class, 'markAllAsRead'])
-                ->name('mes-messages.mark-all-read')
+            Route::post('/mes-annonces/mark-all-read', [ESBTPAnnonceController::class, 'markAllAsRead'])
+                ->name('mes-annonces.mark-all-read')
                 ->middleware('permission:annonces.view');
+
+            // Alias rétrocompat : redirige les anciens bookmarks /mes-messages → /mes-annonces.
+            Route::redirect('/mes-messages', '/esbtp/mes-annonces', 301)->name('mes-messages.index');
         });
 
         // Routes pour la suppression de ressources (protégées par permissions spécifiques)
@@ -2282,7 +2286,7 @@ Route::prefix('esbtp/lmd')->name('esbtp.lmd.')->middleware(['auth', 'permission:
 | Isolation étudiants (issue #315) : le chat user-to-user est réservé aux
 | utilisateurs qui ont la permission `messages.send`. Les étudiants n'ont
 | que `messages.receive` + `annonces.view` et consultent leurs annonces via
-| la page séparée /esbtp/mes-messages. Un étudiant qui tape /messages
+| la page séparée /esbtp/mes-annonces. Un étudiant qui tape /messages
 | directement dans la barre d'adresse est bloqué en 403.
 */
 Route::middleware(['auth', 'paywall', 'permission:messages.send'])->prefix('messages')->name('chat.')->group(function () {


### PR DESCRIPTION
Un étudiant ne reçoit pas de messages personnels (pas d'accès chat) mais des annonces (broadcast admin). Le label `Messages étudiant` créait une ambiguïté avec le chat staff `Messages`.

## Renommage complet
- Sidebar : 'Messages étudiant' → 'Mes annonces' (fa-bullhorn)
- Route : /esbtp/mes-messages → /esbtp/mes-annonces
- Method : studentMessages → studentAnnonces
- Vue : student-messages.blade.php → student-annonces.blade.php
- Hero title : 'Mes Messages' → 'Mes Annonces'
- Refs : NavbarController, NotificationService updated

## BC préservée
- Alias 301 `/mes-messages` → `/mes-annonces`
- Name `mes-messages.index` conservé (redirect)

Aucun impact sur le chat staff `/messages` (système distinct, gated `messages.send`).