### PR TITLE
feat(lmd): TPE Journal etudiant + Workflow validation prof (Options 2+3 opt-in via Setting) — W4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ Le format suit librement [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/
 
 ## Mai 2026
 
+### W4 — TPE Journal + Workflow validation (Options 2+3 opt-in) — 16 mai 2026
+
+#### Ajouts
+- **Module TPE (Travail Personnel Étudiant — UEMOA LMD)** — nouveau module configurable `module.tpe.access`. Permet aux étudiants de déclarer leurs heures TPE par ECUE et par semaine, et aux enseignants de valider/rejeter quand le workflow est activé. Option 2 (journal auto-déclaratif) par défaut, Option 3 (workflow validation prof) **dormante** — code 100% présent mais inactif tant que le tenant ne flip pas le Setting `tpe.validation.enabled = true`.
+- **Strategy pattern `TpeValidationStrategy`** (AutoValidate / TeacherValidate) — pilotage runtime via container binding lisant le Setting tenant. Bascule Option 2 ↔ Option 3 sans redéploiement ni migration.
+- **Page étudiant `/esbtp/tpe-journal`** (namespace `tj-*`) — hero premium KLASSCI avec 4 KPIs (heures déclarées / volume attendu / progression / total), progress bar colorée sémantiquement, formulaire de saisie inline avec `<x-au-select>` ECUE + plafond hebdomadaire configurable, historique groupé par semaine avec badges statuts (Validé / En attente / Rejeté) et motif de rejet inline.
+- **Page enseignant `/esbtp/tpe-validation`** (namespace `tv-*`) — hero + 4 KPIs (en attente / validées semaine / rejetées mois / mes ECUEs), liste déclarations filtrée via scope `pourEnseignant()` (planification académique `enseignant_principal_id`), boutons Valider / Rejeter inline, modal Alpine pour commentaire de rejet (5-500 chars).
+- **Settings TPE** — 5 paramètres tenant configurables via `/esbtp/settings` : `tpe.module.enabled` (active le module), `tpe.validation.enabled` (active Option 3), `tpe.max_hours_per_week_per_ecue` (plafond, défaut 10), `tpe.declaration_window_weeks` (fenêtre rétroactive, défaut 2), `tpe.notify_email` (email opt-in, sinon DB only).
+- **Permissions TPE** dans le registry : `module.tpe.access`, `tpe.declare` (étudiant par défaut), `tpe.validate` (enseignant par défaut), `tpe.view_all` (secrétaire + coordinateur par défaut). Tous configurables via `/esbtp/custom-roles`.
+- **Notification `TpeDeclarationStatusChangedNotification`** — déclenchée à la validation/rejet, channels `database` toujours + `mail` opt-in via setting. Inclut motif de rejet pour que l'étudiant sache comment corriger.
+
+#### Sécurité
+- **Throttle TPE** — 60 requêtes/min sur les routes journal étudiant, 30 requêtes/min sur les routes validation enseignant.
+- **Validation cross-référence ECUE/classe** — `StoreTpeDeclarationRequest` vérifie que la matière (ECUE) déclarée est bien planifiée pour la classe de l'étudiant courant via `esbtp_planifications_academiques` (anti-bypass via ID arbitraire).
+- **Ownership étudiant** — `UpdateTpeDeclarationRequest::authorize()` vérifie `etudiant.user_id === user.id` ET `statut.isEditableByStudent()`. Une déclaration validée/rejetée devient immuable.
+- **Ownership enseignant** — `RejectTpeDeclarationRequest::authorize()` appelle `canBeValidatedBy($user)` qui vérifie que l'enseignant est `enseignant_principal_id` de l'ECUE dans la planification académique active.
+- **Whitelist audit log** — `$auditInclude` sur `ESBTPTpeDeclaration` (heures / description / statut / validated_by / commentaire_rejet) — anti audit-explosion.
+
+#### Tests
+- 3 fichiers de tests Unit ajoutés (`TpeDeclarationStatutTest`, `AutoValidateStrategyTest`, `TeacherValidateStrategyTest`) — 14 tests couvrant cycle de vie statut + contrat Strategy + edge cases (casse, espaces, valeurs inconnues).
+
 ### Switch BTS/LMD étendu aux pages clés + fix UE 0h + tree premium réutilisable (15 mai 2026)
 
 #### Ajouts

--- a/app/Enums/TpeDeclarationStatut.php
+++ b/app/Enums/TpeDeclarationStatut.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Statut d'une déclaration TPE (Travail Personnel Étudiant).
+ *
+ * Source de vérité unique pour `esbtp_tpe_declarations.statut` (VARCHAR).
+ * Le statut initial dépend de la Strategy active (AutoValidate / TeacherValidate)
+ * elle-même pilotée par le Setting `tpe.validation.enabled`.
+ *
+ * Cycle de vie :
+ *   - AutoValidate (Option 2)  : VALIDE direct → fin
+ *   - TeacherValidate (Option 3) : EN_ATTENTE → VALIDE | REJETE
+ */
+enum TpeDeclarationStatut: string
+{
+    case VALIDE = 'valide';
+    case EN_ATTENTE = 'en_attente';
+    case REJETE = 'rejete';
+
+    /**
+     * Libellé court affiché dans l'UI (badges, chips, listings).
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::VALIDE => 'Validé',
+            self::EN_ATTENTE => 'En attente',
+            self::REJETE => 'Rejeté',
+        };
+    }
+
+    /**
+     * Classe CSS du badge (cohérente avec premium-redesign.md).
+     *
+     * Couleurs sémantiques autorisées car elles portent un sens fonctionnel
+     * (statut workflow validation, scanné < 1 sec par l'enseignant).
+     */
+    public function badgeClass(): string
+    {
+        return match ($this) {
+            self::VALIDE => 'tj-badge--success',
+            self::EN_ATTENTE => 'tj-badge--warning',
+            self::REJETE => 'tj-badge--danger',
+        };
+    }
+
+    /**
+     * Icône Font Awesome pour les badges.
+     */
+    public function icon(): string
+    {
+        return match ($this) {
+            self::VALIDE => 'fa-check-circle',
+            self::EN_ATTENTE => 'fa-clock',
+            self::REJETE => 'fa-times-circle',
+        };
+    }
+
+    /**
+     * Une déclaration validée ou rejetée est immuable côté étudiant.
+     * Seul EN_ATTENTE est éditable (par l'étudiant) ou en attente d'action prof.
+     */
+    public function isEditableByStudent(): bool
+    {
+        return $this === self::EN_ATTENTE;
+    }
+
+    /**
+     * Une déclaration validée ou rejetée NE peut PLUS être actionnée par le prof.
+     * Seul EN_ATTENTE est encore actionnable (validate / reject).
+     */
+    public function isPendingTeacherAction(): bool
+    {
+        return $this === self::EN_ATTENTE;
+    }
+
+    /**
+     * Liste des valeurs string pour validation (`Rule::in(...)`).
+     *
+     * @return array<int, string>
+     */
+    public static function values(): array
+    {
+        return array_map(fn (self $case) => $case->value, self::cases());
+    }
+}

--- a/app/Http/Controllers/ESBTPTpeDeclarationController.php
+++ b/app/Http/Controllers/ESBTPTpeDeclarationController.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Helpers\SettingsHelper;
+use App\Http\Requests\Tpe\StoreTpeDeclarationRequest;
+use App\Http\Requests\Tpe\UpdateTpeDeclarationRequest;
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPPlanificationAcademique;
+use App\Models\ESBTPTpeDeclaration;
+use App\Services\LMD\Tpe\TpeValidationStrategy;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\View\View;
+
+/**
+ * Journal TPE — vue étudiant.
+ *
+ * L'étudiant déclare ses heures TPE par ECUE et par semaine.
+ * Le statut initial dépend de la TpeValidationStrategy injectée (Option 2 / Option 3).
+ *
+ * Volontairement mince — orchestration seulement (rule no-god-code).
+ */
+class ESBTPTpeDeclarationController extends Controller
+{
+    public function __construct(
+        private readonly TpeValidationStrategy $strategy,
+    ) {}
+
+    /**
+     * Liste les déclarations de l'étudiant courant (année en cours).
+     */
+    public function index(Request $request): View|RedirectResponse
+    {
+        $etudiant = $this->resolveStudent($request);
+        if (! $etudiant instanceof ESBTPEtudiant) {
+            return redirect()->route('dashboard')
+                ->with('error', 'Profil étudiant introuvable.');
+        }
+
+        $classe = $etudiant->classe;
+        $annee = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+
+        $declarations = ESBTPTpeDeclaration::query()
+            ->where('etudiant_id', $etudiant->id)
+            ->when($annee, fn ($q) => $q->where('annee_universitaire_id', $annee->id))
+            ->with(['matiere:id,name,unite_enseignement_id', 'matiere.uniteEnseignement:id,name'])
+            ->orderByDesc('semaine_debut')
+            ->orderBy('matiere_id')
+            ->get();
+
+        $ecues = $this->buildEcuesForClass($classe, $annee);
+        $progress = $this->computeProgress($declarations, $ecues);
+
+        return view('esbtp.tpe-journal.index', [
+            'etudiant' => $etudiant,
+            'classe' => $classe,
+            'annee' => $annee,
+            'declarations' => $declarations,
+            'declarationsParSemaine' => $declarations->groupBy(fn ($d) => optional($d->semaine_debut)->toDateString()),
+            'ecues' => $ecues,
+            'progress' => $progress,
+            'requiresValidation' => $this->strategy->requiresTeacherAction(),
+            'maxHoursPerWeek' => (float) SettingsHelper::get('tpe.max_hours_per_week_per_ecue', 10),
+            'windowWeeks' => (int) SettingsHelper::get('tpe.declaration_window_weeks', 2),
+        ]);
+    }
+
+    /**
+     * Crée une nouvelle déclaration. Le statut est dérivé de la Strategy injectée.
+     */
+    public function store(StoreTpeDeclarationRequest $request): RedirectResponse
+    {
+        $etudiant = $this->resolveStudent($request);
+        if (! $etudiant) {
+            return back()->with('error', 'Profil étudiant introuvable.');
+        }
+
+        try {
+            ESBTPTpeDeclaration::create([
+                'etudiant_id' => $etudiant->id,
+                'matiere_id' => $request->validated('matiere_id'),
+                'annee_universitaire_id' => $request->validated('annee_universitaire_id'),
+                'semaine_debut' => $request->validated('semaine_debut'),
+                'heures' => $request->validated('heures'),
+                'description' => $request->validated('description'),
+                'statut' => $this->strategy->initialStatut()->value,
+                'created_by' => $request->user()?->id,
+                'updated_by' => $request->user()?->id,
+            ]);
+
+            $msg = $this->strategy->requiresTeacherAction()
+                ? 'Déclaration envoyée. En attente de validation par l\'enseignant.'
+                : 'Déclaration enregistrée.';
+
+            return back()->with('success', $msg);
+        } catch (\Illuminate\Database\QueryException $e) {
+            // UNIQUE composite (étudiant × ECUE × semaine × année)
+            if (str_contains($e->getMessage(), 'tpe_decl_unique')) {
+                return back()
+                    ->withInput()
+                    ->with('error', 'Vous avez déjà déclaré pour cette matière et cette semaine. Modifiez la déclaration existante.');
+            }
+            Log::error('TPE store failed', ['error' => $e->getMessage()]);
+            return back()->withInput()->with('error', 'Erreur lors de la création — réessayez.');
+        }
+    }
+
+    /**
+     * Met à jour heures/description (seulement si EN_ATTENTE — voir UpdateRequest::authorize()).
+     */
+    public function update(UpdateTpeDeclarationRequest $request, ESBTPTpeDeclaration $declaration): RedirectResponse
+    {
+        $declaration->update([
+            'heures' => $request->validated('heures'),
+            'description' => $request->validated('description'),
+            'updated_by' => $request->user()?->id,
+        ]);
+
+        return back()->with('success', 'Déclaration mise à jour.');
+    }
+
+    /**
+     * Supprime une déclaration. Autorisé uniquement si pas encore validée.
+     */
+    public function destroy(Request $request, ESBTPTpeDeclaration $declaration): RedirectResponse
+    {
+        $user = $request->user();
+        $isOwner = $declaration->etudiant && $declaration->etudiant->user_id === $user?->id;
+
+        if (! $isOwner || ! $declaration->statut->isEditableByStudent()) {
+            abort(403, 'Cette déclaration ne peut plus être supprimée.');
+        }
+
+        $declaration->delete();
+
+        return back()->with('success', 'Déclaration supprimée.');
+    }
+
+    // ===== Helpers privés (orchestration légère) =====
+
+    private function resolveStudent(Request $request): ?ESBTPEtudiant
+    {
+        return ESBTPEtudiant::query()
+            ->where('user_id', $request->user()?->id)
+            ->first();
+    }
+
+    /**
+     * Liste les ECUEs accessibles à la classe de l'étudiant (source canonique :
+     * esbtp_planifications_academiques — rule klassci-classe-matieres.md).
+     *
+     * @return \Illuminate\Support\Collection<int, ESBTPMatiere>
+     */
+    private function buildEcuesForClass($classe, $annee)
+    {
+        if (! $classe || ! $annee) {
+            return collect();
+        }
+
+        $matiereIds = ESBTPPlanificationAcademique::query()
+            ->where('filiere_id', $classe->filiere_id)
+            ->where('niveau_etude_id', $classe->niveau_etude_id)
+            ->where('annee_universitaire_id', $annee->id)
+            ->where('is_active', true)
+            ->whereNotNull('matiere_id')
+            ->pluck('matiere_id')
+            ->unique();
+
+        if ($matiereIds->isEmpty()) {
+            return collect();
+        }
+
+        return ESBTPMatiere::query()
+            ->whereIn('id', $matiereIds)
+            ->whereNotNull('unite_enseignement_id') // LMD strict : ECUE only
+            ->orderBy('name')
+            ->get(['id', 'name', 'unite_enseignement_id']);
+    }
+
+    /**
+     * Calcule la progression heures déclarées / heures attendues (volume_horaire_tpe planifié).
+     *
+     * @return array{declared_total: float, expected_total: int, pct: float}
+     */
+    private function computeProgress($declarations, $ecues): array
+    {
+        $declaredValide = (float) $declarations
+            ->where('statut.value', \App\Enums\TpeDeclarationStatut::VALIDE->value)
+            ->sum('heures');
+
+        if ($ecues->isEmpty()) {
+            return [
+                'declared_total' => $declaredValide,
+                'expected_total' => 0,
+                'pct' => 0.0,
+            ];
+        }
+
+        $expected = (int) ESBTPPlanificationAcademique::query()
+            ->whereIn('matiere_id', $ecues->pluck('id'))
+            ->where('is_active', true)
+            ->sum('volume_horaire_tpe');
+
+        $pct = $expected > 0 ? min(100.0, round(($declaredValide / $expected) * 100, 1)) : 0.0;
+
+        return [
+            'declared_total' => $declaredValide,
+            'expected_total' => $expected,
+            'pct' => $pct,
+        ];
+    }
+}

--- a/app/Http/Controllers/ESBTPTpeValidationController.php
+++ b/app/Http/Controllers/ESBTPTpeValidationController.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\Tpe\RejectTpeDeclarationRequest;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPPlanificationAcademique;
+use App\Models\ESBTPTpeDeclaration;
+use App\Models\User;
+use App\Notifications\TpeDeclarationStatusChangedNotification;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\View\View;
+
+/**
+ * Validation TPE — vue enseignant.
+ *
+ * DORMANT par défaut : tant que Setting `tpe.validation.enabled = false`,
+ * AutoValidateStrategy marque les déclarations VALIDE direct → aucune
+ * déclaration n'apparaît ici (statut EN_ATTENTE inexistant). C'est attendu.
+ *
+ * Quand `tpe.validation.enabled = true` :
+ *  - Les nouvelles déclarations arrivent EN_ATTENTE
+ *  - Le prof voit la liste filtrée à SES ECUEs (scope `pourEnseignant`)
+ *  - Bouton Valider / Rejeter inline avec modal commentaire
+ */
+class ESBTPTpeValidationController extends Controller
+{
+    /**
+     * Liste les déclarations en_attente filtrées par enseignant principal.
+     */
+    public function index(Request $request): View
+    {
+        $user = $request->user();
+
+        $declarationsEnAttente = ESBTPTpeDeclaration::query()
+            ->enAttente()
+            ->pourEnseignant($user)
+            ->with([
+                'etudiant:id,nom,prenoms,user_id,photo_url',
+                'matiere:id,name,unite_enseignement_id',
+                'matiere.uniteEnseignement:id,name',
+            ])
+            ->orderByDesc('created_at')
+            ->paginate(20)
+            ->withQueryString();
+
+        // KPIs : compteurs cours/semaine/mois pour le hero
+        $kpiBase = ESBTPTpeDeclaration::query()->pourEnseignant($user);
+        $kpis = [
+            'en_attente' => (clone $kpiBase)->enAttente()->count(),
+            'validees_semaine' => (clone $kpiBase)
+                ->valide()
+                ->where('validated_at', '>=', now()->startOfWeek())
+                ->count(),
+            'rejetees_mois' => (clone $kpiBase)
+                ->rejete()
+                ->where('validated_at', '>=', now()->startOfMonth())
+                ->count(),
+        ];
+
+        // Liste des ECUEs dont l'enseignant est responsable (pour filtre éventuel)
+        $myEcueIds = ESBTPPlanificationAcademique::query()
+            ->where('enseignant_principal_id', $user->id)
+            ->where('is_active', true)
+            ->pluck('matiere_id')
+            ->unique();
+
+        $myEcues = ESBTPMatiere::query()
+            ->whereIn('id', $myEcueIds)
+            ->orderBy('name')
+            ->get(['id', 'name']);
+
+        return view('esbtp.tpe-validation.index', [
+            'declarations' => $declarationsEnAttente,
+            'kpis' => $kpis,
+            'myEcues' => $myEcues,
+        ]);
+    }
+
+    /**
+     * Valide une déclaration. Notifie l'étudiant.
+     */
+    public function validate(Request $request, ESBTPTpeDeclaration $declaration): RedirectResponse
+    {
+        $user = $request->user();
+
+        if (! $declaration->canBeValidatedBy($user)) {
+            abort(403, 'Vous ne pouvez pas valider cette déclaration.');
+        }
+
+        $declaration->markValidatedBy($user);
+
+        $this->notifyStudent($declaration);
+
+        return back()->with('success', 'Déclaration validée.');
+    }
+
+    /**
+     * Rejette une déclaration avec commentaire obligatoire. Notifie l'étudiant.
+     */
+    public function reject(RejectTpeDeclarationRequest $request, ESBTPTpeDeclaration $declaration): RedirectResponse
+    {
+        $declaration->markRejectedBy(
+            $request->user(),
+            $request->validated('commentaire_rejet'),
+        );
+
+        $this->notifyStudent($declaration);
+
+        return back()->with('success', 'Déclaration rejetée. L\'étudiant a été notifié.');
+    }
+
+    /**
+     * Notifie l'étudiant du changement de statut (via User attaché au profil étudiant).
+     */
+    private function notifyStudent(ESBTPTpeDeclaration $declaration): void
+    {
+        $declaration->loadMissing('etudiant');
+        $userId = $declaration->etudiant?->user_id;
+        if (! $userId) {
+            return;
+        }
+        $user = User::find($userId);
+        if (! $user) {
+            return;
+        }
+        Notification::send(
+            $user,
+            new TpeDeclarationStatusChangedNotification($declaration->fresh(), $declaration->statut),
+        );
+    }
+}

--- a/app/Http/Requests/Tpe/RejectTpeDeclarationRequest.php
+++ b/app/Http/Requests/Tpe/RejectTpeDeclarationRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Requests\Tpe;
+
+use App\Models\ESBTPTpeDeclaration;
+use Illuminate\Foundation\Http\FormRequest;
+
+class RejectTpeDeclarationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        if (! $user || ! $user->can('tpe.validate')) {
+            return false;
+        }
+
+        /** @var ESBTPTpeDeclaration|null $declaration */
+        $declaration = $this->route('declaration');
+        if (! $declaration instanceof ESBTPTpeDeclaration) {
+            return false;
+        }
+
+        // Ownership : seul l'enseignant principal de l'ECUE peut rejeter
+        // (superAdmin couvert par Gate::before — pas besoin de l'expliciter).
+        return $declaration->canBeValidatedBy($user);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'commentaire_rejet' => 'required|string|min:5|max:500',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'commentaire_rejet.required' => 'Un motif de rejet est obligatoire — l\'étudiant doit savoir comment corriger.',
+            'commentaire_rejet.min' => 'Le motif doit faire au moins 5 caractères.',
+            'commentaire_rejet.max' => 'Le motif est limité à 500 caractères.',
+        ];
+    }
+}

