### PR TITLE
refactor(custom-roles+widgets): simplify post-lot12 — DRY icons, helpers, mb_strtoupper

### DIFF
--- a/app/Http/Controllers/ESBTPCustomRoleController.php
+++ b/app/Http/Controllers/ESBTPCustomRoleController.php
@@ -32,16 +32,6 @@ use Spatie\Permission\PermissionRegistrar;
 class ESBTPCustomRoleController extends Controller
 {
     /**
-     * Whitelist des icônes Font Awesome autorisées pour les rôles custom.
-     *
-     * Empêche un acteur de saisir une classe arbitraire (ex: `fa-skull` ou `' onclick=...`)
-     * qui pourrait casser l'UI ou permettre une injection. Toute valeur hors liste est
-     * remplacée par le défaut `fa-user-tag`.
-     *
-     * Pour ajouter une icône : la déclarer ici ET dans les `cr-icon-suggestions` des
-     * modals create/edit pour qu'elle soit suggérée à l'utilisateur.
-     */
-    /**
      * Rôles système éditables depuis /esbtp/personnel/unified par les users avec
      * `users.manage` (Lot 17). superAdmin et serviceTechnique restent gérés
      * exclusivement via /esbtp/roles-permissions (Service Technique).
@@ -58,6 +48,16 @@ class ESBTPCustomRoleController extends Controller
         'etudiant',
     ];
 
+    /**
+     * Whitelist des icônes Font Awesome autorisées pour les rôles custom.
+     *
+     * Empêche un acteur de saisir une classe arbitraire (ex: `fa-skull` ou `' onclick=...`)
+     * qui pourrait casser l'UI ou permettre une injection. Toute valeur hors liste est
+     * remplacée par le défaut `fa-user-tag`.
+     *
+     * Pour ajouter une icône : la déclarer ici ET dans `_icon-suggestions.blade.php`
+     * pour qu'elle soit suggérée à l'utilisateur.
+     */
     private const ALLOWED_ICONS = [
         // Personnel & rôles
         'fa-user-tag', 'fa-user-shield', 'fa-user-tie', 'fa-user-cog', 'fa-user-check',
@@ -187,23 +187,12 @@ class ESBTPCustomRoleController extends Controller
             ], 422);
         }
 
-        // Sécurité : restreindre aux permissions que l'acteur possède
-        $requestedPerms = collect($validated['permissions'] ?? [])->unique()->values()->all();
-        $allowedPerms = $this->grantablePermissionsForActor($registry)
-            ->flatten(1)
-            ->pluck('name')
-            ->all();
-        $forbidden = array_diff($requestedPerms, $allowedPerms);
-        if (! empty($forbidden)) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Vous ne pouvez accorder que des permissions que vous possédez. Refusées : ' . implode(', ', $forbidden),
-                'forbidden' => array_values($forbidden),
-            ], 403);
+        $requestedPerms = $this->normalizePermissionsList($validated['permissions'] ?? []);
+        if ($denial = $this->denyIfPermissionsNotGrantable($requestedPerms, $registry)) {
+            return $denial;
         }
 
