### PR TITLE
feat(emploi-temps): TypeSeance enum integration — form validation + monochrome badges

### DIFF
--- a/app/Enums/TypeSeance.php
+++ b/app/Enums/TypeSeance.php
@@ -59,4 +59,14 @@ enum TypeSeance: string
     {
         return in_array($this, [self::CM, self::TD, self::TP], true);
     }
+
+    /** Returns ['VALUE' => 'Label'] array for <x-au-select> :options prop. */
+    public static function selectOptions(): array
+    {
+        $options = [];
+        foreach (self::cases() as $case) {
+            $options[$case->value] = $case->label();
+        }
+        return $options;
+    }
 }

--- a/app/Http/Controllers/ESBTPEmploiTempsController.php
+++ b/app/Http/Controllers/ESBTPEmploiTempsController.php
@@ -1319,21 +1319,9 @@ class ESBTPEmploiTempsController extends Controller
      *
      * @return \Illuminate\Http\Response
      */
-    public function storeSession(Request $request, ESBTPEmploiTemps $emploi_temp)
+    public function storeSession(\App\Http\Requests\StoreSeanceCoursRequest $request, ESBTPEmploiTemps $emploi_temp)
     {
-        $this->authorize('create', ESBTPSeanceCours::class);
-
-        $validated = $request->validate([
-            'matiere_id' => 'required|exists:esbtp_matieres,id',
-            'enseignant_id' => 'required|exists:users,id',
-            'jour' => 'required|string|max:20',
-            'heure_debut' => 'required|date_format:H:i',
-            'heure_fin' => 'required|date_format:H:i|after:heure_debut',
-            'salle' => 'nullable|string|max:50',
-            'description' => 'nullable|string',
-            'classe_id' => 'required|exists:esbtp_classes,id',
-            'annee_universitaire_id' => 'required|exists:esbtp_annee_universitaires,id',
-        ]);
+        $validated = $request->validated();
 
         $validated['emploi_temps_id'] = $emploi_temp->id;
 
@@ -1369,6 +1357,7 @@ class ESBTPEmploiTempsController extends Controller
         $seance->classe_id = $validated['classe_id'];
         $seance->matiere_id = $validated['matiere_id'];
         $seance->enseignant_id = $validated['enseignant_id'];
+        $seance->type_seance = $validated['type_seance'];
         $seance->jour = $validated['jour'];
         $seance->heure_debut = $validated['heure_debut'];
         $seance->heure_fin = $validated['heure_fin'];

--- a/app/Http/Requests/StoreSeanceCoursRequest.php
+++ b/app/Http/Requests/StoreSeanceCoursRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\TypeSeance;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreSeanceCoursRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('create', \App\Models\ESBTPSeanceCours::class) ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'matiere_id'              => 'required|exists:esbtp_matieres,id',
+            'enseignant_id'           => 'required|exists:users,id',
+            'type_seance'             => ['required', Rule::enum(TypeSeance::class)],
+            'jour'                    => 'required|string|max:20',
+            'heure_debut'             => 'required|date_format:H:i',
+            'heure_fin'               => 'required|date_format:H:i|after:heure_debut',
+            'salle'                   => 'nullable|string|max:50',
+            'description'             => 'nullable|string',
+            'classe_id'               => 'required|exists:esbtp_classes,id',
+            'annee_universitaire_id'  => 'required|exists:esbtp_annee_universitaires,id',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'type_seance.required' => 'Le type de séance est obligatoire.',
+            'type_seance.enum'     => 'Le type de séance sélectionné n\'est pas valide.',
+        ];
+    }
+}

--- a/resources/views/esbtp/emploi-temps/add-session.blade.php
+++ b/resources/views/esbtp/emploi-temps/add-session.blade.php
@@ -37,6 +37,19 @@
                     </div>
                     <div class="main-card-body">
                         <div class="form-group">
