### PR TITLE
feat(lmd): volume budget widget CM/TD/TP (TypeSeance enum + VolumeBudgetService + lpv-* widget)

### DIFF
--- a/app/Enums/TypeSeance.php
+++ b/app/Enums/TypeSeance.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Enums;
+
+enum TypeSeance: string
+{
+    case CM      = 'CM';
+    case TD      = 'TD';
+    case TP      = 'TP';
+    case PROJET  = 'PROJET';
+    case TPE     = 'TPE';
+    case EXAMEN  = 'EXAMEN';
+    case AUTRE   = 'AUTRE';
+
+    public function label(): string
+    {
+        return match($this) {
+            self::CM     => 'Cours Magistral',
+            self::TD     => 'Travaux Dirigés',
+            self::TP     => 'Travaux Pratiques',
+            self::PROJET => 'Projet',
+            self::TPE    => 'Travail Personnel Étudiant',
+            self::EXAMEN => 'Examen',
+            self::AUTRE  => 'Autre',
+        };
+    }
+
+    /** Returns all case values as a plain array (for Rule::in()). */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+
+    /**
+     * Map legacy type_seance strings to canonical enum values.
+     * Conservative: ambiguous values ('cours') → AUTRE, not CM.
+     */
+    public static function fromLegacy(?string $raw): self
+    {
+        if ($raw === null || $raw === '') {
+            return self::AUTRE;
+        }
+
+        $upper = strtoupper(trim($raw));
+
+        return match($upper) {
+            'CM'     => self::CM,
+            'TD'     => self::TD,
+            'TP'     => self::TP,
+            'PROJET' => self::PROJET,
+            'TPE'    => self::TPE,
+            'EXAMEN' => self::EXAMEN,
+            default  => self::AUTRE,
+        };
+    }
+
+    /** Whether this type counts toward volume horaire tracking (CM/TD/TP). */
+    public function isVolumeTracked(): bool
+    {
+        return in_array($this, [self::CM, self::TD, self::TP], true);
+    }
+}

--- a/app/Http/Controllers/ESBTPLMDPlanningController.php
+++ b/app/Http/Controllers/ESBTPLMDPlanningController.php
@@ -5,12 +5,14 @@ namespace App\Http\Controllers;
 use App\Http\Requests\BulkUpdatePlanificationRequest;
 use App\Http\Requests\UpdatePlanificationRequest;
 use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
 use App\Models\ESBTPLMDParcours;
 use App\Models\ESBTPMatiere;
 use App\Models\ESBTPNiveauEtude;
 use App\Models\ESBTPPlanificationAcademique;
 use App\Models\ESBTPUniteEnseignement;
 use App\Models\User;
+use App\Services\VolumeBudgetService;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -463,6 +465,31 @@ class ESBTPLMDPlanningController extends Controller
             ->get();
 
         return response()->json(['users' => $users]);
