### PR TITLE
fix(lmd): make code field optional in /esbtp/lmd/ue index modal

### DIFF
--- a/resources/views/esbtp/lmd/ue/index.blade.php
+++ b/resources/views/esbtp/lmd/ue/index.blade.php
@@ -393,8 +393,9 @@
                                 <input type="text" class="form-control" id="ue_name" name="name" required placeholder="Ex: Technologie de Construction">
                             </div>
                             <div>
-                                <label for="ue_code"><i class="fas fa-hashtag"></i> Code <span class="text-danger">*</span></label>
-                                <input type="text" class="form-control" id="ue_code" name="code" required placeholder="Ex: UE:BTCB1" style="font-family: 'SF Mono', 'Consolas', monospace;">
+                                <label for="ue_code"><i class="fas fa-hashtag"></i> Code</label>
+                                <input type="text" class="form-control" id="ue_code" name="code" placeholder="Ex: MAG2001" style="font-family: 'SF Mono', 'Consolas', monospace;">
+                                <small class="text-muted" style="font-size:.72rem;">Optionnel — laisser vide pour une UE virtuelle UEMOA (ex: <em>UE de Méthodologie</em>).</small>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Context

Hotfix follow-up to PR #365 (LMD-1 foundation). 

## Bug

When creating a new UE via the modal on `/esbtp/lmd/ue` (the index page), the **Code** field was still flagged as required (HTML5 `required` + red asterisk `*`). Marcel discovered this while testing on presentation : trying to create a virtual UEMOA UE (e.g. `UE de Méthodologie`) was blocked by the browser "Please fill in this field" prompt.

The controller and the standalone `/esbtp/lmd/ue/create.blade.php` were already correctly aligned (code nullable, validation `Rule::in(TypeUE::values())`). Only the index modal had been missed in PR #365.

## Fix

Single-file change in `resources/views/esbtp/lmd/ue/index.blade.php` :
- Removed `required` from the `<input>`
- Removed the red asterisk `*` from the label
- Added the same hint as the standalone create page ("Optionnel — laisser vide pour une UE virtuelle UEMOA")

No migration, no controller change. Pure UI alignment.

## Test plan

- [ ] On presentation : open `/esbtp/lmd/ue`, click `+ Nouvelle UE`, leave Code empty, fill Intitulé, pick Type `UE de Méthodologie` → submit succeeds
- [ ] Existing UEs with non-NULL codes still display + edit normally