+                            <label class="form-label">Type de séance <span class="text-danger">*</span></label>
+                            <x-au-select
+                                name="type_seance"
+                                :value="old('type_seance', 'CM')"
+                                icon="fa-tag"
+                                placeholder="Sélectionner un type"
+                                :options="\App\Enums\TypeSeance::selectOptions()" />
+                            @error('type_seance')
+                                <div class="form-error">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <div class="form-group">
                             <label for="matiere_id" class="form-label">Matière <span class="text-danger">*</span></label>
                             <select name="matiere_id" id="matiere_id" class="form-select @error('matiere_id') error @enderror" required>
                                 <option value="">Sélectionner une matière</option>

--- a/resources/views/esbtp/emploi-temps/teacher.blade.php
+++ b/resources/views/esbtp/emploi-temps/teacher.blade.php
@@ -71,14 +71,15 @@
 
                                                 @if($seancesDuCreneau->isNotEmpty())
                                                     @foreach($seancesDuCreneau as $seance)
-                                                        <div class="course-card p-2 mb-1 rounded" 
-                                                            style="background-color: {{ $seance->type_seance == 'cours' ? 'rgba(99, 102, 241, 0.1)' : ($seance->type_seance == 'td' ? 'rgba(236, 72, 153, 0.1)' : 'rgba(34, 197, 94, 0.1)') }}">
+                                                        <div class="course-card p-2 mb-1 rounded"
+                                                            style="background-color: rgba(4,83,203,.06); border-left: 3px solid rgba(4,83,203,.3)">
                                                             <div class="course-title fw-semibold">
                                                                 {{ $seance->matiere->name ?? 'Matière non définie' }}
                                                             </div>
                                                             <div class="course-details small">
-                                                                <span class="badge {{ $seance->type_seance == 'cours' ? 'bg-primary' : ($seance->type_seance == 'td' ? 'bg-secondary' : 'bg-success') }}">
-                                                                    {{ strtoupper($seance->type_seance) }}
+                                                                @php $ts = $seance->type_seance instanceof \App\Enums\TypeSeance ? $seance->type_seance : \App\Enums\TypeSeance::fromLegacy($seance->getRawOriginal('type_seance')); @endphp
+                                                                <span class="badge" style="background:rgba(4,83,203,.12);color:#0453cb;border:1px solid rgba(4,83,203,.25)">
+                                                                    {{ $ts->value }}
                                                                 </span>
                                                                 <div class="mt-1">
                                                                     <i class="fas fa-clock me-1"></i>


### PR DESCRIPTION
## Summary

- `TypeSeance::selectOptions()` — méthode statique `['VALUE' => 'Label']` pour le composant `<x-au-select>`
- `StoreSeanceCoursRequest` — Form Request avec `Rule::enum(TypeSeance::class)` remplace la validation inline dans le controller
- `ESBTPEmploiTempsController::storeSession()` — utilise le Form Request, persiste désormais `type_seance` en DB
- `add-session.blade.php` — `<x-au-select>` pour `type_seance` (valeur par défaut CM, 7 options)
- `teacher.blade.php` — badges monochrome KLASSCI (tonal bleu) remplacent les comparaisons de chaînes brisées (`'cours'`/`'td'`/`'tp'`) et les couleurs multicolores (violet/rose/vert) incompatibles avec le design system

## Test plan

- [ ] Créer une séance avec chaque TypeSeance → vérifier que la valeur est bien persistée en DB
- [ ] Vue emploi du temps enseignant `/esbtp/emploi-temps/teacher` → badges bleu tonal uniformes
- [ ] Soumettre le formulaire sans type_seance → message d'erreur "Le type de séance est obligatoire."
- [ ] Soumettre avec une valeur invalide → message "Le type de séance sélectionné n'est pas valide."
- [ ] Vérifier les séances legacy (`cours` backfillé → `AUTRE`) affichent bien le badge sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)