### PR TITLE
refactor(personnel): simplify post-Lot19 — DRY controllers + add missing trait

### DIFF
--- a/app/Http/Controllers/Concerns/ResetsPersonnelPassword.php
+++ b/app/Http/Controllers/Concerns/ResetsPersonnelPassword.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Réinitialisation mot de passe personnel — pattern unifié.
+ *
+ * Utilisé par ESBTPCaissierController + ESBTPComptableController (Lot 18).
+ * Les autres rôles (coordinateur, secrétaire, enseignant, étudiant) ont
+ * actuellement leur propre `resetPassword()` legacy — à migrer ici au fil
+ * des touches.
+ *
+ * Mot de passe par défaut : `Bonjour@2025` + `must_change_password = true`.
+ * Réponse adaptative JSON (AJAX) ou flash redirect.
+ */
+trait ResetsPersonnelPassword
+{
+    /**
+     * Réinitialise le mot de passe à la valeur par défaut et force le changement
+     * à la première connexion.
+     *
+     * @param  string  $roleLabel  ex: "comptable", "caissier" — utilisé dans logs et message
+     */
+    protected function resetPersonnelPassword(User $user, string $roleLabel): JsonResponse|RedirectResponse
+    {
+        try {
+            $defaultPassword = 'Bonjour@2025';
+
+            $user->password = Hash::make($defaultPassword);
+            $user->must_change_password = true;
+            $user->save();
+
+            Log::info('Password reset for personnel to default', [
+                'role' => $roleLabel,
+                'user_id' => $user->id,
+                'user_name' => $user->name,
+                'reset_by' => auth()->user()?->name,
+                'timestamp' => now(),
+            ]);
+
+            if (request()->wantsJson() || request()->ajax()) {
+                return response()->json([
+                    'success' => true,
+                    'password' => $defaultPassword,
+                    'message' => 'Mot de passe réinitialisé avec succès !',
+                ]);
+            }
+
+            return redirect()->back()
+                ->with('success', "Mot de passe réinitialisé à {$defaultPassword} avec succès ! Le {$roleLabel} devra changer son mot de passe à la première connexion.")
+                ->with('new_password', $defaultPassword);
+        } catch (\Exception $e) {
+            Log::error('Password reset failed for personnel', [
+                'role' => $roleLabel,
+                'user_id' => $user->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            if (request()->wantsJson() || request()->ajax()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => 'Erreur lors de la réinitialisation : ' . $e->getMessage(),
+                ], 500);
+            }
+
+            return redirect()->back()
+                ->with('error', 'Erreur lors de la réinitialisation : ' . $e->getMessage());
+        }
+    }
+}