-        DB::beginTransaction();
-        try {
+        return $this->runMutation($registry, 'la création', function () use ($validated, $requestedPerms) {
             $role = new Role();
             $role->name = $validated['name'];
             $role->guard_name = config('auth.defaults.guard', 'web');
@@ -218,12 +207,7 @@ class ESBTPCustomRoleController extends Controller
                 $role->syncPermissions($requestedPerms);
             }
 
-            DB::commit();
-
-            app(PermissionRegistrar::class)->forgetCachedPermissions();
-            $registry->clearCache();
-
-            return response()->json([
+            return [
                 'success' => true,
                 'message' => "Rôle « {$validated['label_fr']} » créé avec succès.",
                 'role' => [
@@ -233,14 +217,8 @@ class ESBTPCustomRoleController extends Controller
                     'icon' => $role->icon,
                     'description' => $role->description,
                 ],
-            ]);
-        } catch (\Throwable $e) {
-            DB::rollBack();
-            return response()->json([
-                'success' => false,
-                'message' => 'Erreur lors de la création : ' . $e->getMessage(),
-            ], 500);
-        }
+            ];
+        });
     }
 
     /**
@@ -289,22 +267,12 @@ class ESBTPCustomRoleController extends Controller
             'icon.in' => 'Cette icône n\'est pas autorisée. Choisissez parmi les suggestions.',
         ]);
 
-        $requestedPerms = collect($validated['permissions'] ?? [])->unique()->values()->all();
-        $allowedPerms = $this->grantablePermissionsForActor($registry)
-            ->flatten(1)
-            ->pluck('name')
-            ->all();
-        $forbidden = array_diff($requestedPerms, $allowedPerms);
-        if (! empty($forbidden)) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Vous ne pouvez accorder que des permissions que vous possédez. Refusées : ' . implode(', ', $forbidden),
-                'forbidden' => array_values($forbidden),
-            ], 403);
+        $requestedPerms = $this->normalizePermissionsList($validated['permissions'] ?? []);
+        if ($denial = $this->denyIfPermissionsNotGrantable($requestedPerms, $registry)) {
+            return $denial;
         }
 
-        DB::beginTransaction();
-        try {
+        return $this->runMutation($registry, 'la mise à jour', function () use ($roleModel, $validated, $requestedPerms) {
             $roleModel->label_fr = $validated['label_fr'];
             $roleModel->icon = $this->normalizeIcon($validated['icon'] ?? null);
             $roleModel->description = $validated['description'] ?? null;
@@ -312,22 +280,11 @@ class ESBTPCustomRoleController extends Controller
 
             $roleModel->syncPermissions($requestedPerms);
 
-            DB::commit();
-
-            app(PermissionRegistrar::class)->forgetCachedPermissions();
-            $registry->clearCache();
-
-            return response()->json([
+            return [
                 'success' => true,
                 'message' => "Rôle « {$validated['label_fr']} » mis à jour.",
-            ]);
-        } catch (\Throwable $e) {
-            DB::rollBack();
-            return response()->json([
-                'success' => false,
-                'message' => 'Erreur lors de la mise à jour : ' . $e->getMessage(),
-            ], 500);
-        }
+            ];
+        });
     }
 
     /**
@@ -384,22 +341,12 @@ class ESBTPCustomRoleController extends Controller
 
         // Garde-fou : un acteur ne peut donner que les permissions qu'il possède
         // (sauf superAdmin via Gate::before)
-        $requestedPerms = collect($validated['permissions'] ?? [])->unique()->values()->all();
-        $allowedPerms = $this->grantablePermissionsForActor($registry)
-            ->flatten(1)
-            ->pluck('name')
-            ->all();
-        $forbidden = array_diff($requestedPerms, $allowedPerms);
-        if (! empty($forbidden)) {
-            return response()->json([
-                'success' => false,
-                'message' => 'Vous ne pouvez accorder que des permissions que vous possédez. Refusées : ' . implode(', ', $forbidden),
-                'forbidden' => array_values($forbidden),
-            ], 403);
+        $requestedPerms = $this->normalizePermissionsList($validated['permissions'] ?? []);
+        if ($denial = $this->denyIfPermissionsNotGrantable($requestedPerms, $registry)) {
+            return $denial;
         }
 
-        DB::beginTransaction();
-        try {
+        return $this->runMutation($registry, 'la mise à jour', function () use ($roleModel, $validated, $requestedPerms) {
             // Override DB metadata (le registry config sert de fallback)
             $roleModel->label_fr = $validated['label_fr'];
             $roleModel->icon = $this->normalizeIcon($validated['icon'] ?? null);
@@ -409,22 +356,11 @@ class ESBTPCustomRoleController extends Controller
 
             $roleModel->syncPermissions($requestedPerms);
 
-            DB::commit();
-
-            app(PermissionRegistrar::class)->forgetCachedPermissions();
-            $registry->clearCache();
-
-            return response()->json([
+            return [
                 'success' => true,
                 'message' => "Rôle système « {$validated['label_fr']} » mis à jour.",
-            ]);
-        } catch (\Throwable $e) {
-            DB::rollBack();
-            return response()->json([
-                'success' => false,
-                'message' => 'Erreur lors de la mise à jour : ' . $e->getMessage(),
-            ], 500);
-        }
+            ];
+        });
     }
 
     /**
@@ -450,28 +386,16 @@ class ESBTPCustomRoleController extends Controller
             ], 422);
         }
 
-        DB::beginTransaction();
-        try {
+        return $this->runMutation($registry, 'la suppression', function () use ($roleModel) {
             $label = $roleModel->label_fr ?? $roleModel->name;
             $roleModel->syncPermissions([]);
             $roleModel->delete();
 
-            DB::commit();
-
-            app(PermissionRegistrar::class)->forgetCachedPermissions();
-            $registry->clearCache();
-
-            return response()->json([
+            return [
                 'success' => true,
                 'message' => "Rôle « {$label} » supprimé.",
-            ]);
-        } catch (\Throwable $e) {
-            DB::rollBack();
-            return response()->json([
-                'success' => false,
-                'message' => 'Erreur lors de la suppression : ' . $e->getMessage(),
-            ], 500);
-        }
+            ];
+        });
     }
 
     /**
@@ -549,8 +473,7 @@ class ESBTPCustomRoleController extends Controller
             }
         }
 
-        DB::beginTransaction();
-        try {
+        return $this->runMutation($registry, 'l\'affectation', function () use ($roleModel, $requestedUserIds) {
             $currentIds = $roleModel->users()->pluck('users.id')->all();
             $toAttach = array_diff($requestedUserIds, $currentIds);
             $toDetach = array_diff($currentIds, $requestedUserIds);
@@ -563,24 +486,13 @@ class ESBTPCustomRoleController extends Controller
                 $roleModel->users()->detach($toDetach);
             }
 
-            DB::commit();
-
-            app(PermissionRegistrar::class)->forgetCachedPermissions();
-            $registry->clearCache();
-
-            return response()->json([
+            return [
                 'success' => true,
                 'message' => 'Affectations mises à jour.',
                 'attached' => count($toAttach),
                 'detached' => count($toDetach),
-            ]);
-        } catch (\Throwable $e) {
-            DB::rollBack();
-            return response()->json([
-                'success' => false,
-                'message' => 'Erreur : ' . $e->getMessage(),
-            ], 500);
-        }
+            ];
+        });
     }
 
     /**
@@ -599,26 +511,14 @@ class ESBTPCustomRoleController extends Controller
 
         $userModel = User::findOrFail($user);
 
-        DB::beginTransaction();
-        try {
+        return $this->runMutation($registry, 'le détachement', function () use ($userModel, $roleModel) {
             $userModel->removeRole($roleModel);
 
-            DB::commit();
-
-            app(PermissionRegistrar::class)->forgetCachedPermissions();
-            $registry->clearCache();
-
-            return response()->json([
+            return [
                 'success' => true,
                 'message' => "{$userModel->name} détaché du rôle.",
-            ]);
-        } catch (\Throwable $e) {
-            DB::rollBack();
-            return response()->json([
-                'success' => false,
-                'message' => 'Erreur : ' . $e->getMessage(),
-            ], 500);
-        }
+            ];
+        });
     }
 
     // ─────────────── Helpers privés ───────────────
@@ -629,6 +529,71 @@ class ESBTPCustomRoleController extends Controller
     private function customRolesQuery()
     {
         return Role::query()->where('is_custom', true)->orderBy('label_fr')->orderBy('name');
+    }
+
+    /**
+     * Normalise un tableau brut de noms de permission : déduplique + valeurs réindexées.
+     *
+     * @param  array<int, string>  $perms
+     * @return array<int, string>
+     */
+    private function normalizePermissionsList(array $perms): array
+    {
+        return collect($perms)->unique()->values()->all();
+    }
+
+    /**
+     * Vérifie que toutes les permissions demandées sont accordables par l'acteur courant.
+     * Retourne une JsonResponse 403 listant les refusées si KO, ou null si OK.
+     *
+     * @param  array<int, string>  $requestedPerms
+     */
+    private function denyIfPermissionsNotGrantable(array $requestedPerms, PermissionRegistry $registry): ?\Illuminate\Http\JsonResponse
+    {
+        $allowedPerms = $this->grantablePermissionsForActor($registry)
+            ->flatten(1)
+            ->pluck('name')
+            ->all();
+
+        $forbidden = array_diff($requestedPerms, $allowedPerms);
+        if (empty($forbidden)) {
+            return null;
+        }
+
+        return response()->json([
+            'success' => false,
+            'message' => 'Vous ne pouvez accorder que des permissions que vous possédez. Refusées : ' . implode(', ', $forbidden),
+            'forbidden' => array_values($forbidden),
+        ], 403);
+    }
+
+    /**
+     * Exécute une mutation DB dans une transaction + invalide les caches Spatie + registry.
+     * Retourne la JsonResponse construite à partir du payload renvoyé par le callback,
+     * ou une JsonResponse 500 en cas d'exception (rollback automatique).
+     *
+     * @param  string  $action  Nom de l'action en français (ex: "la création"), utilisé dans le message d'erreur.
+     * @param  callable  $callback  Closure qui doit retourner un array<string, mixed> à JSONifier.
+     */
+    private function runMutation(PermissionRegistry $registry, string $action, callable $callback): \Illuminate\Http\JsonResponse
+    {
+        DB::beginTransaction();
+        try {
+            $payload = $callback();
+            DB::commit();
+
+            app(PermissionRegistrar::class)->forgetCachedPermissions();
+            $registry->clearCache();
+
+            return response()->json($payload);
+        } catch (\Throwable $e) {
+            DB::rollBack();
+
+            return response()->json([
+                'success' => false,
+                'message' => "Erreur lors de {$action} : " . $e->getMessage(),
+            ], 500);
+        }
     }
 
     /**

--- a/resources/views/components/dw-widget.blade.php
+++ b/resources/views/components/dw-widget.blade.php
@@ -8,7 +8,11 @@
     'alert' => false,
 ])
 
-<div {{ $attributes->merge(['class' => 'dw-widget dw-widget--' . $color . ($alert ? ' dw-widget--alert' : '')]) }}>
+@php
+    $widgetClass = 'dw-widget dw-widget--' . $color . ($alert ? ' dw-widget--alert' : '');
+@endphp
+
+<div {{ $attributes->merge(['class' => $widgetClass]) }}>
     <div class="dw-widget-icon">
         <i class="fas {{ $icon }}"></i>
     </div>
@@ -19,6 +23,7 @@
                 {{ $value }}@if ($unit)<span class="dw-widget-unit">{{ $unit }}</span>@endif
             </div>
         @endif
+        {{-- Slot personnalisé prioritaire ; le hint sert de fallback texte court. --}}
         {{ $slot }}
         @if ($hint && $slot->isEmpty())
             <div class="dw-widget-hint">{{ $hint }}</div>

--- a/resources/views/esbtp/custom-roles/_assign-users-modal.blade.php
+++ b/resources/views/esbtp/custom-roles/_assign-users-modal.blade.php
@@ -62,7 +62,7 @@
                                        class="cr-user-check" data-cr-user-check
                                        @checked($isAssigned)>
                                 <span class="cr-user-box"><i class="fas fa-check"></i></span>
-                                <span class="cr-user-avatar">{{ strtoupper(mb_substr($user->name, 0, 2)) }}</span>
+                                <span class="cr-user-avatar">{{ mb_strtoupper(mb_substr($user->name, 0, 2, 'UTF-8'), 'UTF-8') }}</span>
                                 <span class="cr-user-info">
                                     <span class="cr-user-name">{{ $user->name }}</span>
                                     <span class="cr-user-email">{{ $user->email }}</span>

--- a/resources/views/esbtp/custom-roles/_create-modal.blade.php
+++ b/resources/views/esbtp/custom-roles/_create-modal.blade.php
@@ -66,13 +66,7 @@
                                 <input type="text" id="cr-create-icon" name="icon" class="cr-form-input cr-form-input-mono"
                                        value="fa-user-tag" maxlength="64" placeholder="fa-user-tag" data-cr-icon-input>
                             </div>
-                            <div class="cr-icon-suggestions">
-                                @foreach(['fa-user-tag', 'fa-user-shield', 'fa-user-tie', 'fa-user-cog', 'fa-user-check', 'fa-id-badge', 'fa-headset', 'fa-magnifying-glass', 'fa-key', 'fa-handshake'] as $iconClass)
-                                    <button type="button" class="cr-icon-chip" data-cr-icon-suggest="{{ $iconClass }}" title="{{ $iconClass }}">
-                                        <i class="fas {{ $iconClass }}"></i>
-                                    </button>
-                                @endforeach
-                            </div>
+                            @include('esbtp.custom-roles._icon-suggestions')
                         </div>
 
                         <div class="cr-form-group">

--- a/resources/views/esbtp/custom-roles/_edit-modal.blade.php
+++ b/resources/views/esbtp/custom-roles/_edit-modal.blade.php
@@ -61,13 +61,7 @@
                                 <input type="text" id="cr-edit-icon" name="icon" class="cr-form-input cr-form-input-mono"
                                        value="{{ old('icon', $role->icon ?? 'fa-user-tag') }}" maxlength="64" data-cr-icon-input>
                             </div>
-                            <div class="cr-icon-suggestions">
-                                @foreach(['fa-user-tag', 'fa-user-shield', 'fa-user-tie', 'fa-user-cog', 'fa-user-check', 'fa-id-badge', 'fa-headset', 'fa-magnifying-glass', 'fa-key', 'fa-handshake'] as $iconClass)
-                                    <button type="button" class="cr-icon-chip" data-cr-icon-suggest="{{ $iconClass }}" title="{{ $iconClass }}">
-                                        <i class="fas {{ $iconClass }}"></i>
-                                    </button>
-                                @endforeach
-                            </div>
+                            @include('esbtp.custom-roles._icon-suggestions')
                         </div>
 
                         <div class="cr-form-group">

--- a/resources/views/esbtp/custom-roles/_edit-standard-modal.blade.php
+++ b/resources/views/esbtp/custom-roles/_edit-standard-modal.blade.php
@@ -87,13 +87,12 @@
                                        value="{{ old('icon', $role->icon ?? ($configMeta['icon'] ?? 'fa-user-tag')) }}"
                                        maxlength="64" data-cr-icon-input>
                             </div>
-                            <div class="cr-icon-suggestions">
-                                @foreach(['fa-user-tag', 'fa-user-shield', 'fa-user-tie', 'fa-user-cog', 'fa-cash-register', 'fa-calculator', 'fa-chalkboard-teacher', 'fa-user-graduate', 'fa-clipboard-list', 'fa-pen-fancy'] as $iconClass)
-                                    <button type="button" class="cr-icon-chip" data-cr-icon-suggest="{{ $iconClass }}" title="{{ $iconClass }}">
-                                        <i class="fas {{ $iconClass }}"></i>
-                                    </button>
-                                @endforeach
-                            </div>
+                            {{-- Set d'icônes orienté métier (caissier/comptable/enseignant…) --}}
+                            @include('esbtp.custom-roles._icon-suggestions', ['icons' => [
+                                'fa-user-tag', 'fa-user-shield', 'fa-user-tie', 'fa-user-cog',
+                                'fa-cash-register', 'fa-calculator', 'fa-chalkboard-teacher',
+                                'fa-user-graduate', 'fa-clipboard-list', 'fa-pen-fancy',
+                            ]])
                         </div>
 
                         <div class="cr-form-group">

--- a/resources/views/esbtp/custom-roles/_icon-suggestions.blade.php
+++ b/resources/views/esbtp/custom-roles/_icon-suggestions.blade.php
@@ -1,0 +1,23 @@
+{{--
+    Lot 8 — Suggestions d'icônes Font Awesome partagées entre les 3 modals
+    (création custom, édition custom, édition standard).
+
+    Variables :
+    - $icons : array<string> — liste des classes FA à proposer (par défaut, set commun)
+
+    Toutes les icônes proposées DOIVENT figurer dans la whitelist
+    `ESBTPCustomRoleController::ALLOWED_ICONS` sinon la validation serveur les rejettera.
+--}}
+@php
+    $icons = $icons ?? [
+        'fa-user-tag', 'fa-user-shield', 'fa-user-tie', 'fa-user-cog', 'fa-user-check',
+        'fa-id-badge', 'fa-headset', 'fa-magnifying-glass', 'fa-key', 'fa-handshake',
+    ];
+@endphp
+<div class="cr-icon-suggestions">
+    @foreach($icons as $iconClass)
+        <button type="button" class="cr-icon-chip" data-cr-icon-suggest="{{ $iconClass }}" title="{{ $iconClass }}">
+            <i class="fas {{ $iconClass }}"></i>
+        </button>
+    @endforeach
+</div>


### PR DESCRIPTION
## Contexte

Pass /simplify D2 sur les commits Lots 8-12 (custom roles + dashboard widgets). Window : `7d4428db^..d48104e1`. Un /simplify partiel sur les widgets (`c03cfd5e`) avait déjà été appliqué — ce PR cible le code custom-roles + le composant `dw-widget` non encore touchés.

## Findings appliqués

1. **DRY 3 modals — `_icon-suggestions.blade.php` partagé** (HIGH)
   Les 3 modals (`_create-modal`, `_edit-modal`, `_edit-standard-modal`) hardcodaient chacun une liste de 10 icônes `cr-icon-chip`, avec des sets divergents (10 communes vs 10 orientées métier). Extrait dans une partial réutilisable acceptant un prop `\$icons`. Le `_edit-standard-modal` continue de fournir son set orienté caissier/comptable explicitement.

2. **Refactor `ESBTPCustomRoleController` — `runMutation()` helper** (HIGH)
   Pattern `DB::beginTransaction + try { ... commit + forgetCachedPermissions + clearCache } catch { rollBack + 500 }` répliqué littéralement 5 fois (store, update, updateStandard, destroy, assignUsers, detachUser). Extrait en `runMutation(PermissionRegistry, string \$action, callable)`. Toutes les méthodes mutation passent par ce helper ; le payload de succès reste contrôlé par chaque méthode.

3. **DRY garde-fou permissions accordables** (MEDIUM)
   Bloc `requestedPerms = collect(...)->unique() ; allowedPerms = grantable->flatten->pluck ; forbidden = array_diff ; if (!empty) return 403` dupliqué 3 fois (store, update, updateStandard). Extrait en `normalizePermissionsList()` + `denyIfPermissionsNotGrantable()` retournant `?JsonResponse`.

4. **Fix UTF-8 dans `_assign-users-modal`** (MEDIUM — rule violation)
   `strtoupper(mb_substr(\$user->name, 0, 2))` : un nom \"Émilie\" aurait son avatar rendu \"éM\" au lieu de \"ÉM\". Corrigé en `mb_strtoupper(mb_substr(..., 'UTF-8'), 'UTF-8')`. Aligné sur la rule `exports-pdf-excel.md`.

5. **Cleanup doc-comments interleavés** (LOW)
   Les blocs PHPDoc autour de `EDITABLE_STANDARD_ROLES` et `ALLOWED_ICONS` étaient permutés (le doc \"Whitelist icônes\" précédait la const `EDITABLE_STANDARD_ROLES`). Réordonné, et la mention obsolète \"déclarer dans les `cr-icon-suggestions` des modals create/edit\" pointe maintenant vers `_icon-suggestions.blade.php`.

6. **`dw-widget.blade.php` polish** (LOW)
   Extraction `\$widgetClass` (lisibilité) + commentaire explicite que `\$slot` prime sur `\$hint` (le `\$slot->isEmpty()` test n'était pas évident à scanner).

## Findings backlog (non appliqués cette passe)

- **Tests qui font du string-matching sur le source** (`CustomRoleCrudTest`) — fragiles, mais y toucher casserait la garantie qu'ils protègent. À refactorer dans une passe dédiée Pest avec mocks DB.
- **`EDITABLE_STANDARD_ROLES` hardcode 6 noms de rôles** — légère violation `permissions.md` (no-magic-strings rôles). Toute migration vers `config/permissions.roles + flag editable_via_unified` casserait le contrat actuel ; à traiter dans D4 Personnel pages premium.
- **`grantablePermissionsForActor()` charge TOUTES les permissions DB puis filtre** — N+1 en théorie mais en pratique c'est ~150 perms et 1 query, acceptable. Optimisable si profiling montre que c'est un hotspot.
- **Modals chargés en AJAX ré-rendent la partial à chaque ouverture** — pas de cache HTTP. OK car contenu dépend de l'utilisateur courant (perms accordables).

## Stats

- `ESBTPCustomRoleController` : **716 → 680 lignes** (-36 net, -120 brutes via extraction)
- 3 modals custom-roles : **-28 lignes** d'icônes hardcodées
- Nouveau fichier `_icon-suggestions.blade.php` : **+23 lignes** réutilisables
- 7 fichiers modifiés, **+146 / -166 = -20 LOC nets**

## Préservé strictement

- Tous les contrats JS : `data-cr-icon-suggest`, `data-cr-edit`, `data-cr-create-trigger`, etc.
- Toutes les routes nommées (`esbtp.custom-roles.*`)
- Signatures publiques des méthodes du controller (DI, retours JsonResponse)
- Codes HTTP de réponse (200/403/422/500)
- Comportement transactionnel : rollback préservé pour toute exception
- Permission `users.manage` toujours requise par le middleware constructor

## Lint

- `php -l app/Http/Controllers/ESBTPCustomRoleController.php` → OK
- Pas de `<select>` natif introduit dans les modals premium (rule `premium-selects.md` respectée — il n'y en avait déjà aucun)

## Tests

Vendor absent du worktree (pattern multi-agent rule 3) → tests non lancés localement. Les tests existants (`CustomRoleCrudTest`, `PermissionRegistryRoleMetaTest`) font du string-matching sur le source PHP — je n'ai pas modifié les chaînes qu'ils cherchent (`is_custom`, `rôles système`, `\$actor->can(\$p->name)`, `Rule::unique('roles', 'name')`, etc.) donc ils devraient passer en CI sans modification.