### PR TITLE
feat(compta): S1.5 fenetre 5min annulation paiement par auteur (anti-erreur)

### DIFF
--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -1727,6 +1727,84 @@ class ESBTPPaiementController extends Controller
     }
 
     /**
+     * S1.5 — Annuler son propre paiement créé il y a < N minutes (anti-erreur caissier).
+     *
+     * Évite que le caissier qui s'est trompé (typo cash, mauvais étudiant) doive
+     * appeler un comptable pour annuler. Soft delete + log + audit.
+     *
+     * Permission via Policy::cancelOwnRecent — vérifie auteur + statut + fenêtre temps.
+     */
+    public function cancelOwn(Request $request, ESBTPPaiement $paiement)
+    {
+        $this->authorize('cancelOwnRecent', $paiement);
+
+        try {
+            DB::beginTransaction();
+
+            // Désactive les rappels associés (cohérence avec destroy())
+            try {
+                $reminder = \App\Models\NotificationReminder::where('remindable_type', 'App\Models\ESBTPPaiement')
+                    ->where('remindable_id', $paiement->id)
+                    ->first();
+                if ($reminder) {
+                    $reminder->deactivate();
+                }
+            } catch (\Exception $e) {
+                Log::error('Erreur désactivation reminder paiement (cancel-own): ' . $e->getMessage());
+            }
+
+            $contextLog = [
+                'paiement_id' => $paiement->id,
+                'numero_recu' => $paiement->numero_recu,
+                'inscription_id' => $paiement->inscription_id,
+                'montant' => $paiement->montant,
+                'created_by' => $paiement->created_by,
+                'created_at' => $paiement->created_at?->toIso8601String(),
+                'cancelled_by' => auth()->id(),
+                'cancelled_at' => now()->toIso8601String(),
+            ];
+
+            $paiement->delete(); // Soft delete (trait SoftDeletes)
+
+            DB::commit();
+
+            Log::info('[S1.5] Paiement annulé par son auteur (fenêtre 5min)', $contextLog);
+
+            // Cache invalidation pour mettre à jour les KPIs
+            try {
+                app(\App\Services\GroupCacheInvalidator::class)->invalidate('paiement_cancelled');
+            } catch (\Throwable $e) {
+                // pas bloquant
+            }
+
+            $message = 'Paiement annulé. Vous pouvez en créer un nouveau si nécessaire.';
+
+            if ($request->ajax() || $request->wantsJson()) {
+                return response()->json([
+                    'success' => true,
+                    'message' => $message,
+                    'paiement_id' => $paiement->id,
+                ]);
+            }
+
+            return redirect()->route('esbtp.paiements.index')->with('success', $message);
+
+        } catch (\Throwable $e) {
+            DB::rollback();
+            Log::error('Erreur cancelOwn paiement', [
+                'paiement_id' => $paiement->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            $msg = 'Impossible d\'annuler ce paiement : ' . $e->getMessage();
+            if ($request->ajax() || $request->wantsJson()) {
+                return response()->json(['success' => false, 'message' => $msg], 500);
+            }
+            return redirect()->back()->with('error', $msg);
+        }
+    }
+
+    /**
      * S1.1 — Garde anti-auto-validation (séparation des tâches anti-fraude).
      *
      * Refuse qu'un user valide un paiement qu'il a lui-même créé (créator == auth).

--- a/app/Policies/ESBTPPaiementPolicy.php
+++ b/app/Policies/ESBTPPaiementPolicy.php
@@ -63,4 +63,39 @@ class ESBTPPaiementPolicy
     {
         return $user->can('paiements.delete');
     }
+
+    /**
+     * S1.5 — Fenêtre d'annulation 5 minutes pour le caissier qui s'est trompé.
+     *
+     * Permet d'annuler son propre paiement sans déranger un comptable, à condition que :
+     *   - Le user a saisi ce paiement (created_by == auth.id)
+     *   - Le paiement est encore en_attente (pas encore validé/rejeté)
+     *   - Saisi il y a moins de N minutes (configurable via setting tenant, default 5)
+     *
+     * C'est ANTI-ERREUR (typo cash, mauvais étudiant), pas anti-fraude — donc
+     * pas besoin de permission supplémentaire. Le caissier annule SA SAISIE.
+     *
+     * Au-delà de N min, il faut passer par paiements.delete (rare, comptable only).
+     */
+    public function cancelOwnRecent(User $user, ESBTPPaiement $paiement): bool
+    {
+        if (! $user->can('paiements.create')) {
+            return false;
+        }
+
+        if ((int) ($paiement->created_by ?? 0) !== (int) $user->id) {
+            return false;
+        }
+
+        if ($paiement->status !== 'en_attente') {
+            return false;
+        }
+
+        $windowMinutes = (int) \App\Helpers\SettingsHelper::get('comptabilite.cancel_own_window_minutes', 5);
+        if ($windowMinutes <= 0) {
+            return false;
+        }
+
+        return $paiement->created_at && $paiement->created_at->gt(now()->subMinutes($windowMinutes));
+    }
 }

--- a/resources/views/esbtp/paiements/show.blade.php
+++ b/resources/views/esbtp/paiements/show.blade.php
@@ -380,6 +380,30 @@
                 </button>
                 @endcan
                 @endif
+
+                {{-- S1.5 — Bouton "Annuler ma saisie" si fenêtre 5min ouverte --}}
+                @can('cancelOwnRecent', $paiement)
+                @php
+                    $cancelWindowMin = (int) \App\Helpers\SettingsHelper::get('comptabilite.cancel_own_window_minutes', 5);
+                    $deadline = $paiement->created_at->copy()->addMinutes($cancelWindowMin);
+                    $remainingSeconds = max(0, $deadline->getTimestamp() - now()->getTimestamp());
+                    $remainingMinutes = (int) max(1, ceil($remainingSeconds / 60));
+                @endphp
+                <form id="ps-form-cancel-own-{{ $paiement->id }}" action="{{ route('esbtp.paiements.cancel-own', $paiement->id) }}" method="POST" style="margin:0">
+                    @csrf
+                    <button type="button"
+                            class="ps-btn warning"
+                            style="background:rgba(245,158,11,.12);color:#b45309;border:1px solid rgba(245,158,11,.3);"
+                            data-ii-confirm-form="ps-form-cancel-own-{{ $paiement->id }}"
+                            data-ii-confirm-title="Annuler ma saisie ?"
+                            data-ii-confirm-message="Annuler ce paiement que vous venez de créer ? Vous pourrez en saisir un nouveau si nécessaire. Cette action est tracée."
+                            data-ii-confirm-label="Oui, annuler"
+                            data-ii-confirm-cancel="Garder"
+                            title="Vous pouvez annuler votre saisie pendant encore environ {{ $remainingMinutes }} min">
+                        <i class="fas fa-undo"></i> Annuler ma saisie
+                    </button>
+                </form>
+                @endcan
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -911,6 +911,11 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
                 ->name('paiements.destroy')
                 ->middleware('permission:paiements.delete');
 
+            // ── CANCEL OWN RECENT (S1.5 — fenêtre 5min anti-erreur caissier)
+            Route::post('/paiements/{paiement}/cancel-own', [App\Http\Controllers\ESBTPPaiementController::class, 'cancelOwn'])
+                ->name('paiements.cancel-own')
+                ->middleware('throttle:30,1');
+
             // ── VALIDATE/REJECT (workflow comptable — throttled)
             Route::middleware(['permission:paiements.validate', 'throttle:60,1'])->group(function () {
                 Route::post('/paiements/{paiement}/valider', [App\Http\Controllers\ESBTPPaiementController::class, 'valider'])->name('paiements.valider');


### PR DESCRIPTION
## Sprint 1 — Anti-erreur (S1.5) Complement de S1.1

### Pourquoi
Critic UX : 'Pas de fenetre annulation 5 min cote caissier. Une fois valide, supprimer un paiement = paiements.delete permission (rare). Donc caissier qui s'est trompe doit faire WhatsApp a comptable.'

Avec S1.1 mergee (bloque auto-validation), le caissier qui se trompe ne peut PAS rectifier lui-meme via validate-then-delete. Il faut une voie de secours pour les erreurs benignes.

### Policy::cancelOwnRecent (4 conditions strictes)
1. permission paiements.create
2. created_by == auth.id (auteur)
3. status === en_attente (pas valide)
4. created_at > now() - N minutes (default 5, configurable)

### Setting tenant configurable
`comptabilite.cancel_own_window_minutes` default 5.
- Ecole conservatrice met 0 (desactive)
- Ecole flexible met 15

### Nouvelle route + endpoint
`POST /paiements/{paiement}/cancel-own` throttle 30/min, soft delete + log + audit.

### UI premium dans paiements/show.blade.php
Bouton 'Annuler ma saisie' ambre (warning), visible @can('cancelOwnRecent', $paiement).
- Modal confirm via iiConfirm
- Tooltip 'Vous pouvez annuler votre saisie pendant encore environ N min'
- Pas affiche du tout si fenetre depassee

### Test plan
- [ ] Caissier saisit paiement, ouvre la fiche, voit le bouton 'Annuler ma saisie'
- [ ] Click + confirm → soft delete, redirect liste, message succes
- [ ] Caissier B (autre user) ouvre meme fiche → pas de bouton
- [ ] Apres 5min → bouton invisible
- [ ] Setting cancel_own_window_minutes=0 → bouton invisible immediat
- [ ] Setting cancel_own_window_minutes=15 → bouton visible 15min
- [ ] Paiement deja valide → bouton invisible
- [ ] Log::info enregistre l'evenement avec contexte complet

### Conforme rules
- ✓ customizable-roles : pas de nouveau role, pas de permission custom
- ✓ no-mvp-only-premium : production-grade (logs, JSON, AJAX, transactions, soft delete)