--- a/app/Http/Requests/Tpe/StoreTpeDeclarationRequest.php
+++ b/app/Http/Requests/Tpe/StoreTpeDeclarationRequest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Http\Requests\Tpe;
+
+use App\Helpers\SettingsHelper;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPPlanificationAcademique;
+use Carbon\Carbon;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTpeDeclarationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('tpe.declare') ?? false;
+    }
+
+    /**
+     * Préparation : forcer semaine_debut au lundi ISO de la date envoyée
+     * (déduplication client-side, on évite "mercredi" pour ECUE X de semaine 19).
+     */
+    protected function prepareForValidation(): void
+    {
+        if ($this->filled('semaine_debut')) {
+            try {
+                $date = Carbon::parse($this->input('semaine_debut'));
+                $this->merge([
+                    'semaine_debut' => $date->startOfWeek(Carbon::MONDAY)->format('Y-m-d'),
+                ]);
+            } catch (\Throwable $e) {
+                // Laisse la validation rules() rejeter proprement
+            }
+        }
+    }
+
+    public function rules(): array
+    {
+        $maxHours = (float) SettingsHelper::get('tpe.max_hours_per_week_per_ecue', 10);
+        $windowWeeks = (int) SettingsHelper::get('tpe.declaration_window_weeks', 2);
+        $earliest = Carbon::now()->startOfWeek(Carbon::MONDAY)->subWeeks($windowWeeks)->format('Y-m-d');
+        $latest = Carbon::now()->startOfWeek(Carbon::MONDAY)->format('Y-m-d');
+
+        return [
+            'matiere_id' => [
+                'required',
+                'integer',
+                'exists:esbtp_matieres,id',
+            ],
+            'annee_universitaire_id' => [
+                'required',
+                'integer',
+                'exists:esbtp_annee_universitaires,id',
+            ],
+            'semaine_debut' => [
+                'required',
+                'date_format:Y-m-d',
+                "after_or_equal:{$earliest}",
+                "before_or_equal:{$latest}",
+            ],
+            'heures' => [
+                'required',
+                'numeric',
+                'min:0.25',
+                "max:{$maxHours}",
+            ],
+            'description' => 'nullable|string|max:1000',
+        ];
+    }
+
+    public function messages(): array
+    {
+        $windowWeeks = (int) SettingsHelper::get('tpe.declaration_window_weeks', 2);
+
+        return [
+            'matiere_id.required' => 'Veuillez choisir une matière (ECUE).',
+            'matiere_id.exists' => 'La matière sélectionnée n\'existe pas.',
+            'semaine_debut.required' => 'Veuillez choisir la semaine concernée.',
+            'semaine_debut.after_or_equal' => "Vous ne pouvez déclarer que les {$windowWeeks} dernières semaines.",
+            'semaine_debut.before_or_equal' => 'Vous ne pouvez pas déclarer pour une semaine future.',
+            'heures.required' => 'Le nombre d\'heures est obligatoire.',
+            'heures.min' => 'Saisissez au moins 0,25 heure (15 minutes).',
+            'heures.max' => 'Le plafond hebdomadaire par ECUE est configuré par l\'école.',
+            'description.max' => 'La description est limitée à 1000 caractères.',
+        ];
+    }
+
+    /**
+     * Vérifie après validation que la matière (ECUE) est bien planifiée pour
+     * la classe de l'étudiant courant — anti-bypass via id arbitraire.
+     */
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($v) {
+            /** @var \App\Models\User|null $user */
+            $user = $this->user();
+            $etudiant = ESBTPEtudiant::query()
+                ->where('user_id', $user?->id)
+                ->first();
+
+            if (! $etudiant) {
+                $v->errors()->add('matiere_id', 'Profil étudiant introuvable — contactez la scolarité.');
+                return;
+            }
+
+            $classe = $etudiant->classe; // hasOneThrough via inscription active
+            if (! $classe) {
+                $v->errors()->add('matiere_id', 'Aucune inscription active — déclaration impossible.');
+                return;
+            }
+
+            $planifs = ESBTPPlanificationAcademique::query()
+                ->where('filiere_id', $classe->filiere_id)
+                ->where('niveau_etude_id', $classe->niveau_etude_id)
+                ->where('matiere_id', $this->input('matiere_id'))
+                ->where('annee_universitaire_id', $this->input('annee_universitaire_id'))
+                ->where('is_active', true)
+                ->exists();
+
+            if (! $planifs) {
+                $v->errors()->add(
+                    'matiere_id',
+                    'Cette matière n\'est pas planifiée pour votre classe cette année — choisissez une autre ECUE.'
+                );
+            }
+        });
+    }
+}

