### PR TITLE
feat(compta): QW3 garde-fou montant inhabituel + validation backend défense en profondeur

### DIFF
--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -292,7 +292,11 @@ class ESBTPPaiementController extends Controller
         // Récupérer l'année universitaire en cours
         $anneeEnCours = ESBTPAnneeUniversitaire::where('is_current', true)->first();
 
-        return view('esbtp.paiements.create', compact('etudiant', 'inscription', 'anneeEnCours'));
+        // Seuil "montant inhabituel" — au-delà, le caissier doit confirmer explicitement
+        // Configurable par l'école via /esbtp/settings (tenant-level), default 500 000 FCFA
+        $unusualAmountThreshold = (int) \App\Helpers\SettingsHelper::get('comptabilite.unusual_amount_threshold', 500000);
+
+        return view('esbtp.paiements.create', compact('etudiant', 'inscription', 'anneeEnCours', 'unusualAmountThreshold'));
     }
 
     /**

--- a/app/Http/Requests/Paiement/StorePaiementRequest.php
+++ b/app/Http/Requests/Paiement/StorePaiementRequest.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Requests\Paiement;
 
+use App\Helpers\SettingsHelper;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StorePaiementRequest extends FormRequest
@@ -23,6 +25,34 @@ class StorePaiementRequest extends FormRequest
             'reference_paiement' => 'nullable|string',
             'tranche' => 'nullable|string',
             'commentaire' => 'nullable|string',
+            'confirmed_unusual_amount' => 'nullable|in:0,1',
         ];
+    }
+
+    /**
+     * QW3 — défense en profondeur backend : si montant > seuil tenant
+     * ET pas de confirmation explicite, on refuse le paiement.
+     *
+     * Le seuil 'comptabilite.unusual_amount_threshold' est configurable par l'école
+     * via /esbtp/settings (default 500 000 FCFA).
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $v) {
+            $montant = (int) $this->input('montant', 0);
+            $threshold = (int) SettingsHelper::get('comptabilite.unusual_amount_threshold', 500000);
+            $confirmed = $this->input('confirmed_unusual_amount') === '1' || $this->input('confirmed_unusual_amount') === 1;
+
+            if ($montant > $threshold && !$confirmed) {
+                $v->errors()->add(
+                    'montant',
+                    sprintf(
+                        'Montant inhabituel détecté (%s FCFA, supérieur au seuil de %s FCFA configuré). Cochez la case de confirmation pour valider ce paiement.',
+                        number_format($montant, 0, ',', ' '),
+                        number_format($threshold, 0, ',', ' '),
+                    ),
+                );
+            }
+        });
     }
 }

--- a/resources/views/esbtp/paiements/create.blade.php
+++ b/resources/views/esbtp/paiements/create.blade.php
@@ -290,16 +290,50 @@
                             Détails du Paiement
                         </div>
                         
-                        <div class="row">
+                        <div class="row" x-data="{
+                                montant: {{ (int) old('montant', 0) }},
+                                threshold: {{ (int) ($unusualAmountThreshold ?? 500000) }},
+                                confirmed: false,
+                                get isUnusual() { return this.montant > this.threshold; },
+                                get formattedThreshold() { return new Intl.NumberFormat('fr-FR').format(this.threshold); },
+                                get formattedMontant() { return new Intl.NumberFormat('fr-FR').format(this.montant); },
+                            }">
                             <div class="col-md-6">
                                 <div class="form-floating-modern">
                                     <div class="amount-input-group">
-                                        <input type="number" name="montant" id="montant" class="form-control" min="0" step="1" value="{{ old('montant') }}" required>
+                                        <input type="number" name="montant" id="montant" class="form-control" min="0" step="1"
+                                               value="{{ old('montant') }}" required
+                                               x-on:input="montant = parseInt($event.target.value || 0); confirmed = false"
+                                               :style="isUnusual ? 'border-color:#f59e0b;background:#fffbeb;' : ''">
                                         <span class="position-absolute end-0 top-50 translate-middle-y me-3 text-muted">FCFA</span>
                                     </div>
                                     <label>Montant <span class="text-danger">*</span></label>
                                     <div class="amount-suggestions" id="amount-suggestions">
                                         <!-- Les suggestions de montant seront générées dynamiquement -->
+                                    </div>
+
+                                    {{-- Garde-fou montant inhabituel (QW3) --}}
+                                    <div x-show="isUnusual" x-cloak x-transition.opacity
+                                         class="qw3-unusual-alert" style="margin-top:12px;padding:12px 14px;background:#fffbeb;border:1.5px solid #f59e0b;border-radius:10px;">
+                                        <div style="display:flex;gap:10px;align-items:flex-start;">
+                                            <i class="fas fa-triangle-exclamation" style="color:#d97706;font-size:1.1rem;margin-top:2px;flex-shrink:0;"></i>
+                                            <div style="flex:1;min-width:0;">
+                                                <div style="font-weight:700;color:#92400e;font-size:.88rem;margin-bottom:4px;">
+                                                    Montant inhabituel — vérifiez avant de valider
+                                                </div>
+                                                <div style="font-size:.82rem;color:#7c2d12;line-height:1.5;">
+                                                    Le montant saisi (<strong x-text="formattedMontant + ' FCFA'"></strong>) dépasse le seuil habituel de <strong x-text="formattedThreshold + ' FCFA'"></strong> configuré pour cette école.
+                                                    Vérifiez qu'il ne s'agit pas d'une erreur de frappe (ex: 50&nbsp;000 au lieu de 5&nbsp;000).
+                                                </div>
+                                                <label class="form-check" style="margin-top:8px;display:flex;gap:8px;align-items:center;cursor:pointer;">
+                                                    <input type="checkbox" name="confirmed_unusual_amount" value="1"
+                                                           x-model="confirmed" class="form-check-input" style="margin-top:0;">
+                                                    <span style="font-size:.84rem;color:#92400e;font-weight:600;">
+                                                        Je confirme que ce montant est correct
+                                                    </span>
+                                                </label>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -769,6 +803,22 @@ $(function() {
             e.preventDefault();
             e.stopImmediatePropagation();
             debugWarn('⚠️ Clic bloqué, soumission déjà en cours');
+            return false;
+        }
+
+        // QW3 : Garde-fou montant inhabituel — bloquer si > seuil sans confirmation cochée
+        const montantVal = parseInt($('#montant').val() || 0);
+        const threshold = parseInt(@json((int) ($unusualAmountThreshold ?? 500000)));
+        const $confirmCheckbox = $('input[name="confirmed_unusual_amount"]');
+        if (montantVal > threshold && $confirmCheckbox.length > 0 && !$confirmCheckbox.is(':checked')) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            // Scroll smooth vers le warning + focus checkbox pour faciliter
+            const $alert = $('.qw3-unusual-alert');
+            if ($alert.length) {
+                $alert[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+                setTimeout(() => $confirmCheckbox.trigger('focus'), 400);
+            }
             return false;
         }
 


### PR DESCRIPTION
## QW3 — Quick Win Comptabilité (6/6, dernier !)

### Pourquoi
Critic UX : 'Pas de garde-fou montant inhabituel — Caissier tape 500000 au lieu de 50000 → enregistré sans alerte. Patternez : si montant > 3× moyenne historique de cette catégorie pour cet étudiant → modal Vérifier — montant inhabituel.'

L'erreur de frappe (un zéro de trop) est l'erreur #1 en saisie cash. Aujourd'hui : aucune protection.

### Setting tenant configurable
`comptabilite.unusual_amount_threshold` (default 500 000 FCFA).
- Configurable par l'école via /esbtp/settings ou `SettingsHelper::set()`
- Petite école → 100k, grosse école → 5M

### UI — alerte inline ambre dans paiements/create
Sous le champ Montant, panneau Alpine apparaît dynamiquement quand montant > threshold :
- Border + bg input deviennent ambre (visual cue immédiat)
- Triangle ⚠️ + message : 'Le montant saisi (X FCFA) dépasse le seuil habituel de Y FCFA. Vérifiez qu'il ne s'agit pas d'une erreur de frappe (ex: 50 000 au lieu de 5 000).'
- **Checkbox required 'Je confirme que ce montant est correct'**

### Submit garde-fou (frontend)
Handler jQuery existant intercepté + check :
- Si montant > threshold ET checkbox pas cochée → e.preventDefault()
- Scroll smooth vers l'alerte + focus checkbox

### Validation backend (défense en profondeur)
`StorePaiementRequest::withValidator()` close vérifie :
- Si montant > threshold ET `confirmed_unusual_amount != '1'` → erreur 422 sur `montant`
- Empêche curl/Postman de bypasser le check frontend
- Message FR explicite avec montant + threshold formatés

### Test plan
- [ ] Caissier tape 50 000 → submit normal, pas d'alerte
- [ ] Caissier tape 500 001 → alerte ambre apparaît + checkbox
- [ ] Click submit sans cocher → bloqué + scroll vers alerte + focus checkbox
- [ ] Cocher + submit → OK
- [ ] curl POST sans confirmed_unusual_amount + montant > threshold → 422 sur 'montant'
- [ ] Setting tenant changé via SettingsHelper → seuil dynamique respecté
- [ ] Reset après changement montant : la checkbox se décoche automatiquement (`x-on:input='confirmed = false'`)