### PR TITLE
fix(seances-cours): add type_seance field in create form

### DIFF
--- a/app/Http/Controllers/ESBTPSeanceCoursController.php
+++ b/app/Http/Controllers/ESBTPSeanceCoursController.php
@@ -399,6 +399,7 @@ class ESBTPSeanceCoursController extends Controller
             $baseValidator = Validator::make($request->all(), [
                 'emploi_temps_id' => 'required|exists:esbtp_emploi_temps,id',
                 'type' => 'required|in:course,homework,break,lunch',
+                'type_seance' => ['nullable', \Illuminate\Validation\Rule::enum(\App\Enums\TypeSeance::class)],
                 'jour' => 'required|integer|min:1|max:7',
                 'heure_debut' => 'required|date_format:H:i',
                 'heure_fin' => 'required|date_format:H:i|after:heure_debut',

--- a/resources/views/esbtp/seances-cours/create.blade.php
+++ b/resources/views/esbtp/seances-cours/create.blade.php
@@ -370,6 +370,19 @@
                                     @enderror
                                 </div>
 
+                                <div class="form-group">
+                                    <label class="form-label">Type de séance <span class="text-danger">*</span></label>
+                                    <x-au-select
+                                        name="type_seance"
+                                        :value="old('type_seance', 'CM')"
+                                        icon="fa-tag"
+                                        placeholder="Sélectionner un type"
+                                        :options="\App\Enums\TypeSeance::selectOptions()" />
+                                    @error('type_seance')
+                                        <div class="form-error">{{ $message }}</div>
+                                    @enderror
+                                </div>
+
                                 <div class="form-group" id="teacherFieldGroup">
                                     <label for="teacher_id" class="form-label">Enseignant assigné <span class="text-danger">*</span></label>
                                     <select name="teacher_id" id="teacher_id" class="form-select @error('teacher_id') error @enderror" onchange="showTeacherAvailability()" required>


### PR DESCRIPTION
Adds missing type_seance select (CM/TD/TP/PROJET/TPE/EXAMEN/AUTRE) in seances-cours create form and validates it in store().