### PR TITLE
fix(lmd): replace @click with x-on:click in planning view

### DIFF
--- a/resources/views/esbtp/lmd/planning/index.blade.php
+++ b/resources/views/esbtp/lmd/planning/index.blade.php
@@ -375,7 +375,7 @@
                                 $hasCode = !empty($ue->code);
                                 $typeLabel = $ue->type_ue?->label() ?? '—';
                             @endphp
-                            <tr class="lp-ue-row" @click="expanded[{{ $idx }}] = !expanded[{{ $idx }}]">
+                            <tr class="lp-ue-row" x-on:click="expanded[{{ $idx }}] = !expanded[{{ $idx }}]">
                                 <td>
                                     <span class="lp-ue-caret" :class="{ 'lp-ue-caret--open': expanded[{{ $idx }}] }">
                                         <i class="fas fa-chevron-right"></i>


### PR DESCRIPTION
Fix erreur 500 'syntax error, unexpected end of file' sur /esbtp/lmd/planning. @click était interprété par le parser Blade comme directive opening attendant un endif.