### PR TITLE
feat(compta): S1.3 journal de caisse OHADA - vue chronologique + export PDF

### DIFF
--- a/app/Http/Controllers/ESBTPJournalCaisseController.php
+++ b/app/Http/Controllers/ESBTPJournalCaisseController.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPPaiement;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+/**
+ * S1.3 — Journal de caisse OHADA.
+ *
+ * Vue chronologique des encaissements (livre des recettes) conforme aux exigences
+ * comptables OHADA. Affiche : date paiement, ref, étudiant, catégorie, mode,
+ * montant, encaissé par, validé par, statut.
+ *
+ * Filtres : période, filière, classe, mode de paiement, statut.
+ * Export PDF format officiel via x-pdf-document.
+ *
+ * Permission : `comptabilite.journal.view` (default comptable + superAdmin).
+ */
+class ESBTPJournalCaisseController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('permission:comptabilite.access');
+        $this->middleware('permission:comptabilite.journal.view');
+    }
+
+    public function index(Request $request)
+    {
+        [$dateDebut, $dateFin] = $this->resolvePeriod($request);
+
+        $filters = [
+            'date_debut' => $dateDebut->format('Y-m-d'),
+            'date_fin' => $dateFin->format('Y-m-d'),
+            'filiere_id' => $request->input('filiere_id'),
+            'classe_id' => $request->input('classe_id'),
+            'mode_paiement' => $request->input('mode_paiement'),
+            'statut' => $request->input('statut', 'validé'),
+        ];
+
+        $paiements = $this->buildQuery($filters)->orderBy('date_paiement')->orderBy('id')->paginate(50)->withQueryString();
+
+        $totals = $this->buildTotals($filters);
+
+        $modes = ['Espèces', 'Chèque', 'Virement', 'Mobile Money', 'Carte bancaire'];
+        $filieres = ESBTPFiliere::orderBy('name')->get(['id', 'name']);
+        $classes = ESBTPClasse::orderBy('name')->get(['id', 'name', 'filiere_id']);
+        $anneeActive = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+
+        return view('esbtp.comptabilite.journal-caisse.index', compact(
+            'paiements', 'totals', 'filters', 'modes', 'filieres', 'classes', 'anneeActive', 'dateDebut', 'dateFin'
+        ));
+    }
+
+    /**
+     * Export PDF du journal — format officiel OHADA via x-pdf-document.
+     */
+    public function exportPdf(Request $request)
+    {
+        [$dateDebut, $dateFin] = $this->resolvePeriod($request);
+
+        $filters = [
+            'date_debut' => $dateDebut->format('Y-m-d'),
+            'date_fin' => $dateFin->format('Y-m-d'),
+            'filiere_id' => $request->input('filiere_id'),
+            'classe_id' => $request->input('classe_id'),
+            'mode_paiement' => $request->input('mode_paiement'),
+            'statut' => $request->input('statut', 'validé'),
+        ];
+
+        // Garde-fou volume (rule exports-pdf-excel.md)
+        $count = $this->buildQuery($filters)->count();
+        if ($count > 1000) {
+            return back()->with('error', sprintf(
+                'Trop de lignes (%d) pour l\'export PDF (limite 1000). Affinez la période ou les filtres.',
+                $count,
+            ));
+        }
+
+        $paiements = $this->buildQuery($filters)->orderBy('date_paiement')->orderBy('id')->get();
+        $totals = $this->buildTotals($filters);
+
+        $appliedFilters = $this->humanFilters($filters);
+
+        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('esbtp.comptabilite.journal-caisse.pdf', [
+            'paiements' => $paiements,
+            'totals' => $totals,
+            'filters' => $filters,
+            'appliedFilters' => $appliedFilters,
+            'dateDebut' => $dateDebut,
+            'dateFin' => $dateFin,
+        ])->setPaper('a4', 'landscape');
+
+        $filename = sprintf(
+            'journal-caisse_%s_au_%s.pdf',
+            $dateDebut->format('Y-m-d'),
+            $dateFin->format('Y-m-d'),
+        );
+
+        return $pdf->download($filename);
+    }
+
+    /**
+     * Aperçu PDF inline (rule exports-pdf-excel.md — toujours offrir preview).
+     */
+    public function exportPdfPreview(Request $request)
+    {
+        [$dateDebut, $dateFin] = $this->resolvePeriod($request);
+
+        $filters = [
+            'date_debut' => $dateDebut->format('Y-m-d'),
+            'date_fin' => $dateFin->format('Y-m-d'),
+            'filiere_id' => $request->input('filiere_id'),
+            'classe_id' => $request->input('classe_id'),
+            'mode_paiement' => $request->input('mode_paiement'),
+            'statut' => $request->input('statut', 'validé'),
+        ];
+
+        $paiements = $this->buildQuery($filters)->orderBy('date_paiement')->orderBy('id')->limit(1000)->get();
+        $totals = $this->buildTotals($filters);
+        $appliedFilters = $this->humanFilters($filters);
+
+        $pdf = \Barryvdh\DomPDF\Facade\Pdf::loadView('esbtp.comptabilite.journal-caisse.pdf', [
+            'paiements' => $paiements,
+            'totals' => $totals,
+            'filters' => $filters,
+            'appliedFilters' => $appliedFilters,
+            'dateDebut' => $dateDebut,
+            'dateFin' => $dateFin,
+        ])->setPaper('a4', 'landscape');
+
+        $filename = sprintf('apercu-journal-caisse_%s.pdf', now()->format('Y-m-d_His'));
+
+        return new Response($pdf->output(), 200, [
+            'Content-Type' => 'application/pdf',
+            'Content-Disposition' => 'inline; filename="' . $filename . '"',
+        ]);
+    }
+
+    private function resolvePeriod(Request $request): array
+    {
+        $dateDebut = $request->filled('date_debut')
+            ? Carbon::parse($request->input('date_debut'))->startOfDay()
+            : Carbon::now()->startOfMonth();
+
+        $dateFin = $request->filled('date_fin')
+            ? Carbon::parse($request->input('date_fin'))->endOfDay()
+            : Carbon::now()->endOfDay();
+
+        // Sécurité : si date_debut > date_fin, swap
+        if ($dateDebut->gt($dateFin)) {
+            [$dateDebut, $dateFin] = [$dateFin->copy()->startOfDay(), $dateDebut->copy()->endOfDay()];
+        }
+
+        return [$dateDebut, $dateFin];
+    }
+
+    private function buildQuery(array $filters)
+    {
+        $query = ESBTPPaiement::query()
+            ->with([
+                'inscription.etudiant:id,nom,prenoms,matricule',
+                'inscription.classe:id,name,filiere_id',
+                'fraisCategory:id,name',
+                'createdBy:id,name',
+                'validatedBy:id,name',
+            ])
+            ->whereNull('deleted_at')
+            ->whereDate('date_paiement', '>=', $filters['date_debut'])
+            ->whereDate('date_paiement', '<=', $filters['date_fin']);
+
+        if (!empty($filters['statut'])) {
+            $query->where('status', $filters['statut']);
+        }
+
+        if (!empty($filters['mode_paiement'])) {
+            $query->where('mode_paiement', $filters['mode_paiement']);
+        }
+
+        if (!empty($filters['classe_id'])) {
+            $query->whereHas('inscription', fn ($q) => $q->where('classe_id', $filters['classe_id']));
+        } elseif (!empty($filters['filiere_id'])) {
+            $query->whereHas('inscription.classe', fn ($q) => $q->where('filiere_id', $filters['filiere_id']));
+        }
+
+        return $query;
+    }
+
+    private function buildTotals(array $filters): array
+    {
+        $base = $this->buildQuery($filters);
+
+        $statsByMode = (clone $base)
+            ->selectRaw('mode_paiement, COUNT(*) as nb, COALESCE(SUM(montant), 0) as total')
+            ->groupBy('mode_paiement')
+            ->get()
+            ->keyBy('mode_paiement');
+
+        return [
+            'count' => (clone $base)->count(),
+            'total' => (float) (clone $base)->sum('montant'),
+            'by_mode' => $statsByMode->map(fn ($row) => [
+                'count' => (int) $row->nb,
+                'total' => (float) $row->total,
+            ])->all(),
+        ];
+    }
+
+    private function humanFilters(array $filters): array
+    {
+        $human = [
+            'Période' => sprintf(
+                'du %s au %s',
+                Carbon::parse($filters['date_debut'])->format('d/m/Y'),
+                Carbon::parse($filters['date_fin'])->format('d/m/Y'),
+            ),
+            'Statut' => ucfirst($filters['statut'] ?? 'validé'),
+        ];
+
+        if (!empty($filters['mode_paiement'])) {
+            $human['Mode de paiement'] = $filters['mode_paiement'];
+        }
+        if (!empty($filters['filiere_id'])) {
+            $human['Filière'] = optional(ESBTPFiliere::find($filters['filiere_id']))->name ?? '#' . $filters['filiere_id'];
+        }
+        if (!empty($filters['classe_id'])) {
+            $human['Classe'] = optional(ESBTPClasse::find($filters['classe_id']))->name ?? '#' . $filters['classe_id'];
+        }
+
+        return $human;
+    }
+}

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -765,6 +765,12 @@ return [
             'group' => 'Comptabilité',
             'icon' => 'fa-bell',
         ],