+    }
+
+    /**
+     * GET /esbtp/lmd/planning/volumes
+     * Returns realized vs planned hours per ECUE for the current filters,
+     * aggregated across all LMD classes of the filière.
+     * Used by the lpv-* widget in _listing.blade.php.
+     */
+    public function volumes(Request $request, VolumeBudgetService $service): JsonResponse
+    {
+        $this->authorize('lmd.planning.view');
+
+        $filiereId = $request->integer('filiere_id');
+        $niveauId  = $request->integer('niveau_id');
+        $semestre  = $request->integer('semestre');
+        $anneeId   = $request->integer('annee_id')
+            ?: optional(ESBTPAnneeUniversitaire::where('is_current', true)->first())->id;
+
+        if (!$filiereId || !$niveauId || !$semestre || !$anneeId) {
+            return response()->json(['budgets' => []]);
+        }
+
+        $budgets = $service->forFiliere($filiereId, $niveauId, $semestre, $anneeId);
+
+        return response()->json(['budgets' => $budgets]);
     }
 
     /**

--- a/app/Models/ESBTPSeanceCours.php
+++ b/app/Models/ESBTPSeanceCours.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\TypeSeance;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -45,6 +46,7 @@ class ESBTPSeanceCours extends Model
         'annee_universitaire_id',
         'is_active',
         'date_seance',
+        'type_seance',
     ];
 
     /**
@@ -59,6 +61,7 @@ class ESBTPSeanceCours extends Model
         'is_recurring' => 'boolean',
         'recurrence_days' => 'array',
         'is_active' => 'boolean',
+        'type_seance' => TypeSeance::class,
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
         'deleted_at' => 'datetime',

--- a/app/Services/VolumeBudgetService.php
+++ b/app/Services/VolumeBudgetService.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPPlanificationAcademique;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Calcule les volumes horaires réalisés (depuis esbtp_seance_cours)
+ * vs planifiés (depuis esbtp_planifications_academiques) par ECUE.
+ *
+ * Agnostique filière/parcours :
+ *   - LMD  → jointure via $classe->parcours_id (→ filiere_id dérivé)
+ *   - BTS  → jointure via $classe->filiere_id directement
+ */
+class VolumeBudgetService
+{
+    /**
+     * Bulk: retourne les budgets pour toutes les ECUEs d'une classe
+     * filtrées par niveau et semestre.
+     *
+     * @return array<int, array{cm: array, td: array, tp: array}>
+     *              Indexed by matiere_id (= ecue_id).
+     */
+    public function forClasse(
+        ESBTPClasse $classe,
+        int $niveauId,
+        int $semestre,
+        int $anneeId
+    ): array {
+        $filiereId  = $this->resolveFiliereId($classe);
+        $matiereIds = $this->matiereIdsForNiveauSemestre($filiereId, $niveauId, $semestre);
+
+        if ($matiereIds->isEmpty()) {
+            return [];
+        }
+
+        $planifies  = $this->loadPlanifies($filiereId, $niveauId, $semestre, $matiereIds->all());
+        $realises   = $this->loadRealises($classe->id, $anneeId, $matiereIds->all());
+
+        $result = [];
+        foreach ($matiereIds as $matiereId) {
+            $p = $planifies[$matiereId] ?? [];
+            $r = $realises[$matiereId] ?? [];
+            $result[$matiereId] = [
+                'cm'  => $this->budget($p['cm']  ?? 0, $r['CM']  ?? 0),
+                'td'  => $this->budget($p['td']  ?? 0, $r['TD']  ?? 0),
+                'tp'  => $this->budget($p['tp']  ?? 0, $r['TP']  ?? 0),
+            ];
+        }
+
+        return $result;
+    }
+
+    /**
+     * Bulk: réalisé vs planifié pour toutes les ECUEs d'une filière/niveau/semestre,
+     * agrégé sur TOUTES les classes LMD liées à cette filière.
+     * Utilisé par la page planning (maquette pédagogique) qui n'a pas de filtre classe.
+     *
+     * @return array<int, array{cm: array, td: array, tp: array}>
+     */
+    public function forFiliere(int $filiereId, int $niveauId, int $semestre, int $anneeId): array
+    {
+        $matiereIds = $this->matiereIdsForNiveauSemestre($filiereId, $niveauId, $semestre);
+
+        if ($matiereIds->isEmpty()) {
+            return [];
+        }
+
+        $planifies = $this->loadPlanifies($filiereId, $niveauId, $semestre, $matiereIds->all());
+        $realises  = $this->loadRealisesForFiliere($filiereId, $anneeId, $matiereIds->all());
+
+        $result = [];
+        foreach ($matiereIds as $matiereId) {
+            $p = $planifies[$matiereId] ?? [];
+            $r = $realises[$matiereId] ?? [];
+            $result[$matiereId] = [
+                'cm' => $this->budget($p['cm'] ?? 0, $r['CM'] ?? 0),
+                'td' => $this->budget($p['td'] ?? 0, $r['TD'] ?? 0),
+                'tp' => $this->budget($p['tp'] ?? 0, $r['TP'] ?? 0),
+            ];
+        }
+
+        return $result;
+    }
+
+    // ------------------------------------------------------------------ //
+
+    private function resolveFiliereId(ESBTPClasse $classe): int
+    {
+        if ($classe->parcours_id) {
+            // LMD: derive filiere from parcours
+            return $classe->parcours?->filiere_id ?? $classe->filiere_id;
+        }
+
+        return $classe->filiere_id;
+    }
+
+    private function matiereIdsForNiveauSemestre(int $filiereId, int $niveauId, int $semestre)
+    {
+        return ESBTPPlanificationAcademique::query()
+            ->where('filiere_id', $filiereId)
+            ->where('niveau_etude_id', $niveauId)
+            ->where('semestre', $semestre)
+            ->whereNotNull('matiere_id')
+            ->pluck('matiere_id')
+            ->unique();
+    }
+
+    /** Load planned volumes indexed by matiere_id. */
+    private function loadPlanifies(int $filiereId, int $niveauId, int $semestre, array $matiereIds): array
+    {
+        return ESBTPPlanificationAcademique::query()
+            ->where('filiere_id', $filiereId)
+            ->where('niveau_etude_id', $niveauId)
+            ->where('semestre', $semestre)
+            ->whereIn('matiere_id', $matiereIds)
+            ->get(['matiere_id', 'volume_horaire_cm', 'volume_horaire_td', 'volume_horaire_tp'])
+            ->keyBy('matiere_id')
+            ->map(fn ($p) => [
+                'cm' => (float) $p->volume_horaire_cm,
+                'td' => (float) $p->volume_horaire_td,
+                'tp' => (float) $p->volume_horaire_tp,
+            ])
+            ->all();
+    }
+
+    /**
+     * Load realized hours from seance_cours using a single aggregate query.
+     * Groups by matiere_id and type_seance — no N+1.
+     *
+     * @return array<int, array<string, float>>  e.g. [42 => ['CM' => 12.5, 'TD' => 8.0]]
+     */
+    private function loadRealises(int $classeId, int $anneeId, array $matiereIds): array
+    {
+        $rows = DB::table('esbtp_seance_cours')
+            ->select([
+                'matiere_id',
+                'type_seance',
+                DB::raw("SUM((TIME_TO_SEC(heure_fin) - TIME_TO_SEC(heure_debut)) / 3600.0) AS heures"),
+            ])
+            ->where('classe_id', $classeId)
+            ->where('annee_universitaire_id', $anneeId)
+            ->whereIn('matiere_id', $matiereIds)
+            ->whereIn('type_seance', ['CM', 'TD', 'TP'])
+            ->whereNull('deleted_at')
+            ->groupBy('matiere_id', 'type_seance')
+            ->get();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row->matiere_id][$row->type_seance] = round((float) $row->heures, 2);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Realized hours aggregated across ALL LMD classes whose parcours
+     * belongs to $filiereId. One SQL query, no N+1.
+     *
+     * @return array<int, array<string, float>>
+     */
+    private function loadRealisesForFiliere(int $filiereId, int $anneeId, array $matiereIds): array
+    {
+        $classeIds = ESBTPClasse::query()
+            ->whereHas('parcours', fn ($q) => $q->where('filiere_id', $filiereId))
+            ->pluck('id');
+
+        if ($classeIds->isEmpty()) {
+            return [];
+        }
+
+        $rows = DB::table('esbtp_seance_cours')
+            ->select([
+                'matiere_id',
+                'type_seance',
+                DB::raw("SUM((TIME_TO_SEC(heure_fin) - TIME_TO_SEC(heure_debut)) / 3600.0) AS heures"),
+            ])
+            ->whereIn('classe_id', $classeIds)
+            ->where('annee_universitaire_id', $anneeId)
+            ->whereIn('matiere_id', $matiereIds)
+            ->whereIn('type_seance', ['CM', 'TD', 'TP'])
+            ->whereNull('deleted_at')
+            ->groupBy('matiere_id', 'type_seance')
+            ->get();
+
+        $result = [];
+        foreach ($rows as $row) {
+            $result[$row->matiere_id][$row->type_seance] = round((float) $row->heures, 2);
+        }
+
+        return $result;
+    }
+
+    /** Build a single budget entry with percentage. */
+    private function budget(float $planifie, float $realise): array
+    {
+        $pct = $planifie > 0 ? min(100, round($realise / $planifie * 100)) : ($realise > 0 ? 100 : 0);
+
+        return [
+            'planifie' => $planifie,
+            'realise'  => $realise,
+            'pct'      => $pct,
+        ];
+    }
+}

