### PR TITLE
refactor(chat): simplify findings — N+1 fix + extract ChatMessagePreview + ChatPresenceProjector

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -8,6 +8,8 @@ use App\Models\ESBTPInscription;
 use App\Models\ESBTPPaiement;
 use App\Models\User;
 use App\Services\ChatActionResolver;
+use App\Services\ChatMessagePreview;
+use App\Services\ChatPresenceProjector;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -67,7 +69,7 @@ class ChatController extends Controller
 
         return response()->json([
             'conversation' => array_merge($conversation->only(['id', 'type', 'title', 'context']), [
-                'participants' => $others->map(fn ($p) => $this->mapParticipant($p))->values(),
+                'participants' => $others->map(fn (User $p) => ChatPresenceProjector::project($p))->values(),
             ]),
             'messages' => $messages->map(fn ($m) => [
                 'id' => $m->id,
@@ -142,68 +144,40 @@ class ChatController extends Controller
     {
         $user = $request->user();
 
+        // Sub-select corrélé : 1 query au lieu de N+1 (avant : 1 + 50 count par conv).
         $conversations = ChatConversation::query()
             ->whereHas('participants', fn ($q) => $q->where('user_id', $user->id))
             ->with(['participants:id,name,email,last_seen_at', 'lastMessage'])
+            ->select('chat_conversations.*')
+            ->selectRaw(
+                '(SELECT COUNT(*) FROM chat_messages cm
+                  INNER JOIN chat_conversation_participants ccp
+                      ON ccp.chat_conversation_id = cm.chat_conversation_id
+                      AND ccp.user_id = ?
+                  WHERE cm.chat_conversation_id = chat_conversations.id
+                    AND cm.sender_id != ?
+                    AND (ccp.last_read_at IS NULL OR cm.created_at > ccp.last_read_at)
+                ) as unread_count',
+                [$user->id, $user->id]
+            )
             ->orderByDesc('last_message_at')
             ->limit(50)
             ->get();
 
         return response()->json([
-            'items' => $conversations->map(function (ChatConversation $c) use ($user) {
-                $last = $c->lastMessage;
-                $kind = is_array($last->payload ?? null) ? ($last->payload['kind'] ?? null) : null;
-                $preview = $last ? match ($last->type) {
-                    'action_card' => '📎 ' . match ($kind) {
-                        'inscription' => 'Inscription partagée',
-                        'paiement' => 'Paiement partagé',
-                        default => 'Card partagée',
-                    },
-                    'system' => $last->body ?? 'Notification',
-                    default => $last->body ?? '',
-                } : null;
-
-                $lastReadAt = $c->participants->firstWhere('id', $user->id)?->pivot?->last_read_at;
-                $unreadCount = $last && (!$lastReadAt || $last->created_at->gt($lastReadAt))
-                    ? $c->messages()->where('sender_id', '!=', $user->id)
-                        ->when($lastReadAt, fn ($q) => $q->where('created_at', '>', $lastReadAt))
-                        ->count()
-                    : 0;
-
-                return [
-                    'id' => $c->id,
-                    'type' => $c->type,
-                    'title' => $c->title,
-                    'last_message_at' => $c->last_message_at?->toIso8601String(),
-                    'last_message' => $last ? [
-                        'id' => $last->id,
-                        'body' => $last->body,
-                        'type' => $last->type,
-                        'preview' => $preview,
-                        'sender_id' => $last->sender_id,
-                    ] : null,
-                    'unread_count' => $unreadCount,
-                    'participants' => $c->participants->where('id', '!=', $user->id)
-                        ->map(fn ($p) => $this->mapParticipant($p))->values(),
-                ];
-            })->all(),
+            'items' => $conversations->map(fn (ChatConversation $c) => [
+                'id' => $c->id,
+                'type' => $c->type,
+                'title' => $c->title,
+                'last_message_at' => $c->last_message_at?->toIso8601String(),
+                'last_message' => ChatMessagePreview::forMessage($c->lastMessage),
+                'unread_count' => (int) ($c->unread_count ?? 0),
+                'participants' => $c->participants
+                    ->where('id', '!=', $user->id)
+                    ->map(fn (User $p) => ChatPresenceProjector::project($p))
+                    ->values(),
+            ])->all(),
         ]);
-    }
-
-    /**
-     * Sérialise un participant avec présence (en ligne / dernière connexion).
-     * En ligne = last_seen_at < 2 minutes.
-     */
-    private function mapParticipant($p): array
-    {
-        $lastSeen = $p->last_seen_at;
-        $isOnline = $lastSeen && $lastSeen->gt(now()->subMinutes(2));
-        return [
-            'id' => $p->id,
-            'name' => $p->name,
-            'is_online' => (bool) $isOnline,
-            'last_seen_at' => $lastSeen?->toIso8601String(),
-        ];
     }
 
     public function markNotificationRead(Request $request, string $id): JsonResponse
@@ -218,11 +192,9 @@ class ChatController extends Controller
     {
         $q = $request->validate(['q' => 'required|string|min:2|max:100'])['q'];
 
-        // Issue #315 : isolation étudiants — on n'expose pas les comptes étudiants
-        // dans le picker du chat staff. Les étudiants ne peuvent pas recevoir de DM
-        // (ils consultent leurs annonces via /esbtp/mes-annonces). On exclut donc
-        // explicitement les users qui ont le rôle `etudiant` ET on conserve les
-        // checks existants (auto-exclu, actifs).
+        // Isolation étudiants : on n'expose pas les comptes étudiants dans le picker
+        // du chat staff. Les étudiants ne reçoivent pas de DM (ils consultent leurs
+        // annonces via /esbtp/mes-annonces).
         $users = User::query()
             ->where('id', '!=', $request->user()->id)
             ->where('is_active', true)
@@ -408,9 +380,9 @@ class ChatController extends Controller
     {
         abort_if($recipientId === $sender->id, 422, 'Vous ne pouvez pas vous envoyer un message à vous-même.');
 
-        // Issue #315 : double-check au niveau du repository d'écriture. Toute conversation
-        // existante (legacy) reste accessible — on bloque uniquement la *création* de
-        // nouvelles conversations vers un destinataire qui ne peut pas recevoir de DM.
+        // Double-check au niveau du repository d'écriture. Toute conversation existante
+        // (legacy) reste accessible — on bloque uniquement la création de nouvelles
+        // conversations vers un destinataire qui ne peut pas recevoir de DM.
         $existing = ChatConversation::where('type', 'dm')
             ->whereHas('participants', fn ($q) => $q->where('user_id', $sender->id))
             ->whereHas('participants', fn ($q) => $q->where('user_id', $recipientId))
@@ -437,8 +409,6 @@ class ChatController extends Controller
      * être éligible à un DM est `messages.send` (staff actif). On vérifie donc
      * que le destinataire dispose de cette permission, ce qui exclut nativement
      * les étudiants et tout user désactivé/sans rôle.
-     *
-     * Issue #315 : isoler les étudiants du chat user-to-user.
      */
     private function assertCanReceiveMessages(int $userId): void
     {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,16 @@ class User extends Authenticatable implements Auditable
 {
     use HasApiTokens, HasFactory, Notifiable, SoftDeletes, HasRoles, \OwenIt\Auditing\Auditable;
 
+    /** Seuil de présence "en ligne" : last_seen_at < N minutes. */
+    public const PRESENCE_ONLINE_THRESHOLD_MINUTES = 2;
+
+    /** True si le user a été actif dans la fenêtre de présence. */
+    public function isOnline(): bool
+    {
+        return $this->last_seen_at
+            && $this->last_seen_at->gt(now()->subMinutes(self::PRESENCE_ONLINE_THRESHOLD_MINUTES));
+    }
+
     /**
      * Colonnes auditées (whitelist).
      *

--- a/app/Services/ChatMessagePreview.php
+++ b/app/Services/ChatMessagePreview.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ChatMessage;
+
+/**
+ * Synthèse du dernier message d'une conversation pour la sidebar chat.
+ * Source unique consommée par ChatController::conversationsList et le @php block
+ * de messages/index.blade.php pour éviter le drift des règles de preview.
+ */
+class ChatMessagePreview
+{
+    /**
+     * @return array{id: int, body: ?string, type: string, preview: string, sender_id: int}|null
+     */
+    public static function forMessage(?ChatMessage $message): ?array
+    {
+        if (!$message) {
+            return null;
+        }
+
+        return [
+            'id' => $message->id,
+            'body' => $message->body,
+            'type' => $message->type,
+            'preview' => self::previewText($message),
+            'sender_id' => $message->sender_id,
+        ];
+    }
+
+    private static function previewText(ChatMessage $message): string
+    {
+        $kind = is_array($message->payload ?? null) ? ($message->payload['kind'] ?? null) : null;
+
+        return match ($message->type) {
+            'action_card' => '📎 ' . match ($kind) {
+                'inscription' => 'Inscription partagée',
+                'paiement' => 'Paiement partagé',
+                default => 'Card partagée',
+            },
+            'system' => $message->body ?? 'Notification',
+            default => $message->body ?? '',
+        };
+    }
+}

--- a/app/Services/ChatPresenceProjector.php
+++ b/app/Services/ChatPresenceProjector.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+
+/**
+ * Projection d'un user en participant chat avec présence.
+ * Source unique consommée par ChatController + le @php block de messages/index
+ * pour la sidebar.
+ */
+class ChatPresenceProjector
+{
+    /**
+     * @return array{id: int, name: string, is_online: bool, last_seen_at: ?string}
+     */
+    public static function project(User $user): array
+    {
+        return [
+            'id' => $user->id,
+            'name' => $user->name,
+            'is_online' => $user->isOnline(),
+            'last_seen_at' => $user->last_seen_at?->toIso8601String(),
+        ];
+    }
+}

--- a/resources/views/messages/index.blade.php
+++ b/resources/views/messages/index.blade.php
@@ -867,44 +867,23 @@
 </div>
 
 @php
-    $previewLastMessage = function ($m) {
-        if (!$m) return null;
-        $kind = is_array($m->payload ?? null) ? ($m->payload['kind'] ?? null) : null;
-        $preview = match ($m->type) {
-            'action_card' => '📎 ' . match ($kind) {
-                'inscription' => 'Inscription partagée',
-                'paiement' => 'Paiement partagé',
-                default => 'Card partagée',
-            },
-            'system' => $m->body ?? 'Notification',
-            default => $m->body ?? '',
-        };
-        return ['body' => $m->body, 'type' => $m->type, 'preview' => $preview];
-    };
-    $conversationsPayload = $conversations->map(function ($c) use ($previewLastMessage) {
-        return [
-            'id' => $c->id,
-            'type' => $c->type,
-            'title' => $c->title,
-            'last_message_at' => $c->last_message_at?->toIso8601String(),
-            'last_message' => $previewLastMessage($c->lastMessage),
-            'participants' => $c->participants->where('id', '!=', auth()->id())->map(function ($p) {
-                $isOnline = $p->last_seen_at && $p->last_seen_at->gt(now()->subMinutes(2));
-                return [
-                    'id' => $p->id,
-                    'name' => $p->name,
-                    'is_online' => (bool) $isOnline,
-                    'last_seen_at' => $p->last_seen_at?->toIso8601String(),
-                ];
-            })->values(),
-        ];
-    });
+    $conversationsPayload = $conversations->map(fn ($c) => [
+        'id' => $c->id,
+        'type' => $c->type,
+        'title' => $c->title,
+        'last_message_at' => $c->last_message_at?->toIso8601String(),
+        'last_message' => \App\Services\ChatMessagePreview::forMessage($c->lastMessage),
+        'participants' => $c->participants
+            ->where('id', '!=', auth()->id())
+            ->map(fn ($p) => \App\Services\ChatPresenceProjector::project($p))
+            ->values(),
+    ]);
 @endphp
 <script>
 function messagesPage() {
     return {
         tab: 'all',
-        conversations: {!! json_encode($conversationsPayload) !!},
+        conversations: @json($conversationsPayload),
         activeConvo: null,
         activeOther: null,
         messages: [],


### PR DESCRIPTION
Audit /simplify sur les commits chat récents (3 agents read-only).

## Critical
**N+1 unreadCount** : avant 51 queries/tick × polling 30s × 100 users = **170 qps**. Après : **1 query** avec sub-select corrélé.

## Extractions DRY
- `App\Services\ChatMessagePreview::forMessage()` — preview synthétisé (📎 Inscription/Paiement partagé). Consommé par `ChatController::conversationsList` ET le `@php` block Blade. Plus de drift possible.
- `App\Services\ChatPresenceProjector::project()` — projection user → JSON participant. Idem.
- `User::isOnline()` accessor + `User::PRESENCE_ONLINE_THRESHOLD_MINUTES = 2` → constante remplace la magic value répétée.
- `mapParticipant` supprimé.

## Quality
- `@json()` au lieu de `{!! json_encode !!}` (XSS).
- Comments `Issue #315` retirés.

## Defer (autre PR)
- Enum chat types
- Alpine state grouping
- pull endpoint --ff-only safety