### PR TITLE
feat(compta): S1.1 self-validation guard - separation des taches anti-fraude

### DIFF
--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -1245,6 +1245,14 @@ class ESBTPPaiementController extends Controller
                 return redirect()->back()->with('error', 'Ce paiement a été rejeté et ne peut pas être validé.');
             }
 
+            // S1.1 — Garde anti-auto-validation (séparation des tâches anti-fraude)
+            if ($block = $this->assertNotSelfValidation($paiement)) {
+                if ($request->ajax()) {
+                    return response()->json(['success' => false, 'message' => $block['message']], 403);
+                }
+                return redirect()->back()->with('error', $block['message']);
+            }
+
             DB::beginTransaction();
 
             // Changer le statut du paiement
@@ -1353,6 +1361,11 @@ class ESBTPPaiementController extends Controller
                     'success' => false,
                     'message' => 'Ce paiement a été rejeté et ne peut pas être validé.'
                 ], 400);
+            }
+
+            // S1.1 — Garde anti-auto-validation (séparation des tâches anti-fraude)
+            if ($block = $this->assertNotSelfValidation($paiement)) {
+                return response()->json(['success' => false, 'message' => $block['message']], 403);
             }
 
             DB::beginTransaction();
@@ -1607,6 +1620,7 @@ class ESBTPPaiementController extends Controller
         try {
             DB::beginTransaction();
 
+            $selfBlocked = 0;
             foreach ($request->paiements as $id) {
                 $paiement = ESBTPPaiement::find($id);
 
@@ -1623,6 +1637,12 @@ class ESBTPPaiementController extends Controller
 
                 if ($paiement->status === 'rejeté') {
                     $errorCount++;
+                    continue;
+                }
+
+                // S1.1 — Garde anti-auto-validation (séparation des tâches anti-fraude)
+                if ($this->assertNotSelfValidation($paiement) !== null) {
+                    $selfBlocked++;
                     continue;
                 }
 
@@ -1665,6 +1685,9 @@ class ESBTPPaiementController extends Controller
             if ($alreadyProcessed > 0) {
                 $message .= " $alreadyProcessed paiement(s) déjà validé(s).";
             }
+            if ($selfBlocked > 0) {
+                $message .= " $selfBlocked paiement(s) bloqué(s) — vous ne pouvez pas auto-valider vos propres saisies (séparation des tâches).";
+            }
             if ($errorCount > 0) {
                 $message .= " $errorCount paiement(s) n'ont pas pu être validés.";
             }
@@ -1676,6 +1699,7 @@ class ESBTPPaiementController extends Controller
                     'message' => $message,
                     'successCount' => $successCount,
                     'alreadyProcessed' => $alreadyProcessed,
+                    'selfBlocked' => $selfBlocked,
                     'errorCount' => $errorCount
                 ]);
             }
@@ -1700,6 +1724,50 @@ class ESBTPPaiementController extends Controller
 
             return redirect()->back()->with('error', 'Erreur lors de la validation groupée: ' . $e->getMessage());
         }
