### PR TITLE
fix(routing): 404 sur /esbtp/attendances/justifications + /esbtp/mes-absences

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -69,6 +69,18 @@ class Handler extends ExceptionHandler
                     'message' => 'Vous n\'avez pas la permission d\'effectuer cette action.',
                 ], 403);
             }
+
+            // Guests (non-authenticated) hitting a role/permission gate should be
+            // redirected to /login rather than receiving a confusing 403/404.
+            // Spatie throws UnauthorizedException::notLoggedIn() before auth() check,
+            // which without this branch falls through to parent::render() and can
+            // surface as 404 depending on edge caching / fallback route resolution.
+            if (! auth()->check()) {
+                return redirect()->guest(route('login'));
+            }
+
+            // Authenticated but missing the required role/permission → 403 page.
+            return response()->view('errors.403', ['exception' => $e], 403);
         }
 
         if ($e instanceof CoefficientMissingException) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -839,7 +839,8 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
                     ->middleware(['permission:attendances.justify_process', 'throttle:30,1']);
 
                 // Admin: list of pending justifications to process
-                Route::get('/justifications', [ESBTPAttendanceController::class, 'adminProcessing'])
+                // Path: /esbtp/attendances/justifications (under the esbtp prefix group)
+                Route::get('/attendances/justifications', [ESBTPAttendanceController::class, 'adminProcessing'])
                     ->name('justifications.admin')
                     ->middleware('permission:attendances.justify_process');
             });


### PR DESCRIPTION
## Bugs reproduits par Marcel sur presentation.klassci.com

### Bug 1 — /esbtp/attendances/justifications 404 (Marcel connecte superAdmin)

**Cause** : la route etait declaree dans le groupe `Route::name('attendances.')->group(...)` (routes/web.php:766) qui ajoute UNIQUEMENT un prefix de **name**, pas un prefix de **path**.

Le parent au-dessus est `Route::prefix('esbtp')->name('esbtp.')->group(...)` (ligne 293), donc la route `/justifications` (ligne 842) etait montee sur :

- **Path effectif** : `/esbtp/justifications` (incoherent avec les autres routes du controleur qui sont sur `/esbtp/attendances/*`)
- **Name** : `esbtp.attendances.justifications.admin` (OK, matche la sidebar)

La sidebar appelle `route('esbtp.attendances.justifications.admin')` donc le lien menait au bon endroit MAIS quand Marcel tape `/esbtp/attendances/justifications` manuellement (ce que l'URL devrait etre par convention), il prend 404.

**Fix** : changer le path en `/attendances/justifications` pour qu'il soit monte sur `/esbtp/attendances/justifications` (commit `b83dd4b4`).

### Bug 2 — /esbtp/mes-absences 404 (Marcel deconnecte, attendu 302)

**Cause** : la route `/esbtp/mes-absences` est dans le groupe `Route::middleware(['auth', 'role:etudiant'])->group(...)` (ligne 1227). Spatie `RoleMiddleware::handle()` throws `UnauthorizedException::notLoggedIn()` AVANT le check `auth()->guest()`.

Dans `Handler::render()`, le branch `if (\$e instanceof UnauthorizedException)` traitait UNIQUEMENT le cas AJAX (403 JSON). Pour les requetes non-AJAX, ca tombait dans `parent::render()` qui peut surfacer en 404 selon le cache edge (Varnish/fastestcache sur presentation).

**Fix** : intercepter `UnauthorizedException` dans `Handler::render()` :
- AJAX : 403 JSON (inchange)
- Guest non-auth : `redirect()->guest(route('login'))` => 302 vers /login
- Auth mais perm refusee : page `errors.403` premium (commit `42241997`)

## Test plan

Apres merge + deploiement :

- [ ] Marcel connecte superAdmin : `/esbtp/attendances/justifications` => 200 page admin processing
- [ ] Marcel deconnecte : `/esbtp/mes-absences` => 302 redirect `/login`
- [ ] Marcel deconnecte : `curl -sI 'https://presentation.klassci.com/esbtp/mes-absences'` => HTTP/1.1 302 (pas 404)
- [ ] Sidebar (Marcel admin) clic 'Justifications a traiter' => meme cible, page rendu OK

## Warnings

- **Cache edge Varnish/fastestcache** : presentation a `fastestcache` + `Edge-Cache-Engine: varnish`. Apres merge il faut purger le cache edge cote infra (sinon le 404 cache reste). Le cache-buster `?v=2` n'a pas suffit donc c'est un cache full-URL.
- **Route cache Laravel** : sur le serveur tenant, faire `php artisan route:clear && view:clear && config:clear` apres `klassci pull presentation`. `klassci cache:clear` est suppose le faire mais a verifier.

## Files

- `app/Exceptions/Handler.php` (+12 lignes) — fix Bug 2
- `routes/web.php` (+1 / -1) — fix Bug 1