### PR TITLE
feat(compta): S1.6 notification gros paiement valide aux users habilites

### DIFF
--- a/app/Http/Controllers/ESBTPPaiementController.php
+++ b/app/Http/Controllers/ESBTPPaiementController.php
@@ -1287,6 +1287,9 @@ class ESBTPPaiementController extends Controller
 
             app(\App\Services\GroupCacheInvalidator::class)->invalidate('paiement_validated');
 
+            // S1.6 — Notif gros montant aux users avec permission `comptabilite.notifications.high_amount`
+            $this->notifyHighAmountIfAny($paiement, auth()->user());
+
             // Envoyer notification à l'étudiant
             try {
                 $notificationService = app(\App\Services\NotificationService::class);
@@ -1399,6 +1402,9 @@ class ESBTPPaiementController extends Controller
             }
 
             DB::commit();
+
+            // S1.6 — Notif gros montant
+            $this->notifyHighAmountIfAny($paiement, auth()->user());
 
             // Envoyer notifications
             try {
@@ -1745,6 +1751,48 @@ class ESBTPPaiementController extends Controller
             }
 
             return redirect()->back()->with('error', 'Erreur lors de la validation groupée: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * S1.6 — Notifie les users habilités quand un paiement > seuil tenant est validé.
+     *
+     * Cible : users avec permission `comptabilite.notifications.high_amount`.
+     * Seuil : `comptabilite.notify_high_amount_threshold` (default 5 000 000 FCFA).
+     * Canaux : mail + database (cloche).
+     *
+     * Échec silencieux par design — la validation du paiement ne doit pas dépendre
+     * du succès de la notification. Erreurs loggées en warning.
+     */
+    private function notifyHighAmountIfAny(\App\Models\ESBTPPaiement $paiement, ?\App\Models\User $validateur): void
+    {
+        try {
+            $threshold = (int) \App\Helpers\SettingsHelper::get('comptabilite.notify_high_amount_threshold', 5000000);
+            if ($threshold <= 0 || (float) $paiement->montant < $threshold) {
+                return;
+            }
+
+            $recipients = \App\Models\User::permission('comptabilite.notifications.high_amount')->get();
+            if ($recipients->isEmpty()) {
+                return;
+            }
+
+            \Illuminate\Support\Facades\Notification::send(
+                $recipients,
+                new \App\Notifications\PaiementHighAmountValidatedNotification($paiement, $validateur, $threshold),
+            );
+
+            Log::info('[S1.6] Notification gros paiement envoyée', [
+                'paiement_id' => $paiement->id,
+                'montant' => $paiement->montant,
+                'threshold' => $threshold,
+                'recipients_count' => $recipients->count(),
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('[S1.6] Échec notification gros paiement (non bloquant)', [
+                'paiement_id' => $paiement->id,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/app/Notifications/PaiementHighAmountValidatedNotification.php
+++ b/app/Notifications/PaiementHighAmountValidatedNotification.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\ESBTPPaiement;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * S1.6 — Notification "gros montant validé".
+ *
+ * Envoyée aux users ayant la permission `comptabilite.notifications.high_amount`
+ * dès qu'un paiement supérieur au seuil tenant configuré est validé.
+ *
+ * Vise typiquement le directeur d'école (qui n'est pas comptable mais veut être
+ * informé des grosses entrées). L'école assigne la perm via UI custom roles.
+ */
+class PaiementHighAmountValidatedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly ESBTPPaiement $paiement,
+        public readonly ?User $validateur,
+        public readonly int $threshold,
+    ) {}
+
+    public function via($notifiable): array
+    {
+        return ['mail', 'database'];
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        $etudiantNom = $this->paiement->etudiant
+            ? trim(($this->paiement->etudiant->prenoms ?? '') . ' ' . ($this->paiement->etudiant->nom ?? ''))
+            : 'Étudiant inconnu';
+
+        $montantFmt = number_format((float) $this->paiement->montant, 0, ',', ' ');
+        $thresholdFmt = number_format($this->threshold, 0, ',', ' ');
+        $validateurNom = $this->validateur?->name ?? 'Comptable';
+
+        return (new MailMessage)
+            ->subject(sprintf('[KLASSCI] Paiement de %s FCFA validé', $montantFmt))
+            ->greeting('Bonjour ' . ($notifiable->name ?? ''))
+            ->line(sprintf(
+                'Un paiement supérieur au seuil de notification (%s FCFA) vient d\'être validé.',
+                $thresholdFmt,
+            ))
+            ->line(sprintf('• **Étudiant** : %s', $etudiantNom))
+            ->line(sprintf('• **Montant** : %s FCFA', $montantFmt))
+            ->line(sprintf('• **Catégorie** : %s', $this->paiement->fraisCategory->name ?? $this->paiement->motif ?? 'Non renseignée'))
+            ->line(sprintf('• **Mode de paiement** : %s', $this->paiement->mode_paiement ?? 'Non renseigné'))
+            ->line(sprintf('• **Validé par** : %s', $validateurNom))
+            ->line(sprintf('• **Date validation** : %s', optional($this->paiement->date_validation)->format('d/m/Y à H:i') ?? 'Maintenant'))
+            ->action('Voir le paiement', route('esbtp.paiements.show', $this->paiement->id))
+            ->line('Cette notification est envoyée automatiquement aux personnes habilitées à surveiller les gros montants. Vous pouvez modifier ce seuil ou désactiver cette alerte dans les paramètres comptables.');
+    }
+
+    public function toArray($notifiable): array
+    {
+        return [
+            'paiement_id' => $this->paiement->id,
+            'numero_recu' => $this->paiement->numero_recu,
+            'montant' => (float) $this->paiement->montant,
+            'threshold' => $this->threshold,
+            'etudiant_id' => $this->paiement->etudiant_id ?? null,
+            'etudiant_nom' => $this->paiement->etudiant
+                ? trim(($this->paiement->etudiant->prenoms ?? '') . ' ' . ($this->paiement->etudiant->nom ?? ''))
+                : null,
+            'mode_paiement' => $this->paiement->mode_paiement ?? null,
+            'validateur_id' => $this->validateur?->id,
+            'validateur_nom' => $this->validateur?->name,
+            'validated_at' => optional($this->paiement->date_validation)->toIso8601String() ?? now()->toIso8601String(),
+            'action_url' => route('esbtp.paiements.show', $this->paiement->id),
+        ];
+    }
+}

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -759,6 +759,12 @@ return [
             'group' => 'Comptabilité',
             'icon' => 'fa-key',
         ],
+        'comptabilite.notifications.high_amount' => [
+            'label' => 'Recevoir une notification quand un gros paiement est validé',
+            'description' => 'Notification email + cloche déclenchée à chaque validation de paiement supérieur au seuil tenant configuré (default 5 000 000 FCFA). Vise typiquement le directeur ou le directeur financier qui surveille les grosses entrées sans être lui-même comptable. Permission assignable via UI custom roles.',
+            'group' => 'Comptabilité',
+            'icon' => 'fa-bell',
+        ],
         'comptabilite.sensitive.access' => [
             'label' => 'Accès aux données comptables sensibles',
             'group' => 'Comptabilité',


### PR DESCRIPTION
## Sprint 1 — Surveillance (S1.6)

### Pourquoi
Audit permissions : 'Pas de notification directeur quand paiement > X FCFA valide. Le directeur ne sait pas qu'une grosse entree de tresorerie vient d'arriver.'

### Setting tenant
`comptabilite.notify_high_amount_threshold` (default 5_000_000 FCFA, mettre 0 pour desactiver).

### Permission assignable
`comptabilite.notifications.high_amount` (non grantee par defaut).
L'ecole assigne via UI custom roles ou roles-permissions :
- Petite ecole : grant au superAdmin (qui cumule role directeur)
- Grosse ecole : grant a 'Directeur Financier' role custom

### PaiementHighAmountValidatedNotification
- Channels : mail + database (cloche)
- Mail subject : '[KLASSCI] Paiement de X FCFA valide'
- Mail body : etudiant + montant + categorie + mode + validateur + date + action button
- Database payload structure complet pour cloche

### Helper notifyHighAmountIfAny()
- Lit setting + recipients (Spatie User::permission scope)
- Notification::send() bulk
- ShouldQueue (async via worker)
- Echec silencieux (Log::warning) - n'empeche pas la validation

### Appele dans
- valider()
- validerRapide()
- PAS bulkValider() : eviter spam (workflow recurrent du comptable)

### Test plan
- [ ] Setting threshold = 5M, perm grantee a 1 user X
- [ ] Comptable valide paiement de 6M -> X recoit mail + cloche
- [ ] Comptable valide paiement de 4M -> aucune notif
- [ ] Setting threshold = 0 -> aucune notif jamais
- [ ] Aucun user n'a la perm -> aucun mail (silencieux, pas d'erreur)
- [ ] bulkValider 30 paiements 6M -> aucun mail (volontaire)
- [ ] Mail s'affiche correctement avec donnees etudiant + action button

### Conforme rules
- ✓ customizable-roles : permission assignable, pas de role hardcode
- ✓ no-mvp-only-premium : queued, graceful, logs structures