--- a/database/migrations/2026_05_11_223051_backfill_type_seance_legacy_on_esbtp_seance_cours.php
+++ b/database/migrations/2026_05_11_223051_backfill_type_seance_legacy_on_esbtp_seance_cours.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Idempotent backfill: normalize legacy type_seance values.
+        // Conservative: 'cours' → 'AUTRE' (not 'CM') — we cannot determine
+        // the pedagogical type from a generic label.
+        DB::statement("
+            UPDATE esbtp_seance_cours
+            SET type_seance = CASE
+                WHEN type_seance IS NULL                                                     THEN 'AUTRE'
+                WHEN type_seance = ''                                                        THEN 'AUTRE'
+                WHEN type_seance = 'cours'                                                   THEN 'AUTRE'
+                WHEN type_seance = 'examen'                                                  THEN 'EXAMEN'
+                WHEN type_seance NOT IN ('CM','TD','TP','PROJET','TPE','EXAMEN','AUTRE')     THEN 'AUTRE'
+                ELSE type_seance
+            END
+        ");
+    }
+
+    // No down() — cannot restore arbitrary legacy strings after normalization.
+    public function down(): void {}
+};

--- a/resources/views/esbtp/lmd/planning/_edit_styles.blade.php
+++ b/resources/views/esbtp/lmd/planning/_edit_styles.blade.php
@@ -259,6 +259,70 @@
 .lpt-toast--success { background: linear-gradient(135deg, #059669, #10b981); }
 .lpt-toast--error { background: linear-gradient(135deg, #b91c1c, #dc2626); }
 
+/* ============ Widget progression volumes (lpv-*) ============ */
+.lpv-cell {
+    padding: .6rem 1rem .6rem 2rem;
+    background: #f8fafc;
+    border-top: 1px solid #f1f5f9;
+}
+.lpv-bars {
+    display: flex;
+    gap: 1.25rem;
+    flex-wrap: wrap;
+}
+.lpv-bar-group {
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    min-width: 200px;
+    flex: 1;
+}
+.lpv-bar-label {
+    font-size: .72rem;
+    font-weight: 600;
+    color: #475569;
+    width: 80px;
+    flex-shrink: 0;
+    display: flex;
+    justify-content: space-between;
+}
+.lpv-bar-nums {
+    font-size: .68rem;
+    color: #94a3b8;
+    font-weight: 400;
+}
+.lpv-bar-sep { margin: 0 .15rem; }
+.lpv-bar-track {
+    flex: 1;
+    height: 6px;
+    background: #e2e8f0;
+    border-radius: 999px;
+    overflow: hidden;
+}
+.lpv-bar-fill {
+    height: 100%;
+    background: #0453cb;
+    border-radius: 999px;
+    transition: width .4s ease;
+}
+.lpv-bar-fill--warn { background: #f59e0b; }
+.lpv-bar-fill--done { background: #10b981; }
+.lpv-bar-pct {
+    font-size: .68rem;
+    color: #64748b;
+    width: 34px;
+    text-align: right;
+    flex-shrink: 0;
+}
+.lpv-loading {
+    font-size: .75rem;
+    color: #94a3b8;
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    padding: .25rem 0;
+}
+
 @@media (max-width: 640px) {
     .lpt-modal {
         min-height: 0;

--- a/resources/views/esbtp/lmd/planning/_listing.blade.php
+++ b/resources/views/esbtp/lmd/planning/_listing.blade.php
@@ -170,6 +170,40 @@
                                     <td>{{ $teacherName ?? '—' }}</td>
                                 @endif
                             </tr>
+                            @if($bulkEnabled)
+                            {{-- lpv-* widget: volume budget row (CM/TD/TP réalisé vs planifié) --}}
+                            <tr class="lpv-row js-ecue-row" data-parent-idx="{{ $idx }}" style="display:none;">
+                                <td></td>{{-- bulk checkbox spacer --}}
+                                <td colspan="10" class="lpv-cell"
+                                    x-data="lpvRow()"
+                                    data-lpv-ecue-id="{{ $ecue->id }}">
+                                    <div class="lpv-bars" x-show="loaded" x-cloak>
+                                        <template x-for="bar in bars" :key="bar.type">
+                                            <div class="lpv-bar-group">
+                                                <div class="lpv-bar-label">
+                                                    <span x-text="bar.type"></span>
+                                                    <span class="lpv-bar-nums">
+                                                        <span x-text="bar.realise + 'h'"></span>
+                                                        <span class="lpv-bar-sep">/</span>
+                                                        <span x-text="bar.planifie + 'h'"></span>
+                                                    </span>
+                                                </div>
+                                                <div class="lpv-bar-track">
+                                                    <div class="lpv-bar-fill"
+                                                         :class="bar.pct >= 100 ? 'lpv-bar-fill--done' : (bar.pct >= 70 ? 'lpv-bar-fill--warn' : '')"
+                                                         :style="'width:' + Math.min(bar.pct, 100) + '%'"></div>
+                                                </div>
+                                                <span class="lpv-bar-pct" x-text="bar.pct + '%'"></span>
+                                            </div>
+                                        </template>
+                                    </div>
+                                    <div class="lpv-loading" x-show="!loaded" x-cloak>
+                                        <i class="fas fa-circle-notch fa-spin"></i>
+                                        <span>Chargement des heures réalisées…</span>
+                                    </div>
+                                </td>
+                            </tr>
+                            @endif
                         @endforeach
                     @endforeach
                 </tbody>

--- a/resources/views/esbtp/lmd/planning/_scripts.blade.php
+++ b/resources/views/esbtp/lmd/planning/_scripts.blade.php
@@ -37,7 +37,14 @@ document.addEventListener('alpine:init', () => {
                 if (!resp.ok) throw new Error('HTTP ' + resp.status);
                 const json = await resp.json();
                 document.getElementById('lpKpis').innerHTML = json.kpis || '';
-                document.getElementById('lpContent').innerHTML = json.listing || '';
+                const lpContent = document.getElementById('lpContent');
+                lpContent.innerHTML = json.listing || '';
+                if (window.Alpine && typeof window.Alpine.initTree === 'function') {
+                    window.Alpine.initTree(lpContent);
+                }
+                // Reset cached volume data so lpvRow re-fetches for new filters.
+                window._lpvStore = null;
+                window._lpvPromise = null;
 
                 // Replace the semestre filter HTML and re-init Alpine on it
                 // so the new au-select component options take effect.
@@ -96,6 +103,79 @@ document.addEventListener('alpine:init', () => {
         },
     }));
 });
+
+// ---- lpvRow — Volume budget widget (réalisé vs planifié par ECUE) ----
+// One bulk fetch per listing render, cached in window._lpvStore so each
+// lpvRow component doesn't fire its own request (anti N+1).
+window._lpvStore   = null;  // {ecueId: {cm, td, tp}} | null
+window._lpvPromise = null;  // shared in-flight Promise | null
+
+window.lpvRow = function () {
+    return {
+        loaded: false,
+        bars: [],
+        _handler: null,
+
+        init() {
+            const ecueId = parseInt(this.$el.dataset.lpvEcueId, 10);
+            if (!ecueId) { this.loaded = true; return; }
+
+            // Already fetched for this render cycle?
+            if (window._lpvStore) {
+                this._apply(ecueId, window._lpvStore);
+                return;
+            }
+
+            // Listen for when the shared fetch completes.
+            this._handler = (e) => this._apply(ecueId, e.detail || {});
+            window.addEventListener('lpv:ready', this._handler);
+
+            // First instance triggers the bulk fetch; others just wait.
+            if (!window._lpvPromise) {
+                window._lpvPromise = this._bulkFetch();
+            }
+        },
+
+        _apply(ecueId, store) {
+            const d = store[ecueId];
+            if (!d) { this.loaded = true; return; }
+            this.bars = [
+                d.cm && d.cm.planifie + d.cm.realise > 0 ? { type: 'CM', ...d.cm } : null,
+                d.td && d.td.planifie + d.td.realise > 0 ? { type: 'TD', ...d.td } : null,
+                d.tp && d.tp.planifie + d.tp.realise > 0 ? { type: 'TP', ...d.tp } : null,
+            ].filter(Boolean);
+            this.loaded = true;
+        },
+
+        async _bulkFetch() {
+            try {
+                const root = document.querySelector('[data-lpe-context]');
+                const ctx  = root ? JSON.parse(root.dataset.lpeContext || '{}') : {};
+                if (!ctx.filiere_id || !ctx.niveau_id || !ctx.semestre) return;
+
+                const params = new URLSearchParams({
+                    filiere_id: ctx.filiere_id,
+                    niveau_id:  ctx.niveau_id,
+                    semestre:   ctx.semestre,
+                    annee_id:   ctx.annee_universitaire_id || '',
+                });
+                const resp = await fetch(@json(route('esbtp.lmd.planning.volumes')) + '?' + params, {
+                    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+                });
+                if (!resp.ok) return;
+                const json = await resp.json();
+                window._lpvStore = json.budgets || {};
+                window.dispatchEvent(new CustomEvent('lpv:ready', { detail: window._lpvStore }));
+            } catch (e) {
+                console.error('lpvRow bulk fetch failed:', e);
+            }
+        },
+
+        destroy() {
+            if (this._handler) window.removeEventListener('lpv:ready', this._handler);
+        },
+    };
+};
 
 // UE row expand/collapse — event delegation survives AJAX innerHTML replace.
 document.addEventListener('click', function (e) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -2452,6 +2452,9 @@ Route::prefix('esbtp/lmd')->name('esbtp.lmd.')->middleware(['auth', 'permission:
     Route::get('planning/enseignants', [\App\Http\Controllers\ESBTPLMDPlanningController::class, 'enseignants'])
         ->middleware(['permission:lmd.planning.edit', 'throttle:60,1'])
         ->name('planning.enseignants');
+    Route::get('planning/volumes', [\App\Http\Controllers\ESBTPLMDPlanningController::class, 'volumes'])
+        ->middleware(['permission:lmd.planning.view', 'throttle:60,1'])
+        ->name('planning.volumes');
     Route::patch('planifications/{ecueId}', [\App\Http\Controllers\ESBTPLMDPlanningController::class, 'updatePlanification'])
         ->middleware(['permission:lmd.planning.edit', 'throttle:60,1'])
         ->whereNumber('ecueId')

--- a/tests/Unit/Enums/TypeSeanceTest.php
+++ b/tests/Unit/Enums/TypeSeanceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\TypeSeance;
+use PHPUnit\Framework\TestCase;
+
+class TypeSeanceTest extends TestCase
+{
+    public function test_values_returns_all_seven_strings(): void
+    {
+        $values = TypeSeance::values();
+        $this->assertCount(7, $values);
+        $this->assertContains('CM', $values);
+        $this->assertContains('TD', $values);
+        $this->assertContains('TP', $values);
+        $this->assertContains('PROJET', $values);
+        $this->assertContains('TPE', $values);
+        $this->assertContains('EXAMEN', $values);
+        $this->assertContains('AUTRE', $values);
+    }
+
+    public function test_from_legacy_maps_null_to_autre(): void
+    {
+        $this->assertSame(TypeSeance::AUTRE, TypeSeance::fromLegacy(null));
+    }
+
+    public function test_from_legacy_maps_empty_to_autre(): void
+    {
+        $this->assertSame(TypeSeance::AUTRE, TypeSeance::fromLegacy(''));
+    }
+
+    public function test_from_legacy_maps_cours_to_autre(): void
+    {
+        $this->assertSame(TypeSeance::AUTRE, TypeSeance::fromLegacy('cours'));
+    }
+
+    public function test_from_legacy_maps_examen_to_examen(): void
+    {
+        $this->assertSame(TypeSeance::EXAMEN, TypeSeance::fromLegacy('examen'));
+    }
+
+    public function test_from_legacy_maps_valid_values_correctly(): void
+    {
+        $this->assertSame(TypeSeance::CM,  TypeSeance::fromLegacy('CM'));
+        $this->assertSame(TypeSeance::TD,  TypeSeance::fromLegacy('TD'));
+        $this->assertSame(TypeSeance::TP,  TypeSeance::fromLegacy('TP'));
+        $this->assertSame(TypeSeance::TPE, TypeSeance::fromLegacy('TPE'));
+    }
+
+    public function test_from_legacy_maps_unknown_to_autre(): void
+    {
+        $this->assertSame(TypeSeance::AUTRE, TypeSeance::fromLegacy('random_legacy_value'));
+    }
+
+    public function test_is_volume_tracked_for_cm_td_tp(): void
+    {
+        $this->assertTrue(TypeSeance::CM->isVolumeTracked());
+        $this->assertTrue(TypeSeance::TD->isVolumeTracked());
+        $this->assertTrue(TypeSeance::TP->isVolumeTracked());
+    }
+
+    public function test_is_volume_tracked_false_for_others(): void
+    {
+        $this->assertFalse(TypeSeance::PROJET->isVolumeTracked());
+        $this->assertFalse(TypeSeance::TPE->isVolumeTracked());
+        $this->assertFalse(TypeSeance::EXAMEN->isVolumeTracked());
+        $this->assertFalse(TypeSeance::AUTRE->isVolumeTracked());
+    }
+
+    public function test_label_returns_french_string(): void
+    {
+        $this->assertSame('Cours Magistral', TypeSeance::CM->label());
+        $this->assertSame('Travaux Dirigés', TypeSeance::TD->label());
+        $this->assertSame('Travaux Pratiques', TypeSeance::TP->label());
+    }
+}


### PR DESCRIPTION
## Summary

- **PR1** `7a8afc8d` — `TypeSeance` backed enum PHP (CM/TD/TP/PROJET/TPE/EXAMEN/AUTRE), migration idempotente backfill legacy (`cours`→`AUTRE`, `examen`→`EXAMEN`), cast sur `ESBTPSeanceCours.type_seance`, 10 tests unitaires
- **PR2** `3da37ab0` — `VolumeBudgetService::forFiliere()` (1 requête SQL agrégée, anti-N+1) + endpoint `GET /esbtp/lmd/planning/volumes` (filiere_id/niveau_id/semestre/annee_id, throttle:60,1)
- **PR3** `251424e5` — Widget `lpv-*` dans `_listing.blade.php` : barres de progression CM/TD/TP réalisé vs planifié par ECUE, visible quand niveau+semestre sélectionnés. Alpine `lpvRow` avec fetch partagé (1 requête pour tous les ECUEs du listing)

## Test plan

- [ ] Sélectionner un parcours + niveau + semestre sur `/esbtp/lmd/planning`
- [ ] Vérifier que les barres de progression apparaissent sous chaque ECUE (expand UE d'abord)
- [ ] Vérifier que CM/TD/TP affichent `0h / Xh planifié` si pas de séances saisies
- [ ] Changer les filtres → les barres se rechargent avec les nouvelles valeurs