+        'comptabilite.journal.view' => [
+            'label' => 'Consulter le journal de caisse OHADA',
+            'description' => 'Donne accès au journal des recettes chronologique, conforme aux standards OHADA. Affiche par défaut les encaissements du mois en cours avec filtres par période/filière/mode de paiement. Exportable en PDF format officiel. Permission assignable à un rôle custom (Directeur Financier, Auditeur Externe).',
+            'group' => 'Comptabilité',
+            'icon' => 'fa-book',
+        ],
         'comptabilite.sensitive.access' => [
             'label' => 'Accès aux données comptables sensibles',
             'group' => 'Comptabilité',
@@ -1211,6 +1217,7 @@ return [
             'comptabilite.analytics.run_now', 'comptabilite.analytics.configure',
             'comptabilite.recouvrement.access',
             'comptabilite.audit.view',  // QW6 mai 2026 — comptable doit auditer son module
+            'comptabilite.journal.view',  // S1.3 mai 2026 — comptable consulte le journal de caisse OHADA
             'paiements.view', 'paiements.create', 'paiements.edit', 'paiements.validate',
             'paiements.export',  // Lot 15
             'frais.view', 'frais.create', 'frais.edit', 'frais.configure',

--- a/resources/views/esbtp/comptabilite/journal-caisse/index.blade.php
+++ b/resources/views/esbtp/comptabilite/journal-caisse/index.blade.php
@@ -1,0 +1,327 @@
+@extends('layouts.app')
+
+@section('title', 'Journal de caisse OHADA')
+
+@push('styles')
+<style>
+/* Namespace jc-* — Journal de caisse OHADA */
+.jc-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 2rem 2.5rem 1.5rem;
+    color: #fff;
+    margin-bottom: 1.25rem;
+}
+.jc-hero-top {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    flex-wrap: wrap; gap: 1rem;
+}
+.jc-hero-left { display: flex; align-items: center; gap: 1rem; }
+.jc-hero-icon {
+    width: 52px; height: 52px; border-radius: 14px;
+    background: rgba(255,255,255,.12);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.35rem; flex-shrink: 0; color: #fff;
+}
+.jc-hero h1 { font-size: 1.45rem; font-weight: 700; color: #fff; margin: 0; letter-spacing: -.01em; }
+.jc-hero p { color: rgba(255,255,255,.7); font-size: .88rem; margin: 0; }
+.jc-hero-actions { display: flex; gap: .5rem; flex-wrap: wrap; }
+.jc-btn {
+    background: rgba(255,255,255,.15); color: #fff;
+    border: 1px solid rgba(255,255,255,.2); border-radius: 10px;
+    padding: .5rem 1rem; font-size: .82rem; font-weight: 600;
+    text-decoration: none; display: inline-flex; align-items: center; gap: .4rem;
+    transition: all .2s ease;
+}
+.jc-btn:hover { background: rgba(255,255,255,.22); color: #fff; text-decoration: none; transform: translateY(-1px); }
+.jc-btn--white { background: #fff; color: #0453cb; border-color: transparent; }
+.jc-btn--white:hover { background: #f8fafc; color: #033a8e; }
+
+.jc-hero-kpis { display: flex; gap: .75rem; margin-top: 1.5rem; flex-wrap: wrap; }
+.jc-hero-kpi {
+    flex: 1; min-width: 140px;
+    background: rgba(255,255,255,.1);
+    border: 1px solid rgba(255,255,255,.18);
+    border-radius: 12px; padding: .9rem 1rem;
+}
+.jc-hero-kpi-label { font-size: .72rem; color: rgba(255,255,255,.7); margin-bottom: 4px; font-weight: 600; }
+.jc-hero-kpi-value { font-size: 1.2rem; font-weight: 700; color: #fff; line-height: 1.1; letter-spacing: -.02em; }
+.jc-hero-kpi-unit { font-size: .7rem; font-weight: 600; opacity: .65; margin-left: 4px; }
+
+/* Filters */
+.jc-filters {
+    background: #fff; border: 1px solid #e2e8f0; border-radius: 14px;
+    padding: 1rem 1.25rem; margin-bottom: 1rem;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04);
+}
+.jc-filters-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: .75rem; }
+.jc-filter-group { display: flex; flex-direction: column; gap: 4px; }
+.jc-filter-label {
+    font-size: .7rem; font-weight: 700; color: #64748b;
+    text-transform: uppercase; letter-spacing: .04em;
+}
+.jc-filter-input, .jc-filter-select {
+    width: 100%; padding: .5rem .65rem;
+    border: 1px solid #e2e8f0; border-radius: 8px;
+    font-size: .85rem; color: #1e293b; background: #fff;
+    transition: border-color .15s, box-shadow .15s;
+}
+.jc-filter-input:focus, .jc-filter-select:focus {
+    outline: none; border-color: #0453cb; box-shadow: 0 0 0 3px rgba(4,83,203,.08);
+}
+.jc-filter-actions { display: flex; gap: .5rem; align-items: flex-end; }
+.jc-btn-filter, .jc-btn-reset {
+    padding: .5rem 1rem; border-radius: 8px; font-size: .82rem; font-weight: 600;
+    border: none; cursor: pointer; display: inline-flex; align-items: center; gap: 4px;
+    transition: all .15s;
+}
+.jc-btn-filter { background: #0453cb; color: #fff; }
+.jc-btn-filter:hover { background: #033a8e; }
+.jc-btn-reset { background: #f1f5f9; color: #64748b; border: 1px solid #e2e8f0; text-decoration: none; }
+.jc-btn-reset:hover { background: #e2e8f0; color: #1e293b; }
+
+/* Table */
+.jc-table-card {
+    background: #fff; border: 1px solid #e2e8f0; border-radius: 14px;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04);
+    overflow: hidden;
+}
+.jc-table-header {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 1rem 1.25rem; border-bottom: 1px solid #e2e8f0;
+}
+.jc-table-title {
+    font-weight: 700; color: #1e293b; font-size: 1rem;
+    display: flex; align-items: center; gap: .5rem;
+}
+.jc-table-title i { color: #0453cb; }
+.jc-table-count { color: #64748b; font-size: .82rem; font-weight: 500; }
+.jc-table-wrap { overflow-x: auto; }
+.jc-table { width: 100%; border-collapse: collapse; font-size: .85rem; }
+.jc-table th {
+    background: #f8fafc; color: #475569;
+    text-transform: uppercase; font-size: .68rem; font-weight: 700; letter-spacing: .04em;
+    padding: .65rem .75rem; text-align: left;
+    border-bottom: 1px solid #e2e8f0;
+    position: sticky; top: 0;
+}
+.jc-table td { padding: .65rem .75rem; border-bottom: 1px solid #f1f5f9; vertical-align: middle; }
+.jc-table tr:hover { background: #fafbfd; }
+.jc-table tr:last-child td { border-bottom: none; }
+.jc-table-num { font-weight: 700; color: #0453cb; }
+.jc-table-amount { font-weight: 700; color: #059669; text-align: right; white-space: nowrap; }
+.jc-table-amount--rejected { color: #dc2626; }
+.jc-table-amount--pending { color: #d97706; }
+.jc-table-meta { font-size: .75rem; color: #64748b; }
+.jc-table-empty { padding: 3rem 1rem; text-align: center; color: #94a3b8; }
+.jc-table-empty i { font-size: 2rem; color: #cbd5e1; margin-bottom: .5rem; }
+
+.jc-statut {
+    display: inline-flex; align-items: center; gap: 4px;
+    padding: 2px 8px; border-radius: 999px;
+    font-size: .7rem; font-weight: 700;
+}
+.jc-statut--validé { background: rgba(16,185,129,.12); color: #059669; }
+.jc-statut--en_attente { background: rgba(245,158,11,.12); color: #b45309; }
+.jc-statut--rejeté { background: rgba(220,38,38,.12); color: #b91c1c; }
+
+.jc-pagination { padding: 1rem 1.25rem; border-top: 1px solid #f1f5f9; }
+
+/* Responsive */
+@media (max-width: 768px) {
+    .jc-hero { padding: 1.5rem 1.25rem 1rem; }
+    .jc-hero h1 { font-size: 1.2rem; }
+    .jc-table { font-size: .78rem; }
+    .jc-table th, .jc-table td { padding: .5rem; }
+}
+
+[x-cloak] { display: none !important; }
+</style>
+@endpush
+
+@section('content')
+<div class="dashboard-acasi">
+    <div class="main-content">
+
+        @if(session('success'))
+        <div class="alert alert-success alert-dismissible fade show rounded-3 mb-4">
+            <i class="fas fa-check-circle me-2"></i>{{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+        @endif
+        @if(session('error'))
+        <div class="alert alert-danger alert-dismissible fade show rounded-3 mb-4">
+            <i class="fas fa-exclamation-triangle me-2"></i>{{ session('error') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+        @endif
+
+        {{-- ── HERO ── --}}
+        <div class="jc-hero">
+            <div class="jc-hero-top">
+                <div class="jc-hero-left">
+                    <div class="jc-hero-icon"><i class="fas fa-book"></i></div>
+                    <div>
+                        <h1>Journal de caisse</h1>
+                        <p>Livre des recettes chronologique conforme OHADA · {{ \Carbon\Carbon::parse($filters['date_debut'])->format('d/m/Y') }} → {{ \Carbon\Carbon::parse($filters['date_fin'])->format('d/m/Y') }}</p>
+                    </div>
+                </div>
+                <div class="jc-hero-actions">
+                    <a href="{{ route('esbtp.comptabilite.journal-caisse.export-pdf-preview', request()->query()) }}" target="_blank" class="jc-btn">
+                        <i class="fas fa-eye"></i> Aperçu PDF
+                    </a>
+                    <a href="{{ route('esbtp.comptabilite.journal-caisse.export-pdf', request()->query()) }}" class="jc-btn jc-btn--white">
+                        <i class="fas fa-file-pdf"></i> Télécharger PDF
+                    </a>
+                </div>
+            </div>
+
+            <div class="jc-hero-kpis">
+                <div class="jc-hero-kpi">
+                    <div class="jc-hero-kpi-label">Lignes</div>
+                    <div class="jc-hero-kpi-value">{{ number_format($totals['count'], 0, ',', ' ') }}</div>
+                </div>
+                <div class="jc-hero-kpi">
+                    <div class="jc-hero-kpi-label">Total encaissé</div>
+                    <div class="jc-hero-kpi-value">{{ number_format($totals['total'], 0, ',', ' ') }}<span class="jc-hero-kpi-unit">FCFA</span></div>
+                </div>
+                @foreach($totals['by_mode'] as $mode => $stat)
+                <div class="jc-hero-kpi">
+                    <div class="jc-hero-kpi-label">{{ $mode ?: 'Non renseigné' }}</div>
+                    <div class="jc-hero-kpi-value">{{ number_format($stat['total'], 0, ',', ' ') }}<span class="jc-hero-kpi-unit">F · {{ $stat['count'] }}</span></div>
+                </div>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- ── FILTERS ── --}}
+        <form method="GET" action="{{ route('esbtp.comptabilite.journal-caisse.index') }}" class="jc-filters">
+            <div class="jc-filters-row">
+                <div class="jc-filter-group">
+                    <label class="jc-filter-label">Du</label>
+                    <input type="date" name="date_debut" value="{{ $filters['date_debut'] }}" class="jc-filter-input">
+                </div>
+                <div class="jc-filter-group">
+                    <label class="jc-filter-label">Au</label>
+                    <input type="date" name="date_fin" value="{{ $filters['date_fin'] }}" class="jc-filter-input">
+                </div>
+                <div class="jc-filter-group">
+                    <label class="jc-filter-label">Filière</label>
+                    <select name="filiere_id" class="jc-filter-select">
+                        <option value="">Toutes</option>
+                        @foreach($filieres as $f)
+                        <option value="{{ $f->id }}" {{ $filters['filiere_id'] == $f->id ? 'selected' : '' }}>{{ $f->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="jc-filter-group">
+                    <label class="jc-filter-label">Classe</label>
+                    <select name="classe_id" class="jc-filter-select">
+                        <option value="">Toutes</option>
+                        @foreach($classes as $c)
+                        <option value="{{ $c->id }}" {{ $filters['classe_id'] == $c->id ? 'selected' : '' }}>{{ $c->name }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="jc-filter-group">
+                    <label class="jc-filter-label">Mode</label>
+                    <select name="mode_paiement" class="jc-filter-select">
+                        <option value="">Tous</option>
+                        @foreach($modes as $m)
+                        <option value="{{ $m }}" {{ $filters['mode_paiement'] == $m ? 'selected' : '' }}>{{ $m }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="jc-filter-group">
+                    <label class="jc-filter-label">Statut</label>
+                    <select name="statut" class="jc-filter-select">
+                        <option value="validé" {{ $filters['statut'] == 'validé' ? 'selected' : '' }}>Validé</option>
+                        <option value="en_attente" {{ $filters['statut'] == 'en_attente' ? 'selected' : '' }}>En attente</option>
+                        <option value="rejeté" {{ $filters['statut'] == 'rejeté' ? 'selected' : '' }}>Rejeté</option>
+                        <option value="" {{ $filters['statut'] == '' ? 'selected' : '' }}>Tous</option>
+                    </select>
+                </div>
+                <div class="jc-filter-actions">
+                    <button type="submit" class="jc-btn-filter"><i class="fas fa-filter"></i> Filtrer</button>
+                    <a href="{{ route('esbtp.comptabilite.journal-caisse.index') }}" class="jc-btn-reset"><i class="fas fa-times"></i> Reset</a>
+                </div>
+            </div>
+        </form>
+
+        {{-- ── TABLE ── --}}
+        <div class="jc-table-card">
+            <div class="jc-table-header">
+                <div class="jc-table-title">
+                    <i class="fas fa-list-ol"></i>
+                    Détail chronologique des encaissements
+                </div>
+                <div class="jc-table-count">{{ $totals['count'] }} ligne{{ $totals['count'] > 1 ? 's' : '' }}</div>
+            </div>
+
+            @if($paiements->total() === 0)
+            <div class="jc-table-empty">
+                <i class="fas fa-folder-open d-block"></i>
+                <div>Aucun paiement pour cette période/critères.</div>
+            </div>
+            @else
+            <div class="jc-table-wrap">
+                <table class="jc-table">
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>N° Reçu</th>
+                            <th>Étudiant</th>
+                            <th>Catégorie</th>
+                            <th>Mode</th>
+                            <th class="text-end">Montant</th>
+                            <th>Encaissé par</th>
+                            <th>Validé par</th>
+                            <th>Statut</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($paiements as $p)
+                        <tr>
+                            <td>{{ optional($p->date_paiement)->format('d/m/Y') ?? '—' }}</td>
+                            <td><a href="{{ route('esbtp.paiements.show', $p->id) }}" class="jc-table-num">{{ $p->numero_recu ?: '#'.$p->id }}</a></td>
+                            <td>
+                                @if($p->inscription && $p->inscription->etudiant)
+                                <div>{{ trim(($p->inscription->etudiant->prenoms ?? '') . ' ' . ($p->inscription->etudiant->nom ?? '')) }}</div>
+                                <div class="jc-table-meta">{{ $p->inscription->etudiant->matricule ?? '—' }}{{ $p->inscription->classe ? ' · ' . $p->inscription->classe->name : '' }}</div>
+                                @else
+                                <span class="jc-table-meta">—</span>
+                                @endif
+                            </td>
+                            <td>{{ $p->fraisCategory->name ?? $p->motif ?? '—' }}</td>
+                            <td>{{ $p->mode_paiement ?? '—' }}</td>
+                            <td class="jc-table-amount {{ $p->status === 'rejeté' ? 'jc-table-amount--rejected' : ($p->status === 'en_attente' ? 'jc-table-amount--pending' : '') }}">
+                                {{ number_format((float) $p->montant, 0, ',', ' ') }}
+                            </td>
+                            <td>{{ $p->createdBy->name ?? '—' }}</td>
+                            <td>
+                                @if($p->validatedBy)
+                                {{ $p->validatedBy->name }}
+                                <div class="jc-table-meta">{{ optional($p->date_validation)->format('d/m/Y H:i') }}</div>
+                                @else
+                                <span class="jc-table-meta">—</span>
+                                @endif
+                            </td>
+                            <td><span class="jc-statut jc-statut--{{ $p->status }}">{{ ucfirst(str_replace('_', ' ', $p->status)) }}</span></td>
+                        </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+            <div class="jc-pagination">
+                {{ $paiements->links() }}
+            </div>
+            @endif
+        </div>
+
+    </div>
+</div>
+
+<x-fab-encaisser />
+@endsection

--- a/resources/views/esbtp/comptabilite/journal-caisse/pdf.blade.php
+++ b/resources/views/esbtp/comptabilite/journal-caisse/pdf.blade.php
@@ -1,0 +1,111 @@
+@php
+    $totalCount = $totals['count'];
+    $totalAmount = $totals['total'];
+@endphp
+
+<x-pdf-document
+    title="Journal de caisse"
+    subtitle="Livre des recettes chronologique — conforme OHADA"
+    :filters="$appliedFilters"
+    orientation="landscape">
+
+    <style>
+        .jc-pdf-table { width: 100%; border-collapse: collapse; font-size: 8.5pt; margin-top: 8px; }
+        .jc-pdf-table th {
+            background: #0453cb; color: #fff;
+            padding: 5px 6px; text-align: left;
+            font-size: 7.5pt; font-weight: bold; text-transform: uppercase;
+            border: 1px solid #033a8e;
+        }
+        .jc-pdf-table td {
+            padding: 4px 6px;
+            border-bottom: 1px solid #e2e8f0;
+            color: #1e293b;
+        }
+        .jc-pdf-table tr:nth-child(even) td { background: #f8fafc; }
+        .jc-pdf-table .num { font-weight: bold; color: #0453cb; }
+        .jc-pdf-table .amount { font-weight: bold; text-align: right; white-space: nowrap; }
+        .jc-pdf-table .amount-rejected { color: #b91c1c; }
+        .jc-pdf-table .amount-pending { color: #b45309; }
+        .jc-pdf-table .meta { color: #64748b; font-size: 7.5pt; }
+
+        .jc-pdf-totals {
+            margin-top: 12px; padding: 10px;
+            background: #f0f5ff; border: 1px solid #bfdbfe; border-radius: 6px;
+        }
+        .jc-pdf-totals-title { font-weight: bold; color: #0453cb; font-size: 9.5pt; margin-bottom: 6px; }
+        .jc-pdf-totals-row { display: flex; justify-content: space-between; font-size: 9pt; padding: 2px 0; }
+        .jc-pdf-totals-row strong { color: #0f172a; }
+
+        .jc-pdf-empty {
+            text-align: center; padding: 30px 10px;
+            color: #94a3b8; font-style: italic; font-size: 10pt;
+        }
+    </style>
+
+    @if($paiements->isEmpty())
+    <div class="jc-pdf-empty">
+        Aucun paiement enregistré pour cette période ni ces critères.
+    </div>
+    @else
+    <table class="jc-pdf-table">
+        <thead>
+            <tr>
+                <th style="width:7%;">Date</th>
+                <th style="width:9%;">N° Reçu</th>
+                <th style="width:18%;">Étudiant</th>
+                <th style="width:14%;">Catégorie</th>
+                <th style="width:10%;">Mode</th>
+                <th style="width:11%; text-align:right;">Montant</th>
+                <th style="width:13%;">Encaissé par</th>
+                <th style="width:13%;">Validé par</th>
+                <th style="width:5%;">Statut</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($paiements as $p)
+            <tr>
+                <td>{{ optional($p->date_paiement)->format('d/m/Y') ?? '—' }}</td>
+                <td class="num">{{ $p->numero_recu ?: '#'.$p->id }}</td>
+                <td>
+                    @if($p->inscription && $p->inscription->etudiant)
+                    {{ trim(($p->inscription->etudiant->prenoms ?? '') . ' ' . ($p->inscription->etudiant->nom ?? '')) }}<br>
+                    <span class="meta">{{ $p->inscription->etudiant->matricule ?? '' }}{{ $p->inscription->classe ? ' · ' . $p->inscription->classe->name : '' }}</span>
+                    @else
+                    —
+                    @endif
+                </td>
+                <td>{{ $p->fraisCategory->name ?? $p->motif ?? '—' }}</td>
+                <td>{{ $p->mode_paiement ?? '—' }}</td>
+                <td class="amount {{ $p->status === 'rejeté' ? 'amount-rejected' : ($p->status === 'en_attente' ? 'amount-pending' : '') }}">
+                    {{ number_format((float) $p->montant, 0, ',', ' ') }} F
+                </td>
+                <td>{{ $p->createdBy->name ?? '—' }}</td>
+                <td>
+                    @if($p->validatedBy)
+                    {{ $p->validatedBy->name }}<br>
+                    <span class="meta">{{ optional($p->date_validation)->format('d/m/Y H:i') }}</span>
+                    @else
+                    —
+                    @endif
+                </td>
+                <td>{{ ucfirst(str_replace('_', ' ', $p->status)) }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    <div class="jc-pdf-totals">
+        <div class="jc-pdf-totals-title">Récapitulatif de la période</div>
+        <div class="jc-pdf-totals-row"><span>Nombre de lignes</span><strong>{{ number_format($totalCount, 0, ',', ' ') }}</strong></div>
+        <div class="jc-pdf-totals-row"><span>Total encaissé</span><strong>{{ number_format($totalAmount, 0, ',', ' ') }} FCFA</strong></div>
+        @foreach($totals['by_mode'] as $mode => $stat)
+        <div class="jc-pdf-totals-row" style="font-size:8.5pt; color:#475569;">
+            <span>· {{ $mode ?: 'Mode non renseigné' }} ({{ $stat['count'] }} ligne{{ $stat['count'] > 1 ? 's' : '' }})</span>
+            <span>{{ number_format($stat['total'], 0, ',', ' ') }} FCFA</span>
+        </div>
+        @endforeach
+    </div>
+    @endif
+
+</x-pdf-document>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -2048,6 +2048,13 @@
                                     <span>Analytics prédictifs</span>
                                 </a>
                                 @endcan
+                                {{-- Journal de caisse OHADA (S1.3) --}}
+                                @can('comptabilite.journal.view')
+                                <a href="{{ route('esbtp.comptabilite.journal-caisse.index') }}" class="menu-sublink {{ Request::routeIs('esbtp.comptabilite.journal-caisse.*') ? 'active' : '' }}">
+                                    <span class="menu-dot"></span>
+                                    <span>Journal de caisse</span>
+                                </a>
+                                @endcan
                             </div>
                         </div>
                     @endcan

--- a/routes/web.php
+++ b/routes/web.php
@@ -916,6 +916,17 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
                 ->name('paiements.cancel-own')
                 ->middleware('throttle:30,1');
 
+            // ── JOURNAL DE CAISSE OHADA (S1.3)
+            Route::prefix('comptabilite/journal-caisse')->name('comptabilite.journal-caisse.')->group(function () {
+                Route::get('/', [App\Http\Controllers\ESBTPJournalCaisseController::class, 'index'])->name('index');
+                Route::get('/export-pdf', [App\Http\Controllers\ESBTPJournalCaisseController::class, 'exportPdf'])
+                    ->middleware('throttle:10,1')
+                    ->name('export-pdf');
+                Route::get('/export-pdf/preview', [App\Http\Controllers\ESBTPJournalCaisseController::class, 'exportPdfPreview'])
+                    ->middleware('throttle:30,1')
+                    ->name('export-pdf-preview');
+            });
+
             // ── VALIDATE/REJECT (workflow comptable — throttled)
             Route::middleware(['permission:paiements.validate', 'throttle:60,1'])->group(function () {
                 Route::post('/paiements/{paiement}/valider', [App\Http\Controllers\ESBTPPaiementController::class, 'valider'])->name('paiements.valider');


### PR DESCRIPTION
## Sprint 1 — Compliance (S1.3) BLOCKER #2

### Pourquoi
Critic UX du plan compta killer : 'Pas de cloture de caisse / journal de caisse formel. Grep cloture/journal_caisse retourne ZERO match. DGI Cote d'Ivoire et OHADA exigent un journal de caisse chronologique scelle. Sans ca, KLASSCI est inacceptable pour audit comptable formel.'

### Page /esbtp/comptabilite/journal-caisse premium
- Hero namespace jc-* avec 4+ KPIs (lignes, total, breakdown par mode)
- Filtres : date_debut/fin (default mois courant), filiere, classe, mode, statut
- Table chronologique : Date | N°Recu | Etudiant + classe | Categorie | Mode | Montant | Encaisse par | Valide par + date | Statut
- Pagination 50/page, hover, status badges semantiques
- Lien clickable vers fiche paiement

### Export PDF format OHADA officiel
Via composant <x-pdf-document> existant (rule exports-pdf-excel.md) :
- A4 paysage avec theme tenant (header logo + nom + adresse)
- Bandeau filtres applique en sous-titre
- Footer pagine + date generation + utilisateur (signature numerique)
- Recap final : total + breakdown par mode (utile rapprochement)
- 2 routes : download (throttle 10/min, max 1000 lignes) + preview inline (throttle 30/min)
- Garde-fou volume : redirect-back + message si > 1000

### Permission comptabilite.journal.view
- Nouvelle perm grantee par defaut au comptable
- Assignable via UI custom roles (Auditeur Externe, Directeur Financier)
- Sidebar entry dans accordeon Comptabilite

### Test plan
- [ ] /esbtp/comptabilite/journal-caisse rend la page premium pour comptable
- [ ] Filtres fonctionnent (periode, filiere, classe, mode, statut)
- [ ] KPIs hero coherent avec table affichee
- [ ] Export PDF download genere fichier .pdf horodate
- [ ] Apercu PDF s'ouvre inline new tab
- [ ] Garde-fou > 1000 lignes : redirect avec message
- [ ] Caissier (sans permission) : pas de menu sidebar
- [ ] Liens cliquables vers fiches paiements OK
- [ ] Status badges colores (vert/orange/rouge)

### Conforme rules
- ✓ exports-pdf-excel : x-pdf-document, throttle, garde-fou, preview + download
- ✓ premium-redesign : hero 2-rows, namespace jc-*, monochrome bleu
- ✓ customizable-roles : permission assignable
- ✓ no-mvp-only-premium : pagination, empty state, status badges, mobile responsive