### PR TITLE
feat(compta): QW5 motif rejet paiement renforcé + timeline visible caissier

### DIFF
--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -1434,12 +1434,8 @@ class ESBTPPaiementController extends Controller
     /**
      * Rejeter un paiement
      */
-    public function rejeter(Request $request, $id)
+    public function rejeter(\App\Http\Requests\Paiement\RejeterPaiementRequest $request, $id)
     {
-        $request->validate([
-            'motif_rejet' => 'required|string|max:500'
-        ]);
-
         try {
             $paiement = ESBTPPaiement::findOrFail($id);
 
@@ -1710,7 +1706,11 @@ class ESBTPPaiementController extends Controller
         $request->validate([
             'paiements' => 'required|array|min:1',
             'paiements.*' => 'exists:esbtp_paiements,id',
-            'motif_rejet' => 'required|string|max:500'
+            'motif_rejet' => 'required|string|min:10|max:500',
+        ], [
+            'motif_rejet.required' => 'Le motif de rejet est obligatoire.',
+            'motif_rejet.min' => 'Le motif de rejet doit faire au moins 10 caractères.',
+            'motif_rejet.max' => 'Le motif de rejet ne peut pas dépasser 500 caractères.',
         ]);
 
         $successCount = 0;

--- a/app/Http/Requests/Paiement/RejeterPaiementRequest.php
+++ b/app/Http/Requests/Paiement/RejeterPaiementRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Paiement;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validation du motif de rejet d'un paiement (action unitaire ou bulk).
+ *
+ * Le motif est obligatoire et doit être suffisamment explicite (min 10 chars)
+ * pour permettre au caissier qui a saisi le paiement de comprendre la raison
+ * du rejet et corriger sa saisie.
+ */
+class RejeterPaiementRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('paiements.validate') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'motif_rejet' => 'required|string|min:10|max:500',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'motif_rejet.required' => 'Le motif de rejet est obligatoire.',
+            'motif_rejet.min' => 'Le motif de rejet doit faire au moins 10 caractères pour être utile au caissier qui a saisi le paiement.',
+            'motif_rejet.max' => 'Le motif de rejet ne peut pas dépasser 500 caractères.',
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'motif_rejet' => 'motif de rejet',
+        ];
+    }
+}

