### PR TITLE
fix(lmd): modal trigger broken — raw json_encode breaks onclick attribute

### DIFF
--- a/resources/views/esbtp/lmd/planning/_listing.blade.php
+++ b/resources/views/esbtp/lmd/planning/_listing.blade.php
@@ -18,7 +18,9 @@
         <p>Le parcours <strong>{{ $parcoursSelected->name }}</strong> n'a pas encore d'unités d'enseignement associées.</p>
         <button type="button"
             class="lp-empty-cta"
-            onclick="window.dispatchEvent(new CustomEvent('lpm:open', { detail: { parcoursId: {{ $parcoursSelected->id }}, parcoursName: {!! json_encode($parcoursSelected->name) !!} } }))">
+            data-parcours-id="{{ $parcoursSelected->id }}"
+            data-parcours-name="{{ $parcoursSelected->name }}"
+            onclick="window.dispatchEvent(new CustomEvent('lpm:open', { detail: { parcoursId: parseInt(this.dataset.parcoursId, 10), parcoursName: this.dataset.parcoursName } }))">
             <i class="fas fa-link"></i> Lier des UE au parcours
         </button>
     </div>
@@ -30,7 +32,9 @@
                 <span class="lp-card-meta">{{ $rows->count() }} UE · {{ $kpis['ecue_count'] }} ECUE</span>
                 <button type="button"
                     class="lp-empty-cta lp-empty-cta-sm"
-                    onclick="window.dispatchEvent(new CustomEvent('lpm:open', { detail: { parcoursId: {{ $parcoursSelected->id }}, parcoursName: {!! json_encode($parcoursSelected->name) !!} } }))">
+                    data-parcours-id="{{ $parcoursSelected->id }}"
+                    data-parcours-name="{{ $parcoursSelected->name }}"
+                    onclick="window.dispatchEvent(new CustomEvent('lpm:open', { detail: { parcoursId: parseInt(this.dataset.parcoursId, 10), parcoursName: this.dataset.parcoursName } }))">
                     <i class="fas fa-edit"></i> Modifier les UE
                 </button>
             </div>


### PR DESCRIPTION
Hotfix : empty-state CTA "Lier des UE au parcours" ne fait rien quand cliqué. Cause: `{!! json_encode($name) !!}` dans `onclick="..."` injecte un ` " ` brut qui termine prématurément l'attribut HTML. Le navigateur parse onclick comme cassé, le clic n'exécute rien.

Fix: data-* attributes + this.dataset lookup. Robuste face aux noms avec apostrophes/guillemets.

Test: refresh page, click "Lier des UE au parcours" → modal doit s'ouvrir.