### PR TITLE
feat(lmd): bulk import maquette UEMOA via JSON spec + CLI endpoint

### DIFF
--- a/app/Http/Controllers/API/CLI/CLILMDSetupController.php
+++ b/app/Http/Controllers/API/CLI/CLILMDSetupController.php
@@ -8,6 +8,7 @@ use App\Models\ESBTPLMDDomaine;
 use App\Models\ESBTPLMDMention;
 use App\Models\ESBTPLMDParcours;
 use App\Models\ESBTPUniteEnseignement;
+use App\Services\LMD\LMDImportService;
 use App\Services\LMD\ParcoursUeSyncService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -176,6 +177,71 @@ class CLILMDSetupController extends BaseApiController
             $stats['updated'],
             $stats['detached'],
             $stats['unchanged'],
+        ));
+    }
+
+    /**
+     * POST /api/cli/lmd/import
+     *
+     * Bulk import a full LMD maquette (Domaine + Mention + Parcours + Filière + UEs +
+     * ECUEs + Planifications) from a JSON spec. Idempotent — re-runs upsert silently.
+     *
+     * Body: see LMDImportService::import() docblock for the spec schema.
+     * Returns: { domaine, mention, parcours, filiere, niveaux, stats: {ues_attached, ecues_updated, ...} }
+     */
+    public function import(Request $request, LMDImportService $importer): JsonResponse
+    {
+        if (!$request->user()->tokenCan('cli:admin')) {
+            return $this->errorResponse('Token missing cli:admin ability', [], 403);
+        }
+
+        $validated = $request->validate([
+            'domaine.name' => 'required|string|max:255',
+            'domaine.code' => 'nullable|string|max:50',
+            'mention.name' => 'required|string|max:255',
+            'mention.code' => 'nullable|string|max:50',
+            'parcours.name' => 'required|string|max:255',
+            'parcours.code' => 'nullable|string|max:50',
+            'parcours.credits_licence' => 'nullable|integer|min:0|max:600',
+            'parcours.credits_master' => 'nullable|integer|min:0|max:600',
+            'filiere.name' => 'nullable|string|max:255',
+            'filiere.code' => 'nullable|string|max:50',
+            'niveaux' => 'required|array|min:1',
+            'niveaux.*.name' => 'required|string|max:50',
+            'niveaux.*.year' => 'required|integer|between:1,8',
+            'ues' => 'required|array|min:1',
+            'ues.*.code' => 'nullable|string|max:50',
+            'ues.*.name' => 'required|string|max:255',
+            'ues.*.type_ue' => 'required|string',
+            'ues.*.credit' => 'required|integer|min:0|max:60',
+            'ues.*.niveau_year' => 'required|integer|between:1,8',
+            'ues.*.semestre' => 'required|integer|between:1,10',
+            'ues.*.is_optional' => 'sometimes|boolean',
+            'ues.*.ordre' => 'sometimes|integer|min:0|max:65535',
+            'ues.*.ecues' => 'required|array|min:1',
+            'ues.*.ecues.*.code' => 'nullable|string|max:50',
+            'ues.*.ecues.*.name' => 'required|string|max:255',
+            'ues.*.ecues.*.credit_ecue' => 'required|integer|min:0|max:60',
+            'ues.*.ecues.*.cm' => 'sometimes|integer|min:0|max:1000',
+            'ues.*.ecues.*.td' => 'sometimes|integer|min:0|max:1000',
+            'ues.*.ecues.*.tp' => 'sometimes|integer|min:0|max:1000',
+            'ues.*.ecues.*.projet' => 'sometimes|integer|min:0|max:1000',
+            'ues.*.ecues.*.tpe' => 'sometimes|integer|min:0|max:1000',
+        ]);
+
+        $result = $importer->import($validated, $request->user()->id);
+
+        return $this->successResponse($result, sprintf(
+            'Maquette importée : %d UE (+%d/~%d), %d ECUE (+%d/~%d), %d planif (+%d/~%d)',
+            $result['stats']['ues_attached'] + $result['stats']['ues_updated'],
+            $result['stats']['ues_attached'],
+            $result['stats']['ues_updated'],
+            $result['stats']['ecues_attached'] + $result['stats']['ecues_updated'],
+            $result['stats']['ecues_attached'],
+            $result['stats']['ecues_updated'],
+            $result['stats']['planifs_attached'] + $result['stats']['planifs_updated'],
+            $result['stats']['planifs_attached'],
+            $result['stats']['planifs_updated'],
         ));
     }
 

