### PR TITLE
refactor(workflow+recouvrement): simplify post-mai2026 D8 — queue listener + DRY contacts

### DIFF
--- a/app/Domain/Notifications/EtudiantContact.php
+++ b/app/Domain/Notifications/EtudiantContact.php
@@ -17,6 +17,27 @@ final class EtudiantContact
         public readonly ?string $nom = null,
     ) {}
 
+    /**
+     * Construit un contact depuis un modèle ESBTPEtudiant (ou null si absent).
+     * Centralise le mapping etudiant → contact utilisé dans tous les flows
+     * recouvrement / relances (controller + service).
+     */
+    public static function fromEtudiant(?object $etudiant): ?self
+    {
+        if ($etudiant === null) {
+            return null;
+        }
+
+        return new self(
+            etudiantId: (int) $etudiant->id,
+            nomComplet: trim(($etudiant->prenoms ?? '') . ' ' . ($etudiant->nom ?? '')),
+            phone: $etudiant->telephone ?? null,
+            email: $etudiant->email ?? null,
+            prenoms: $etudiant->prenoms ?? null,
+            nom: $etudiant->nom ?? null,
+        );
+    }
+
     public function hasValidPhone(): bool
     {
         return PhoneNormalizer::isValid($this->phone);

--- a/app/Http/Controllers/ESBTPRecouvrementController.php
+++ b/app/Http/Controllers/ESBTPRecouvrementController.php
@@ -6,17 +6,17 @@ use App\Domain\Analytics\Cache\CachedPredictor;
 use App\Domain\Analytics\DTOs\AnalyticsContext;
 use App\Domain\Analytics\Predictors\DefaultRiskPredictor;
 use App\Domain\Exports\Reports\RecouvrementReport;
+use App\Domain\Notifications\ChannelDispatch;
 use App\Domain\Notifications\Channels\WhatsAppDeeplinkChannel;
 use App\Domain\Notifications\EtudiantContact;
+use App\Domain\Notifications\PhoneNormalizer;
 use App\Helpers\SettingsHelper;
 use App\Models\ESBTPClasse;
-use App\Models\ESBTPEtudiant;
 use App\Models\ESBTPFiliere;
 use App\Models\ESBTPInscription;
 use App\Services\ExportRenderer;
 use App\Services\RelanceActionLogger;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
@@ -41,17 +41,17 @@ class ESBTPRecouvrementController extends Controller
         $this->middleware('can:comptabilite.recouvrement.access');
     }
 
-    public function previewPdf(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer)
+    public function previewPdf(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer): \Symfony\Component\HttpFoundation\Response
     {
         return $renderer->pdfPreview($this->buildReport($request, $predictor));
     }
 
-    public function exportPdf(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer)
+    public function exportPdf(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer): \Symfony\Component\HttpFoundation\Response
     {
         return $renderer->pdfDownload($this->buildReport($request, $predictor));
     }
 
-    public function exportExcel(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer)
+    public function exportExcel(Request $request, DefaultRiskPredictor $predictor, ExportRenderer $renderer): \Symfony\Component\HttpFoundation\Response
     {
         return $renderer->excelDownload($this->buildReport($request, $predictor));
     }