--- a/app/Http/Controllers/ESBTPCaissierController.php
+++ b/app/Http/Controllers/ESBTPCaissierController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\ResetsPersonnelPassword;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 
 /**
  * ESBTPCaissierController
@@ -20,6 +20,8 @@ use Illuminate\Support\Facades\Hash;
  */
 class ESBTPCaissierController extends Controller
 {
+    use ResetsPersonnelPassword;
+
     public function __construct()
     {
         $this->middleware('auth');
@@ -63,19 +65,17 @@ class ESBTPCaissierController extends Controller
         ]);
 
         try {
-            DB::beginTransaction();
-
-            $caissier->name  = $validated['name'];
-            $caissier->email = $validated['email'] ?? null;
-            $caissier->phone = $validated['phone'] ?? null;
+            $caissier->fill([
+                'name'  => $validated['name'],
+                'email' => $validated['email'] ?? null,
+                'phone' => $validated['phone'] ?? null,
+            ]);
 
             if (array_key_exists('is_active', $validated)) {
                 $caissier->is_active = (bool) $validated['is_active'];
             }
 
             $caissier->save();
-
-            DB::commit();
 
             if ($request->expectsJson() || $request->ajax()) {
                 return response()->json([
@@ -88,8 +88,6 @@ class ESBTPCaissierController extends Controller
             return redirect()->route('esbtp.caissiers.show', $caissier)
                 ->with('success', 'Caissier mis à jour avec succès.');
         } catch (\Exception $e) {
-            DB::rollBack();
-
             if ($request->expectsJson() || $request->ajax()) {
                 return response()->json([
                     'success' => false,
@@ -160,55 +158,14 @@ class ESBTPCaissierController extends Controller
 
     /**
      * Réinitialise le mot de passe à Bonjour@2025 et force le changement
-     * à la première connexion. Pattern aligné sur ESBTPCoordinateurController.
+     * à la première connexion. Logique partagée via ResetsPersonnelPassword.
      */
     public function resetPassword(User $caissier)
     {
         $this->ensureCanManage();
         $this->ensureIsCaissier($caissier);
 
-        try {
-            $defaultPassword = 'Bonjour@2025';
-
-            $caissier->password              = Hash::make($defaultPassword);
-            $caissier->must_change_password  = true;
-            $caissier->save();
-
-            \Log::info('🔑 Password reset for caissier to default', [
-                'caissier_id'           => $caissier->id,
-                'caissier_name'         => $caissier->name,
-                'reset_by'              => auth()->user()->name,
-                'timestamp'             => now(),
-                'must_change_password'  => true,
-            ]);
-
-            if (request()->wantsJson() || request()->ajax()) {
-                return response()->json([
-                    'success'  => true,
-                    'password' => $defaultPassword,
-                    'message'  => 'Mot de passe réinitialisé avec succès !',
-                ]);
-            }
-
-            return redirect()->back()
-                ->with('success', 'Mot de passe réinitialisé à Bonjour@2025 avec succès ! Le caissier devra changer son mot de passe à la première connexion.')
-                ->with('new_password', $defaultPassword);
-        } catch (\Exception $e) {
-            \Log::error('❌ Password reset failed for caissier', [
-                'caissier_id' => $caissier->id,
-                'error'       => $e->getMessage(),
-            ]);
-
-            if (request()->wantsJson() || request()->ajax()) {
-                return response()->json([
-                    'success' => false,
-                    'message' => 'Erreur lors de la réinitialisation : ' . $e->getMessage(),
-                ], 500);
-            }
-
-            return redirect()->back()
-                ->with('error', 'Erreur lors de la réinitialisation : ' . $e->getMessage());
-        }
+        return $this->resetPersonnelPassword($caissier, 'caissier');
     }
 
     /**

--- a/app/Http/Controllers/ESBTPComptableController.php
+++ b/app/Http/Controllers/ESBTPComptableController.php
@@ -2,16 +2,18 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Controllers\Concerns\ResetsPersonnelPassword;
 use App\Models\User;
 use App\Services\UserService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 use Spatie\Permission\Models\Role;
 
 class ESBTPComptableController extends Controller
 {
+    use ResetsPersonnelPassword;
+
     protected $userService;
 
     public function __construct(UserService $userService)
@@ -203,8 +205,8 @@ class ESBTPComptableController extends Controller
 
     /**
      * Lot 18d — Réinitialise le mot de passe du comptable à Bonjour@2025 et
-     * force le changement à la première connexion. Pattern aligné sur les
-     * autres rôles (coordinateur, secretaire, caissier).
+     * force le changement à la première connexion. Logique partagée via
+     * ResetsPersonnelPassword (alignée sur caissier, coordinateur, etc.).
      */
     public function resetPassword(User $user)
     {
@@ -212,47 +214,6 @@ class ESBTPComptableController extends Controller
             abort(404, 'Comptable non trouvé.');
         }
 
-        try {
-            $defaultPassword = 'Bonjour@2025';
-
-            $user->password              = Hash::make($defaultPassword);
-            $user->must_change_password  = true;
-            $user->save();
-
-            \Log::info('🔑 Password reset for comptable to default', [
-                'comptable_id'         => $user->id,
-                'comptable_name'       => $user->name,
-                'reset_by'             => auth()->user()->name,
-                'timestamp'            => now(),
-                'must_change_password' => true,
-            ]);
-
-            if (request()->wantsJson() || request()->ajax()) {
-                return response()->json([
-                    'success'  => true,
-                    'password' => $defaultPassword,
-                    'message'  => 'Mot de passe réinitialisé avec succès !',
-                ]);
-            }
-
-            return redirect()->back()
-                ->with('success', 'Mot de passe réinitialisé à Bonjour@2025 avec succès ! Le comptable devra changer son mot de passe à la première connexion.')
-                ->with('new_password', $defaultPassword);
-        } catch (\Exception $e) {
-            \Log::error('❌ Password reset failed for comptable', [
-                'comptable_id' => $user->id,
-                'error'        => $e->getMessage(),
-            ]);
-
-            if (request()->wantsJson() || request()->ajax()) {
-                return response()->json([
-                    'success' => false,
-                    'message' => 'Erreur lors de la réinitialisation : ' . $e->getMessage(),
-                ], 500);
-            }
-
-            return redirect()->back()
-                ->with('error', 'Erreur lors de la réinitialisation : ' . $e->getMessage());
-        }
+        return $this->resetPersonnelPassword($user, 'comptable');
     }
 }

--- a/app/Http/Controllers/ESBTPPersonnelUnifiedController.php
+++ b/app/Http/Controllers/ESBTPPersonnelUnifiedController.php
@@ -2,129 +2,80 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\User;
 use App\Models\ESBTPTeacher;
+use App\Models\User;
 use App\Services\PermissionRegistry;
+use App\Services\UserService;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
-use App\Services\UserService;
 use Spatie\Permission\Models\Role;
 
 class ESBTPPersonnelUnifiedController extends Controller
 {
-    protected $userService;
+    /**
+     * Champs searchables additionnels par rôle (au-delà de name/email/telephone).
+     */
+    private const ROLE_SEARCH_FIELDS = [
+        'coordinateur' => ['specialite'],
+        'comptable' => ['department'],
+        'secretaire' => [],
+        'caissier' => [],
+    ];
 
-    public function __construct(UserService $userService)
+    public function __construct(protected UserService $userService)
     {
-        $this->userService = $userService;
     }
+
     /**
      * Display a listing of all personnel with sliders.
      */
     public function index(Request $request)
     {
-        // Vérifier les permissions via toggle (manage_personnel)
-        if (!auth()->user()->can('personnel.manage')) {
+        if (! auth()->user()->can('personnel.manage')) {
             abort(403, 'Accès non autorisé');
         }
 
         // Rôle principal de l'utilisateur connecté — on cache le tab de son propre rôle
-        // (un secretaire ne gère pas d'autres secretaires, un coordinateur ne gère pas d'autres coordinateurs)
+        // (un secretaire ne gère pas d'autres secretaires, idem coordinateur).
         $userRole = auth()->user()->getRoleNames()->first();
 
-        // Récupérer tous les types de personnel avec vérification des rôles
-        $coordinateurs = collect();
-        $secretaires = collect();
+        // Coordinateurs/secrétaires masqués si l'utilisateur a ce rôle lui-même.
+        $coordinateurs = $userRole === 'coordinateur' ? collect() : $this->loadActiveByRole('coordinateur');
+        $secretaires = $userRole === 'secretaire' ? collect() : $this->loadActiveByRole('secretaire');
+        $comptables = $this->loadActiveByRole('comptable');
+        $caissiers = $this->loadActiveByRole('caissier');
 
-        try {
-            // Ne récupérer les coordinateurs que si l'utilisateur n'est pas coordinateur lui-même
-            if ($userRole !== 'coordinateur' && Role::where('name', 'coordinateur')->exists()) {
-                $coordinateurs = User::role('coordinateur')
-                    ->with(['roles'])
-                    ->where('is_active', true)
-                    ->orderBy('name')
-                    ->get();
-            }
-        } catch (\Exception $e) {
-            // Si le rôle n'existe pas, garder une collection vide
-            $coordinateurs = collect();
-        }
-            
         $enseignants = ESBTPTeacher::with(['user'])
-            ->whereHas('user', function($query) {
-                $query->where('is_active', true);
-            })
+            ->whereHas('user', fn ($q) => $q->where('is_active', true))
             ->orderBy('created_at', 'desc')
             ->get();
-            
-        try {
-            // Ne récupérer les secrétaires que si l'utilisateur n'est pas secrétaire lui-même
-            if ($userRole !== 'secretaire' && Role::where('name', 'secretaire')->exists()) {
-                $secretaires = User::role('secretaire')
-                    ->with(['roles'])
-                    ->where('is_active', true)
-                    ->orderBy('name')
-                    ->get();
-            }
-        } catch (\Exception $e) {
-            // Si le rôle n'existe pas, garder une collection vide
-            $secretaires = collect();
-        }
 
-        // Récupérer les comptables
-        $comptables = collect();
-        try {
-            if (Role::where('name', 'comptable')->exists()) {
-                $comptables = User::role('comptable')
-                    ->with(['roles'])
-                    ->where('is_active', true)
-                    ->orderBy('name')
-                    ->get();
-            }
-        } catch (\Exception $e) {
-            $comptables = collect();
-        }
-
-        // Récupérer les caissiers
-        $caissiers = collect();
-        try {
-            if (Role::where('name', 'caissier')->exists()) {
-                $caissiers = User::role('caissier')
-                    ->with(['roles'])
-                    ->where('is_active', true)
-                    ->orderBy('name')
-                    ->get();
-            }
-        } catch (\Exception $e) {
-            $caissiers = collect();
-        }
-
-        // Calculer les statistiques
         $stats = [
             'coordinateurs' => $coordinateurs->count(),
             'enseignants' => $enseignants->count(),
             'secretaires' => $secretaires->count(),
             'comptables' => $comptables->count(),
             'caissiers' => $caissiers->count(),
-            'total' => $coordinateurs->count() + $enseignants->count() + $secretaires->count() + $comptables->count() + $caissiers->count(),
+            'total' => $coordinateurs->count() + $enseignants->count() + $secretaires->count()
+                + $comptables->count() + $caissiers->count(),
         ];
 
-        // Rétro-compatibilité : $isCoordinateur est dérivé de $userRole
         $isCoordinateur = ($userRole === 'coordinateur');
 
         // Lot 8/17 — Rôles custom + standards éditables (visibles si users.manage)
         $customRoles = collect();
         $standardRoles = collect();
-        // Lot 19 — Users assignés à chaque rôle custom, indexé par roleName, pour générer un tab par rôle
+        // Lot 19 — users assignés à chaque rôle custom, indexé par roleName, pour générer un tab par rôle
         $customRoleUsers = collect();
+
         if (auth()->user()->can('users.manage')) {
             try {
                 $registry = app(PermissionRegistry::class);
 
-                // Custom roles (is_custom = true)
                 $customRolesQuery = Role::query()
                     ->where('is_custom', true)
                     ->withCount(['users', 'permissions'])
@@ -139,7 +90,7 @@ class ESBTPPersonnelUnifiedController extends Controller
                 // (évite le N+1 d'une query par rôle).
                 $customRoleNames = $customRolesQuery->pluck('name')->all();
                 $usersByRole = collect();
-                if (!empty($customRoleNames)) {
+                if (! empty($customRoleNames)) {
                     $usersByRole = User::role($customRoleNames)
                         ->where('is_active', true)
                         ->with(['roles:id,name'])
@@ -152,7 +103,6 @@ class ESBTPPersonnelUnifiedController extends Controller
 
                 foreach ($customRolesQuery as $role) {
                     // Slug ASCII-safe pour les sélecteurs HTML/JS (data-tab, id, etc.).
-                    // Le nom brut du rôle reste utilisable comme paramètre de route.
                     $customRoleUsers[$role->name] = [
                         'role' => $role,
                         'slug' => Str::slug($role->name) ?: 'role-'.$role->id,
@@ -165,8 +115,8 @@ class ESBTPPersonnelUnifiedController extends Controller
                     ];
                 }
 
-                // Standard roles éditables (Lot 17c) — whitelist depuis le controller
-                $standardRoleNames = \App\Http\Controllers\ESBTPCustomRoleController::EDITABLE_STANDARD_ROLES;
+                // Standard roles éditables (Lot 17c) — whitelist depuis le controller.
+                $standardRoleNames = ESBTPCustomRoleController::EDITABLE_STANDARD_ROLES;
                 $standardRoles = Role::query()
                     ->whereIn('name', $standardRoleNames)
                     ->withCount(['users', 'permissions'])
@@ -175,7 +125,7 @@ class ESBTPPersonnelUnifiedController extends Controller
                     ->values()
                     ->map(fn (Role $role) => $this->buildRoleCardData($role, $registry));
             } catch (\Throwable $e) {
-                // Migration pas encore lancée ou registry indispo — degrade silencieusement
+                // Migration pas encore lancée ou registry indispo — degrade silencieusement.
                 $customRoles = collect();
                 $standardRoles = collect();
                 $customRoleUsers = collect();
@@ -203,6 +153,7 @@ class ESBTPPersonnelUnifiedController extends Controller
     private function buildRoleCardData(Role $role, PermissionRegistry $registry): array
     {
         $meta = $registry->roleMeta($role->name) ?? [];
+
         return [
             'id' => $role->id,
             'name' => $role->name,
@@ -215,150 +166,109 @@ class ESBTPPersonnelUnifiedController extends Controller
     }
 
     /**
-     * Get personnel data via AJAX for dynamic loading
+     * Charge tous les utilisateurs actifs d'un rôle, retourne collect() vide
+     * si le rôle n'existe pas (degrade silencieusement).
+     */
+    private function loadActiveByRole(string $roleName)
+    {
+        try {
+            if (! Role::where('name', $roleName)->exists()) {
+                return collect();
+            }
+
+            return User::role($roleName)
+                ->with(['roles'])
+                ->where('is_active', true)
+                ->orderBy('name')
+                ->get();
+        } catch (\Exception $e) {
+            return collect();
+        }
+    }
+
+    /**
+     * Recherche filtrée d'utilisateurs par rôle (utilisée par getData).
+     * Retourne collect() vide si le rôle n'existe pas.
+     */
+    private function searchByRole(string $roleName, ?string $search, ?string $status)
+    {
+        try {
+            if (! Role::where('name', $roleName)->exists()) {
+                return collect();
+            }
+
+            $query = User::role($roleName)->with(['roles']);
+
+            if ($status) {
+                $query->where('is_active', $status === 'active');
+            }
+
+            if ($search) {
+                $extraFields = self::ROLE_SEARCH_FIELDS[$roleName] ?? [];
+                $query->where(function (Builder $q) use ($search, $extraFields) {
+                    $q->where('name', 'like', "%{$search}%")
+                        ->orWhere('email', 'like', "%{$search}%")
+                        ->orWhere('telephone', 'like', "%{$search}%");
+                    foreach ($extraFields as $field) {
+                        $q->orWhere($field, 'like', "%{$search}%");
+                    }
+                });
+            }
+
+            return $query->orderBy('name')->get();
+        } catch (\Exception $e) {
+            return collect();
+        }
+    }
+
+    /**
+     * Garde-fou commun : users.manage avec fallback admin.access.
+     */
+    private function ensureCanManagePersonnel(): void
+    {
+        $user = auth()->user();
+        if ($user && ($user->can('users.manage') || $user->can('admin.access'))) {
+            return;
+        }
+
+        abort(403, 'Accès non autorisé');
+    }
+
+    /**
+     * Get personnel data via AJAX for dynamic loading.
      */
     public function getData(Request $request)
     {
-        try {
-            $this->authorize('users.manage');
-        } catch (\Exception $e) {
-            if (!auth()->user()->can('admin.access')) {
-                abort(403, 'Accès non autorisé');
-            }
-        }
-        
-        $type = $request->get('type'); // coordinateur, enseignant, secretaire
+        $this->ensureCanManagePersonnel();
+
+        $type = $request->get('type'); // coordinateur, enseignant, secretaire, comptable, caissier
         $search = $request->get('search');
         $status = $request->get('status');
-        $filter = $request->get('filter'); // spécialité, matière, service
-        
-        $data = [];
-        
-        switch($type) {
-            case 'coordinateur':
-                $data = collect();
-                try {
-                    if (Role::where('name', 'coordinateur')->exists()) {
-                        $query = User::role('coordinateur')->with(['roles']);
-                        
-                        if ($status) {
-                            $query->where('is_active', $status === 'active');
-                        }
-                        
-                        if ($search) {
-                            $query->where(function($q) use ($search) {
-                                $q->where('name', 'like', "%{$search}%")
-                                  ->orWhere('email', 'like', "%{$search}%")
-                                  ->orWhere('telephone', 'like', "%{$search}%")
-                                  ->orWhere('specialite', 'like', "%{$search}%");
-                            });
-                        }
-                        
-                        $data = $query->orderBy('name')->get();
-                    }
-                } catch (\Exception $e) {
-                    $data = collect();
-                }
-                break;
-                
-            case 'enseignant':
-                $query = ESBTPTeacher::with(['user']);
-                
-                if ($status) {
-                    $query->where('status', $status);
-                }
-                
-                if ($search) {
-                    $query->whereHas('user', function($q) use ($search) {
-                        $q->where('name', 'like', "%{$search}%")
-                          ->orWhere('email', 'like', "%{$search}%");
-                    })->orWhere('specialization', 'like', "%{$search}%");
-                }
-                
-                $data = $query->orderBy('created_at', 'desc')->get();
-                break;
-                
-            case 'secretaire':
-                $data = collect();
-                try {
-                    if (Role::where('name', 'secretaire')->exists()) {
-                        $query = User::role('secretaire')->with(['roles']);
 
-                        if ($status) {
-                            $query->where('is_active', $status === 'active');
-                        }
+        if ($type === 'enseignant') {
+            $query = ESBTPTeacher::with(['user']);
 
-                        if ($search) {
-                            $query->where(function($q) use ($search) {
-                                $q->where('name', 'like', "%{$search}%")
-                                  ->orWhere('email', 'like', "%{$search}%")
-                                  ->orWhere('telephone', 'like', "%{$search}%");
-                            });
-                        }
+            if ($status) {
+                $query->where('status', $status);
+            }
 
-                        $data = $query->orderBy('name')->get();
-                    }
-                } catch (\Exception $e) {
-                    $data = collect();
-                }
-                break;
+            if ($search) {
+                $query->whereHas('user', fn ($q) => $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%"))
+                    ->orWhere('specialization', 'like', "%{$search}%");
+            }
 
-            case 'comptable':
-                $data = collect();
-                try {
-                    if (Role::where('name', 'comptable')->exists()) {
-                        $query = User::role('comptable')->with(['roles']);
-
-                        if ($status) {
-                            $query->where('is_active', $status === 'active');
-                        }
-
-                        if ($search) {
-                            $query->where(function($q) use ($search) {
-                                $q->where('name', 'like', "%{$search}%")
-                                  ->orWhere('email', 'like', "%{$search}%")
-                                  ->orWhere('telephone', 'like', "%{$search}%")
-                                  ->orWhere('department', 'like', "%{$search}%");
-                            });
-                        }
-
-                        $data = $query->orderBy('name')->get();
-                    }
-                } catch (\Exception $e) {
-                    $data = collect();
-                }
-                break;
-
-            case 'caissier':
-                $data = collect();
-                try {
-                    if (Role::where('name', 'caissier')->exists()) {
-                        $query = User::role('caissier')->with(['roles']);
-
-                        if ($status) {
-                            $query->where('is_active', $status === 'active');
-                        }
-
-                        if ($search) {
-                            $query->where(function($q) use ($search) {
-                                $q->where('name', 'like', "%{$search}%")
-                                  ->orWhere('email', 'like', "%{$search}%")
-                                  ->orWhere('telephone', 'like', "%{$search}%");
-                            });
-                        }
-
-                        $data = $query->orderBy('name')->get();
-                    }
-                } catch (\Exception $e) {
-                    $data = collect();
-                }
-                break;
+            $data = $query->orderBy('created_at', 'desc')->get();
+        } elseif (in_array($type, ['coordinateur', 'secretaire', 'comptable', 'caissier'], true)) {
+            $data = $this->searchByRole($type, $search, $status);
+        } else {
+            $data = collect();
         }
 
         return response()->json([
             'success' => true,
             'data' => $data,
-            'count' => $data->count()
+            'count' => $data->count(),
         ]);
     }
 
@@ -367,16 +277,10 @@ class ESBTPPersonnelUnifiedController extends Controller
      */
     public function store(Request $request)
     {
-        try {
-            $this->authorize('users.manage');
-        } catch (\Exception $e) {
-            if (!auth()->user()->can('admin.access')) {
-                abort(403, 'Accès non autorisé');
-            }
-        }
-        
-        $type = $request->get('type'); // coordinateur, enseignant, secretaire
-        
+        $this->ensureCanManagePersonnel();
+
+        $type = $request->get('type');
+
         $rules = [
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
@@ -395,13 +299,12 @@ class ESBTPPersonnelUnifiedController extends Controller
         } elseif ($type === 'comptable') {
             $rules['department'] = 'nullable|string|max:255';
         }
-        
+
         $validated = $request->validate($rules);
 
         try {
             DB::beginTransaction();
 
-            // Utiliser UserService pour username auto + mot de passe par défaut
             $defaultPassword = $this->userService->generateDefaultPassword();
             $user = $this->userService->createUserWithAutoCredentials([
                 'name' => $validated['name'],
@@ -409,7 +312,7 @@ class ESBTPPersonnelUnifiedController extends Controller
                 'phone' => $validated['telephone'] ?? null,
             ], $validated['type']);
 
-            // Mettre à jour les champs spécifiques au type
+            // Mettre à jour les champs spécifiques au type.
             $user->update(array_filter([
                 'specialite' => $validated['specialite'] ?? null,
                 'service' => $validated['service'] ?? null,
@@ -417,10 +320,8 @@ class ESBTPPersonnelUnifiedController extends Controller
                 'email_verified_at' => now(),
             ]));
 
-            // Assigner le rôle approprié
             $user->assignRole($validated['type']);
 
-            // Si c'est un enseignant, créer aussi dans la table ESBTPTeacher
             if ($type === 'enseignant') {
                 ESBTPTeacher::create([
                     'user_id' => $user->id,
@@ -434,22 +335,36 @@ class ESBTPPersonnelUnifiedController extends Controller
 
             return response()->json([
                 'success' => true,
-                'message' => ucfirst($validated['type']) . ' créé avec succès.',
+                'message' => ucfirst($validated['type']).' créé avec succès.',
                 'data' => $user,
                 'credentials' => [
                     'username' => $user->username,
                     'password' => $defaultPassword,
                     'must_change_password' => true,
-                ]
+                ],
             ]);
-
         } catch (\Exception $e) {
             DB::rollBack();
+
             return response()->json([
                 'success' => false,
-                'message' => 'Erreur lors de la création : ' . $e->getMessage()
+                'message' => 'Erreur lors de la création : '.$e->getMessage(),
             ], 500);
         }
+    }
+
+    /**
+     * Resolve the user (and teacher when applicable) for a given personnel type.
+     */
+    private function resolvePersonnel(string $type, $id): array
+    {
+        if ($type === 'enseignant') {
+            $teacher = ESBTPTeacher::findOrFail($id);
+
+            return [$teacher->user, $teacher];
+        }
+
+        return [User::findOrFail($id), null];
     }
 
     /**
@@ -457,30 +372,18 @@ class ESBTPPersonnelUnifiedController extends Controller
      */
     public function update(Request $request, $type, $id)
     {
-        try {
-            $this->authorize('users.manage');
-        } catch (\Exception $e) {
-            if (!auth()->user()->can('admin.access')) {
-                abort(403, 'Accès non autorisé');
-            }
-        }
-        
-        if ($type === 'enseignant') {
-            $teacher = ESBTPTeacher::findOrFail($id);
-            $user = $teacher->user;
-        } else {
-            $user = User::findOrFail($id);
-        }
-        
+        $this->ensureCanManagePersonnel();
+
+        [$user, $teacher] = $this->resolvePersonnel($type, $id);
+
         $rules = [
             'name' => 'required|string|max:255',
-            'email' => 'required|string|email|max:255|unique:users,email,' . $user->id,
+            'email' => 'required|string|email|max:255|unique:users,email,'.$user->id,
             'password' => 'nullable|string|min:8|confirmed',
             'telephone' => 'nullable|string|max:20',
             'is_active' => 'required|boolean',
         ];
-        
-        // Règles spécifiques selon le type
+
         if ($type === 'coordinateur') {
             $rules['specialite'] = 'nullable|string|max:255';
         } elseif ($type === 'enseignant') {
@@ -504,7 +407,6 @@ class ESBTPPersonnelUnifiedController extends Controller
                 'is_active' => $validated['is_active'],
             ];
 
-            // Champs spécifiques selon le type
             if ($type === 'coordinateur') {
                 $updateData['specialite'] = $validated['specialite'] ?? null;
             } elseif ($type === 'secretaire') {
@@ -513,15 +415,13 @@ class ESBTPPersonnelUnifiedController extends Controller
                 $updateData['department'] = $validated['department'] ?? null;
             }
 
-            // Si un nouveau mot de passe est fourni
-            if (!empty($validated['password'])) {
+            if (! empty($validated['password'])) {
                 $updateData['password'] = Hash::make($validated['password']);
             }
 
             $user->update($updateData);
-            
-            // Mise à jour spécifique pour les enseignants
-            if ($type === 'enseignant') {
+
+            if ($teacher) {
                 $teacher->update([
                     'specialization' => $validated['specialization'] ?? null,
                     'qualification' => $validated['qualification'] ?? null,
@@ -534,14 +434,14 @@ class ESBTPPersonnelUnifiedController extends Controller
             return response()->json([
                 'success' => true,
                 'message' => 'Personnel mis à jour avec succès.',
-                'data' => $user
+                'data' => $user,
             ]);
-
         } catch (\Exception $e) {
             DB::rollBack();
+
             return response()->json([
                 'success' => false,
-                'message' => 'Erreur lors de la mise à jour : ' . $e->getMessage()
+                'message' => 'Erreur lors de la mise à jour : '.$e->getMessage(),
             ], 500);
         }
     }
@@ -551,40 +451,27 @@ class ESBTPPersonnelUnifiedController extends Controller
      */
     public function destroy($type, $id)
     {
-        try {
-            $this->authorize('users.manage');
-        } catch (\Exception $e) {
-            if (!auth()->user()->can('admin.access')) {
-                abort(403, 'Accès non autorisé');
-            }
-        }
-        
-        if ($type === 'enseignant') {
-            $teacher = ESBTPTeacher::findOrFail($id);
-            $user = $teacher->user;
-        } else {
-            $user = User::findOrFail($id);
-        }
-        
-        // Empêcher la suppression de son propre compte
+        $this->ensureCanManagePersonnel();
+
+        [$user, $teacher] = $this->resolvePersonnel($type, $id);
+
         if ($user->id === Auth::id()) {
             return response()->json([
                 'success' => false,
-                'message' => 'Vous ne pouvez pas supprimer votre propre compte.'
+                'message' => 'Vous ne pouvez pas supprimer votre propre compte.',
             ], 403);
         }
 
         try {
             DB::beginTransaction();
 
-            // Marquer comme inactif au lieu de supprimer complètement
+            // Marquer comme inactif au lieu de supprimer complètement.
             $user->update([
                 'is_active' => false,
-                'email' => $user->email . '_deleted_' . time(),
+                'email' => $user->email.'_deleted_'.time(),
             ]);
-            
-            // Mise à jour spécifique pour les enseignants
-            if ($type === 'enseignant') {
+
+            if ($teacher) {
                 $teacher->update(['status' => 'inactive']);
             }
 
@@ -592,92 +479,73 @@ class ESBTPPersonnelUnifiedController extends Controller
 
             return response()->json([
                 'success' => true,
-                'message' => 'Personnel supprimé avec succès.'
+                'message' => 'Personnel supprimé avec succès.',
             ]);
-
         } catch (\Exception $e) {
             DB::rollBack();
+
             return response()->json([
                 'success' => false,
-                'message' => 'Erreur lors de la suppression : ' . $e->getMessage()
+                'message' => 'Erreur lors de la suppression : '.$e->getMessage(),
             ], 500);
         }
     }
 
     /**
-     * Toggle active status of personnel
+     * Toggle active status of personnel.
      */
     public function toggleStatus($type, $id)
     {
-        try {
-            $this->authorize('users.manage');
-        } catch (\Exception $e) {
-            if (!auth()->user()->can('admin.access')) {
-                abort(403, 'Accès non autorisé');
-            }
-        }
-        
-        if ($type === 'enseignant') {
-            $teacher = ESBTPTeacher::findOrFail($id);
-            $user = $teacher->user;
-        } else {
-            $user = User::findOrFail($id);
-        }
-        
-        $user->update([
-            'is_active' => !$user->is_active
-        ]);
-        
-        // Mise à jour spécifique pour les enseignants
-        if ($type === 'enseignant') {
-            $teacher->update([
-                'status' => $user->is_active ? 'active' : 'inactive'
-            ]);
+        $this->ensureCanManagePersonnel();
+
+        [$user, $teacher] = $this->resolvePersonnel($type, $id);
+
+        $user->update(['is_active' => ! $user->is_active]);
+
+        if ($teacher) {
+            $teacher->update(['status' => $user->is_active ? 'active' : 'inactive']);
         }
 
         $status = $user->is_active ? 'activé' : 'désactivé';
-        
+
         return response()->json([
             'success' => true,
             'message' => "Personnel {$status} avec succès.",
-            'is_active' => $user->is_active
+            'is_active' => $user->is_active,
         ]);
     }
 
     /**
-     * Get personnel statistics
+     * Get personnel statistics.
      */
     public function getStats()
     {
-        try {
-            $this->authorize('users.manage');
-        } catch (\Exception $e) {
-            if (!auth()->user()->can('admin.access')) {
-                abort(403, 'Accès non autorisé');
-            }
-        }
-        
+        $this->ensureCanManagePersonnel();
+
         $stats = [
-            'coordinateurs' => [
-                'total' => User::role('coordinateur')->count(),
-                'actifs' => User::role('coordinateur')->where('is_active', true)->count(),
-                'inactifs' => User::role('coordinateur')->where('is_active', false)->count(),
-                'nouveau_ce_mois' => User::role('coordinateur')->where('created_at', '>=', now()->startOfMonth())->count(),
-            ],
+            'coordinateurs' => $this->roleStats('coordinateur'),
             'enseignants' => [
                 'total' => ESBTPTeacher::count(),
                 'actifs' => ESBTPTeacher::where('status', 'active')->count(),
                 'inactifs' => ESBTPTeacher::where('status', 'inactive')->count(),
                 'nouveau_ce_mois' => ESBTPTeacher::where('created_at', '>=', now()->startOfMonth())->count(),
             ],
-            'secretaires' => [
-                'total' => User::role('secretaire')->count(),
-                'actifs' => User::role('secretaire')->where('is_active', true)->count(),
-                'inactifs' => User::role('secretaire')->where('is_active', false)->count(),
-                'nouveau_ce_mois' => User::role('secretaire')->where('created_at', '>=', now()->startOfMonth())->count(),
-            ],
+            'secretaires' => $this->roleStats('secretaire'),
         ];
-        
+
         return response()->json($stats);
+    }
+
+    /**
+     * Stats actifs/inactifs/nouveaux pour un rôle Spatie.
+     */
+    private function roleStats(string $roleName): array
+    {
+        return [
+            'total' => User::role($roleName)->count(),
+            'actifs' => User::role($roleName)->where('is_active', true)->count(),
+            'inactifs' => User::role($roleName)->where('is_active', false)->count(),
+            'nouveau_ce_mois' => User::role($roleName)->where('created_at', '>=', now()->startOfMonth())->count(),
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Domain D4 simplify pass on **Lots 17-19 personnel pages premium** (commit range `1bc07005^..a2a97b3f`). Focus on the controller layer; views (`cs-*`/`ce-*` namespaces) preserved as-is.

### Critical fix (caught by simplify)

- **Missing `ResetsPersonnelPassword` trait file**: both `ESBTPCaissierController` and `ESBTPComptableController` had been refactored locally to `use ResetsPersonnelPassword`, but the trait file lived only in the working tree (untracked). Production was running the legacy duplicated `resetPassword()` bodies. This PR adds the trait, completes the refactor on both controllers, and DRYs ~80 lines of password-reset logic.

### Controller simplifications

`ESBTPPersonnelUnifiedController` (682 → 551 LOC, **-131, -19%**) — extracted helpers:
- `loadActiveByRole(string)` replaces 5 nearly identical try/catch role-existence blocks in `index()`
- `searchByRole(string, ?string, ?string)` replaces 4 duplicated query builders in `getData()` with a `ROLE_SEARCH_FIELDS` constant for role-specific extra search columns (e.g. `specialite`, `department`)
- `ensureCanManagePersonnel()` replaces 5 instances of `try authorize() catch admin.access fallback`
- `resolvePersonnel(string, $id)` unifies the `enseignant` vs other-roles branching
- `roleStats(string)` replaces 3 hardcoded stat blocks in `getStats()`

`ESBTPCaissierController.update()`:
- Drop superfluous `DB::beginTransaction/commit/rollBack` around a single `$caissier->save()` (Eloquent already wraps single saves)
- `$caissier->fill([...])` replaces 3 manual property assignments

### Out of scope (kept for future passes)

- View-side CSS duplication between `cs-*` (caissier show 920 LOC) and `cs-comptable-*` (comptable show 968 LOC) — extracting a shared `<x-personnel-show-hero>` component is meaningful but invasive; deferred.
- `<x-pdf-document>` migration of Lot 17 PDF templates (D7).
- `personnel/unified-index.blade.php` (2696 LOC) — no actionable duplication caught at this pass; the Lot 19 dynamic custom-role tabs already use a single eager-loaded query (`User::role($customRoleNames)` in `index()`).

## Behavior preservation

- Identical routes, identical JSON shapes, identical flash redirects, identical permission gates.
- `php -l` clean on all 4 modified files.
- No view, asset, or migration touched.

## Test plan

- [ ] `/esbtp/personnel/unified` loads as superAdmin (5 role tabs + custom roles tab + standard roles tab visible)
- [ ] `/esbtp/personnel/unified` as secretaire (own tab hidden)
- [ ] AJAX `getData` for each role type returns the same payload as before
- [ ] AJAX `getStats` returns the 3-domain stats payload
- [ ] Caissier `resetPassword`, `update`, `destroy`, `toggleStatus` all work (JSON + redirect paths)
- [ ] Comptable `resetPassword` works (now via shared trait)
- [ ] No regression on `/esbtp/comptables/{id}/show` reset-password button (Lot 18d)