--- a/app/Services/LMD/LMDImportService.php
+++ b/app/Services/LMD/LMDImportService.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace App\Services\LMD;
+
+use App\Enums\TypeUE;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPLMDDomaine;
+use App\Models\ESBTPLMDMention;
+use App\Models\ESBTPLMDParcours;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPNiveauEtude;
+use App\Models\ESBTPPlanificationAcademique;
+use App\Models\ESBTPUniteEnseignement;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Bulk import a full LMD maquette (Domaine + Mention + Parcours + Filière + UEs +
+ * ECUEs + Planifications) from a structured JSON spec. Idempotent end-to-end :
+ * re-running with the same spec is a no-op (upsert by code at every level).
+ *
+ * Designed to consume a JSON file extracted from a tenant's PDF maquette
+ * (UEMOA standard), enabling provisioning of an entire Licence in one CLI call
+ * instead of dozens of UI form submits.
+ */
+class LMDImportService
+{
+    public function __construct(private ParcoursUeSyncService $parcoursUeSync) {}
+
+    /**
+     * @param  array  $spec  See JSON schema in resources/docs or LmdImportCommand help
+     * @return array{domaine:array, mention:array, parcours:array, filiere:?array, niveaux:array, stats:array}
+     */
+    public function import(array $spec, ?int $userId = null): array
+    {
+        return DB::transaction(function () use ($spec, $userId) {
+            $domaine = $this->upsertDomaine($spec['domaine'], $userId);
+            $mention = $this->upsertMention($spec['mention'], $domaine, $userId);
+            $filiere = isset($spec['filiere']) ? $this->upsertFiliere($spec['filiere'], $userId) : null;
+            $parcours = $this->upsertParcours($spec['parcours'], $mention, $filiere, $userId);
+
+            $niveauxByYear = [];
+            foreach ($spec['niveaux'] ?? [] as $niveau) {
+                $entity = $this->upsertNiveau($niveau);
+                $niveauxByYear[(int) $niveau['year']] = $entity;
+            }
+
+            $stats = ['ues_attached' => 0, 'ues_updated' => 0, 'ecues_attached' => 0, 'ecues_updated' => 0, 'planifs_attached' => 0, 'planifs_updated' => 0];
+            $linksByParcours = [];
+
+            foreach ($spec['ues'] ?? [] as $ueSpec) {
+                $niveauYear = (int) $ueSpec['niveau_year'];
+                $niveau = $niveauxByYear[$niveauYear] ?? null;
+                if (!$niveau) {
+                    throw new \InvalidArgumentException("Niveau d'étude year={$niveauYear} référencé par UE {$ueSpec['code']} mais absent de spec.niveaux");
+                }
+
+                [$ue, $ueCreated] = $this->upsertUE($ueSpec, $parcours, $filiere, $niveau, $userId);
+                $stats[$ueCreated ? 'ues_attached' : 'ues_updated']++;
+
+                $linksByParcours[] = [
+                    'id' => $ue->id,
+                    'semestres' => [(int) $ueSpec['semestre']],
+                    'is_optional' => (bool) ($ueSpec['is_optional'] ?? false),
+                    'ordre' => (int) ($ueSpec['ordre'] ?? 0),
+                ];
+
+                foreach ($ueSpec['ecues'] ?? [] as $ecueSpec) {
+                    [$ecue, $ecueCreated] = $this->upsertECUE($ecueSpec, $ue, $filiere, $niveau, $userId);
+                    $stats[$ecueCreated ? 'ecues_attached' : 'ecues_updated']++;
+
+                    [, $planifCreated] = $this->upsertPlanification($ecueSpec, $ecue, $filiere, $niveau, (int) $ueSpec['semestre']);
+                    $stats[$planifCreated ? 'planifs_attached' : 'planifs_updated']++;
+                }
+            }
+
+            $linkStats = $this->parcoursUeSync->sync($parcours, $linksByParcours, detachMissing: false);
+            $stats['ues_linked_to_parcours'] = $linkStats['attached'] + $linkStats['updated'] + $linkStats['unchanged'];
+
+            return [
+                'domaine' => $this->summarize($domaine, ['name', 'code']),
+                'mention' => $this->summarize($mention, ['name', 'code']),
+                'parcours' => $this->summarize($parcours, ['name', 'code']),
+                'filiere' => $filiere ? $this->summarize($filiere, ['name', 'code']) : null,
+                'niveaux' => array_map(fn ($n) => $this->summarize($n, ['name', 'year']), $niveauxByYear),
+                'stats' => $stats,
+            ];
+        });
+    }
+
+    private function upsertDomaine(array $data, ?int $userId): ESBTPLMDDomaine
+    {
+        return ESBTPLMDDomaine::updateOrCreate(
+            ['code' => $data['code'] ?? Str::slug($data['name'])],
+            ['name' => $data['name'], 'description' => $data['description'] ?? null, 'created_by' => $userId, 'is_active' => true]
+        );
+    }
+
+    private function upsertMention(array $data, ESBTPLMDDomaine $domaine, ?int $userId): ESBTPLMDMention
+    {
+        return ESBTPLMDMention::updateOrCreate(
+            ['code' => $data['code'] ?? Str::slug($data['name'])],
+            ['name' => $data['name'], 'domaine_id' => $domaine->id, 'created_by' => $userId, 'is_active' => true]
+        );
+    }
+
+    private function upsertParcours(array $data, ESBTPLMDMention $mention, ?ESBTPFiliere $filiere, ?int $userId): ESBTPLMDParcours
+    {
+        return ESBTPLMDParcours::updateOrCreate(
+            ['code' => $data['code'] ?? Str::slug($data['name'])],
+            [
+                'name' => $data['name'],
+                'mention_id' => $mention->id,
+                'filiere_id' => $filiere?->id,
+                'credits_licence' => (int) ($data['credits_licence'] ?? 180),
+                'credits_master' => (int) ($data['credits_master'] ?? 120),
+                'created_by' => $userId,
+                'is_active' => true,
+            ]
+        );
+    }
+
+    private function upsertFiliere(array $data, ?int $userId): ESBTPFiliere
+    {
+        return ESBTPFiliere::updateOrCreate(
+            ['code' => $data['code'] ?? Str::slug($data['name'])],
+            ['name' => $data['name'], 'description' => $data['description'] ?? null, 'is_active' => true]
+        );
+    }
+
+    private function upsertNiveau(array $data): ESBTPNiveauEtude
+    {
+        return ESBTPNiveauEtude::firstOrCreate(
+            ['year' => (int) $data['year']],
+            ['name' => $data['name'], 'libelle' => $data['libelle'] ?? $data['name'], 'is_active' => true]
+        );
+    }
+
+    /** @return array{0: ESBTPUniteEnseignement, 1: bool} */
+    private function upsertUE(array $data, ESBTPLMDParcours $parcours, ?ESBTPFiliere $filiere, ESBTPNiveauEtude $niveau, ?int $userId): array
+    {
+        $code = $data['code'] ?? null;
+        $existing = $code ? ESBTPUniteEnseignement::where('code', $code)->first() : null;
+        $created = $existing === null;
+
+        $payload = [
+            'name' => $data['name'],
+            'code' => $code,
+            'credit' => (int) ($data['credit'] ?? 0),
+            'type_ue' => TypeUE::tryFrom($data['type_ue'] ?? '') ?? TypeUE::FONDAMENTALE,
+            'semestre' => (int) ($data['semestre'] ?? 1),
+            'parcours_id' => $parcours->id,
+            'filiere_id' => $filiere?->id,
+            'niveau_id' => $niveau->id,
+            'is_active' => true,
+            'created_by' => $existing?->created_by ?? $userId,
+            'updated_by' => $userId,
+        ];
+
+        $ue = $existing ?? new ESBTPUniteEnseignement();
+        $ue->fill($payload);
+        $ue->save();
+        return [$ue, $created];
+    }
+
+    /** @return array{0: ESBTPMatiere, 1: bool} */
+    private function upsertECUE(array $data, ESBTPUniteEnseignement $ue, ?ESBTPFiliere $filiere, ESBTPNiveauEtude $niveau, ?int $userId): array
+    {
+        $code = $data['code'] ?? null;
+        $existing = $code ? ESBTPMatiere::where('code', $code)->first() : null;
+        $created = $existing === null;
+
+        $payload = [
+            'name' => $data['name'],
+            'code' => $code,
+            'unite_enseignement_id' => $ue->id,
+            'filiere_id' => $filiere?->id,
+            'niveau_etude_id' => $niveau->id,
+            'coefficient' => (int) ($data['credit_ecue'] ?? 1),
+            'type_formation' => 'lmd',
+            'is_active' => true,
+            'created_by' => $existing?->created_by ?? $userId,
+            'updated_by' => $userId,
+        ];
+
+        $matiere = $existing ?? new ESBTPMatiere();
+        $matiere->fill($payload);
+        $matiere->save();
+        return [$matiere, $created];
+    }
+
+    /** @return array{0: ESBTPPlanificationAcademique, 1: bool} */
+    private function upsertPlanification(array $data, ESBTPMatiere $matiere, ?ESBTPFiliere $filiere, ESBTPNiveauEtude $niveau, int $semestre): array
+    {
+        if (!$filiere) {
+            throw new \InvalidArgumentException("Planification requiert une filière (matière {$matiere->name})");
+        }
+
+        $cm = (int) ($data['cm'] ?? 0);
+        $td = (int) ($data['td'] ?? 0);
+        $tp = (int) ($data['tp'] ?? 0);
+        $projet = (int) ($data['projet'] ?? 0);
+        $tpe = (int) ($data['tpe'] ?? 0);
+
+        $existing = ESBTPPlanificationAcademique::where('filiere_id', $filiere->id)
+            ->where('niveau_etude_id', $niveau->id)
+            ->where('semestre', $semestre)
+            ->where('matiere_id', $matiere->id)
+            ->first();
+        $created = $existing === null;
+
+        $payload = [
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+            'semestre' => $semestre,
+            'matiere_id' => $matiere->id,
+            'volume_horaire_cm' => $cm,
+            'volume_horaire_td' => $td,
+            'volume_horaire_tp' => $tp,
+            'volume_horaire_projet' => $projet,
+            'volume_horaire_tpe' => $tpe,
+            'volume_horaire_total' => $cm + $td + $tp + $projet + $tpe,
+            'coefficient' => (int) ($data['credit_ecue'] ?? 1),
+            'credits_ects' => (int) ($data['credit_ecue'] ?? 1),
+        ];
+
+        $planif = $existing ?? new ESBTPPlanificationAcademique();
+        $planif->fill($payload);
+        $planif->save();
+        return [$planif, $created];
+    }
+
+    private function summarize($model, array $keys): array
+    {
+        $out = ['id' => $model->id];
+        foreach ($keys as $k) {
+            $out[$k] = $model->{$k} ?? null;
+        }
+        return $out;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -280,6 +280,9 @@ Route::middleware(['auth:sanctum', 'throttle:60,1'])->prefix('cli')->name('api.c
         // LMD UE linking (idempotent — append by default, sync mode opt-in)
         Route::post('/lmd/parcours/{parcours}/link-ues', [App\Http\Controllers\API\CLI\CLILMDSetupController::class, 'linkUes'])->name('lmd.link-ues');
 
+        // LMD bulk import (Domaine + Mention + Parcours + Filière + UEs + ECUEs + Planifications)
+        Route::post('/lmd/import', [App\Http\Controllers\API\CLI\CLILMDSetupController::class, 'import'])->name('lmd.import');
+
         // Settings
         Route::put('/settings/{key}', [App\Http\Controllers\API\CLI\CLIDataController::class, 'settingsUpdate'])->name('settings.update');
 


### PR DESCRIPTION
## Résumé

Phase 1 de la PR LMD-3 (bulk import PDF maquette). Permet d'importer une maquette LMD complète (Domaine + Mention + Parcours + Filière + UEs + ECUEs + Planifications) depuis un fichier JSON spec en UNE commande `klassci lmd:import`.

## Architecture

- **`LMDImportService`** (~190 LOC) — orchestrateur transactionnel + idempotent
  - Wraps tout dans `DB::transaction` (rollback sur n'importe quelle erreur)
  - Upsert par `code` à chaque niveau (Domaine, Mention, Parcours, Filière, UE, ECUE)
  - `firstOrCreate` Niveau par `year`
  - Upsert Planification par (filiere, niveau, semestre, matiere) avec volumes UEMOA
  - Réutilise `ParcoursUeSyncService::sync(append mode)` pour le pivot UE↔Parcours
- **`CLILMDSetupController::import`** (~70 LOC) — endpoint POST /api/cli/lmd/import
  - throttle:60,1 + tokenCan('cli:admin')
  - Validation FormRequest stricte (8 niveaux deep) AVANT toute écriture
  - Retourne stats détaillées par catégorie

Companion CLI command `klassci lmd:import` shipped séparément dans le repo klassci-cli.

## Test sur presentation prévu

```bash
klassci lmd:import presentation --file=~/Downloads/licence-droit-ephrata.json
# Doit créer : 1 Domaine + 1 Mention + 1 Parcours + 1 Filière + 1 Niveau (L1) + 8 UEs + 15 ECUEs + 15 planifications

klassci lmd:import presentation --file=~/Downloads/licence-droit-ephrata.json
# Re-run = 0 changements (idempotent)
```

## Phase 2/3 prévues

- Phase 2 : extension du JSON aux 5 sémestres restants (S2-S6) → +75 ECUEs
- Phase 3 : cross-sync `presentation:ephrata` + import sur ephrata
