### PR TITLE
fix(install): redirect to login/dashboard instead of 404 when installed

### DIFF
--- a/app/Http/Middleware/BlockInstallIfReady.php
+++ b/app/Http/Middleware/BlockInstallIfReady.php
@@ -5,22 +5,32 @@ namespace App\Http\Middleware;
 use App\Helpers\InstallationHelper;
 use Closure;
 use Illuminate\Http\Request;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Illuminate\Support\Facades\Auth;
 
 class BlockInstallIfReady
 {
     /**
-     * Retourne 404 si l'application est déjà installée (superAdmin présent + DB OK + APP_INSTALLED=true).
+     * Bloque l'accès aux routes /install/* quand l'app est déjà installée
+     * (superAdmin présent + DB OK + APP_INSTALLED=true).
      *
      * Sans ce middleware, un attaquant peut POST sur /install/database et réécrire le .env
-     * (host/user/password DB) puis prendre le contrôle total du tenant.
+     * (host/user/password DB) puis prendre le contrôle total du tenant. Audit 2026-05-21.
      *
-     * Voir audit sécurité 2026-05-21 — finding CRITICAL #1.
+     * Comportement (normal Laravel) :
+     *   - User authentifié → redirect vers /dashboard
+     *   - User anonyme    → redirect vers /login
+     *
+     * Pour un NOUVEAU tenant (DB vide, pas de superAdmin, pas d'APP_INSTALLED dans .env),
+     * isInstalled() retourne false et le flow install passe normalement (database →
+     * migration → admin → finalize).
      */
     public function handle(Request $request, Closure $next)
     {
         if (InstallationHelper::isInstalled()) {
-            throw new NotFoundHttpException();
+            if (Auth::check()) {
+                return redirect()->route('dashboard');
+            }
+            return redirect()->route('login');
         }
 
         return $next($request);


### PR DESCRIPTION
## Summary

Suite au feedback de Marcel sur PR #403 — au lieu de retourner 404 sur /install/* quand le tenant est déjà installé, redirige vers login (anonyme) ou dashboard (authentifié). Comportement Laravel normal.

## Avant / Après

| Scénario | Avant (#403) | Après (cette PR) |
|---|---|---|
| Nouveau tenant, /install/* | ✅ flow passe (DB vide → setup) | ✅ flow passe (inchangé) |
| Tenant installé, anonyme, /install/* | 404 | 302 → /login |
| Tenant installé, authentifié, /install/* | 404 | 302 → /dashboard |

La protection sécurité est préservée : un attaquant ne peut toujours pas hit `POST /install/database` sur un tenant en prod — la requête est redirigée AVANT que le controller ne réécrive le `.env`.

## Test plan

- [ ] presentation : `curl -sI https://presentation.klassci.com/install` → 302 vers /login
- [ ] Login sur presentation puis visiter /install → 302 vers /dashboard
- [ ] Tenant fresh (local-test ?) : /install/database accessible (flow install passe)