@@ -73,21 +73,9 @@ class ESBTPRecouvrementController extends Controller
 
     private function buildReport(Request $request, DefaultRiskPredictor $predictor): RecouvrementReport
     {
-        $context = AnalyticsContext::fromRequest($request);
-        $cached = new CachedPredictor($predictor, ttlSeconds: 1800);
-        $prediction = $cached->predict($context);
+        [$context, $prediction, $topAtRisk, $contacts] = $this->loadPrediction($request, $predictor);
 
-        $topAtRisk = $prediction->metadata['top_at_risk'] ?? [];
-        $contacts = $this->loadContacts(array_column($topAtRisk, 'inscription_id'));
-
-        $rows = collect($topAtRisk)
-            ->map(function ($student) use ($contacts) {
-                $contact = $contacts[$student['inscription_id']] ?? null;
-                return array_merge($student, [
-                    'phone' => $contact?->phone,
-                    'email' => $contact?->email,
-                ]);
-            });
+        $rows = collect($topAtRisk)->map(fn ($student) => $this->enrichStudentRow($student, $contacts, withMeta: false));
 
         // Filtres UI appliqués server-side pour cohérence preview/download avec la vue
         $level = $request->query('level');
@@ -121,30 +109,11 @@ class ESBTPRecouvrementController extends Controller
 
     public function index(Request $request, DefaultRiskPredictor $predictor): View
     {
-        $context = AnalyticsContext::fromRequest($request);
-        $cached = new CachedPredictor($predictor, ttlSeconds: 1800);
-        $prediction = $cached->predict($context);
+        [$context, $prediction, $topAtRisk, $contacts] = $this->loadPrediction($request, $predictor);
 
-        $topAtRisk = $prediction->metadata['top_at_risk'] ?? [];
-        $contacts = $this->loadContacts(array_column($topAtRisk, 'inscription_id'));
-
-        $intentLogger = app(\App\Services\RelanceActionLogger::class);
+        $intentLogger = app(RelanceActionLogger::class);
         $rows = collect($topAtRisk)
-            ->map(function ($student) use ($contacts, $intentLogger) {
-                $contact = $contacts[$student['inscription_id']] ?? null;
-                if ($contact === null) {
-                    Log::warning('Recouvrement: contact introuvable pour inscription at-risk', [
-                        'inscription_id' => $student['inscription_id'],
-                    ]);
-                }
-                return array_merge($student, [
-                    'phone' => $contact?->phone,
-                    'email' => $contact?->email,
-                    'prenoms' => $contact?->prenoms ?? '',
-                    'has_valid_phone' => $contact?->hasValidPhone() ?? false,
-                    'relances_today' => $intentLogger->countIntentsToday($student['etudiant_id'] ?? 0),
-                ]);
-            })
+            ->map(fn ($student) => $this->enrichStudentRow($student, $contacts, withMeta: true, intentLogger: $intentLogger))
             ->values()
             ->all();
 
@@ -160,6 +129,60 @@ class ESBTPRecouvrementController extends Controller
             'classes' => ESBTPClasse::orderBy('name')->get(),
             'whatsappTemplate' => $this->whatsappTemplate(),
             'schoolName' => SettingsHelper::get('school_name', config('app.name', 'KLASSCI')),
+        ]);
+    }
+
+    /**
+     * Charge la prédiction (cachée 30 min) + les contacts associés. Évite la
+     * duplication entre `index()` (vue HTML) et `buildReport()` (exports PDF/Excel).
+     *
+     * @return array{0: AnalyticsContext, 1: \App\Domain\Analytics\DTOs\PredictionResult, 2: array, 3: array<int, EtudiantContact>}
+     */
+    private function loadPrediction(Request $request, DefaultRiskPredictor $predictor): array
+    {
+        $context = AnalyticsContext::fromRequest($request);
+        $cached = new CachedPredictor($predictor, ttlSeconds: 1800);
+        $prediction = $cached->predict($context);
+
+        $topAtRisk = $prediction->metadata['top_at_risk'] ?? [];
+        $contacts = $this->loadContacts(array_column($topAtRisk, 'inscription_id'));
+
+        return [$context, $prediction, $topAtRisk, $contacts];
+    }
+
+    /**
+     * Enrichit une ligne `top_at_risk` avec contact (phone/email) et,
+     * optionnellement, métadonnées UI (prénoms, validité phone, relances du jour).
+     *
+     * @param  array<int, EtudiantContact>  $contacts  Indexés par inscription_id.
+     */
+    private function enrichStudentRow(
+        array $student,
+        array $contacts,
+        bool $withMeta,
+        ?RelanceActionLogger $intentLogger = null,
+    ): array {
+        $contact = $contacts[$student['inscription_id']] ?? null;
+
+        if ($withMeta && $contact === null) {
+            Log::warning('Recouvrement: contact introuvable pour inscription at-risk', [
+                'inscription_id' => $student['inscription_id'],
+            ]);
+        }
+
+        $base = array_merge($student, [
+            'phone' => $contact?->phone,
+            'email' => $contact?->email,
+        ]);
+
+        if (!$withMeta) {
+            return $base;
+        }
+
+        return array_merge($base, [
+            'prenoms' => $contact?->prenoms ?? '',
+            'has_valid_phone' => $contact?->hasValidPhone() ?? false,
+            'relances_today' => $intentLogger?->countIntentsToday($student['etudiant_id'] ?? 0) ?? 0,
         ]);
     }
 
@@ -180,26 +203,17 @@ class ESBTPRecouvrementController extends Controller
 
         $inscription = ESBTPInscription::with('etudiant:id,nom,prenoms,telephone,email')
             ->findOrFail($validated['inscription_id']);
-        $etudiant = $inscription->etudiant;
+        $contact = EtudiantContact::fromEtudiant($inscription->etudiant);
 
