### PR TITLE
refactor(perms): simplify post-lot7 — DRY alias map + drop dead Gates

### DIFF
--- a/app/Console/Commands/PermissionsAuditCommand.php
+++ b/app/Console/Commands/PermissionsAuditCommand.php
@@ -25,6 +25,16 @@ class PermissionsAuditCommand extends Command
 
     protected $description = 'Audite la cohérence rôles/permissions code ↔ registry ↔ DB';
 
+    /**
+     * Policy abilities standard (Laravel) — à ignorer (gérées par Policy classes,
+     * pas par permissions Spatie).
+     */
+    private const POLICY_ABILITIES = [
+        'view', 'viewAny', 'view-any', 'create', 'update', 'delete',
+        'restore', 'forceDelete', 'force-delete', 'replicate',
+        'download', 'upload',
+    ];
+
     /** Permissions référencées en code (chaque clé = nom utilisé) */
     private array $usedInCode = [];
 
@@ -36,11 +46,8 @@ class PermissionsAuditCommand extends Command
         $this->scanCode();
 
         $registryNames = $registry->all()->keys()->all();
-        $registryAliases = collect();
-        foreach ($registryNames as $canonical) {
-            $registryAliases = $registryAliases->merge($registry->aliasesOf($canonical));
-        }
-        $allRegistryNames = collect($registryNames)->merge($registryAliases)->unique()->values()->all();
+        $aliasMap = $registry->aliasMap();
+        $allRegistryNames = $registry->allNames()->all();
 
         try {
             $dbNames = Permission::pluck('name')->all();
@@ -56,41 +63,38 @@ class PermissionsAuditCommand extends Command
         $broken = [];        // référencé en code, ni en registry ni en DB
         $offRegistry = [];   // référencé en code, en DB, mais pas dans le registry
         $aliasesUsed = [];   // alias legacy utilisé en code (à migrer)
+        $dbNamesIndex = array_flip($dbNames);
 
         foreach ($this->usedInCode as $name => $locations) {
-            $isCanonical = in_array($name, $registryNames, true);
-            $isAlias = in_array($name, $registryAliases->all(), true);
-            $inDb = in_array($name, $dbNames, true);
+            $sample = array_slice($locations, 0, 3);
 
-            if ($isAlias) {
+            if (isset($aliasMap[$name])) {
                 $aliasesUsed[$name] = [
-                    'canonical' => $registry->canonicalize($name),
-                    'locations' => array_slice($locations, 0, 3),
+                    'canonical' => $aliasMap[$name],
+                    'locations' => $sample,
                 ];
                 continue;
             }
 
-            if ($isCanonical) {
+            if ($registry->isCanonical($name)) {
                 continue; // OK, canonique utilisé directement
             }
 
             // Pas dans le registry
-            if ($inDb) {
-                $offRegistry[$name] = ['locations' => array_slice($locations, 0, 3)];
+            if (isset($dbNamesIndex[$name])) {
+                $offRegistry[$name] = ['locations' => $sample];
             } else {
-                $broken[$name] = ['locations' => array_slice($locations, 0, 3)];
+                $broken[$name] = ['locations' => $sample];
             }
         }
 
+        $allRegistryIndex = array_flip($allRegistryNames);
         $orphaned = [];
-        foreach ($dbNames as $dbName) {
-            if (! isset($this->usedInCode[$dbName]) && ! in_array($dbName, $allRegistryNames, true)) {
-                $orphaned[] = $dbName;
-            }
-        }
-
         $deprecatedAssigned = [];
         foreach ($dbNames as $dbName) {
+            if (! isset($this->usedInCode[$dbName]) && ! isset($allRegistryIndex[$dbName])) {
+                $orphaned[] = $dbName;
+            }
             if ($registry->isDeprecated($dbName)) {
                 $deprecatedAssigned[$dbName] = $registry->deprecatedReason($dbName);
             }
@@ -138,16 +142,6 @@ class PermissionsAuditCommand extends Command
 
         return empty($broken) ? self::SUCCESS : self::FAILURE;
     }
-
-    /**
-     * Policy abilities standard (Laravel) — à ignorer (gérées par Policy classes,
-     * pas par permissions Spatie).
-     */
-    private const POLICY_ABILITIES = [
-        'view', 'viewAny', 'view-any', 'create', 'update', 'delete',
-        'restore', 'forceDelete', 'force-delete', 'replicate',
-        'download', 'upload',
-    ];
 
     /**
      * Scanne tous les fichiers pertinents et collecte les permissions référencées.

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,24 +2,20 @@
 
 namespace App\Providers;
 
+use App\Models\ESBTPBulletin;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPNote;
+use App\Models\ESBTPPaiement;
+use App\Models\ESBTPSeanceCours;
+use App\Policies\ESBTPBulletinPolicy;
+use App\Policies\ESBTPInscriptionPolicy;
+use App\Policies\ESBTPMatierePolicy;
+use App\Policies\ESBTPNotePolicy;
+use App\Policies\ESBTPPaiementPolicy;
+use App\Policies\ESBTPSeanceCoursPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Gate;
-use App\Models\ESBTPEmploiTemps;
-use App\Models\ESBTPSeanceCours;
-use App\Models\ESBTPMatiere;
-use App\Models\ESBTPPaiement;
-use App\Models\ESBTPNote;
-use App\Models\ESBTPInscription;
-use App\Models\ESBTPBulletin;
-use App\Models\User;
-use App\Policies\ESBTPSeanceCoursPolicy;
-use App\Policies\ESBTPMatierePolicy;
-use App\Policies\ESBTPPaiementPolicy;
-use App\Policies\ESBTPNotePolicy;
-use App\Policies\ESBTPInscriptionPolicy;
-use App\Policies\ESBTPBulletinPolicy;
-use App\Policies\UserManagementPolicy;
-use App\Services\UserManagementService;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -46,22 +42,19 @@ class AuthServiceProvider extends ServiceProvider
     {
         $this->registerPolicies();
 
+        // superAdmin court-circuite tous les checks (Lot 0).
         Gate::before(function ($user, $ability) {
             return $user && $user->hasRole('superAdmin') ? true : null;
         });
 
+        // `users.manage` : exposé en Gate explicite pour éviter toute ambiguïté
+        // entre les routes qui consomment Gate::* et le résolveur Spatie.
         Gate::define('users.manage', function ($user) {
             return $user && $user->hasPermissionTo('users.manage');
         });
 
-        // Lot 5 : Matrice de gestion users granulaire (qui peut gérer qui)
-        Gate::define('manage-user', function (User $actor, User $target) {
-            return app(UserManagementService::class)->canManage($actor, $target);
-        });
-
-        Gate::define('assign-role', function (User $actor, User $target, string $role) {
-            $service = app(UserManagementService::class);
-            return $service->canManage($actor, $target) && $service->canAssignRole($actor, $role);
-        });
+        // Lot 5 : la matrice "qui peut gérer qui" et l'assignation de rôle
+        // passent par UserManagementPolicy. Les anciens Gate::define
+        // 'manage-user' / 'assign-role' ont été retirés (jamais appelés).
     }
 }

--- a/app/Services/PermissionRegistry.php
+++ b/app/Services/PermissionRegistry.php
@@ -19,7 +19,7 @@ use Throwable;
 class PermissionRegistry
 {
     /** Cache des aliases inversés : alias => canonical */
-    private ?array $aliasMap = null;
+    private ?array $aliasMapCache = null;
 
     /** Cache des rôles DB (incl. is_custom) pour la requête courante */
     private ?array $dbRolesCache = null;
@@ -116,6 +116,22 @@ class PermissionRegistry
         return $this->aliasMap()[$name] ?? $name;
     }
 
+    /**
+     * Indique si $name est l'alias legacy d'une permission canonique.
+     */
+    public function isAlias(string $name): bool
+    {
+        return isset($this->aliasMap()[$name]);
+    }
+
+    /**
+     * Indique si $name est une permission canonique connue.
+     */
+    public function isCanonical(string $name): bool
+    {
+        return $this->permissionMeta($name) !== null;
+    }
+
     public function aliasesOf(string $canonical): array
     {
         return $this->permissionMeta($canonical)['aliases'] ?? [];
@@ -126,9 +142,30 @@ class PermissionRegistry
      */
     public function allNames(): Collection
     {
-        return $this->all()->keys()->merge(
-            $this->all()->flatMap(fn ($meta) => $meta['aliases'] ?? [])
-        )->unique()->values();
+        return $this->all()->keys()->merge(array_keys($this->aliasMap()))
+            ->unique()->values();
+    }
+
+    /**
+     * Map alias => canonical, exposée publiquement pour les outils d'audit
+     * qui ont besoin de filtrer/inverser. Cachée à la première lecture.
+     *
+     * @return array<string, string>
+     */
+    public function aliasMap(): array
+    {
+        if ($this->aliasMapCache !== null) {
+            return $this->aliasMapCache;
+        }
+
+        $map = [];
+        foreach (config('permissions.permissions', []) as $canonical => $meta) {
+            foreach ($meta['aliases'] ?? [] as $alias) {
+                $map[$alias] = $canonical;
+            }
+        }
+
+        return $this->aliasMapCache = $map;
     }
 
     /**
@@ -164,30 +201,13 @@ class PermissionRegistry
     }
 
     /**
-     * Vide le cache interne (utile après création/édition d'un rôle custom).
+     * Vide les caches internes (utile après création/édition d'un rôle custom
+     * ou rechargement de config dans les tests).
      */
     public function clearCache(): void
     {
         $this->dbRolesCache = null;
-    }
-
-    /**
-     * Map alias => canonical, calculé à la demande puis caché.
-     */
-    private function aliasMap(): array
-    {
-        if ($this->aliasMap !== null) {
-            return $this->aliasMap;
-        }
-
-        $map = [];
-        foreach (config('permissions.permissions', []) as $canonical => $meta) {
-            foreach ($meta['aliases'] ?? [] as $alias) {
-                $map[$alias] = $canonical;
-            }
-        }
-
-        return $this->aliasMap = $map;
+        $this->aliasMapCache = null;
     }
 
     /**


### PR DESCRIPTION
## Contexte

Simplify pass sur le domaine **Permissions overhaul** (Lots 0-7, range \`57239924^..ece1b6df\`). 7 fichiers cibles audités, 3 modifiés (les autres soit déjà clean soit hors-scope/risque).

## Changements (no behavior change)

### \`app/Services/PermissionRegistry.php\`
- Renommé le **field** \`aliasMap\` → \`aliasMapCache\` pour ne plus shadow la méthode \`aliasMap()\`. Le piège : avoir un champ et une méthode du même nom rendait le code confus à lire (\"où va le \$this->aliasMap ? field ou méthode ?\").
- **Exposé \`aliasMap()\` en public** + ajouté \`isCanonical()\` et \`isAlias()\`. Le \`PermissionsAuditCommand\` reconstruisait la map alias→canonical à la main. Désormais le registry est l'unique source.
- \`allNames()\` utilise désormais \`aliasMap()\` au lieu de re-flatMapper les aliases (DRY, et la cache est partagée).
- \`clearCache()\` reset aussi \`aliasMapCache\` (pas seulement \`dbRolesCache\`). Bug latent en tests qui rechargent la config.

### \`app/Console/Commands/PermissionsAuditCommand.php\`
- Utilise \`registry->aliasMap()\` + \`registry->allNames()\` + \`registry->isCanonical()\` au lieu de rebuilder la collection à la main (3 lignes au lieu de 5).
- Remplacé les \`in_array(...)\` hot loops par des \`array_flip\` index lookups (\`isset($index[$name])\`). Audit est OK rapide, mais le pattern est mieux.
- Fold du \`foreach\` orphelins + \`foreach\` deprecated en un seul pass.
- Hoist du \`const POLICY_ABILITIES\` en haut de la classe (était déclaré entre 2 méthodes — bizarre, et masqué dans l'IDE).

### \`app/Providers/AuthServiceProvider.php\`
- **Retiré** les \`Gate::define('manage-user', ...)\` et \`Gate::define('assign-role', ...)\` : jamais appelés nulle part dans le repo. La granularité passe par \`UserManagementPolicy\` (Lot 5) qui couvre les mêmes cas.
- **Conservé** \`Gate::define('users.manage', ...)\` : c'est utilisé par 5 controllers + 2 vues. Ne pas toucher pour ne pas risquer de divergence Spatie/Gate sur les call sites existants.
- Imports alphabétiques + drop unused (\`User\`, \`UserManagementService\`, \`UserManagementPolicy\`, \`ESBTPEmploiTemps\`).

## Findings appliqués

| # | Finding | Fix | Impact |
|---|---------|-----|--------|
| 1 | Field/method name collision \`aliasMap\` | Rename field → \`aliasMapCache\` | Lisibilité |
| 2 | DRY violation: alias map computée 3 fois | Public \`aliasMap()\` + helpers | -8 LOC dans Audit |
| 3 | \`clearCache()\` partial — laisse alias cache stale | Reset both | Bug latent test |
| 4 | Dead Gates \`manage-user\` / \`assign-role\` | Retirés | -10 LOC |
| 5 | \`POLICY_ABILITIES\` const positionné en milieu de classe | Hoist top | Style |
| 6 | \`in_array\` hot loops sur dbNames | \`array_flip\` index | Micro perf |
| 7 | Double pass foreach orphaned/deprecated | Single pass | -3 LOC |

## Findings NON appliqués (gardés en backlog)

| # | Finding | Raison |
|---|---------|--------|
| A | Magic strings \`'superAdmin'\`/\`'serviceTechnique'\` dans \`UserManagementService::canManage\` (target sans rôles → fallback) | Refactor non-trivial : nécessiterait une notion de \"super-roles\" dans le registry. Backlog Lot 8/9. |
| B | \`RoleHelper.php\` (legacy LMS) duplique la logique de role checks | Helper utilisé uniquement par \`API/AuthController\` (LMS). Hors scope perms overhaul. |
| C | \`Gate::define('users.manage', ...)\` redondant avec Spatie | Risque silent : 5 controllers + 2 vues consomment cette ability. Conservé pour ne pas casser. |
| D | \`fix_permissions.php\` audit users sans rôle pourrait migrer dans \`PermissionSyncService\` | Le script reste lisible et la logique CLI-only (sortie texte) ne se prête pas au service. |
| E | Tests Pest manquants pour \`PermissionsAuditCommand\` | Hors scope simplify, à ajouter en Lot dédié. Ne pas créer de tests pour ce simplify (rule). |

## Stats

- **+84 / -77** sur 3 fichiers
- 0 nouvelle dépendance, 0 changement public API breakant
- 2 nouvelles méthodes publiques: \`aliasMap()\`, \`isCanonical()\`, \`isAlias()\` (purement additives)

## Tests

- ❌ Tests **non lancés en local** (vendor absent du worktree, conformément à la rule \`multi-agent-git-safety.md\` §3 option 1). Lint PHP \`-l\` clean sur les 3 fichiers.
- ✅ Aucun test existant ne touche aux internals modifiés (vérifié : \`PermissionRegistryTest\`, \`UserManagementServiceTest\`, \`PermissionRegistryRoleMetaTest\`, \`CustomRoleCrudTest\` testent tous l'API publique stable).
- ✅ Compatible avec \`fix_permissions.php\`, \`PermissionSyncService\` (utilisent \`allNames()\`, \`canonicalize()\`, \`aliasesOf()\` — tous inchangés).

## Test plan (CI)

- [ ] \`php artisan test --filter=Permission\` doit rester vert
- [ ] \`php artisan permissions:audit\` doit produire le même rapport qu'avant (mêmes catégories, même comptage)
- [ ] \`php bin/deploy/fix_permissions.php\` doit s'exécuter sans erreur sur un tenant test

## Scope préservé

- ✅ Aucune permission ajoutée/supprimée dans \`config/permissions.php\`
- ✅ Aucun rôle perdu de permission (matrice \`role_defaults\` intacte)
- ✅ Aucun alias supprimé (rétrocompat Lot 6 préservée)
- ✅ Convention canonique \`domaine.action[.qualifier]\` snake_case respectée