### PR TITLE
fix(lmd): order niveaux by year not by missing 'ordre' column

### DIFF
--- a/app/Http/Controllers/ESBTPLMDPlanningController.php
+++ b/app/Http/Controllers/ESBTPLMDPlanningController.php
@@ -24,7 +24,7 @@ class ESBTPLMDPlanningController extends Controller
             ->orderBy('name')
             ->get();
 
-        $niveaux = ESBTPNiveauEtude::orderBy('ordre')->get();
+        $niveaux = ESBTPNiveauEtude::orderBy('year')->orderBy('name')->get();
         $semestres = range(1, 10);
 
         $filters = [


### PR DESCRIPTION
Hotfix urgent : la page /esbtp/lmd/planning crashait avec un 500 SQL parce que ESBTPLMDPlanningController ordonnait les niveaux par 'ordre' qui n'existe pas dans esbtp_niveau_etudes. La table a name/libelle/code/type/year — order by year donne L1<L2<L3<M1<M2 naturellement.