--- a/app/Http/Requests/Tpe/UpdateTpeDeclarationRequest.php
+++ b/app/Http/Requests/Tpe/UpdateTpeDeclarationRequest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Requests\Tpe;
+
+use App\Helpers\SettingsHelper;
+use App\Models\ESBTPTpeDeclaration;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateTpeDeclarationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        if (! $user || ! $user->can('tpe.declare')) {
+            return false;
+        }
+
+        /** @var ESBTPTpeDeclaration|null $declaration */
+        $declaration = $this->route('declaration') ?? $this->route('tpe_journal');
+        if (! $declaration instanceof ESBTPTpeDeclaration) {
+            return false;
+        }
+
+        // Ownership : la déclaration appartient à l'étudiant courant
+        $isOwner = $declaration->etudiant
+            && $declaration->etudiant->user_id === $user->id;
+
+        if (! $isOwner) {
+            return false;
+        }
+
+        // L'étudiant ne peut modifier que les déclarations encore actionnables
+        // par lui (statut EN_ATTENTE en mode Option 3 — Option 2 : tout est VALIDE
+        // donc plus modifiable une fois soumis).
+        return $declaration->statut->isEditableByStudent();
+    }
+
+    public function rules(): array
+    {
+        $maxHours = (float) SettingsHelper::get('tpe.max_hours_per_week_per_ecue', 10);
+
+        return [
+            'heures' => [
+                'required',
+                'numeric',
+                'min:0.25',
+                "max:{$maxHours}",
+            ],
+            'description' => 'nullable|string|max:1000',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'heures.required' => 'Le nombre d\'heures est obligatoire.',
+            'heures.min' => 'Saisissez au moins 0,25 heure.',
+            'heures.max' => 'Le plafond hebdomadaire par ECUE est configuré par l\'école.',
+            'description.max' => 'La description est limitée à 1000 caractères.',
+        ];
+    }
+}

--- a/app/Models/ESBTPTpeDeclaration.php
+++ b/app/Models/ESBTPTpeDeclaration.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\TpeDeclarationStatut;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use OwenIt\Auditing\Contracts\Auditable;
+
+/**
+ * TPE — Travail Personnel Étudiant (déclaration auto par étudiant).
+ *
+ * Voir migration `2026_05_16_110104_create_esbtp_tpe_declarations_table.php`
+ * et `App\Services\LMD\Tpe\TpeValidationStrategy` pour le pilotage workflow.
+ */
+class ESBTPTpeDeclaration extends Model implements Auditable
+{
+    use HasFactory;
+    use \OwenIt\Auditing\Auditable;
+
+    protected $table = 'esbtp_tpe_declarations';
+
+    protected $fillable = [
+        'etudiant_id',
+        'matiere_id',
+        'annee_universitaire_id',
+        'semaine_debut',
+        'heures',
+        'description',
+        'statut',
+        'validated_by',
+        'validated_at',
+        'commentaire_rejet',
+        'created_by',
+        'updated_by',
+    ];
+
+    protected $casts = [
+        'semaine_debut' => 'date',
+        'heures' => 'decimal:2',
+        'statut' => TpeDeclarationStatut::class,
+        'validated_at' => 'datetime',
+    ];
+
+    /**
+     * Whitelist d'audit (anti audit-explosion).
+     *
+     * Voir feedback_owen_it_auditable_pattern.md + rule pre-merge-checklist.md
+     * — Auditable obligatoirement assorti d'$auditInclude.
+     */
+    protected $auditInclude = [
+        'heures',
+        'description',
+        'statut',
+        'validated_by',
+        'commentaire_rejet',
+    ];
+
+    // ===== Relations =====
+
+    public function etudiant(): BelongsTo
+    {
+        return $this->belongsTo(ESBTPEtudiant::class, 'etudiant_id');
+    }
+
+    /**
+     * En LMD, matiere = ECUE (esbtp_matieres avec unite_enseignement_id != null).
+     */
+    public function matiere(): BelongsTo
+    {
+        return $this->belongsTo(ESBTPMatiere::class, 'matiere_id');
+    }
+
+    public function anneeUniversitaire(): BelongsTo
+    {
+        return $this->belongsTo(ESBTPAnneeUniversitaire::class, 'annee_universitaire_id');
+    }
+
+    /**
+     * L'enseignant qui a validé/rejeté la déclaration (NULL tant que statut == EN_ATTENTE).
+     */
+    public function validator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'validated_by');
+    }
+
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function updatedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    // ===== Scopes =====
+
+    public function scopeValide($query)
+    {
+        return $query->where('statut', TpeDeclarationStatut::VALIDE->value);
+    }
+
+    public function scopeEnAttente($query)
+    {
+        return $query->where('statut', TpeDeclarationStatut::EN_ATTENTE->value);
+    }
+
+    public function scopeRejete($query)
+    {
+        return $query->where('statut', TpeDeclarationStatut::REJETE->value);
+    }
+
+    /**
+     * Filtre les déclarations dont l'ECUE a un enseignant_principal_id = $user->id
+     * dans esbtp_planifications_academiques.
+     *
+     * Source canonique : rule globale klassci-classe-matieres.md
+     * (matière = ECUE → planification académique par filière/niveau/semestre).
+     */
+    public function scopePourEnseignant($query, User $user)
+    {
+        return $query->whereExists(function ($sub) use ($user) {
+            $sub->select(\DB::raw(1))
+                ->from('esbtp_planifications_academiques as pa')
+                ->whereColumn('pa.matiere_id', 'esbtp_tpe_declarations.matiere_id')
+                ->where('pa.enseignant_principal_id', $user->id)
+                ->where('pa.is_active', true);
+        });
+    }
+
+    // ===== Méthodes métier =====
+
+    /**
+     * Un enseignant peut valider/rejeter une déclaration ssi il est l'enseignant
+     * principal de l'ECUE concerné dans la planification académique active.
+     *
+     * (Le superAdmin passe via Gate::before — pas besoin de l'expliciter ici.)
+     */
+    public function canBeValidatedBy(User $user): bool
+    {
+        if (! $this->statut->isPendingTeacherAction()) {
+            return false;
+        }
+
+        return ESBTPPlanificationAcademique::query()
+            ->where('matiere_id', $this->matiere_id)
+            ->where('enseignant_principal_id', $user->id)
+            ->where('is_active', true)
+            ->exists();
+    }
+
+    public function markValidatedBy(User $user): void
+    {
+        $this->statut = TpeDeclarationStatut::VALIDE;
+        $this->validated_by = $user->id;
+        $this->validated_at = now();
+        $this->commentaire_rejet = null;
+        $this->updated_by = $user->id;
+        $this->save();
+    }
+
+    public function markRejectedBy(User $user, string $commentaire): void
+    {
+        $this->statut = TpeDeclarationStatut::REJETE;
+        $this->validated_by = $user->id;
+        $this->validated_at = now();
+        $this->commentaire_rejet = $commentaire;
+        $this->updated_by = $user->id;
+        $this->save();
+    }
+}

