### PR TITLE
feat(security): Phase B — auth hardening + leaks (audit 2026-05-21)

### DIFF
--- a/app/Http/Controllers/API/CLI/CLIUserController.php
+++ b/app/Http/Controllers/API/CLI/CLIUserController.php
@@ -211,6 +211,30 @@ class CLIUserController extends BaseApiController
             return $this->errorResponse("User #{$id} not found", [], 404);
         }
 
+        // Guard target = superAdmin/serviceTechnique (audit sécurité 2026-05-21).
+        // Avant ce fix : un token cli:admin volé pouvait reset le mot de passe
+        // d'un superAdmin et compromettre tout le tenant. Seul un superAdmin
+        // (via son propre token) peut désormais reset un compte privilégié.
+        $caller = $request->user();
+        $targetIsPrivileged = $user->hasAnyRole(['superAdmin', 'serviceTechnique']);
+        $callerIsSuperAdmin = $caller->hasRole('superAdmin');
+
+        if ($targetIsPrivileged && !$callerIsSuperAdmin) {
+            Log::warning('CLI: reset-password DENIED on privileged target', [
+                'target_user_id' => $user->id,
+                'target_roles' => $user->getRoleNames()->toArray(),
+                'caller_user_id' => $caller->id,
+                'caller_roles' => $caller->getRoleNames()->toArray(),
+                'ip' => $request->ip(),
+            ]);
+
+            return $this->errorResponse(
+                'Cannot reset password of a privileged user (superAdmin or serviceTechnique) without superAdmin caller.',
+                [],
+                403
+            );
+        }
+
         $validated = $request->validate(['password' => 'required|string|min:8']);
 
         $user->update([
@@ -219,7 +243,16 @@ class CLIUserController extends BaseApiController
             'password_changed_at'  => now(),
         ]);
 
-        Log::info('CLI: password reset', ['user_id' => $user->id, 'by' => $request->user()->id]);
+        // Audit log enrichi pour traçabilité forensique (les tokens du target
+        // sont automatiquement révoqués par User::booted, voir audit Phase B1).
+        Log::info('CLI: password reset', [
+            'target_user_id' => $user->id,
+            'target_roles' => $user->getRoleNames()->toArray(),
+            'caller_user_id' => $caller->id,
+            'caller_roles' => $caller->getRoleNames()->toArray(),
+            'ip' => $request->ip(),
+            'user_agent' => $request->userAgent(),
+        ]);
 
         return $this->successResponse(
             ['name' => $user->name, 'email' => $user->email, 'username' => $user->username],

--- a/app/Http/Controllers/AdminProfileController.php
+++ b/app/Http/Controllers/AdminProfileController.php
@@ -40,10 +40,12 @@ class AdminProfileController extends Controller
      */
     public function update(Request $request)
     {
+        // Logs minimaux pour traçabilité — JAMAIS de $request->all() qui leak
+        // name/email/phone/address en plain log (audit sécurité 2026-05-21).
         \Log::info('Début de la mise à jour du profil admin', [
             'user_id' => auth()->id(),
             'has_file' => $request->hasFile('profile_photo'),
-            'all_data' => $request->all()
+            'fields_provided' => array_keys($request->except(['_token', 'password', 'password_confirmation', 'profile_photo'])),
         ]);
 
         try {
@@ -137,19 +139,22 @@ class AdminProfileController extends Controller
 
             return redirect()->back()->with('success', 'Profil mis à jour avec succès');
         } catch (\Exception $e) {
+            // Trace seulement en local — éviter leak chemin/structure en prod.
             \Log::error('Erreur lors de la mise à jour du profil', [
+                'user_id' => auth()->id(),
                 'error' => $e->getMessage(),
-                'trace' => config('app.debug') ? $e->getTraceAsString() : null
+                'trace' => app()->environment('local') ? $e->getTraceAsString() : null,
             ]);
-            
+
             // Pour les requêtes AJAX, renvoyer une erreur JSON
+            // (jamais $e->getMessage() en prod — peut leak du contexte technique)
             if ($request->ajax()) {
                 return response()->json([
                     'success' => false,
                     'message' => 'Une erreur est survenue lors de la mise à jour du profil'
                 ], 500);
             }
-            
+
             return redirect()->back()->with('error', 'Une erreur est survenue lors de la mise à jour du profil');
         }
     }

--- a/app/Http/Controllers/InstallController.php
+++ b/app/Http/Controllers/InstallController.php
@@ -112,14 +112,17 @@ class InstallController extends Controller
                 // Clear config cache and regenerate config cache
                 Artisan::call('config:clear');
                 
-                // Store database configuration in session to ensure it's available
+                // Store database configuration in session to ensure it's available.
+                // Note (audit sécurité 2026-05-21) : db_password retiré de la session.
+                // Le mot de passe est déjà persisté dans .env via updateEnvironmentFile()
+                // ci-dessus, inutile de le stocker en plus dans le session file (driver
+                // file = lisible si compromission FS).
                 session([
                     'db_configured' => true,
                     'db_host' => $request->host,
                     'db_port' => $request->port,
                     'db_database' => $request->database,
                     'db_username' => $request->username,
-                    'db_password' => $request->password,
                 ]);
                 
                 // Debug information
@@ -140,12 +143,18 @@ class InstallController extends Controller
                 'message' => $connection['message']
             ], 422);
         } catch (Exception $e) {
-            // Debug information
-            \Log::error('Database connection failed: ' . $e->getMessage());
-            
+            // Log détaillé uniquement en local — pas exposer le contenu d'erreur DB
+            // au client en prod (peut révéler version MySQL, structure, etc.).
+            \Log::error('Database connection failed', [
+                'error' => app()->environment('local') ? $e->getMessage() : 'redacted',
+            ]);
+
             return response()->json([
                 'status' => 'error',
-                'message' => 'Database connection failed: ' . $e->getMessage()
+                // Pas de $e->getMessage() en prod — détail de l'erreur DB seulement en local.
+                'message' => app()->environment('local')
+                    ? 'Database connection failed: ' . $e->getMessage()
+                    : 'Database connection failed. Verify the credentials and host reachability.',
             ], 422);
         }
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -128,6 +128,31 @@ class User extends Authenticatable implements Auditable
         }
     }
 