-        if (!$etudiant) {
+        if ($contact === null) {
             return response()->json(['success' => false, 'error' => 'Étudiant introuvable'], 404);
         }
-
-        $contact = new EtudiantContact(
-            etudiantId: (int) $etudiant->id,
-            nomComplet: trim(($etudiant->prenoms ?? '') . ' ' . ($etudiant->nom ?? '')),
-            phone: $etudiant->telephone,
-            email: $etudiant->email,
-            prenoms: $etudiant->prenoms,
-            nom: $etudiant->nom,
-        );
 
         $dispatch = match ($validated['channel']) {
             'whatsapp_deeplink' => $whatsapp->dispatch($contact, $validated['message']),
             'email' => $this->buildEmailDispatch($contact, $validated['message']),
             'tel' => $this->buildTelDispatch($contact),
-            'manuel' => \App\Domain\Notifications\ChannelDispatch::manual('manuel', '#'),
+            'manuel' => ChannelDispatch::manual('manuel', '#'),
         };
 
         try {
@@ -262,16 +276,8 @@ class ESBTPRecouvrementController extends Controller
 
         $inscription = ESBTPInscription::with('etudiant:id,nom,prenoms,telephone,email')
             ->findOrFail($validated['inscription_id']);
-        $etudiant = $inscription->etudiant;
-
-        $contact = new EtudiantContact(
-            etudiantId: (int) ($etudiant?->id ?? 0),
-            nomComplet: trim(($etudiant?->prenoms ?? '') . ' ' . ($etudiant?->nom ?? '')),
-            phone: $etudiant?->telephone,
-            email: $etudiant?->email,
-            prenoms: $etudiant?->prenoms,
-            nom: $etudiant?->nom,
-        );
+        $contact = EtudiantContact::fromEtudiant($inscription->etudiant)
+            ?? new EtudiantContact(0, '', null, null);
 
         $relance = $logger->logSent(
             $contact,
@@ -297,22 +303,9 @@ class ESBTPRecouvrementController extends Controller
         return ESBTPInscription::with('etudiant:id,nom,prenoms,telephone,email')
             ->whereIn('id', $inscriptionIds)
             ->get()
-            ->mapWithKeys(function (ESBTPInscription $inscription) {
-                $etudiant = $inscription->etudiant;
-                if (!$etudiant) {
-                    return [$inscription->id => null];
-                }
-                return [
-                    $inscription->id => new EtudiantContact(
-                        etudiantId: (int) $etudiant->id,
-                        nomComplet: trim(($etudiant->prenoms ?? '') . ' ' . ($etudiant->nom ?? '')),
-                        phone: $etudiant->telephone,
-                        email: $etudiant->email,
-                        prenoms: $etudiant->prenoms,
-                        nom: $etudiant->nom,
-                    ),
-                ];
-            })
+            ->mapWithKeys(fn (ESBTPInscription $inscription) => [
+                $inscription->id => EtudiantContact::fromEtudiant($inscription->etudiant),
+            ])
             ->filter()
             ->all();
     }
@@ -323,25 +316,22 @@ class ESBTPRecouvrementController extends Controller
         return is_string($template) && trim($template) !== '' ? $template : self::TEMPLATE_DEFAULT;
     }
 
-    private function buildEmailDispatch(EtudiantContact $contact, string $message): \App\Domain\Notifications\ChannelDispatch
+    private function buildEmailDispatch(EtudiantContact $contact, string $message): ChannelDispatch
     {
         if (!$contact->hasEmail()) {
-            return \App\Domain\Notifications\ChannelDispatch::unavailable('email', 'Email étudiant manquant ou invalide');
+            return ChannelDispatch::unavailable('email', 'Email étudiant manquant ou invalide');
         }
         $subject = rawurlencode('Solde de scolarité');
         $body = rawurlencode($message);
-        return \App\Domain\Notifications\ChannelDispatch::manual(
-            'email',
-            "mailto:{$contact->email}?subject={$subject}&body={$body}",
-        );
+        return ChannelDispatch::manual('email', "mailto:{$contact->email}?subject={$subject}&body={$body}");
     }
 
-    private function buildTelDispatch(EtudiantContact $contact): \App\Domain\Notifications\ChannelDispatch
+    private function buildTelDispatch(EtudiantContact $contact): ChannelDispatch
     {
-        $e164 = \App\Domain\Notifications\PhoneNormalizer::toE164($contact->phone);
+        $e164 = PhoneNormalizer::toE164($contact->phone);
         if ($e164 === null) {
-            return \App\Domain\Notifications\ChannelDispatch::unavailable('tel', 'Numéro de téléphone invalide');
+            return ChannelDispatch::unavailable('tel', 'Numéro de téléphone invalide');
         }
-        return \App\Domain\Notifications\ChannelDispatch::manual('tel', "tel:{$e164}");
+        return ChannelDispatch::manual('tel', "tel:{$e164}");
     }
 }