--- a/app/Notifications/TpeDeclarationStatusChangedNotification.php
+++ b/app/Notifications/TpeDeclarationStatusChangedNotification.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Enums\TpeDeclarationStatut;
+use App\Helpers\SettingsHelper;
+use App\Models\ESBTPTpeDeclaration;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Notifie l'étudiant quand sa déclaration TPE passe de EN_ATTENTE à VALIDE
+ * ou REJETE (Option 3 — workflow prof).
+ *
+ * Channels :
+ *  - 'database' (toujours) : badge cloche dans le header
+ *  - 'mail' (opt-in via Setting `tpe.notify_email = true`)
+ */
+class TpeDeclarationStatusChangedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public readonly ESBTPTpeDeclaration $declaration,
+        public readonly TpeDeclarationStatut $newStatut,
+    ) {}
+
+    /**
+     * @return array<int, string>
+     */
+    public function via($notifiable): array
+    {
+        $channels = ['database'];
+        if ((bool) SettingsHelper::get('tpe.notify_email', false)) {
+            $channels[] = 'mail';
+        }
+        return $channels;
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        $matiereNom = $this->declaration->matiere->name ?? 'Matière';
+        $semaine = optional($this->declaration->semaine_debut)->format('d/m/Y') ?? '—';
+        $heures = number_format((float) $this->declaration->heures, 2, ',', ' ');
+
+        $message = (new MailMessage())
+            ->subject(sprintf(
+                '[KLASSCI] Déclaration TPE %s : %s',
+                $this->newStatut->label(),
+                $matiereNom,
+            ))
+            ->greeting('Bonjour ' . ($notifiable->name ?? ''))
+            ->line(sprintf(
+                'Votre déclaration TPE pour **%s** (semaine du %s, %s heures) a été **%s**.',
+                $matiereNom,
+                $semaine,
+                $heures,
+                mb_strtolower($this->newStatut->label(), 'UTF-8'),
+            ));
+
+        if ($this->newStatut === TpeDeclarationStatut::REJETE && $this->declaration->commentaire_rejet) {
+            $message->line('**Motif** : ' . $this->declaration->commentaire_rejet);
+        }
+
+        return $message
+            ->action('Voir mon journal TPE', route('esbtp.tpe-journal.index'))
+            ->line('Vous pouvez consulter le détail et corriger si nécessaire depuis votre journal.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray($notifiable): array
+    {
+        return [
+            'declaration_id' => $this->declaration->id,
+            'matiere_id' => $this->declaration->matiere_id,
+            'matiere_nom' => $this->declaration->matiere->name ?? null,
+            'semaine_debut' => optional($this->declaration->semaine_debut)->toDateString(),
+            'heures' => (float) $this->declaration->heures,
+            'statut' => $this->newStatut->value,
+            'statut_label' => $this->newStatut->label(),
+            'commentaire_rejet' => $this->declaration->commentaire_rejet,
+            'validator_id' => $this->declaration->validated_by,
+            'validated_at' => optional($this->declaration->validated_at)->toIso8601String(),
+            'action_url' => route('esbtp.tpe-journal.index'),
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,6 +26,21 @@ class AppServiceProvider extends ServiceProvider
         // Une seule instance par requête pour qu'AnomalyDetector et le contrôleur
         // analytics partagent le même cache de buckets attendu/encaissé.
         $this->app->scoped(\App\Services\Analytics\RecouvrementGapService::class);
+
+        // TPE — Strategy de validation pilotée par Setting tenant.
+        // Setting `tpe.validation.enabled` = false (defaut) → AutoValidateStrategy (Option 2)
+        // Setting `tpe.validation.enabled` = true            → TeacherValidateStrategy (Option 3)
+        // Opt-in dormant : 100% du code Option 3 est présent mais inactif tant
+        // que l'école ne flip pas le toggle via /esbtp/settings.
+        $this->app->bind(
+            \App\Services\LMD\Tpe\TpeValidationStrategy::class,
+            function ($app) {
+                $enabled = (bool) \App\Helpers\SettingsHelper::get('tpe.validation.enabled', false);
+                return $enabled
+                    ? new \App\Services\LMD\Tpe\TeacherValidateStrategy()
+                    : new \App\Services\LMD\Tpe\AutoValidateStrategy();
+            }
+        );
     }
 
 

--- a/app/Services/LMD/Tpe/AutoValidateStrategy.php
+++ b/app/Services/LMD/Tpe/AutoValidateStrategy.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services\LMD\Tpe;
+
+use App\Enums\TpeDeclarationStatut;
+
+/**
+ * Option 2 — Journal auto-déclaratif sans intervention prof.
+ *
+ * L'étudiant déclare ses heures → elles sont marquées VALIDE immédiatement.
+ * Pas de notification prof, pas d'écran de validation.
+ *
+ * Strategy par défaut (Setting `tpe.validation.enabled = false`).
+ */
+class AutoValidateStrategy implements TpeValidationStrategy
+{
+    public function initialStatut(): TpeDeclarationStatut
+    {
+        return TpeDeclarationStatut::VALIDE;
+    }
+
+    public function requiresTeacherAction(): bool
+    {
+        return false;
+    }
+}

--- a/app/Services/LMD/Tpe/TeacherValidateStrategy.php
+++ b/app/Services/LMD/Tpe/TeacherValidateStrategy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Services\LMD\Tpe;
+
+use App\Enums\TpeDeclarationStatut;
+
+/**
+ * Option 3 — Workflow validation prof activé.
+ *
+ * L'étudiant déclare ses heures → statut EN_ATTENTE.
+ * L'enseignant principal de l'ECUE doit valider ou rejeter via
+ * /esbtp/tpe-validation.
+ *
+ * Strategy activée quand Setting `tpe.validation.enabled = true`.
+ *
+ * IMPORTANT — opt-in dormant : code 100% présent en DB/code mais inactif
+ * tant que l'école ne flip pas le toggle. Aucun risque par défaut, dispo
+ * immédiatement si une école différenciée le demande.
+ */
+class TeacherValidateStrategy implements TpeValidationStrategy
+{
+    public function initialStatut(): TpeDeclarationStatut
+    {
+        return TpeDeclarationStatut::EN_ATTENTE;
+    }
+
+    public function requiresTeacherAction(): bool
+    {
+        return true;
+    }
+}

--- a/app/Services/LMD/Tpe/TpeValidationStrategy.php
+++ b/app/Services/LMD/Tpe/TpeValidationStrategy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services\LMD\Tpe;
+
+use App\Enums\TpeDeclarationStatut;
+
+/**
+ * Strategy de validation des déclarations TPE.
+ *
+ * Pilotée via container binding dans AppServiceProvider, déterminée par
+ * le Setting `tpe.validation.enabled` :
+ *  - false → AutoValidateStrategy (Option 2 : journal seul, valide direct)
+ *  - true  → TeacherValidateStrategy (Option 3 : workflow prof activé)
+ *
+ * Marcel garde `tpe.validation.enabled = false` par défaut pour ne pas
+ * surcharger les profs. L'école l'active via /esbtp/settings sans redeploy.
+ */
+interface TpeValidationStrategy
+{
+    /**
+     * Statut initial à appliquer à une déclaration nouvellement créée.
+     */
+    public function initialStatut(): TpeDeclarationStatut;
+
+    /**
+     * Indique si la Strategy nécessite une action manuelle du prof
+     * (valide / rejete) après création.
+     *
+     * Sert à conditionner les notifications, le rendu UI (badge "en attente"),
+     * et les routes de validation.
+     */
+    public function requiresTeacherAction(): bool;
+}

--- a/config/permissions.php
+++ b/config/permissions.php
@@ -1196,6 +1196,35 @@ return [
             'group' => 'Modules',
             'icon' => 'fa-tools',
         ],
+        'module.tpe.access' => [
+            'label' => 'Module : TPE — Journal & validation (LMD)',
+            'description' => 'Auto-déclaration étudiant des heures de Travail Personnel Étudiant. '
+                . 'Workflow validation prof activable via Setting tpe.validation.enabled.',
+            'group' => 'Modules',
+            'icon' => 'fa-book-reader',
+        ],
+
+        // ===== TPE (Travail Personnel Étudiant — LMD UEMOA) =====
+        'tpe.declare' => [
+            'label' => 'Déclarer ses heures TPE',
+            'description' => 'Permet à un étudiant de saisir des heures TPE par ECUE et par semaine.',
+            'group' => 'TPE',
+            'icon' => 'fa-pen-to-square',
+        ],
+        'tpe.validate' => [
+            'label' => 'Valider les heures TPE des étudiants',
+            'description' => 'Permet à un enseignant de valider/rejeter les déclarations TPE '
+                . 'des étudiants pour les ECUE dont il est responsable. '
+                . 'Workflow activé uniquement quand Setting tpe.validation.enabled = true.',
+            'group' => 'TPE',
+            'icon' => 'fa-check-double',
+        ],
+        'tpe.view_all' => [
+            'label' => 'Voir toutes les déclarations TPE',
+            'description' => 'Vue admin/coordinateur : toutes les déclarations toutes ECUE confondues.',
+            'group' => 'TPE',
+            'icon' => 'fa-list-check',
+        ],
 
         // ===== Service Technique (paywall) =====
         'paywall.configure' => [
@@ -1338,6 +1367,8 @@ return [
             'module.academique.access', 'module.etudiants.access', 'module.enseignants.access',
             'module.notes_evaluations.access', 'module.emploi_temps.access', 'module.presences.access',
             'module.lmd.access', 'module.comptabilite.access', 'module.communication.access',
+            // TPE — admin observe toutes les déclarations (dormant tant que module désactivé)
+            'tpe.view_all',
         ],
 
         'comptable' => [
@@ -1414,6 +1445,8 @@ return [
             'module.academique.access', 'module.etudiants.access', 'module.enseignants.access',
             'module.notes_evaluations.access', 'module.emploi_temps.access', 'module.presences.access',
             'module.lmd.access', 'module.communication.access',
+            // TPE — coordinateur observe toutes les déclarations (dormant)
+            'tpe.view_all',
         ],
 
         'enseignant' => [
@@ -1431,6 +1464,8 @@ return [
             'messages.send', 'messages.receive', 'annonces.view',
             'identity.teach',
             'module.notes_evaluations.access', 'module.presences.access', 'module.communication.access',
+            // TPE — workflow validation (dormant tant que tpe.validation.enabled = false)
+            'tpe.validate',
         ],
 
         'etudiant' => [
@@ -1444,6 +1479,8 @@ return [
             'exams.view_own',
             'messages.receive', 'annonces.view',
             'identity.student',
+            // TPE — déclaration auto (dormant tant que module.tpe.access désactivé)
+            'tpe.declare',
         ],
     ],
 

--- a/database/migrations/2026_05_16_110104_create_esbtp_tpe_declarations_table.php
+++ b/database/migrations/2026_05_16_110104_create_esbtp_tpe_declarations_table.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * TPE — Travail Personnel Étudiant (UEMOA LMD).
+ *
+ * Table d'auto-déclaration des heures TPE par étudiant et par ECUE (matière).
+ *
+ * Options livrées :
+ *  - Option 2 : Journal auto-déclaratif étudiant (statut = 'valide' direct
+ *    via AutoValidateStrategy quand `tpe.validation.enabled = false`)
+ *  - Option 3 : Workflow validation prof (statut = 'en_attente' via
+ *    TeacherValidateStrategy quand `tpe.validation.enabled = true`)
+ *
+ * Le pilotage Option 2 vs Option 3 se fait via Setting tenant
+ * `tpe.validation.enabled` (defaut false → tout est auto-validé).
+ *
+ * Tout le code Option 3 est PRÉSENT mais DORMANT par défaut. L'école active
+ * via `/esbtp/settings` (toggle Setting) sans aucune migration ni redeploy.
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('esbtp_tpe_declarations')) {
+            return; // idempotent
+        }
+
+        Schema::create('esbtp_tpe_declarations', function (Blueprint $table) {
+            $table->id();
+
+            $table->foreignId('etudiant_id')
+                ->constrained('esbtp_etudiants')
+                ->cascadeOnDelete();
+
+            // matiere_id pointe sur l'ECUE (esbtp_matieres avec unite_enseignement_id != null)
+            $table->foreignId('matiere_id')
+                ->constrained('esbtp_matieres')
+                ->cascadeOnDelete();
+
+            $table->foreignId('annee_universitaire_id')
+                ->constrained('esbtp_annee_universitaires');
+
+            // Lundi de la semaine ISO (clé canonique)
+            $table->date('semaine_debut');
+
+            // Heures déclarées (ex: 4.5)
+            $table->decimal('heures', 5, 2);
+
+            // Description optionnelle de ce que l'étudiant a fait
+            $table->text('description')->nullable();
+
+            // Statut : 'valide' | 'en_attente' | 'rejete' — voir App\Enums\TpeDeclarationStatut
+            $table->string('statut', 20)->default('valide');
+
+            // Quand prof valide / rejette
+            $table->foreignId('validated_by')->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->timestamp('validated_at')->nullable();
+
+            // Commentaire de rejet (requis si statut = 'rejete')
+            $table->text('commentaire_rejet')->nullable();
+
+            // Audit utilisateur
+            $table->foreignId('created_by')->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->foreignId('updated_by')->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+
+            $table->timestamps();
+
+            // Une déclaration par étudiant × ECUE × semaine × année
+            // (évite les doublons quand l'étudiant resoumet la même semaine)
+            $table->unique(
+                ['etudiant_id', 'matiere_id', 'semaine_debut', 'annee_universitaire_id'],
+                'tpe_decl_unique'
+            );
+
+            // Index workflow prof : récupère vite les "en_attente" assignées à un prof
+            $table->index(['statut', 'validated_by'], 'tpe_decl_statut_validator_idx');
+
+            // Index étudiant : récupère vite les déclarations d'un étudiant pour une année
+            $table->index(['etudiant_id', 'annee_universitaire_id'], 'tpe_decl_etudiant_annee_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('esbtp_tpe_declarations');
+    }
+};

--- a/resources/views/esbtp/tpe-journal/index.blade.php
+++ b/resources/views/esbtp/tpe-journal/index.blade.php
@@ -1,0 +1,444 @@
+@extends('layouts.app')
+
+@section('title', 'Journal TPE')
+
+@push('styles')
+<style>
+/* ═══════════════════════════════════════════════════════════
+   Journal TPE — Travail Personnel Étudiant (étudiant)
+   Namespace : tj-* (TPE Journal)
+   Palette : monochrome bleu KLASSCI + couleurs sémantiques workflow
+   ═══════════════════════════════════════════════════════════ */
+.tj-page { max-width: 1200px; margin: 0 auto; }
+
+/* Hero — pattern KLASSCI canonique (planning-header) */
+.tj-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 2rem 2.5rem 1.5rem;
+    color: #fff;
+    margin-bottom: 1.25rem;
+    box-shadow: 0 8px 30px rgba(4,83,203,.18);
+}
+.tj-hero-top {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    flex-wrap: wrap; gap: 1rem;
+}
+.tj-hero-left { display: flex; align-items: center; gap: 1rem; }
+.tj-hero-icon {
+    width: 52px; height: 52px; border-radius: 14px;
+    background: rgba(255,255,255,.12);
+    backdrop-filter: blur(8px);
+    border: 1px solid rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.35rem; flex-shrink: 0; color: #fff;
+}
+.tj-hero h1 { font-size: 1.45rem; font-weight: 700; color: #fff; margin: 0; }
+.tj-hero p { color: rgba(255,255,255,.7); font-size: .88rem; margin: 0; }
+
+/* KPIs hero */
+.tj-kpis {
+    display: flex; gap: .75rem; margin-top: 1.5rem; flex-wrap: wrap;
+}
+.tj-kpi {
+    flex: 1; min-width: 160px;
+    background: rgba(255,255,255,.1);
+    border: 1px solid rgba(255,255,255,.15);
+    border-radius: 12px;
+    padding: .9rem 1rem;
+    display: flex; align-items: center; gap: .75rem;
+}
+.tj-kpi-icon {
+    width: 36px; height: 36px; border-radius: 9px;
+    background: rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: .95rem;
+}
+.tj-kpi-value { font-size: 1.35rem; font-weight: 700; color: #fff; line-height: 1.1; }
+.tj-kpi-label { font-size: .72rem; color: rgba(255,255,255,.65); margin-top: .15rem; }
+
+/* Progress bar (heures déclarées vs attendues TPE) */
+.tj-progress-wrap {
+    margin-top: 1.25rem;
+    background: rgba(255,255,255,.12);
+    border-radius: 10px;
+    height: 10px;
+    overflow: hidden;
+    position: relative;
+}
+.tj-progress-bar {
+    height: 100%;
+    border-radius: 10px;
+    transition: width .4s ease;
+}
+.tj-progress-meta {
+    display: flex; justify-content: space-between;
+    margin-top: .5rem;
+    font-size: .78rem;
+    color: rgba(255,255,255,.85);
+}
+
+/* Cards section */
+.tj-card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
+    margin-bottom: 1rem;
+}
+.tj-card-header {
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid #f1f5f9;
+    display: flex; align-items: center; gap: .75rem;
+}
+.tj-card-icon {
+    width: 36px; height: 36px; border-radius: 10px;
+    background: linear-gradient(135deg, #0453cb, #3b7ddb);
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: .9rem;
+}
+.tj-card-title { font-size: 1rem; font-weight: 700; color: #1e293b; margin: 0; }
+.tj-card-subtitle { font-size: .78rem; color: #64748b; margin: 0; }
+.tj-card-body { padding: 1.25rem; }
+
+/* Form saisie */
+.tj-form-grid {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr .8fr;
+    gap: .75rem;
+    margin-bottom: .75rem;
+}
+@@media (max-width: 768px) {
+    .tj-form-grid { grid-template-columns: 1fr; }
+}
+.tj-form-label {
+    display: block; font-size: .75rem; font-weight: 700;
+    color: #64748b; text-transform: uppercase; letter-spacing: .5px;
+    margin-bottom: .4rem;
+}
+.tj-input, .tj-textarea {
+    width: 100%;
+    padding: .65rem .9rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    font-size: .9rem;
+    transition: border-color .15s, box-shadow .15s;
+    background: #fff;
+    color: #1e293b;
+}
+.tj-input:focus, .tj-textarea:focus {
+    outline: none;
+    border-color: #0453cb;
+    box-shadow: 0 0 0 3px rgba(4,83,203,.12);
+}
+.tj-textarea { resize: vertical; min-height: 60px; }
+.tj-btn--primary {
+    background: #0453cb;
+    color: #fff;
+    border: none;
+    padding: .65rem 1.5rem;
+    border-radius: 10px;
+    font-size: .88rem; font-weight: 600;
+    cursor: pointer;
+    transition: background .15s, transform .15s;
+    display: inline-flex; align-items: center; gap: .5rem;
+}
+.tj-btn--primary:hover { background: #033a8e; }
+.tj-btn--ghost {
+    background: transparent;
+    color: #64748b;
+    border: 1px solid #e2e8f0;
+    padding: .4rem .75rem;
+    border-radius: 8px;
+    font-size: .82rem;
+    cursor: pointer;
+    transition: border-color .15s, color .15s;
+}
+.tj-btn--ghost:hover { border-color: #0453cb; color: #0453cb; }
+.tj-btn--danger-ghost {
+    background: transparent;
+    color: #dc2626;
+    border: 1px solid #fecaca;
+    padding: .35rem .65rem;
+    border-radius: 8px;
+    font-size: .78rem;
+    cursor: pointer;
+}
+.tj-btn--danger-ghost:hover { background: #fef2f2; }
+
+/* Liste déclarations groupées par semaine */
+.tj-week-header {
+    display: flex; align-items: center; gap: .5rem;
+    font-size: .85rem; font-weight: 700;
+    color: #033a8e;
+    padding: .5rem 0;
+    margin-top: .5rem;
+    border-bottom: 1px solid #f1f5f9;
+}
+.tj-decl-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto auto;
+    gap: 1rem;
+    align-items: center;
+    padding: .75rem 0;
+    border-bottom: 1px solid #f8fafc;
+}
+.tj-decl-row:last-child { border-bottom: none; }
+.tj-decl-matiere { font-weight: 600; color: #1e293b; font-size: .9rem; }
+.tj-decl-meta { font-size: .75rem; color: #64748b; margin-top: .2rem; }
+.tj-decl-heures {
+    font-weight: 700; color: #0453cb; font-size: .95rem;
+    background: rgba(4,83,203,.06); padding: .2rem .6rem; border-radius: 8px;
+}
+
+/* Badges statuts (sémantiques OK — workflow validation) */
+.tj-badge {
+    display: inline-flex; align-items: center; gap: .35rem;
+    padding: .25rem .55rem;
+    border-radius: 6px;
+    font-size: .7rem; font-weight: 700;
+    text-transform: uppercase; letter-spacing: .4px;
+}
+.tj-badge--success { background: rgba(16,185,129,.10); color: #047857; border: 1px solid rgba(16,185,129,.25); }
+.tj-badge--warning { background: rgba(245,158,11,.10); color: #b45309; border: 1px solid rgba(245,158,11,.30); }
+.tj-badge--danger  { background: rgba(220,38,38,.10);  color: #b91c1c; border: 1px solid rgba(220,38,38,.30); }
+
+.tj-empty {
+    text-align: center; padding: 2rem 1rem;
+    color: #64748b;
+}
+.tj-empty-icon {
+    font-size: 2.2rem; color: #cbd5e1; margin-bottom: .75rem;
+}
+.tj-rejet-note {
+    margin-top: .35rem;
+    padding: .5rem .7rem;
+    background: rgba(220,38,38,.06);
+    border-left: 3px solid #dc2626;
+    border-radius: 6px;
+    font-size: .78rem;
+    color: #7f1d1d;
+}
+
+[x-cloak] { display: none !important; }
+</style>
+@endpush
+
+@section('content')
+<div class="tj-page">
+
+    @if (session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    @if (session('error'))
+        <div class="alert alert-danger">{{ session('error') }}</div>
+    @endif
+
+    {{-- ═══ Hero premium ═══ --}}
+    <div class="tj-hero">
+        <div class="tj-hero-top">
+            <div class="tj-hero-left">
+                <div class="tj-hero-icon"><i class="fas fa-book-reader"></i></div>
+                <div>
+                    <h1>Journal de Travail Personnel</h1>
+                    <p>
+                        @if ($classe)
+                            {{ $classe->name ?? 'Classe' }}
+                            @if ($annee) · {{ $annee->name ?? 'Année en cours' }} @endif
+                        @else
+                            Déclarez vos heures de TPE par matière et par semaine
+                        @endif
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="tj-kpis">
+            <div class="tj-kpi">
+                <div class="tj-kpi-icon"><i class="fas fa-clock"></i></div>
+                <div>
+                    <div class="tj-kpi-value">{{ number_format($progress['declared_total'], 1, ',', ' ') }}h</div>
+                    <div class="tj-kpi-label">Heures déclarées validées</div>
+                </div>
+            </div>
+            <div class="tj-kpi">
+                <div class="tj-kpi-icon"><i class="fas fa-bullseye"></i></div>
+                <div>
+                    <div class="tj-kpi-value">{{ $progress['expected_total'] }}h</div>
+                    <div class="tj-kpi-label">Volume TPE attendu (semestre)</div>
+                </div>
+            </div>
+            <div class="tj-kpi">
+                <div class="tj-kpi-icon"><i class="fas fa-percentage"></i></div>
+                <div>
+                    <div class="tj-kpi-value">{{ rtrim(rtrim(number_format($progress['pct'], 1, ',', ' '), '0'), ',') }}%</div>
+                    <div class="tj-kpi-label">Progression</div>
+                </div>
+            </div>
+            <div class="tj-kpi">
+                <div class="tj-kpi-icon"><i class="fas fa-list-check"></i></div>
+                <div>
+                    <div class="tj-kpi-value">{{ $declarations->count() }}</div>
+                    <div class="tj-kpi-label">Déclarations totales</div>
+                </div>
+            </div>
+        </div>
+
+        @php
+            $pct = $progress['pct'];
+            $color = $pct >= 80 ? '#34d399' : ($pct >= 40 ? '#fbbf24' : '#93c5fd');
+        @endphp
+        <div class="tj-progress-wrap" title="{{ number_format($pct, 1, ',', ' ') }}% des heures TPE déclarées">
+            <div class="tj-progress-bar" style="width: {{ $pct }}%; background: {{ $color }};"></div>
+        </div>
+        <div class="tj-progress-meta">
+            <span>Plafond hebdo / ECUE : {{ rtrim(rtrim(number_format($maxHoursPerWeek, 1, ',', ' '), '0'), ',') }}h</span>
+            <span>Fenêtre déclarative : {{ $windowWeeks }} dernière(s) semaine(s)</span>
+        </div>
+    </div>
+
+    {{-- ═══ Section saisie ═══ --}}
+    @if ($ecues->isEmpty())
+        <div class="tj-card">
+            <div class="tj-card-body tj-empty">
+                <div class="tj-empty-icon"><i class="fas fa-graduation-cap"></i></div>
+                <div><strong>Aucune matière planifiée pour votre classe cette année.</strong></div>
+                <div style="margin-top:.5rem; font-size:.85rem;">Contactez la scolarité.</div>
+            </div>
+        </div>
+    @else
+        <div class="tj-card">
+            <div class="tj-card-header">
+                <div class="tj-card-icon"><i class="fas fa-pen-to-square"></i></div>
+                <div>
+                    <p class="tj-card-title">Déclarer mes heures de la semaine</p>
+                    <p class="tj-card-subtitle">
+                        @if ($requiresValidation)
+                            La déclaration sera <strong>en attente de validation</strong> par l'enseignant.
+                        @else
+                            La déclaration est enregistrée immédiatement.
+                        @endif
+                    </p>
+                </div>
+            </div>
+            <div class="tj-card-body">
+                <form method="POST" action="{{ route('esbtp.tpe-journal.store') }}">
+                    @csrf
+                    <input type="hidden" name="annee_universitaire_id" value="{{ $annee?->id }}">
+
+                    <div class="tj-form-grid">
+                        <div>
+                            <label class="tj-form-label">Matière (ECUE)</label>
+                            <x-au-select
+                                name="matiere_id"
+                                :options="$ecues->pluck('name', 'id')->toArray()"
+                                placeholder="— Choisir une matière —"
+                                icon="fa-book"
+                                :searchable="$ecues->count() > 8" />
+                        </div>
+                        <div>
+                            <label class="tj-form-label">Semaine du lundi</label>
+                            <input type="date" name="semaine_debut" class="tj-input"
+                                   value="{{ now()->startOfWeek()->format('Y-m-d') }}"
+                                   max="{{ now()->startOfWeek()->format('Y-m-d') }}"
+                                   min="{{ now()->startOfWeek()->subWeeks($windowWeeks)->format('Y-m-d') }}"
+                                   required>
+                        </div>
+                        <div>
+                            <label class="tj-form-label">Heures effectuées</label>
+                            <input type="number" name="heures" class="tj-input"
+                                   step="0.25" min="0.25" max="{{ $maxHoursPerWeek }}"
+                                   placeholder="Ex: 4.5" required>
+                        </div>
+                    </div>
+
+                    <div style="margin-bottom: .75rem;">
+                        <label class="tj-form-label">Description (optionnel) — décrivez ce que vous avez fait</label>
+                        <textarea name="description" class="tj-textarea" maxlength="1000"
+                                  placeholder="Ex: Lecture du chapitre 3, exercices p.42..."></textarea>
+                    </div>
+
+                    <button type="submit" class="tj-btn--primary">
+                        <i class="fas fa-plus"></i>Enregistrer la déclaration
+                    </button>
+                </form>
+
+                @if ($errors->any())
+                    <div style="margin-top: 1rem; padding: .65rem .85rem; background: rgba(220,38,38,.08); border-left: 3px solid #dc2626; border-radius: 6px;">
+                        @foreach ($errors->all() as $err)
+                            <div style="font-size: .82rem; color: #b91c1c;">{{ $err }}</div>
+                        @endforeach
+                    </div>
+                @endif
+            </div>
+        </div>
+    @endif
+
+    {{-- ═══ Historique déclarations ═══ --}}
+    <div class="tj-card">
+        <div class="tj-card-header">
+            <div class="tj-card-icon"><i class="fas fa-clock-rotate-left"></i></div>
+            <div>
+                <p class="tj-card-title">Mes déclarations</p>
+                <p class="tj-card-subtitle">Groupées par semaine, plus récentes en premier</p>
+            </div>
+        </div>
+        <div class="tj-card-body">
+            @if ($declarationsParSemaine->isEmpty())
+                <div class="tj-empty">
+                    <div class="tj-empty-icon"><i class="fas fa-inbox"></i></div>
+                    <div>Aucune déclaration pour le moment.</div>
+                    <div style="margin-top: .5rem; font-size: .85rem;">Saisissez votre première déclaration ci-dessus.</div>
+                </div>
+            @else
+                @foreach ($declarationsParSemaine as $semaineDebut => $declsBucket)
+                    @php
+                        $semaineLabel = $semaineDebut
+                            ? \Carbon\Carbon::parse($semaineDebut)->isoFormat('[Semaine du] D MMMM YYYY')
+                            : 'Semaine inconnue';
+                    @endphp
+                    <div class="tj-week-header">
+                        <i class="fas fa-calendar-week"></i>
+                        <span>{{ $semaineLabel }}</span>
+                    </div>
+                    @foreach ($declsBucket as $decl)
+                        <div class="tj-decl-row">
+                            <div>
+                                <div class="tj-decl-matiere">{{ $decl->matiere->name ?? 'Matière supprimée' }}</div>
+                                @if ($decl->matiere && $decl->matiere->uniteEnseignement)
+                                    <div class="tj-decl-meta">{{ $decl->matiere->uniteEnseignement->name }}</div>
+                                @endif
+                                @if ($decl->description)
+                                    <div class="tj-decl-meta">{{ \Illuminate\Support\Str::limit($decl->description, 160) }}</div>
+                                @endif
+                                @if ($decl->statut->value === \App\Enums\TpeDeclarationStatut::REJETE->value && $decl->commentaire_rejet)
+                                    <div class="tj-rejet-note">
+                                        <strong>Motif du rejet :</strong> {{ $decl->commentaire_rejet }}
+                                    </div>
+                                @endif
+                            </div>
+                            <div class="tj-decl-heures">{{ number_format((float) $decl->heures, 2, ',', ' ') }}h</div>
+                            <span class="tj-badge {{ $decl->statut->badgeClass() }}">
+                                <i class="fas {{ $decl->statut->icon() }}"></i>
+                                {{ $decl->statut->label() }}
+                            </span>
+                            <div>
+                                @if ($decl->statut->isEditableByStudent())
+                                    <form method="POST" action="{{ route('esbtp.tpe-journal.destroy', $decl) }}" style="display:inline;"
+                                          onsubmit="return confirm('Supprimer cette déclaration ?');">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit" class="tj-btn--danger-ghost" title="Supprimer">
+                                            <i class="fas fa-trash"></i>
+                                        </button>
+                                    </form>
+                                @endif
+                            </div>
+                        </div>
+                    @endforeach
+                @endforeach
+            @endif
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/esbtp/tpe-validation/index.blade.php
+++ b/resources/views/esbtp/tpe-validation/index.blade.php
@@ -1,0 +1,335 @@
+@extends('layouts.app')
+
+@section('title', 'Validation TPE')
+
+@push('styles')
+<style>
+/* ═══════════════════════════════════════════════════════════
+   Validation TPE — vue enseignant
+   Namespace : tv-* (TPE Validation)
+   ═══════════════════════════════════════════════════════════ */
+.tv-page { max-width: 1200px; margin: 0 auto; }
+
+.tv-hero {
+    background: linear-gradient(135deg, #0a3d8f 0%, #0453cb 40%, #3b7ddb 100%);
+    border-radius: 18px;
+    padding: 2rem 2.5rem 1.5rem;
+    color: #fff;
+    margin-bottom: 1.25rem;
+    box-shadow: 0 8px 30px rgba(4,83,203,.18);
+}
+.tv-hero-top {
+    display: flex; align-items: flex-start; justify-content: space-between;
+    flex-wrap: wrap; gap: 1rem;
+}
+.tv-hero-left { display: flex; align-items: center; gap: 1rem; }
+.tv-hero-icon {
+    width: 52px; height: 52px; border-radius: 14px;
+    background: rgba(255,255,255,.12); backdrop-filter: blur(8px);
+    border: 1px solid rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.35rem; flex-shrink: 0; color: #fff;
+}
+.tv-hero h1 { font-size: 1.45rem; font-weight: 700; color: #fff; margin: 0; }
+.tv-hero p { color: rgba(255,255,255,.7); font-size: .88rem; margin: 0; }
+
+.tv-kpis {
+    display: flex; gap: .75rem; margin-top: 1.5rem; flex-wrap: wrap;
+}
+.tv-kpi {
+    flex: 1; min-width: 160px;
+    background: rgba(255,255,255,.1);
+    border: 1px solid rgba(255,255,255,.15);
+    border-radius: 12px;
+    padding: .9rem 1rem;
+    display: flex; align-items: center; gap: .75rem;
+}
+.tv-kpi-icon {
+    width: 36px; height: 36px; border-radius: 9px;
+    background: rgba(255,255,255,.15);
+    display: flex; align-items: center; justify-content: center;
+    color: #fff; font-size: .95rem;
+}
+.tv-kpi-value { font-size: 1.35rem; font-weight: 700; color: #fff; line-height: 1.1; }
+.tv-kpi-label { font-size: .72rem; color: rgba(255,255,255,.65); margin-top: .15rem; }
+
+.tv-card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    box-shadow: 0 1px 3px rgba(15,23,42,.04), 0 1px 2px rgba(15,23,42,.06);
+}
+.tv-card-header {
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid #f1f5f9;
+    display: flex; align-items: center; gap: .75rem;
+}
+.tv-card-icon {
+    width: 36px; height: 36px; border-radius: 10px;
+    background: linear-gradient(135deg, #0453cb, #3b7ddb);
+    display: flex; align-items: center; justify-content: center;
+    color: #fff;
+}
+.tv-card-title { font-size: 1rem; font-weight: 700; color: #1e293b; margin: 0; }
+.tv-card-subtitle { font-size: .78rem; color: #64748b; margin: 0; }
+
+.tv-decl-row {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr auto auto;
+    gap: 1rem;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid #f8fafc;
+}
+.tv-decl-row:last-child { border-bottom: none; }
+.tv-decl-etudiant {
+    display: flex; align-items: center; gap: .65rem;
+}
+.tv-avatar {
+    width: 36px; height: 36px; border-radius: 50%;
+    background: linear-gradient(135deg, #0453cb, #3b7ddb);
+    color: #fff;
+    display: flex; align-items: center; justify-content: center;
+    font-weight: 700;
+    font-size: .85rem;
+    flex-shrink: 0;
+}
+.tv-decl-name { font-weight: 600; color: #1e293b; font-size: .9rem; }
+.tv-decl-meta { font-size: .75rem; color: #64748b; margin-top: .15rem; }
+.tv-decl-heures {
+    font-weight: 700; color: #0453cb; font-size: 1.05rem;
+    background: rgba(4,83,203,.06); padding: .35rem .7rem; border-radius: 8px;
+    display: inline-block;
+}
+
+.tv-actions { display: flex; gap: .5rem; }
+.tv-btn--validate {
+    background: #10b981; color: #fff; border: none;
+    padding: .45rem .85rem; border-radius: 8px;
+    font-size: .82rem; font-weight: 600;
+    cursor: pointer; transition: background .15s;
+    display: inline-flex; align-items: center; gap: .4rem;
+}
+.tv-btn--validate:hover { background: #047857; }
+.tv-btn--reject {
+    background: transparent; color: #dc2626; border: 1px solid #fecaca;
+    padding: .45rem .85rem; border-radius: 8px;
+    font-size: .82rem; font-weight: 600;
+    cursor: pointer; transition: background .15s;
+    display: inline-flex; align-items: center; gap: .4rem;
+}
+.tv-btn--reject:hover { background: #fef2f2; }
+
+.tv-empty {
+    text-align: center; padding: 3rem 1rem; color: #64748b;
+}
+.tv-empty-icon {
+    font-size: 2.4rem; color: #cbd5e1; margin-bottom: .75rem;
+}
+
+/* Reject modal */
+.tv-modal-bg {
+    position: fixed; inset: 0; background: rgba(15,23,42,.55);
+    z-index: 1050; display: flex; align-items: center; justify-content: center;
+}
+.tv-modal {
+    background: #fff; border-radius: 14px;
+    box-shadow: 0 8px 30px rgba(15,23,42,.18);
+    max-width: 500px; width: 90%;
+    overflow: hidden;
+}
+.tv-modal-header {
+    padding: 1rem 1.25rem;
+    background: linear-gradient(135deg, #b91c1c, #dc2626);
+    color: #fff;
+    display: flex; align-items: center; gap: .65rem;
+}
+.tv-modal-body { padding: 1.25rem; }
+.tv-modal-footer {
+    padding: .85rem 1.25rem;
+    background: #f8fafc;
+    border-top: 1px solid #f1f5f9;
+    display: flex; justify-content: flex-end; gap: .5rem;
+}
+.tv-input {
+    width: 100%; padding: .65rem .9rem;
+    border: 1px solid #e2e8f0; border-radius: 10px;
+    font-size: .9rem; resize: vertical; min-height: 90px;
+}
+.tv-input:focus {
+    outline: none; border-color: #dc2626;
+    box-shadow: 0 0 0 3px rgba(220,38,38,.12);
+}
+
+[x-cloak] { display: none !important; }
+</style>
+@endpush
+
+@section('content')
+<div class="tv-page" x-data="{
+    showReject: false,
+    rejectId: null,
+    rejectAction: '',
+    openReject(id, action) { this.showReject = true; this.rejectId = id; this.rejectAction = action; }
+}">
+
+    @if (session('success'))
+        <div class="alert alert-success">{{ session('success') }}</div>
+    @endif
+    @if (session('error'))
+        <div class="alert alert-danger">{{ session('error') }}</div>
+    @endif
+
+    {{-- ═══ Hero ═══ --}}
+    <div class="tv-hero">
+        <div class="tv-hero-top">
+            <div class="tv-hero-left">
+                <div class="tv-hero-icon"><i class="fas fa-check-double"></i></div>
+                <div>
+                    <h1>Validation TPE</h1>
+                    <p>Validez les heures de Travail Personnel déclarées par vos étudiants</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="tv-kpis">
+            <div class="tv-kpi">
+                <div class="tv-kpi-icon"><i class="fas fa-clock"></i></div>
+                <div>
+                    <div class="tv-kpi-value">{{ $kpis['en_attente'] }}</div>
+                    <div class="tv-kpi-label">En attente de validation</div>
+                </div>
+            </div>
+            <div class="tv-kpi">
+                <div class="tv-kpi-icon"><i class="fas fa-check-circle"></i></div>
+                <div>
+                    <div class="tv-kpi-value">{{ $kpis['validees_semaine'] }}</div>
+                    <div class="tv-kpi-label">Validées cette semaine</div>
+                </div>
+            </div>
+            <div class="tv-kpi">
+                <div class="tv-kpi-icon"><i class="fas fa-times-circle"></i></div>
+                <div>
+                    <div class="tv-kpi-value">{{ $kpis['rejetees_mois'] }}</div>
+                    <div class="tv-kpi-label">Rejetées ce mois</div>
+                </div>
+            </div>
+            <div class="tv-kpi">
+                <div class="tv-kpi-icon"><i class="fas fa-book"></i></div>
+                <div>
+                    <div class="tv-kpi-value">{{ $myEcues->count() }}</div>
+                    <div class="tv-kpi-label">Mes ECUEs</div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- ═══ Liste déclarations en attente ═══ --}}
+    <div class="tv-card">
+        <div class="tv-card-header">
+            <div class="tv-card-icon"><i class="fas fa-list-check"></i></div>
+            <div>
+                <p class="tv-card-title">Déclarations en attente</p>
+                <p class="tv-card-subtitle">
+                    Triées par date de soumission, plus récentes en premier
+                </p>
+            </div>
+        </div>
+
+        @if ($declarations->isEmpty())
+            <div class="tv-empty">
+                <div class="tv-empty-icon"><i class="fas fa-circle-check"></i></div>
+                <div><strong>Aucune déclaration en attente.</strong></div>
+                <div style="margin-top: .5rem; font-size: .85rem;">
+                    Tout est à jour. Les nouvelles déclarations apparaîtront ici.
+                </div>
+            </div>
+        @else
+            @foreach ($declarations as $decl)
+                @php
+                    $initial = mb_strtoupper(mb_substr($decl->etudiant->prenoms ?? $decl->etudiant->nom ?? '?', 0, 1, 'UTF-8'), 'UTF-8');
+                    $nomComplet = trim(($decl->etudiant->prenoms ?? '') . ' ' . ($decl->etudiant->nom ?? '')) ?: 'Étudiant inconnu';
+                    $semaine = optional($decl->semaine_debut)->isoFormat('D MMM YYYY');
+                @endphp
+                <div class="tv-decl-row">
+                    <div class="tv-decl-etudiant">
+                        <div class="tv-avatar">{{ $initial }}</div>
+                        <div>
+                            <div class="tv-decl-name">{{ $nomComplet }}</div>
+                            <div class="tv-decl-meta">
+                                {{ $decl->matiere->name ?? 'Matière supprimée' }}
+                                @if ($decl->matiere && $decl->matiere->uniteEnseignement)
+                                    · {{ $decl->matiere->uniteEnseignement->name }}
+                                @endif
+                            </div>
+                            @if ($decl->description)
+                                <div class="tv-decl-meta" style="margin-top:.35rem; max-width: 480px;">
+                                    <em>{{ \Illuminate\Support\Str::limit($decl->description, 200) }}</em>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+                    <div>
+                        <div class="tv-decl-meta">Semaine du</div>
+                        <div style="font-weight: 600; color: #1e293b; font-size: .88rem;">{{ $semaine ?: '—' }}</div>
+                    </div>
+                    <div class="tv-decl-heures">
+                        {{ number_format((float) $decl->heures, 2, ',', ' ') }}h
+                    </div>
+                    <div class="tv-actions">
+                        <form method="POST" action="{{ route('esbtp.tpe-validation.validate', $decl) }}" style="display:inline;">
+                            @csrf
+                            @method('PATCH')
+                            <button type="submit" class="tv-btn--validate" title="Valider">
+                                <i class="fas fa-check"></i>Valider
+                            </button>
+                        </form>
+                        <button type="button" class="tv-btn--reject"
+                                @click="openReject({{ $decl->id }}, '{{ route('esbtp.tpe-validation.reject', $decl) }}')"
+                                title="Rejeter">
+                            <i class="fas fa-times"></i>Rejeter
+                        </button>
+                    </div>
+                </div>
+            @endforeach
+
+            @if (method_exists($declarations, 'links'))
+                <div style="padding: 1rem 1.25rem;">
+                    {{ $declarations->links() }}
+                </div>
+            @endif
+        @endif
+    </div>
+
+    {{-- ═══ Modal rejet (Alpine) ═══ --}}
+    <template x-if="showReject">
+        <div class="tv-modal-bg" @click.self="showReject = false" x-cloak>
+            <form method="POST" :action="rejectAction" class="tv-modal" @keydown.escape.window="showReject = false">
+                @csrf
+                @method('PATCH')
+                <div class="tv-modal-header">
+                    <i class="fas fa-exclamation-triangle"></i>
+                    <strong>Rejeter la déclaration</strong>
+                </div>
+                <div class="tv-modal-body">
+                    <label class="tj-form-label" style="font-size:.75rem; font-weight:700; color:#64748b; text-transform:uppercase; letter-spacing:.5px; display:block; margin-bottom:.4rem;">
+                        Motif du rejet (5-500 caractères)
+                    </label>
+                    <textarea name="commentaire_rejet" class="tv-input" minlength="5" maxlength="500"
+                              placeholder="Ex: Heures déclarées trop élevées par rapport au volume attendu, manque de détail dans la description..."
+                              required></textarea>
+                    <div style="margin-top:.65rem; font-size:.78rem; color:#64748b;">
+                        L'étudiant recevra ce motif par notification.
+                    </div>
+                </div>
+                <div class="tv-modal-footer">
+                    <button type="button" class="tj-btn--ghost" @click="showReject = false">Annuler</button>
+                    <button type="submit" class="tv-btn--reject" style="font-size:.85rem;">
+                        <i class="fas fa-times"></i>Confirmer le rejet
+                    </button>
+                </div>
+            </form>
+        </div>
+    </template>
+</div>
+@endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1768,6 +1768,26 @@
                     @endcan
                     @endcan
 
+                    {{-- TPE — Travail Personnel Etudiant (LMD UEMOA) --}}
+                    @can('module.tpe.access')
+                        @can('tpe.declare')
+                            <div class="menu-item">
+                                <a href="{{ route('esbtp.tpe-journal.index') }}" class="menu-link {{ Request::routeIs('esbtp.tpe-journal.*') ? 'active' : '' }}">
+                                    <div class="menu-icon"><i class="fas fa-book-reader"></i></div>
+                                    <div class="menu-text">Mon journal TPE</div>
+                                </a>
+                            </div>
+                        @endcan
+                        @can('tpe.validate')
+                            <div class="menu-item">
+                                <a href="{{ route('esbtp.tpe-validation.index') }}" class="menu-link {{ Request::routeIs('esbtp.tpe-validation.*') ? 'active' : '' }}">
+                                    <div class="menu-icon"><i class="fas fa-check-double"></i></div>
+                                    <div class="menu-text">Valider les heures TPE</div>
+                                </a>
+                            </div>
+                        @endcan
+                    @endcan
+
                     <!-- Administration Section -->
                     @can('personnel.view')
                         <div class="menu-category">Administration</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2515,3 +2515,36 @@ Route::middleware(['auth', 'paywall', 'permission:messages.send'])->prefix('mess
         ->middleware('throttle:30,1')
         ->name('share.paiement');
 });
+
+// ============================================================
+// Routes TPE — Travail Personnel Étudiant (LMD UEMOA)
+// Options 2 (journal étudiant) + 3 (workflow validation prof opt-in)
+// ============================================================
+Route::middleware(['auth', 'permission:module.tpe.access'])->group(function () {
+
+    // --- Journal étudiant (Option 2 — toujours actif si module enabled) ---
+    Route::middleware(['permission:tpe.declare', 'throttle:60,1'])->group(function () {
+        Route::get('esbtp/tpe-journal', [\App\Http\Controllers\ESBTPTpeDeclarationController::class, 'index'])
+            ->name('esbtp.tpe-journal.index');
+        Route::post('esbtp/tpe-journal', [\App\Http\Controllers\ESBTPTpeDeclarationController::class, 'store'])
+            ->name('esbtp.tpe-journal.store');
+        Route::put('esbtp/tpe-journal/{declaration}', [\App\Http\Controllers\ESBTPTpeDeclarationController::class, 'update'])
+            ->whereNumber('declaration')
+            ->name('esbtp.tpe-journal.update');
+        Route::delete('esbtp/tpe-journal/{declaration}', [\App\Http\Controllers\ESBTPTpeDeclarationController::class, 'destroy'])
+            ->whereNumber('declaration')
+            ->name('esbtp.tpe-journal.destroy');
+    });
+
+    // --- Validation enseignant (Option 3 — dormant tant que Setting tpe.validation.enabled = false) ---
+    Route::middleware(['permission:tpe.validate', 'throttle:30,1'])->group(function () {
+        Route::get('esbtp/tpe-validation', [\App\Http\Controllers\ESBTPTpeValidationController::class, 'index'])
+            ->name('esbtp.tpe-validation.index');
+        Route::patch('esbtp/tpe-validation/{declaration}/validate', [\App\Http\Controllers\ESBTPTpeValidationController::class, 'validate'])
+            ->whereNumber('declaration')
+            ->name('esbtp.tpe-validation.validate');
+        Route::patch('esbtp/tpe-validation/{declaration}/reject', [\App\Http\Controllers\ESBTPTpeValidationController::class, 'reject'])
+            ->whereNumber('declaration')
+            ->name('esbtp.tpe-validation.reject');
+    });
+});

--- a/tests/Unit/Enums/TpeDeclarationStatutTest.php
+++ b/tests/Unit/Enums/TpeDeclarationStatutTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\TpeDeclarationStatut;
+use PHPUnit\Framework\TestCase;
+
+class TpeDeclarationStatutTest extends TestCase
+{
+    public function test_exposes_three_workflow_states(): void
+    {
+        $values = TpeDeclarationStatut::values();
+
+        $this->assertCount(3, $values);
+        $this->assertContains('valide', $values);
+        $this->assertContains('en_attente', $values);
+        $this->assertContains('rejete', $values);
+    }
+
+    public function test_try_from_recognizes_all_canonical_values(): void
+    {
+        foreach (['valide', 'en_attente', 'rejete'] as $value) {
+            $this->assertInstanceOf(
+                TpeDeclarationStatut::class,
+                TpeDeclarationStatut::tryFrom($value),
+                "Statut '{$value}' devrait être reconnu",
+            );
+        }
+    }
+
+    public function test_try_from_returns_null_for_unknown_value(): void
+    {
+        $this->assertNull(TpeDeclarationStatut::tryFrom('inconnu'));
+        $this->assertNull(TpeDeclarationStatut::tryFrom(''));
+        $this->assertNull(TpeDeclarationStatut::tryFrom('VALIDE'));   // pas de casse mixte
+        $this->assertNull(TpeDeclarationStatut::tryFrom('en attente')); // espace pas underscore
+    }
+
+    public function test_label_is_french_humanized(): void
+    {
+        $this->assertSame('Validé', TpeDeclarationStatut::VALIDE->label());
+        $this->assertSame('En attente', TpeDeclarationStatut::EN_ATTENTE->label());
+        $this->assertSame('Rejeté', TpeDeclarationStatut::REJETE->label());
+    }
+
+    public function test_badge_class_returns_premium_semantic_classes(): void
+    {
+        $this->assertSame('tj-badge--success', TpeDeclarationStatut::VALIDE->badgeClass());
+        $this->assertSame('tj-badge--warning', TpeDeclarationStatut::EN_ATTENTE->badgeClass());
+        $this->assertSame('tj-badge--danger', TpeDeclarationStatut::REJETE->badgeClass());
+    }
+
+    public function test_icon_returns_fontawesome_class(): void
+    {
+        foreach (TpeDeclarationStatut::cases() as $case) {
+            $this->assertStringStartsWith('fa-', $case->icon(),
+                "L'icône doit être une classe Font Awesome (préfixe fa-) pour {$case->value}");
+        }
+    }
+
+    public function test_is_editable_by_student_only_when_en_attente(): void
+    {
+        $this->assertFalse(TpeDeclarationStatut::VALIDE->isEditableByStudent());
+        $this->assertTrue(TpeDeclarationStatut::EN_ATTENTE->isEditableByStudent());
+        $this->assertFalse(TpeDeclarationStatut::REJETE->isEditableByStudent());
+    }
+
+    public function test_is_pending_teacher_action_only_when_en_attente(): void
+    {
+        $this->assertFalse(TpeDeclarationStatut::VALIDE->isPendingTeacherAction());
+        $this->assertTrue(TpeDeclarationStatut::EN_ATTENTE->isPendingTeacherAction());
+        $this->assertFalse(TpeDeclarationStatut::REJETE->isPendingTeacherAction());
+    }
+
+    public function test_values_match_db_column_string_storage(): void
+    {
+        // Les valeurs sont stockées en string snake_case dans la DB (cf migration).
+        // Tout drift ici casserait les enregistrements existants en prod.
+        $values = TpeDeclarationStatut::values();
+        foreach ($values as $value) {
+            $this->assertMatchesRegularExpression(
+                '/^[a-z_]+$/',
+                $value,
+                "Statut '{$value}' doit être en snake_case ASCII pour matcher la colonne DB",
+            );
+        }
+    }
+}

--- a/tests/Unit/Services/LMD/Tpe/AutoValidateStrategyTest.php
+++ b/tests/Unit/Services/LMD/Tpe/AutoValidateStrategyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit\Services\LMD\Tpe;
+
+use App\Enums\TpeDeclarationStatut;
+use App\Services\LMD\Tpe\AutoValidateStrategy;
+use App\Services\LMD\Tpe\TpeValidationStrategy;
+use PHPUnit\Framework\TestCase;
+
+class AutoValidateStrategyTest extends TestCase
+{
+    public function test_initial_statut_is_valide(): void
+    {
+        $strategy = new AutoValidateStrategy();
+
+        $this->assertSame(
+            TpeDeclarationStatut::VALIDE,
+            $strategy->initialStatut(),
+            'Option 2 doit créer une déclaration directement VALIDE (pas de workflow prof)',
+        );
+    }
+
+    public function test_does_not_require_teacher_action(): void
+    {
+        $strategy = new AutoValidateStrategy();
+
+        $this->assertFalse(
+            $strategy->requiresTeacherAction(),
+            'Option 2 ne sollicite jamais l\'enseignant — pas de notification, pas d\'écran de validation',
+        );
+    }
+
+    public function test_implements_strategy_contract(): void
+    {
+        $this->assertInstanceOf(
+            TpeValidationStrategy::class,
+            new AutoValidateStrategy(),
+            'AutoValidateStrategy doit implémenter le contrat pour être bindable dans le container',
+        );
+    }
+}

--- a/tests/Unit/Services/LMD/Tpe/TeacherValidateStrategyTest.php
+++ b/tests/Unit/Services/LMD/Tpe/TeacherValidateStrategyTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Services\LMD\Tpe;
+
+use App\Enums\TpeDeclarationStatut;
+use App\Services\LMD\Tpe\TeacherValidateStrategy;
+use App\Services\LMD\Tpe\TpeValidationStrategy;
+use PHPUnit\Framework\TestCase;
+
+class TeacherValidateStrategyTest extends TestCase
+{
+    public function test_initial_statut_is_en_attente(): void
+    {
+        $strategy = new TeacherValidateStrategy();
+
+        $this->assertSame(
+            TpeDeclarationStatut::EN_ATTENTE,
+            $strategy->initialStatut(),
+            'Option 3 doit créer une déclaration EN_ATTENTE pour ouvrir le workflow prof',
+        );
+    }
+
+    public function test_requires_teacher_action(): void
+    {
+        $strategy = new TeacherValidateStrategy();
+
+        $this->assertTrue(
+            $strategy->requiresTeacherAction(),
+            'Option 3 requiert validation/rejet par l\'enseignant principal de l\'ECUE',
+        );
+    }
+
+    public function test_implements_strategy_contract(): void
+    {
+        $this->assertInstanceOf(
+            TpeValidationStrategy::class,
+            new TeacherValidateStrategy(),
+            'TeacherValidateStrategy doit implémenter le contrat pour être bindable dans le container',
+        );
+    }
+
+    public function test_initial_statut_is_pending_teacher_action(): void
+    {
+        $strategy = new TeacherValidateStrategy();
+
+        // Sanity check : le statut initial DOIT être actionnable côté prof
+        // (sinon le workflow Option 3 serait cassé d'entrée — déclaration créée
+        //  mais aucun bouton Valider/Rejeter ne s'afficherait).
+        $this->assertTrue(
+            $strategy->initialStatut()->isPendingTeacherAction(),
+            'Le statut initial Option 3 doit être actionnable par le prof',
+        );
+    }
+}


### PR DESCRIPTION
## Résumé

Livraison du **CHANTIER B = TPE Options 2+3** : auto-déclaration étudiant des heures de Travail Personnel + workflow validation prof, avec Strategy pattern et Setting opt-in.

**Stratégie clé — opt-in dormant** : 100% du code Option 3 (workflow prof) est livré en DB/code mais **inactif par défaut** via `Setting tpe.validation.enabled = false`. Aucun risque par défaut, dispo immédiatement si une école KLASSCI Élite veut la différenciation. Bascule Option 2 ↔ Option 3 sans redéploiement.

## What is in the box

### Schéma DB
- `esbtp_tpe_declarations` (idempotent) — UNIQUE composite étudiant × ECUE × semaine × année + 2 index workflow

### Code (5 commits atomiques)
1. **Migration + Model Auditable + Enum** — `ESBTPTpeDeclaration` (whitelist `$auditInclude`), `TpeDeclarationStatut` (VALIDE / EN_ATTENTE / REJETE)
2. **Strategy pattern + permissions** — `TpeValidationStrategy` interface + 2 implementations, container binding lit `Setting tpe.validation.enabled`, 4 permissions registry (`module.tpe.access`, `tpe.declare`, `tpe.validate`, `tpe.view_all`)
3. **Controllers + FormRequests + Notification + Routes** — `ESBTPTpeDeclarationController` (étudiant, < 200 LOC), `ESBTPTpeValidationController` (prof, < 200 LOC), 3 FormRequests avec validation cross-ref ECUE/classe + ownership, `TpeDeclarationStatusChangedNotification` (database + mail opt-in)
4. **Vues premium** — Namespace `tj-*` (étudiant) avec hero + 4 KPIs + progress bar sémantique + saisie inline + historique par semaine, namespace `tv-*` (prof) avec hero + KPIs + liste actions + modal rejet Alpine
5. **Tests Unit + sidebar + CHANGELOG** — 14 tests sans DB (extends PHPUnit\Framework\TestCase), 2 entrées sidebar gated par permissions

### Settings TPE (tenant, via `/esbtp/settings`)

| Setting | Default | Description |
|---|---|---|
| `tpe.module.enabled` | `false` | Active le module global |
| `tpe.validation.enabled` | `false` | **Option 3** (workflow prof activé) |
| `tpe.max_hours_per_week_per_ecue` | `10` | Plafond hebdo / ECUE |
| `tpe.declaration_window_weeks` | `2` | Fenêtre rétroactive |
| `tpe.notify_email` | `false` | Email opt-in (sinon DB only) |

## Architecture — Strategy injection flow

```mermaid
flowchart LR
    A[POST /esbtp/tpe-journal] --> B[ESBTPTpeDeclarationController::store]
    B --> C{Setting tpe.validation.enabled?}
    C -->|false| D[AutoValidateStrategy]
    C -->|true| E[TeacherValidateStrategy]
    D --> F[statut = VALIDE]
    E --> G[statut = EN_ATTENTE]
    F --> H[Création DB]
    G --> H
    G --> I[Prof voit dans /esbtp/tpe-validation]
    I --> J{Validate / Reject}
    J -->|validate| K[markValidatedBy]
    J -->|reject + commentaire| L[markRejectedBy]
    K --> M[Notification statut VALIDE]
    L --> N[Notification statut REJETE + motif]
    M --> O[Étudiant voit badge mis a jour]
    N --> O
```

## Test plan utilisateur (Marcel sur ephrata)

### Étape 1 — Activer le module (admin)
- `klassci permissions:fix ephrata` puis aller dans `/esbtp/custom-roles` ou `/esbtp/roles-permissions`
- Activer la permission `module.tpe.access` pour les rôles `etudiant`, `enseignant`, `superAdmin`
- Aller dans `/esbtp/settings` → onglet TPE → flip `tpe.module.enabled = true`

### Étape 2 — Tester Option 2 (auto-validation, défaut)
- Login en tant qu'étudiant LMD
- Sidebar : "Mon journal TPE" visible
- Aller sur `/esbtp/tpe-journal`
- Choisir une ECUE planifiée, semaine = lundi courant, heures = 4.5, description
- Soumettre → la déclaration apparaît immédiatement avec badge **vert "Validé"**
- KPIs progress bar mis à jour

### Étape 3 — Activer Option 3 (workflow prof)
- Login admin → `/esbtp/settings` → flip `tpe.validation.enabled = true`
- Login en tant qu'étudiant → nouvelle déclaration → badge **orange "En attente"**
- Login en tant qu'enseignant (qui doit être `enseignant_principal_id` d'au moins une ECUE planifiée)
- Sidebar : "Valider les heures TPE" visible
- Aller sur `/esbtp/tpe-validation` → la déclaration de l'étudiant apparaît
- Cliquer **Valider** → l'étudiant reçoit notification + voit son badge passer vert
- OU cliquer **Rejeter** → modal commentaire → soumettre → l'étudiant reçoit notification + voit son badge rouge + motif inline

### Étape 4 — Vérifier les garde-fous
- Étudiant tente de déclarer matière hors planning de sa classe → 422 + message clair
- Étudiant tente d'éditer une déclaration validée → 403
- Enseignant non-responsable tente de valider → 403
- Étudiant tente de déclarer > plafond → 422 avec message setting

## Audit 4-axes self-review

| Axe | Verdict | Détail |
|---|---|---|
| **Architecture** | PASS | Strategy pattern + container binding (OCP respecté, ajout d'une 3e Strategy = 0 modif controller). Controllers minces (≤ 200 LOC). Source canonique matières via `ESBTPPlanificationAcademique`. |
| **Qualité vs Speed** | WARN | 14 tests Unit livrés (Strategy + Enum). **Tests Feature deferé** (DB nécessaire — incompatible worktree sparse). À ajouter en gap-fill si bug observé. Validation cross-réf ECUE/classe couverte par FormRequest. |
| **Production-grade** | PASS | Throttle (60/30 par min), ownership étudiant + enseignant, audit whitelist, transaction implicite via `save()`, idempotent migration, multi-tenant safe (Setting tenant + branches). |
| **SOLID** | PASS | Liskov : les 2 Strategies respectent le contrat. ISP : interface minimaliste (2 méthodes). DIP : controller dépend de l'abstraction injectée. Pas de god-class. |

## Warnings et post-merge actions (Marcel)

1. **`php bin/deploy/fix_permissions.php`** à exécuter sur chaque tenant après merge pour synchroniser les 4 nouvelles permissions (`module.tpe.access`, `tpe.declare`, `tpe.validate`, `tpe.view_all`).
2. **Migration `2026_05_16_110104_create_esbtp_tpe_declarations_table`** à `klassci migrate <tenant>` par tenant cible.
3. **Settings TPE** à créer via `/esbtp/settings` (ou `Setting::set('tpe.module.enabled', false, 'tpe')` au tinker initial). UI Settings devrait les détecter via leur préfixe `tpe.` une fois en DB.
4. **Tests Feature deferé** — pas de DB dans le worktree sparse. À ajouter dans une PR de suivi : test happy path Option 2 (status = VALIDE direct) + test Option 3 transitions (EN_ATTENTE → VALIDE / REJETE).
5. **Doctrine PHP 8.2 bug** — connu sur certains setups locaux : tests qui touchent DB peuvent échouer même avec worktree complet. Tests Unit isolés sont OK.

## Rules respectées (checklist)

- `no-god-code` : Controllers < 200 LOC, Services minimalistes, tests séparés par fichier
- `premium-redesign` : monochrome bleu, namespace `tj-*`/`tv-*`, hero canonique, sémantiques workflow autorisées (badges statut)
- `premium-selects` : `<x-au-select>` utilisé pour le picker ECUE
- `customizable-roles` : aucun rôle nouveau, permissions configurables via `/esbtp/custom-roles`
- `klassci-classe-matieres` : `ESBTPPlanificationAcademique` source canonique
- `blade-pitfalls` : audit `<x-` dans commentaires (0 occurrence), pairs `@if/@endif` équilibrés, `@@media` escaped
- `multi-agent-git-safety` cmd 13 : push branche + `gh pr create` (pas de merge depuis worktree)
- `pre-merge-checklist` : Test Unit Strategy + Enum livrés, visual-check par Marcel pre-merge
- `marcel-global-preferences` : pas de Co-Authored-By, `git add` explicite par fichier
- `migrations.md` : timestamp `2026_05_16_110104` format Laravel valide

## Commits

```
a71b1cfa feat(tpe): tests Unit Strategy + Enum + sidebar gating + CHANGELOG
91578afb feat(tpe): vues premium etudiant (tj-*) + prof (tv-*)
8b024ce7 feat(tpe): controllers etudiant + prof + FormRequests + Notification + routes
eb5dc497 feat(tpe): Strategy pattern AutoValidate / TeacherValidate + permissions registry
843cb4f9 feat(tpe): migration esbtp_tpe_declarations + Model Auditable + Enum statut
```