+    /**
+     * Hook Eloquent : révoque TOUS les tokens Sanctum quand le password change
+     * (audit sécurité 2026-05-21).
+     *
+     * Pourquoi : un token Sanctum volé survivait au changement de mot de passe.
+     * Avec cette révocation, dès qu'un user (ou un admin pour lui) change son
+     * password, tous les tokens existants sont invalidés et il faut s'en
+     * générer de nouveaux.
+     *
+     * Impact pratique :
+     *   - Auth web (session) : pas d'impact (la session reste valide).
+     *   - klassci-cli (Sanctum token) : le user devra régénérer un token via
+     *     `php artisan klassci:create-token` après reset.
+     */
+    protected static function booted(): void
+    {
+        static::updated(function (User $user) {
+            if ($user->wasChanged('password')) {
+                // tokens() est défini par HasApiTokens (Laravel\Sanctum).
+                // Ne touche pas aux sessions HTTP — uniquement aux PAT.
+                $user->tokens()->delete();
+            }
+        });
+    }
+
     public function getFullNameAttribute()
     {
         return "{$this->first_name} {$this->last_name}";

--- a/config/session.php
+++ b/config/session.php
@@ -44,9 +44,15 @@ return [
     | should be encrypted before it is stored. All encryption will be run
     | automatically by Laravel and you can use the Session like normal.
     |
+    | KLASSCI : activé suite à audit 2026-05-21 — la session contient des
+    | générés (generated_password / account_info) lors de la création de
+    | comptes étudiants. Sans chiffrement, le driver file stocke ces données
+    | en plain text dans storage/framework/sessions/.
+    | Override via SESSION_ENCRYPT=false dans .env si besoin (déconseillé prod).
+    |
     */
 
-    'encrypt' => false,
+    'encrypt' => env('SESSION_ENCRYPT', true),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase B du chantier sécurité — stack sur Phase A (#403). Si #403 mergée d'abord, je rebaserai cette PR sur \`presentation\`.

5 fixes ciblés auth/session/leaks. Aucun changement métier visible. Aucune migration DB.

## Fixes inclus

| # | Finding | Sévérité | Fix |
|---|---------|----------|-----|
| 1 | Token Sanctum survit au reset password | HIGH | \`User::booted\` hook → \`tokens()->delete()\` si \`wasChanged('password')\` |
| 2 | CLI reset-password sans guard cible privilégiée | CRITICAL | Refus si target ∈ {superAdmin, serviceTechnique} et caller ≠ superAdmin |
| 3 | \`AdminProfileController\` log \`\$request->all()\` (PII) | MEDIUM | \`fields_provided\` (clés seules) + trace local-only + message générique prod |
| 4 | \`InstallController\` db_password en session + stack traces JSON | MEDIUM | Password retiré session + erreur redacted en prod |
| 5 | Sessions non chiffrées (driver file = plain text) | MEDIUM | \`encrypt => env('SESSION_ENCRYPT', true)\` |

## Test plan

- [ ] Connexion superAdmin > changement de mot de passe > vérifier que tokens CLI existants sont révoqués (table personal_access_tokens vide pour ce user)
- [ ] CLI reset-password sur cible \"comptable\" avec token cli:admin d'un \"secretaire\" → 200 OK (autorisé)
- [ ] CLI reset-password sur cible \"superAdmin\" avec token cli:admin d'un \"secretaire\" → 403 + log warning
- [ ] CLI reset-password sur cible \"superAdmin\" avec token cli:admin d'un autre superAdmin → 200 OK
- [ ] \`storage/framework/sessions/*\` : ouvrir un fichier session → contenu chiffré (illisible plain text)
- [ ] Tester /admin/profile : photo upload + nom/email modifiables, aucun crash, logs ne contiennent plus PII
- [ ] InstallController : Phase A bloque déjà l'accès en prod, donc ces fixes sont défense en profondeur

## Déploiement

Identique à PR #403 : après merge sur \`presentation\` (puis sur #403 mergée), cross-branch push aux tenants + klassci pull + cache:clear.

⚠️ **Important** : la révocation auto des tokens sur password change va **invalider tous les tokens CLI existants** pour tout user qui change son MDP après déploiement. Communiquer la procédure de régénération via \`php artisan klassci:create-token\`.

## Audit 4 axes

| Axe | Verdict |
|-----|---------|
| Architecture | PASS — hooks Eloquent natifs, pas de god-code |
| Qualité vs Vitesse | PASS — commentaires explicites de l'audit + raison |
| Production-grade | PASS — pas de breaking change autre que documenté (CLI tokens) |
| SOLID | PASS — single responsibility par fix |

## Encore à traiter (Phase D ou suivante)

- CSRF cleanup \`esbtp/api/*\` — audit AJAX d'abord
- Policies authorize() : couverture étendue (god controllers ~3-10 calls sur 2000+ LOC)
- File upload UUID filename + storage privé (ESBTPEtudiantController:2454)
- IDOR Bulletin/Inscription/Paiement spécifiques (à coupler avec split god-code)