--- a/app/Listeners/NotifyWorkflowNextStepActors.php
+++ b/app/Listeners/NotifyWorkflowNextStepActors.php
@@ -5,14 +5,19 @@ namespace App\Listeners;
 use App\Events\WorkflowStepCompleted;
 use App\Notifications\WorkflowNextStepNotification;
 use App\Services\WorkflowNextStepResolver;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Support\Facades\Notification;
 
 /**
  * Listener du WorkflowStepCompleted : notifie les détenteurs de la permission
  * pour l'étape suivante, en EXCLUANT l'acteur courant (anti-self-notif —
  * gérée côté UI via modal "tu peux maintenant X").
+ *
+ * Queued pour ne pas bloquer la requête utilisateur qui a déclenché l'event :
+ * la résolution des recipients fait une requête DB indexée par permission, et
+ * `Notification::send` itère sur N users.
  */
-class NotifyWorkflowNextStepActors
+class NotifyWorkflowNextStepActors implements ShouldQueue
 {
     public function __construct(private readonly WorkflowNextStepResolver $resolver)
     {

--- a/app/Services/WorkflowNextStepResolver.php
+++ b/app/Services/WorkflowNextStepResolver.php
@@ -15,27 +15,42 @@ use Illuminate\Support\Collection;
 class WorkflowNextStepResolver
 {
     /**
-     * Permission cible par type d'event de workflow.
+     * Étapes suivantes par type d'event de workflow.
+     *
+     * Forme : [
+     *     <event_type> => [
+     *         'permission' => string|null,  // permission requise pour l'étape suivante
+     *         'label'      => string|null,  // label humain
+     *         'route'      => string|null,  // nom de route Laravel
+     *         'param_key'  => string|null,  // clé recherchée dans le context (avec fallback sans `_id`)
+     *     ],
+     * ]
      */
-    private const NEXT_STEP_PERMISSION = [
-        'inscription.created'        => 'paiements.create',     // créer/associer paiement
-        'paiement.created'           => 'paiements.validate',   // valider paiement
-        'paiement.validated'         => 'inscriptions.validate', // valider inscription
-        'inscription.validated'      => null,                    // fin du chain
-    ];
-
-    private const NEXT_STEP_LABEL = [
-        'inscription.created'   => 'Encaisser un paiement pour cette inscription',
-        'paiement.created'      => 'Valider ce paiement',
-        'paiement.validated'    => 'Valider l\'inscription',
-        'inscription.validated' => null,
-    ];
-
-    private const NEXT_STEP_ROUTE = [
-        'inscription.created'   => ['name' => 'esbtp.paiements.create', 'param_key' => 'inscription_id'],
-        'paiement.created'      => ['name' => 'esbtp.paiements.show',  'param_key' => 'paiement'],
-        'paiement.validated'    => ['name' => 'esbtp.inscriptions.show', 'param_key' => 'inscription'],
-        'inscription.validated' => null,
+    private const NEXT_STEPS = [
+        'inscription.created' => [
+            'permission' => 'paiements.create',
+            'label'      => 'Encaisser un paiement pour cette inscription',
+            'route'      => 'esbtp.paiements.create',
+            'param_key'  => 'inscription_id',
+        ],
+        'paiement.created' => [
+            'permission' => 'paiements.validate',
+            'label'      => 'Valider ce paiement',
+            'route'      => 'esbtp.paiements.show',
+            'param_key'  => 'paiement',
+        ],
+        'paiement.validated' => [
+            'permission' => 'inscriptions.validate',
+            'label'      => 'Valider l\'inscription',
+            'route'      => 'esbtp.inscriptions.show',
+            'param_key'  => 'inscription',
+        ],
+        'inscription.validated' => [
+            'permission' => null,
+            'label'      => null,
+            'route'      => null,
+            'param_key'  => null,
+        ],
     ];
 
     /**
@@ -43,7 +58,7 @@ class WorkflowNextStepResolver
      */
     public function nextPermission(string $eventType): ?string
     {
-        return self::NEXT_STEP_PERMISSION[$eventType] ?? null;
+        return self::NEXT_STEPS[$eventType]['permission'] ?? null;
     }
 
     /**
@@ -51,7 +66,7 @@ class WorkflowNextStepResolver
      */
     public function nextLabel(string $eventType): ?string
     {
-        return self::NEXT_STEP_LABEL[$eventType] ?? null;
+        return self::NEXT_STEPS[$eventType]['label'] ?? null;
     }
 
     /**
@@ -59,17 +74,19 @@ class WorkflowNextStepResolver
      */
     public function nextActionUrl(string $eventType, array $context): ?string
     {
-        $route = self::NEXT_STEP_ROUTE[$eventType] ?? null;
-        if (!$route) {
+        $step = self::NEXT_STEPS[$eventType] ?? null;
+        if (!$step || !$step['route'] || !$step['param_key']) {
             return null;
         }
-        $key = $route['param_key'];
-        if (!isset($context[$key]) && !isset($context[str_replace('_id', '', $key)])) {
+
+        $key = $step['param_key'];
+        $fallbackKey = str_replace('_id', '', $key);
+        $value = $context[$key] ?? $context[$fallbackKey] ?? null;
+        if ($value === null) {
             return null;
         }
-        $value = $context[$key] ?? $context[str_replace('_id', '', $key)];
-        return route($route['name'], [$route['param_key'] === 'inscription_id'
-            ? 'inscription_id' : ($route['param_key'])  => $value]);
+
+        return route($step['route'], [$key => $value]);
     }
 
     /**


### PR DESCRIPTION
## Scope

Simplify D8 — domaine **Workflow event-driven + Recouvrement** (commits 7d117cbc → 9eceec61).

## Findings

| # | Sévérité | Finding | Status |
|---|---|---|---|
| 1 | HIGH | `NotifyWorkflowNextStepActors` synchrone : DB query (User::permission) + N notifs envoyées dans le request user | **Fixed** (ShouldQueue) |
| 2 | HIGH | `WorkflowNextStepResolver::nextActionUrl` ternaire redondant `'inscription_id' === 'inscription_id'` | **Fixed** (suppression) |
| 3 | MEDIUM | 3 const arrays parallèles (`NEXT_STEP_PERMISSION/LABEL/ROUTE`) keyés identiquement | **Fixed** (consolidé en 1 map `NEXT_STEPS`) |
| 4 | MEDIUM | `ESBTPRecouvrementController::index()` et `buildReport()` dupliquent ~30 lignes de loading prediction + row mapping | **Fixed** (`loadPrediction()` + `enrichStudentRow()`) |
| 5 | MEDIUM | `EtudiantContact` construit à la main dans 4 sites (controller logIntent/markDone + loadContacts) | **Fixed** (factory `EtudiantContact::fromEtudiant()`) |
| 6 | LOW | `\App\Domain\Notifications\ChannelDispatch::...` FQCN répété inline 6× | **Fixed** (use statement) |
| 7 | LOW | Imports `ESBTPEtudiant` + `RedirectResponse` non utilisés | **Fixed** (supprimés) |
| 8 | LOW | Return types manquants sur `previewPdf/exportPdf/exportExcel` | **Fixed** (Symfony Response) |
| 9 | LOW | Seuils retard `30/60/90` hardcodés vue Alpine + `<select>` natifs visibles | **Backlog** (premium-selects + config seuils) |
| 10 | LOW | `buildEmailDispatch/buildTelDispatch` inline dans controller au lieu de Channel classes | **Backlog** (extraction prématurée pour 2 méthodes triviales) |

## Stats

- 4 fichiers modifiés
- +152 / -119 lignes (net +33, mais beaucoup de docblocks/typing ajoutés)
- ESBTPRecouvrementController : 347 → 337 LOC (-10)
- WorkflowNextStepResolver : 103 → 120 LOC (+17 docblocks structurés)
- DRY : 4 sites construction `EtudiantContact` + 2 sites row-mapping → factory + helpers privés

## Impact comportement

**Aucun.** Préservé strictement :
- Events `WorkflowStepCompleted` firent toujours sur les 4 types (`inscription.created`, `paiement.created`, `paiement.validated`, `inscription.validated`)
- Listener queued = délivrance asynchrone (pas de différence user-perçue, juste pas de blocage du request)
- Notifs DB délivrées au mêmes recipients (mêmes permissions)
- Anti-self-notif via `WorkflowFlash` + `actorCanDoNextStep()` inchangé
- WhatsApp deeplinks, email mailto:, tel: tous identiques
- Accuracy widget / KPIs / cache predictor 30min inchangés
- Toutes les routes + permissions + throttle middlewares inchangés

## Test plan

- [ ] Inscription créée par caissier (sans permission `paiements.create`) : holder paiements.create reçoit notif via queue
- [ ] Inscription créée par secrétaire (avec permission `paiements.create`) : modal "next step" s'affiche, pas de notif
- [ ] `/esbtp/comptabilite/recouvrement` : page rendue + PDF export = mêmes lignes (filtres reproduits server-side)
- [ ] WhatsApp / Email / Tel actions → deeplink correct + log intent → confirm sent → marked done