### PR TITLE
feat(cli): API endpoints + klassci lmd:setup/tree commands

### DIFF
--- a/app/Http/Controllers/API/CLI/CLILMDSetupController.php
+++ b/app/Http/Controllers/API/CLI/CLILMDSetupController.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Http\Controllers\API\CLI;
+
+use App\Http\Controllers\API\BaseApiController;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPLMDDomaine;
+use App\Models\ESBTPLMDMention;
+use App\Models\ESBTPLMDParcours;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * Bulk-setup endpoints for LMD hierarchy provisioning via klassci-cli.
+ *
+ * Allows provisioning a new instance with Domaine + Mention + Parcours (+ optional
+ * Filiere) in one transactional call. Designed for bootstrapping LMD instances
+ * (e.g. ephrata, future Hetec/Rostan) without UI clicks.
+ */
+class CLILMDSetupController extends BaseApiController
+{
+    /**
+     * POST /api/cli/lmd/setup
+     *
+     * Body (JSON):
+     *   {
+     *     "domaine":  {"name": "Sciences et Technologie", "code": "ST", "description": "..."},
+     *     "mention":  {"name": "Agroforesterie - SVT", "code": "SVT-MENT"},
+     *     "parcours": {"name": "Sciences de la Vie et de la Terre", "code": "SVT-PARC", "credits_licence": 180},
+     *     "filiere":  {"name": "Sciences de la Vie et de la Terre", "code": "SVT"}  // optional
+     *   }
+     *
+     * Cascades creation in transaction. Re-uses existing entities (matching name+code)
+     * if found — idempotent for repeated calls with same payload.
+     */
+    public function setup(Request $request): JsonResponse
+    {
+        if (!$request->user()->tokenCan('cli:admin')) {
+            return $this->errorResponse('Token missing cli:admin ability', [], 403);
+        }
+
+        $validated = $request->validate([
+            'domaine.name' => 'required|string|max:255',
+            'domaine.code' => 'nullable|string|max:50',
+            'domaine.description' => 'nullable|string|max:1000',
+            'mention.name' => 'required|string|max:255',
+            'mention.code' => 'nullable|string|max:50',
+            'parcours.name' => 'required|string|max:255',
+            'parcours.code' => 'nullable|string|max:50',
+            'parcours.credits_licence' => 'nullable|integer|min:30|max:360',
+            'parcours.credits_master' => 'nullable|integer|min:30|max:240',
+            'filiere.name' => 'nullable|string|max:255',
+            'filiere.code' => 'nullable|string|max:50',
+        ]);
+
+        try {
+            $result = DB::transaction(function () use ($validated) {
+                $userId = optional($this->resolveActor())->id;
+
+                $domaine = $this->upsertDomaine($validated['domaine'], $userId);
+                $mention = $this->upsertMention($validated['mention'], $domaine->id, $userId);
+                $filiere = isset($validated['filiere'])
+                    ? $this->upsertFiliere($validated['filiere'], $userId)
+                    : null;
+                $parcours = $this->upsertParcours(
+                    $validated['parcours'],
+                    $mention->id,
+                    $filiere?->id,
+                    $userId
+                );
+
+                return compact('domaine', 'mention', 'filiere', 'parcours');
+            });
+
+            return $this->successResponse([
+                'domaine' => $this->formatModel($result['domaine']),
+                'mention' => $this->formatModel($result['mention']),
+                'filiere' => $result['filiere'] ? $this->formatModel($result['filiere']) : null,
+                'parcours' => $this->formatModel($result['parcours']),
+            ], 'LMD hierarchy created/updated');
+        } catch (\Throwable $e) {
+            Log::error('CLI: lmd setup failed', ['error' => $e->getMessage(), 'trace' => $e->getTraceAsString()]);
+            return $this->errorResponse('Setup failed: ' . $e->getMessage(), [], 500);
+        }
+    }
+
+    /**
+     * GET /api/cli/lmd/tree
+     *
+     * Returns the full Domaine -> Mention -> Parcours hierarchy of the instance.
+     */
+    public function tree(Request $request): JsonResponse
+    {
+        if (!$request->user()->tokenCan('cli:read')) {
+            return $this->errorResponse('Token missing cli:read ability', [], 403);
+        }
+
+        $domaines = ESBTPLMDDomaine::with(['mentions.parcours.filiere'])
+            ->orderBy('name')
+            ->get()
+            ->map(fn (ESBTPLMDDomaine $d) => [
+                'id' => $d->id,
+                'name' => $d->name,
+                'code' => $d->code,
+                'mentions' => $d->mentions->map(fn (ESBTPLMDMention $m) => [
+                    'id' => $m->id,
+                    'name' => $m->name,
+                    'code' => $m->code,
+                    'parcours' => $m->parcours->map(fn (ESBTPLMDParcours $p) => [
+                        'id' => $p->id,
+                        'name' => $p->name,
+                        'code' => $p->code,
+                        'filiere' => $p->filiere?->only(['id', 'name', 'code']),
+                        'credits_licence' => $p->credits_licence,
+                        'credits_master' => $p->credits_master,
+                    ])->values(),
+                ])->values(),
+            ]);
+
+        return $this->successResponse([
+            'domaines' => $domaines,
+            'totals' => [
+                'domaines' => $domaines->count(),
+                'mentions' => $domaines->sum(fn ($d) => count($d['mentions'])),
+                'parcours' => $domaines->sum(fn ($d) => collect($d['mentions'])->sum(fn ($m) => count($m['parcours']))),
+            ],
+        ], 'LMD hierarchy retrieved');
+    }
+
+    private function upsertDomaine(array $data, ?int $userId): ESBTPLMDDomaine
+    {
+        $code = $data['code'] ?? Str::upper(Str::slug($data['name'], ''));
+        return ESBTPLMDDomaine::updateOrCreate(
+            ['code' => $code],
+            [
+                'name' => $data['name'],
+                'description' => $data['description'] ?? null,
+                'is_active' => true,
+                'created_by' => $userId,
+                'updated_by' => $userId,
+            ]
+        );
+    }
+
+    private function upsertMention(array $data, int $domaineId, ?int $userId): ESBTPLMDMention
+    {
+        $code = $data['code'] ?? Str::upper(Str::slug($data['name'], ''));
+        return ESBTPLMDMention::updateOrCreate(
+            ['code' => $code, 'domaine_id' => $domaineId],
+            [
+                'name' => $data['name'],
+                'is_active' => true,
+                'created_by' => $userId,
+                'updated_by' => $userId,
+            ]
+        );
+    }
+
+    private function upsertFiliere(array $data, ?int $userId): ESBTPFiliere
+    {
+        $code = $data['code'] ?? Str::upper(Str::slug($data['name'], ''));
+        return ESBTPFiliere::updateOrCreate(
+            ['code' => $code],
+            [
+                'name' => $data['name'],
+                'is_active' => true,
+                'created_by' => $userId,
+                'updated_by' => $userId,
+            ]
+        );
+    }
+
+    private function upsertParcours(array $data, int $mentionId, ?int $filiereId, ?int $userId): ESBTPLMDParcours
+    {
+        $code = $data['code'] ?? Str::upper(Str::slug($data['name'], ''));
+        return ESBTPLMDParcours::updateOrCreate(
+            ['code' => $code, 'mention_id' => $mentionId],
+            [
+                'name' => $data['name'],
+                'filiere_id' => $filiereId,
+                'credits_licence' => $data['credits_licence'] ?? 180,
+                'credits_master' => $data['credits_master'] ?? 120,
+                'is_active' => true,
+                'created_by' => $userId,
+                'updated_by' => $userId,
+            ]
+        );
+    }
+
+    private function resolveActor(): ?\App\Models\User
+    {
+        return request()->user();
+    }
+
+    private function formatModel($model): array
+    {
+        return [
+            'id' => $model->id,
+            'name' => $model->name,
+            'code' => $model->code,
+            'created' => $model->wasRecentlyCreated,
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -258,6 +258,9 @@ Route::middleware(['auth:sanctum', 'throttle:60,1'])->prefix('cli')->name('api.c
     Route::get('/roles', [App\Http\Controllers\API\CLI\CLIPermissionController::class, 'roles'])->name('roles.list');
     Route::get('/roles/{role}', [App\Http\Controllers\API\CLI\CLIPermissionController::class, 'roleShow'])->name('roles.show');
 
+    // LMD hierarchy (read)
+    Route::get('/lmd/tree', [App\Http\Controllers\API\CLI\CLILMDSetupController::class, 'tree'])->name('lmd.tree');
+
     // Admin endpoints (strict throttle)
     Route::middleware('throttle:5,1')->group(function () {
         // Maintenance
@@ -269,6 +272,9 @@ Route::middleware(['auth:sanctum', 'throttle:60,1'])->prefix('cli')->name('api.c
         Route::post('/migrate', [App\Http\Controllers\API\CLI\CLIMaintenanceController::class, 'migrate'])->name('migrate');
         Route::post('/pull', [App\Http\Controllers\API\CLI\CLIMaintenanceController::class, 'pull'])->name('pull');
         Route::post('/seed-demo', [App\Http\Controllers\API\CLI\CLIMaintenanceController::class, 'seedDemo'])->name('seed-demo');
+
+        // LMD hierarchy (write — bulk setup of Domaine + Mention + Parcours + optional Filiere)
+        Route::post('/lmd/setup', [App\Http\Controllers\API\CLI\CLILMDSetupController::class, 'setup'])->name('lmd.setup');
 
         // Settings
         Route::put('/settings/{key}', [App\Http\Controllers\API\CLI\CLIDataController::class, 'settingsUpdate'])->name('settings.update');


### PR DESCRIPTION
## Context

Permet à klassci-cli de provisionner la hiérarchie LMD (Domaine → Mention → Parcours, + Filière optionnelle) sans passer par l'UI ou SSH. Workflow validé pour bootstrap du tenant ephrata + futurs tenants LMD (Hetec, Rostan).

## Endpoints

- `POST /api/cli/lmd/setup` (cli:admin) — création transactionnelle en cascade, idempotent sur (code, parent_id)
- `GET /api/cli/lmd/tree` (cli:read) — retourne la hiérarchie complète + totaux

## Commandes klassci-cli (repo séparé)

```bash
# Interactif
klassci lmd:setup ephrata

# Batch
klassci lmd:setup ephrata     --domaine='Sciences et Technologie'     --mention='Agroforesterie - SVT'     --parcours='Sciences de la Vie et de la Terre'     --filiere='SVT'

# Audit
klassci lmd:tree ephrata
```

## Test plan

- [ ] `POST /api/cli/lmd/setup` crée Domaine + Mention + Parcours en transaction
- [ ] Re-run avec mêmes codes → updateOrCreate (pas de doublon)
- [ ] Filière optionnelle fonctionne (avec et sans)
- [ ] `GET /api/cli/lmd/tree` retourne la hiérarchie correcte