--- a/resources/views/esbtp/paiements/index.blade.php
+++ b/resources/views/esbtp/paiements/index.blade.php
@@ -2053,10 +2053,20 @@ $(document).ready(function() {
                         Vous êtes sur le point de rejeter <strong><span id="bulk-rejet-count">0</span> paiement(s)</strong>.
                     </div>
 
-                    <div class="mb-3">
-                        <label for="bulk_motif_rejet" class="form-label">Motif du rejet <span class="text-danger">*</span></label>
+                    <div class="mb-3" x-data="{ count: 0 }">
+                        <label for="bulk_motif_rejet" class="form-label">
+                            Motif du rejet <span class="text-danger">*</span>
+                            <span style="font-weight:400; color:#64748b; font-size:.78rem;">(min. 10 caractères)</span>
+                        </label>
                         <textarea class="form-control" id="bulk_motif_rejet" name="motif_rejet" rows="4"
-                                  placeholder="Expliquez pourquoi ces paiements sont rejetés..." required></textarea>
+                                  minlength="10" maxlength="500"
+                                  placeholder="Ex : Justificatifs manquants, à représenter avec preuve de virement bancaire."
+                                  x-on:input="count = $event.target.value.length"
+                                  required></textarea>
+                        <div style="display:flex; justify-content:space-between; margin-top:6px; font-size:.74rem; color:#94a3b8;">
+                            <span>Le caissier qui a saisi ces paiements verra ce motif.</span>
+                            <span x-text="count + ' / 500'" :style="count < 10 ? 'color:#dc2626;font-weight:600' : (count > 480 ? 'color:#d97706;font-weight:600' : '')">0 / 500</span>
+                        </div>
                     </div>
 
                     <div class="form-check">

--- a/resources/views/esbtp/paiements/show.blade.php
+++ b/resources/views/esbtp/paiements/show.blade.php
@@ -582,6 +582,25 @@
                     </div>
                 </div>
                 @endif
+
+                @if($paiement->status == 'rejeté' && $paiement->date_validation)
+                <div class="ps-tl-item">
+                    <div class="ps-tl-dot rejected" style="background:rgba(220,38,38,.12);color:#dc2626;"><i class="fas fa-times"></i></div>
+                    <div class="ps-tl-text">
+                        <strong style="color:#dc2626;">Paiement rejeté</strong>
+                        @if($paiement->validatedBy) par <strong>{{ $paiement->validatedBy->name }}</strong>@endif
+                        <br><span class="ps-tl-date"><i class="fas fa-clock me-1"></i>{{ $paiement->date_validation->format('d/m/Y à H:i') }}</span>
+                        @if($paiement->commentaire)
+                        <div class="ps-tl-reason" style="margin-top:8px;padding:10px 12px;background:#fef2f2;border-left:3px solid #dc2626;border-radius:6px;font-size:.85rem;color:#7f1d1d;line-height:1.5;">
+                            <strong style="color:#dc2626;font-size:.78rem;text-transform:uppercase;letter-spacing:.5px;display:block;margin-bottom:4px;">
+                                <i class="fas fa-quote-left me-1" style="font-size:.65rem;"></i> Motif du rejet
+                            </strong>
+                            {{ $paiement->commentaire }}
+                        </div>
+                        @endif
+                    </div>
+                </div>
+                @endif
             </div>
         </div>
     </div>
@@ -614,12 +633,21 @@
                         <div><strong>Montant :</strong> {{ number_format($paiement->montant, 0, ',', ' ') }} FCFA</div>
                         <div><strong>Réf :</strong> {{ $paiement->numero_recu }}</div>
                     </div>
-                    <label for="motif_rejet" class="form-label fw-semibold" style="font-size:.88rem;">
-                        Motif du rejet <span class="text-danger">*</span>
-                    </label>
-                    <textarea name="motif_rejet" id="motif_rejet" rows="4" class="form-control" required
-                              placeholder="Expliquez la raison du rejet..."
-                              style="border:2px solid #dee2e6; border-radius:10px; resize:none;"></textarea>
+                    <div x-data="{ count: 0 }">
+                        <label for="motif_rejet" class="form-label fw-semibold" style="font-size:.88rem;">
+                            Motif du rejet <span class="text-danger">*</span>
+                            <span style="font-weight:400; color:#64748b; font-size:.78rem;">(min. 10 caractères)</span>
+                        </label>
+                        <textarea name="motif_rejet" id="motif_rejet" rows="4" class="form-control" required
+                                  minlength="10" maxlength="500"
+                                  placeholder="Ex : Montant incorrect, doit être 50&nbsp;000 FCFA au lieu de 5&nbsp;000."
+                                  x-on:input="count = $event.target.value.length"
+                                  style="border:2px solid #dee2e6; border-radius:10px; resize:none;"></textarea>
+                        <div style="display:flex; justify-content:space-between; margin-top:6px; font-size:.74rem; color:#94a3b8;">
+                            <span>Le caissier qui a saisi ce paiement verra ce motif pour corriger sa saisie.</span>
+                            <span x-text="count + ' / 500'" :style="count < 10 ? 'color:#dc2626;font-weight:600' : (count > 480 ? 'color:#d97706;font-weight:600' : '')">0 / 500</span>
+                        </div>
+                    </div>
                 </div>
                 <div class="modal-footer" style="background:#f8f9fa; border-radius:0 0 15px 15px; padding:1rem 1.5rem; border:none;">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" style="border-radius:8px; font-weight:600;">


### PR DESCRIPTION
## QW5 — Quick Win Comptabilité (3/6)

### Pourquoi
Audit permissions compta : 'Pas de motif rejet obligatoire substantiel - rejet sans raison enregistrée -> imputabilité floue + le caissier ne sait pas pourquoi son paiement a été rejeté'.

Auparavant : motif required mais accepte 'x' (1 char). Caissier voit son paiement passer en 'rejeté' sans aucune explication visible.

### Ce qui change

**Backend — FormRequest dédié**
`app/Http/Requests/Paiement/RejeterPaiementRequest.php` :
- authorize() vérifie permission `paiements.validate` (anti-IDOR au lieu de just true)
- rules : `required|string|min:10|max:500`
- Messages FR personnalisés (ex: 'doit faire au moins 10 caractères pour être utile au caissier qui a saisi le paiement')

`ESBTPPaiementController@rejeter` migré vers FormRequest. `bulkRejeter()` validation inline alignée min:10.

**UI — Timeline rejet visible** (paiements.show.blade.php)
Nouvelle entrée timeline avec :
- Dot rouge `fa-times`
- 'Paiement rejeté par X' + date
- **Encadré rouge** affichant le motif en clair

Avant le caissier devait deviner / appeler le comptable. Maintenant il voit immédiatement.

**Modal rejet renforcés** (show + bulk dans index)
- minlength=10 + maxlength=500 HTML5
- Compteur live Alpine x-data : '5 / 500' rouge si < 10, orange si > 480
- Placeholder éloquent ('Ex : Montant incorrect, doit être 50 000 FCFA au lieu de 5 000.')
- Sous-titre : 'Le caissier qui a saisi ce paiement verra ce motif pour corriger sa saisie.'

### Test plan
- [ ] Rejet avec motif < 10 chars → erreur backend visible
- [ ] Rejet avec motif >= 10 chars OK
- [ ] Compteur live met à jour en rouge si < 10, orange si > 480
- [ ] Timeline paiements.show affiche le motif rejet pour un paiement status='rejeté'
- [ ] Bulk rejet : validation min:10 appliquée
- [ ] Caissier sans `paiements.validate` → 403 (FormRequest authorize)