+    }
+
+    /**
+     * S1.1 — Garde anti-auto-validation (séparation des tâches anti-fraude).
+     *
+     * Refuse qu'un user valide un paiement qu'il a lui-même créé (créator == auth).
+     * Bypass possible via permission `paiements.validate.self_override` (réservée
+     * aux toutes petites écoles avec un seul user comptable, fortement déconseillé).
+     *
+     * superAdmin/serviceTechnique passent automatiquement (Gate::before * couverture).
+     *
+     * @return array{message: string}|null Null si OK, ou ['message' => '...'] si bloqué.
+     */
+    private function assertNotSelfValidation(\App\Models\ESBTPPaiement $paiement): ?array
+    {
+        $userId = auth()->id();
+        $createdBy = $paiement->created_by ?? null;
+
+        // Pas de created_by (legacy data pré-audit log) → pas de garde
+        if (!$createdBy) {
+            return null;
+        }
+
+        // Permission self_override (Gate::before couvre superAdmin/serviceTechnique)
+        if (auth()->user()?->can('paiements.validate.self_override')) {
+            return null;
+        }
+
+        // Auteur != validateur → OK (séparation respectée)
+        if ((int) $createdBy !== (int) $userId) {
+            return null;
+        }
+
+        // Bloqué : self-validation tentée sans override permission
+        Log::warning('[S1.1] Tentative auto-validation paiement bloquée', [
+            'paiement_id' => $paiement->id,
+            'user_id' => $userId,
+            'created_by' => $createdBy,
+            'montant' => $paiement->montant,
+        ]);
+
+        return [
+            'message' => 'Vous ne pouvez pas valider votre propre paiement (séparation des tâches anti-fraude). Demandez à un autre comptable.',
+        ];
     }
 
     /**

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -625,6 +625,12 @@ return [
             'group' => 'Paiements',
             'icon' => 'fa-check',
         ],
+        'paiements.validate.self_override' => [
+            'label' => 'Auto-valider ses propres paiements (exception, déconseillé)',
+            'description' => 'Permet à un user de valider un paiement qu\'il a lui-même créé. Bypasse le principe de séparation des tâches (anti-fraude). À réserver aux très petites écoles avec un seul user comptable.',
+            'group' => 'Paiements',
+            'icon' => 'fa-shield-virus',
+        ],
         'paiements.manage' => [
             'label' => 'Gérer tous les paiements (action globale)',
             'group' => 'Paiements',


### PR DESCRIPTION
## Sprint 1 — Anti-fraude (S1.1) BLOCKER critique

### Pourquoi
Audit permissions du plan compta killer : 'paiements.validate accordee a caissier+comptable+secretaire. Sans garde, un caissier peut creer un paiement de 500k cash + se l'auto-valider + dechirer le recu. Fraude triviale, non auditable.'

C'est LE blocker #1 pour qu'une ecole serieuse adopte KLASSCI.

### Garde technique
Nouveau `assertNotSelfValidation()` private dans ESBTPPaiementController :
- Compare `paiement->created_by` avec `auth()->id()`
- Si egaux ET pas de permission `paiements.validate.self_override` → bloque (403)
- Log::warning [S1.1] avec contexte complet pour audit retroactif
- Pas de garde si `created_by` NULL (legacy data pre-audit log → backward compat)

### Permission echappatoire
`paiements.validate.self_override` (nouvelle) :
- Label : 'Auto-valider ses propres paiements (exception, deconseille)'
- Description : 'Bypasse le principe de separation des taches (anti-fraude). A reserver aux tres petites ecoles avec un seul user comptable.'
- **NON grantee par defaut** (registry)
- superAdmin/serviceTechnique passent via Gate::before \*
- L'ecole peut la grant via UI custom roles si besoin (cf rule customizable-roles.md)

### 3 endpoints proteges
| Endpoint | Comportement bloque |
|---|---|
| `POST /paiements/{id}/valider` | 403 JSON ou redirect error |
| `POST /paiements/{id}/valider-rapide` | 403 JSON |
| `POST /paiements/bulk-valider` | skip + count selfBlocked + message recap |

### Test plan
- [ ] Caissier A cree paiement → Caissier A clique 'Valider' → 403 + message
- [ ] Caissier A cree paiement → Comptable B clique 'Valider' → OK
- [ ] superAdmin clique 'Valider' sur son propre paiement → OK (Gate::before)
- [ ] User avec `paiements.validate.self_override` → OK + log warning
- [ ] Bulk : 5 paiements dont 2 du meme user → 3 valides, 2 selfBlocked, message recap
- [ ] Paiement legacy avec created_by NULL → validation OK (backward compat)
- [ ] Audit log enregistre la tentative bloquee (`Log::warning`)

### Deploiement requis apres merge
`klassci permissions:fix <tenant>` pour propager la nouvelle permission au registry tenant. Pas d'impact data — juste registry sync.

### Conforme rules
- ✓ `.claude/rules/customizable-roles.md` : permission assignable, pas de nouveau role
- ✓ `.claude/rules/no-mvp-only-premium.md` : production-grade (logs + JSON + bulk + UX message)
- ✓ `.claude/rules/permissions.md` : convention `domaine.action.qualifier` snake_case ASCII