### PR TITLE
feat(compta): QW6 audit comptabilité accessible au rôle comptable + assignable rôles custom

### DIFF
--- a/config/permissions.php
+++ b/config/permissions.php
@@ -737,6 +737,7 @@ return [
         ],
         'comptabilite.audit.view' => [
             'label' => 'Voir le journal d\'audit comptable',
+            'description' => 'Permet de consulter qui a créé/modifié/validé/rejeté les paiements et configuré les frais. Permission assignable à un rôle custom (ex: Directeur Financier, Auditeur Interne) via /esbtp/custom-roles.',
             'group' => 'Comptabilité',
             'icon' => 'fa-history',
         ],
@@ -1185,6 +1186,7 @@ return [
             'comptabilite.analytics.view', 'comptabilite.analytics.refresh',
             'comptabilite.analytics.run_now', 'comptabilite.analytics.configure',
             'comptabilite.recouvrement.access',
+            'comptabilite.audit.view',  // QW6 mai 2026 — comptable doit auditer son module
             'paiements.view', 'paiements.create', 'paiements.edit', 'paiements.validate',
             'paiements.export',  // Lot 15
             'frais.view', 'frais.create', 'frais.edit', 'frais.configure',


### PR DESCRIPTION
## QW6 — Quick Win Comptabilité (4/6)

### Pourquoi
Audit permissions du plan compta killer : la permission `comptabilite.audit.view` existait depuis l'audit log overhaul (2 mai 2026, PR #311) mais n'était grantée à aucun rôle système hors superAdmin/serviceTechnique (qui ont `*`).

Conséquence : le **comptable** ne pouvait PAS consulter le journal d'audit de son propre module — il devait demander à un superAdmin pour vérifier qui avait validé/rejeté un paiement contesté.

### Ce qui change

**`config/permissions.php`** :
- `role_defaults['comptable']` reçoit `comptabilite.audit.view` (+1 perm)
- Description de la permission enrichie : 'Permission assignable à un rôle custom (ex: Directeur Financier, Auditeur Interne) via /esbtp/custom-roles.'

### Conforme rule `.claude/rules/customizable-roles.md` (créée QW1)
On NE crée PAS de rôle 'directeur_financier' système. La permission est assignable :
1. **Par défaut** au comptable (registry)
2. **Custom roles UI** (`/esbtp/custom-roles`) — l'école crée 'Directeur Financier ESBTP' ou 'Auditeur' et coche
3. **Roles standards UI** (`/esbtp/roles-permissions`) — l'école peut grant à secrétaire, coordinateur, etc.

L'école configure sa structure RH selon sa taille — petite école (1 directeur cumule), grosse école (auditeur séparé).

### Déploiement requis après merge
```bash
klassci permissions:fix <tenant>
# OU
php bin/deploy/fix_permissions.php
```

Sur chaque tenant pour propager le nouveau default au rôle comptable existant.

### Anti-régression vérifiée
- Aucun `hasRole()` hardcodé dans `ESBTPAuditController` (utilise authorize + middleware permission only)
- Aucune `excluded_permissions` dans `ESBTPCustomRoleController`
- `@can('comptabilite.audit.view')` déjà présent dans sidebar (layouts/app.blade.php:2127)

### Test plan
- [ ] Après deploy : login comptable → menu Comptabilité affiche 'Audit comptable'
- [ ] Click → /esbtp/audit/comptabilite rend la page sans 403
- [ ] Comptable peut filtrer par modèle (paiement / frais / etc.)
- [ ] Caissier (sans audit) ne voit toujours pas le menu
- [ ] /esbtp/custom-roles propose la permission `comptabilite.audit.view` dans la liste assignable