### PR TITLE
feat(lmd): auto-fill Intitulé from Type for virtual UEMOA UEs

### DIFF
--- a/resources/views/esbtp/lmd/ue/create.blade.php
+++ b/resources/views/esbtp/lmd/ue/create.blade.php
@@ -209,7 +209,8 @@
                 </div>
                 <div class="col-md-4">
                     <label class="form-label fw-semibold">Type UE</label>
-                    <select name="type_ue" class="form-select @error('type_ue') is-invalid @enderror">
+                    <select name="type_ue" class="form-select @error('type_ue') is-invalid @enderror"
+                            @change="autoFillNameFromType($event)">
                         <option value="">-- Choisir --</option>
                         @php
                             $currentTypeUe = old('type_ue', $ue->type_ue?->value ?? '');
@@ -421,6 +422,13 @@
                 const words = this.ueName.trim().split(/\s+/).filter(w => w.length > 0);
                 const abbr = words.map(w => w.substring(0, 3).toUpperCase()).slice(0, 3).join('-');
                 this.ueCode = 'UE-' + abbr;
+            },
+
+            // UE virtuelle UEMOA : si Code et Intitulé vides, utiliser le label du Type comme Intitulé
+            autoFillNameFromType(event) {
+                if (!this.ueCode.trim() && !this.ueName.trim() && event.target.value) {
+                    this.ueName = event.target.options[event.target.selectedIndex].text;
+                }
             },
 
             addEcue() {

--- a/resources/views/esbtp/lmd/ue/index.blade.php
+++ b/resources/views/esbtp/lmd/ue/index.blade.php
@@ -1110,5 +1110,19 @@ document.getElementById('ecue_form').addEventListener('submit', async function(e
     btn.disabled = false;
     updateCreditGauge();
 });
+
+// ── UE virtuelle UEMOA : auto-fill Intitulé depuis Type quand Code est vide ──
+(function () {
+    const codeEl = document.getElementById('ue_code');
+    const nameEl = document.getElementById('ue_name');
+    const typeEl = document.getElementById('ue_type_ue');
+    if (!codeEl || !nameEl || !typeEl) return;
+
+    typeEl.addEventListener('change', () => {
+        if (!codeEl.value.trim() && !nameEl.value.trim() && typeEl.value) {
+            nameEl.value = typeEl.options[typeEl.selectedIndex]?.text || '';
+        }
+    });
+})();
 </script>
 @endpush


### PR DESCRIPTION
Follow-up to PR #365 + #366. When user creates a virtual UE (no code), auto-fill the Intitulé with the Type label so they don't have to type it manually. Triggers only when Code AND Intitulé are both empty — never overwrites user input.