### PR TITLE
fix: hotfix LMD picker ECUE + collapse Suivi + warning parcours + boutons enseignants

### DIFF
--- a/resources/views/components/emploi-temps/planification-section.blade.php
+++ b/resources/views/components/emploi-temps/planification-section.blade.php
@@ -1,7 +1,8 @@
-@props(['planificationData' => null, 'emploiTemps'])
+@props(['planificationData' => null, 'emploiTemps', 'open' => true])
 
 @once
 <style>
+    [x-cloak] { display: none !important; }
     .epl-card {
         background: #fff;
         border: 1px solid #e2e8f0;
@@ -11,13 +12,18 @@
     }
     .epl-header {
         padding: 1rem 1.25rem;
-        border-bottom: 1px solid #e2e8f0;
+        border-bottom: 1px solid transparent;
         display: flex;
         align-items: center;
         justify-content: space-between;
         flex-wrap: wrap;
         gap: .5rem;
+        cursor: pointer;
+        user-select: none;
+        transition: background .15s ease;
     }
+    .epl-header:hover { background: #f8fafc; }
+    .epl-header--open { border-bottom-color: #e2e8f0; }
     .epl-header-title {
         display: flex;
         align-items: center;
@@ -25,6 +31,18 @@
         color: #0f172a;
         font-weight: 700;
         font-size: .92rem;
+    }
+    .epl-caret {
+        margin-left: .5rem;
+        color: #94a3b8;
+        font-size: .75rem;
+        transition: transform .2s ease;
+        width: 14px;
+        text-align: center;
+    }
+    .epl-caret--open {
+        transform: rotate(90deg);
+        color: #0453cb;
     }
     .epl-header-title i {
         width: 28px;
@@ -203,11 +221,12 @@
 </style>
 @endonce
 
-<div class="epl-card">
-    <div class="epl-header">
+<div class="epl-card" x-data="{ open: @json((bool) $open) }">
+    <div class="epl-header" :class="open ? 'epl-header--open' : ''" @click="open = !open" role="button" tabindex="0" :aria-expanded="open ? 'true' : 'false'" @keydown.enter.prevent="open = !open" @keydown.space.prevent="open = !open">
         <div class="epl-header-title">
             <i class="fas fa-calendar-check"></i>
             Suivi par matière
+            <i class="fas fa-chevron-right epl-caret" :class="open ? 'epl-caret--open' : ''"></i>
         </div>
 
         @if(isset($planificationData['planifications_configurees']) && $planificationData['planifications_configurees'])
@@ -224,7 +243,7 @@
         @endif
     </div>
 
-    <div class="epl-body">
+    <div class="epl-body" x-show="open" x-cloak x-transition.opacity>
         @if(empty($planificationData) || empty($planificationData['planifications_configurees']))
             <div class="epl-empty">
                 <div class="epl-empty-icon">

--- a/resources/views/components/sce-ecue-picker.blade.php
+++ b/resources/views/components/sce-ecue-picker.blade.php
@@ -1,0 +1,352 @@
+@props([
+    'name' => 'matiere_id',
+    'id' => null,
+    'value' => null,
+    'matieres' => null,
+    'required' => false,
+    'placeholder' => 'Rechercher une ECUE…',
+    'onchangeJs' => null,
+])
+@php
+    // Default id = name so legacy JS document.getElementById('matiere_id') keeps working
+    $nativeId = $id ?? $name;
+@endphp
+
+@php
+    use App\Enums\TypeUE;
+    // Groupement par UE → données pour Alpine
+    $groups = collect($matieres ?? [])
+        ->map(function ($entry) {
+            $m = $entry['matiere'];
+            $ue = $m->uniteEnseignement ?? null;
+            $heuresRestantes = $entry['heures_restantes_formatted'] ?? ($entry['heures_restantes'] ?? 0);
+            $volumeTotal = $entry['volume_horaire_total_formatted'] ?? ($entry['volume_horaire_total'] ?? 0);
+            return [
+                'id' => (int) $m->id,
+                'code' => (string) ($m->code ?? ''),
+                'name' => (string) $m->name,
+                'ue_id' => $ue?->id ? (int) $ue->id : 0,
+                'ue_code' => (string) ($ue->code ?? ''),
+                'ue_name' => (string) ($ue->name ?? 'Hors UE'),
+                'ue_type' => $ue && $ue->type_ue ? ($ue->type_ue->label() ?? 'UE') : 'UE',
+                'heures_restantes' => (string) $heuresRestantes,
+                'volume_total' => (string) $volumeTotal,
+                'enseignants' => ($entry['enseignants_selectables'] ?? collect())->pluck('id')->values()->all(),
+                'planification_id' => $entry['planification_id'] ?? null,
+                'heures_restantes_raw' => (float) ($entry['heures_restantes'] ?? 0),
+                'volume_total_raw' => (float) ($entry['volume_horaire_total'] ?? 0),
+            ];
+        })
+        ->groupBy(fn ($item) => sprintf('%d|%s|%s', $item['ue_id'], $item['ue_type'], $item['ue_code'] ?: $item['ue_name']))
+        ->map(function ($items, $key) {
+            $first = $items->first();
+            return [
+                'ue_id' => $first['ue_id'],
+                'ue_label' => trim(sprintf('%s · %s', $first['ue_type'], $first['ue_code'] ?: $first['ue_name'])),
+                'ue_subtitle' => $first['ue_code'] && $first['ue_name'] && $first['ue_code'] !== $first['ue_name']
+                    ? $first['ue_name']
+                    : '',
+                'ecues' => $items->values()->all(),
+            ];
+        })
+        ->sortBy(fn ($g) => $g['ue_id'] === 0 ? 'zzz' : $g['ue_label'])
+        ->values();
+@endphp
+
+@once
+<style>
+[x-cloak] { display: none !important; }
+.scep-wrap { position: relative; }
+.scep-native {
+    position: absolute !important;
+    opacity: 0 !important;
+    clip: rect(0,0,0,0) !important;
+    pointer-events: none !important;
+    height: 1px !important;
+    width: 1px !important;
+}
+.scep-trigger {
+    width: 100%;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    padding: .75rem 2.5rem .75rem 2.65rem;
+    text-align: left;
+    cursor: pointer;
+    font-size: .88rem;
+    color: #1e293b;
+    font-weight: 500;
+    position: relative;
+    transition: all .15s ease;
+    display: flex;
+    align-items: center;
+    gap: .5rem;
+    min-height: 44px;
+}
+.scep-trigger:hover { border-color: rgba(4,83,203,.35); }
+.scep-trigger:focus, .scep-trigger.is-open {
+    outline: none;
+    border-color: #0453cb;
+    box-shadow: 0 0 0 3px rgba(4,83,203,.12);
+}
+.scep-trigger-icon { position: absolute; left: 1rem; top: 50%; transform: translateY(-50%); color: #94a3b8; font-size: .85rem; pointer-events: none; }
+.scep-trigger-caret { position: absolute; right: 1rem; top: 50%; transform: translateY(-50%); color: #94a3b8; font-size: .75rem; pointer-events: none; transition: transform .2s; }
+.scep-trigger.is-open .scep-trigger-caret { transform: translateY(-50%) rotate(180deg); color: #0453cb; }
+.scep-trigger-placeholder { color: #94a3b8; }
+
+.scep-trigger-selected { display: flex; align-items: center; gap: .55rem; flex: 1; min-width: 0; }
+.scep-trigger-code {
+    font-family: 'Courier New', monospace; font-size: .7rem; font-weight: 700;
+    color: #0453cb; background: rgba(4,83,203,.08);
+    padding: .15rem .45rem; border-radius: 4px; flex-shrink: 0;
+}
+.scep-trigger-name { font-weight: 600; color: #1e293b; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+.scep-menu {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0; right: 0;
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    box-shadow: 0 12px 32px rgba(15,23,42,.12), 0 4px 8px rgba(15,23,42,.06);
+    z-index: 1080;
+    max-height: 420px;
+    display: flex; flex-direction: column;
+    overflow: hidden;
+}
+.scep-search {
+    padding: .65rem .75rem;
+    border-bottom: 1px solid #f1f5f9;
+    background: #fff;
+    flex-shrink: 0;
+    position: sticky; top: 0;
+}
+.scep-search-input {
+    width: 100%;
+    padding: .5rem .75rem .5rem 2.2rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 8px;
+    font-size: .85rem;
+    background: #f8fafc url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="%2394a3b8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>') no-repeat .75rem center;
+}
+.scep-search-input:focus {
+    outline: none; border-color: #0453cb;
+    box-shadow: 0 0 0 3px rgba(4,83,203,.10);
+    background-color: #fff;
+}
+
+.scep-list { overflow-y: auto; flex: 1; padding: .25rem 0; }
+.scep-group { padding: .25rem 0; }
+.scep-group-header {
+    padding: .45rem .9rem .25rem;
+    font-size: .65rem;
+    font-weight: 700;
+    color: #475569;
+    text-transform: uppercase;
+    letter-spacing: .5px;
+    background: #f8fafc;
+    border-top: 1px solid #f1f5f9;
+    position: sticky; top: 0;
+    display: flex; align-items: center; gap: .45rem;
+    z-index: 1;
+}
+.scep-group:first-child .scep-group-header { border-top: none; }
+.scep-group-header-icon {
+    width: 18px; height: 18px; border-radius: 5px;
+    background: rgba(4,83,203,.1); color: #0453cb;
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: .55rem;
+}
+.scep-group-header-sub { color: #94a3b8; font-weight: 500; text-transform: none; letter-spacing: 0; }
+
+.scep-option {
+    padding: .55rem .9rem;
+    cursor: pointer;
+    display: flex; align-items: center; gap: .65rem;
+    border-left: 3px solid transparent;
+    transition: background .12s;
+}
+.scep-option:hover { background: rgba(4,83,203,.05); border-left-color: #0453cb; }
+.scep-option.is-selected { background: rgba(4,83,203,.08); border-left-color: #0453cb; }
+.scep-option-code {
+    font-family: 'Courier New', monospace; font-size: .68rem; font-weight: 700;
+    color: #0453cb; background: rgba(4,83,203,.08);
+    padding: .12rem .4rem; border-radius: 4px; flex-shrink: 0;
+}
+.scep-option-name { flex: 1; min-width: 0; font-size: .85rem; color: #1e293b; font-weight: 500; line-height: 1.3; }
+.scep-option-volume {
+    font-size: .68rem; color: #64748b; flex-shrink: 0;
+    background: #f1f5f9; padding: .12rem .4rem; border-radius: 4px;
+    font-weight: 600; white-space: nowrap;
+}
+.scep-option-volume.is-low { background: rgba(245,158,11,.12); color: #b45309; }
+.scep-option-volume.is-done { background: rgba(220,38,38,.12); color: #b91c1c; }
+
+.scep-empty {
+    padding: 1.5rem 1rem;
+    text-align: center;
+    color: #94a3b8;
+    font-size: .85rem;
+}
+.scep-empty i { display: block; font-size: 1.5rem; margin-bottom: .5rem; color: #cbd5e1; }
+</style>
+@endonce
+
+<div class="scep-wrap"
+    x-data="sceEcuePicker({
+        groups: {{ Js::from($groups) }},
+        initialId: {{ Js::from($value ? (int) $value : null) }},
+        placeholder: {{ Js::from($placeholder) }},
+        name: {{ Js::from($name) }},
+        @if($onchangeJs) onChange: function(value, ecue) { {{ $onchangeJs }} } @endif
+    })"
+    x-init="init()"
+    @keydown.escape.window="open = false"
+    @click.outside="open = false">
+
+    {{-- Native hidden select : preserve JS legacy data-attributes for update teacher logic --}}
+    {{-- ATTENTION : id="matiere_id" obligatoire pour document.getElementById('matiere_id') (JS legacy create.blade) --}}
+    <select name="{{ $name }}" id="{{ $nativeId }}" x-ref="native" class="scep-native @error($name) is-invalid @enderror" @if($required) required @endif>
+        <option value="">—</option>
+        @foreach($matieres as $matiere)
+            @php $m = $matiere['matiere']; @endphp
+            <option value="{{ $m->id }}"
+                data-heures-restantes="{{ $matiere['heures_restantes'] ?? 0 }}"
+                data-heures-restantes-formatted="{{ $matiere['heures_restantes_formatted'] ?? ($matiere['heures_restantes'] ?? 0) }}"
+                data-volume-total="{{ $matiere['volume_horaire_total'] ?? 0 }}"
+                data-volume-total-formatted="{{ $matiere['volume_horaire_total_formatted'] ?? ($matiere['volume_horaire_total'] ?? 0) }}"
+                data-enseignants="{{ ($matiere['enseignants_selectables'] ?? collect())->pluck('id')->toJson() }}"
+                data-planification-id="{{ $matiere['planification_id'] ?? '' }}"
+                {{ old($name, $value) == $m->id ? 'selected' : '' }}>{{ $m->name }}</option>
+        @endforeach
+    </select>
+
+    <button type="button" class="scep-trigger" :class="open ? 'is-open' : ''"
+            @click="open = !open" :aria-expanded="open ? 'true' : 'false'">
+        <i class="fas fa-graduation-cap scep-trigger-icon"></i>
+        <template x-if="selected">
+            <span class="scep-trigger-selected">
+                <span class="scep-trigger-code" x-show="selected?.code" x-text="selected?.code"></span>
+                <span class="scep-trigger-name" x-text="selected?.name"></span>
+            </span>
+        </template>
+        <template x-if="!selected">
+            <span class="scep-trigger-placeholder" x-text="placeholder"></span>
+        </template>
+        <i class="fas fa-chevron-down scep-trigger-caret"></i>
+    </button>
+
+    <div class="scep-menu" x-show="open" x-cloak x-transition.opacity.duration.150ms>
+        <div class="scep-search">
+            <input type="text" x-model="search" class="scep-search-input"
+                   placeholder="Rechercher par code, nom ou UE…"
+                   x-ref="searchInput"
+                   @keydown.escape.prevent="open = false">
+        </div>
+        <div class="scep-list">
+            <template x-for="group in filteredGroups" :key="group.ue_id || group.ue_label">
+                <div class="scep-group">
+                    <div class="scep-group-header">
+                        <span class="scep-group-header-icon"><i class="fas fa-layer-group"></i></span>
+                        <span x-text="group.ue_label"></span>
+                        <template x-if="group.ue_subtitle">
+                            <span class="scep-group-header-sub" x-text="'— ' + group.ue_subtitle"></span>
+                        </template>
+                    </div>
+                    <template x-for="ecue in group.ecues" :key="ecue.id">
+                        <div class="scep-option"
+                             :class="selected?.id === ecue.id ? 'is-selected' : ''"
+                             @click="select(ecue)">
+                            <span class="scep-option-code" x-show="ecue.code" x-text="ecue.code"></span>
+                            <span class="scep-option-name" x-text="ecue.name"></span>
+                            <span class="scep-option-volume"
+                                  :class="volumeClass(ecue)"
+                                  x-text="ecue.heures_restantes + 'h / ' + ecue.volume_total + 'h'"></span>
+                        </div>
+                    </template>
+                </div>
+            </template>
+            <template x-if="filteredGroups.length === 0">
+                <div class="scep-empty">
+                    <i class="fas fa-inbox"></i>
+                    Aucune ECUE ne correspond à votre recherche.
+                </div>
+            </template>
+        </div>
+    </div>
+</div>
+
+@once
+@push('scripts')
+<script>
+if (typeof window.sceEcuePicker !== 'function') {
+    window.sceEcuePicker = function (config) {
+        return {
+            groups: config.groups || [],
+            search: '',
+            open: false,
+            selected: null,
+            name: config.name,
+            placeholder: config.placeholder || 'Sélectionner…',
+            _onChange: config.onChange || null,
+
+            init() {
+                if (config.initialId) {
+                    for (const group of this.groups) {
+                        const match = group.ecues.find(e => e.id === config.initialId);
+                        if (match) { this.selected = match; break; }
+                    }
+                }
+                this.$watch('open', (val) => {
+                    if (val) {
+                        this.$nextTick(() => this.$refs.searchInput?.focus());
+                    }
+                });
+            },
+
+            get filteredGroups() {
+                const q = (this.search || '').toLowerCase().trim();
+                if (!q) return this.groups;
+                return this.groups
+                    .map(g => ({
+                        ...g,
+                        ecues: g.ecues.filter(e => {
+                            return (e.code || '').toLowerCase().includes(q)
+                                || (e.name || '').toLowerCase().includes(q)
+                                || (g.ue_label || '').toLowerCase().includes(q)
+                                || (g.ue_subtitle || '').toLowerCase().includes(q);
+                        })
+                    }))
+                    .filter(g => g.ecues.length > 0);
+            },
+
+            select(ecue) {
+                this.selected = ecue;
+                this.open = false;
+                this.search = '';
+
+                const native = this.$refs.native;
+                if (native) {
+                    native.value = String(ecue.id);
+                    native.dispatchEvent(new Event('change', { bubbles: true }));
+                }
+                if (typeof this._onChange === 'function') {
+                    this._onChange(ecue.id, ecue);
+                }
+            },
+
+            volumeClass(ecue) {
+                const r = ecue.heures_restantes_raw;
+                const t = ecue.volume_total_raw;
+                if (t <= 0) return '';
+                if (r <= 0) return 'is-done';
+                if (r / t < 0.2) return 'is-low';
+                return '';
+            }
+        };
+    };
+}
+</script>
+@endpush
+@endonce

--- a/resources/views/esbtp/emploi-temps/partials/bulk-block.blade.php
+++ b/resources/views/esbtp/emploi-temps/partials/bulk-block.blade.php
@@ -31,7 +31,8 @@
         @if(!empty($planificationData) && ($planificationData['planifications_configurees'] ?? false))
             <x-emploi-temps.planification-section
                 :planificationData="$planificationData"
-                :emploiTemps="$emploiTemps" />
+                :emploiTemps="$emploiTemps"
+                :open="false" />
         @elseif(!empty($planificationData))
             <div class="alert alert-warning mb-4">
                 <div class="d-flex align-items-center">

--- a/resources/views/esbtp/seances-cours/create.blade.php
+++ b/resources/views/esbtp/seances-cours/create.blade.php
@@ -285,7 +285,12 @@
 <div class="dashboard-acasi">
     <div class="main-content">
         @php
-            $isClasseLmd = ($emploiTemps->classe->systeme_academique ?? '') === 'LMD';
+            // PR17.1 hotfix : unifier detection LMD (etait 2 helpers contradictoires lines 288 vs 565).
+            // Bug observe par Marcel : si systeme_academique = NULL mais niveau.type = Licence,
+            // les 2 sets de types (BTS legacy + LMD UEMOA) s'affichaient simultanement.
+            // Solution : detection inclusive partout = (systeme_academique='LMD' OR niveau.type IN [Licence/Master/Doctorat]).
+            $isClasseLmd = ($emploiTemps->classe->systeme_academique ?? '') === 'LMD'
+                || in_array($emploiTemps->classe->niveau->type ?? '', ['Licence', 'Master', 'Doctorat'], true);
         @endphp
         {{-- Hero premium namespace sce-* (Seance Creation Edit) --}}
         <div class="sce-hero">
@@ -340,6 +345,40 @@
                 </div>
             @endif
         </div>
+
+        {{-- PR17.1 LMD B : warning explicite si classe LMD sans parcours_id configure.
+             Sinon le fallback charge des planifs BTS generiques de la combinaison filiere+niveau
+             et l'utilisateur voit des matieres BTS au lieu d'ECUE LMD. --}}
+        @if($isClasseLmd && empty($emploiTemps->classe->parcours_id))
+            <div class="alert alert-warning border-start border-warning border-4 mb-4">
+                <div class="d-flex">
+                    <div class="me-3">
+                        <i class="fas fa-triangle-exclamation fs-4"></i>
+                    </div>
+                    <div class="flex-grow-1">
+                        <h5 class="alert-heading mb-1">Classe LMD sans parcours configuré</h5>
+                        <p class="mb-2">
+                            La classe <strong>{{ $emploiTemps->classe->name }}</strong> est en système LMD
+                            ({{ $emploiTemps->classe->niveau->name ?? 'niveau' }}) mais n'a ni
+                            <strong>parcours</strong>, ni <strong>mention</strong>, ni <strong>domaine</strong>
+                            assigné. Les matières affichées ci-dessous sont issues du <em>fallback BTS générique</em>
+                            (filière + niveau) au lieu des ECUE configurées dans Planning LMD.
+                        </p>
+                        <div class="d-flex gap-2 flex-wrap">
+                            <a href="{{ route('esbtp.classes.edit', $emploiTemps->classe->id) }}"
+                               class="btn btn-warning btn-sm">
+                                <i class="fas fa-cog me-1"></i>Configurer Domaine / Mention / Parcours
+                            </a>
+                            <a href="{{ route('esbtp.lmd.planning.index') }}"
+                               target="_blank"
+                               class="btn btn-outline-warning btn-sm">
+                                <i class="fas fa-graduation-cap me-1"></i>Aller au Planning LMD
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        @endif
 
         @if ($errors->any())
             <div class="alert alert-danger border-start border-danger border-4 mb-4">
@@ -590,6 +629,24 @@
                                     <select name="teacher_id" id="teacher_id" class="form-select @error('teacher_id') error @enderror" onchange="showTeacherAvailability()" required>
                                         <option value="">Sélectionner d'abord une matière</option>
                                     </select>
+                                    @if($isClasseLmd)
+                                        {{-- LMD : les boutons quick-create et manage-teachers BTS ne sont pas applicables ici
+                                             (planification_id est null en LMD, enseignants_selectables vient des
+                                             enseignants assignés via Planning LMD). Renvoyer vers la page LMD. --}}
+                                        <div class="alert alert-info mt-2 mb-0">
+                                            <div class="d-flex align-items-start gap-2">
+                                                <i class="fas fa-info-circle mt-1"></i>
+                                                <div>
+                                                    <strong>Mode LMD — gestion enseignants via Planning LMD</strong>
+                                                    <div class="small text-muted mt-1">
+                                                        Les enseignants ECUE sont attribués depuis la page
+                                                        <a href="{{ route('esbtp.lmd.planning.index') }}" target="_blank" class="fw-semibold">Planning LMD</a>
+                                                        (responsable d'UE + enseignant par ECUE).
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    @else
                                     <div class="teacher-create-actions" id="teacherCreateActions" style="display: none;">
                                         <div class="alert alert-info mt-2 mb-0" id="teacherEmptyState" style="display: none;">
                                             <div class="d-flex align-items-start gap-2">
@@ -609,6 +666,7 @@
                                             </button>
                                         </div>
                                     </div>
+                                    @endif
                                     <div id="teacher-info" class="form-info" style="display: none;">
                                         <i class="fas fa-check-circle"></i>
                                         <span id="teacher-assignment-text"></span>

--- a/resources/views/esbtp/seances-cours/partials/_form_matiere.blade.php
+++ b/resources/views/esbtp/seances-cours/partials/_form_matiere.blade.php
@@ -1,9 +1,11 @@
 {{-- Picker matière conditionnel LMD vs BTS pour /esbtp/seances-cours/create --}}
 {{-- Recoit : $matieres (collection planificationData), $emploiTemps --}}
-{{-- NOTE : on garde le <select> natif (JS legacy data-* attributes utilise pour update teacher select). --}}
-{{-- Le stylise via .sce-matiere-select pour un look premium tout en preservant les hooks JS. --}}
+{{-- LMD : <x-sce-ecue-picker> avec recherche + groupement par UE (premium custom) --}}
+{{-- BTS : <select> natif stylé .sce-matiere-select (preserve JS legacy data-* hooks) --}}
 @php
-    $isLmd = ($emploiTemps->classe->systeme_academique ?? '') === 'LMD';
+    // Detection LMD inclusive : systeme_academique OR niveau.type (cf hotfix PR17.1 create.blade)
+    $isLmd = ($emploiTemps->classe->systeme_academique ?? '') === 'LMD'
+        || in_array($emploiTemps->classe->niveau->type ?? '', ['Licence', 'Master', 'Doctorat'], true);
 @endphp
 
 <div class="form-group">
@@ -14,47 +16,46 @@
         @endif
     </label>
 
-    <div class="sce-select-wrap">
-        <i class="fas fa-graduation-cap sce-select-icon"></i>
-        <select name="matiere_id" id="matiere_id"
-                class="sce-matiere-select @error('matiere_id') is-invalid @enderror"
-                onchange="updateTeachersForSubject()"
-                required>
-            <option value="">{{ $isLmd ? 'Rechercher une ECUE...' : 'Sélectionner une matière...' }}</option>
-            @foreach($matieres as $matiere)
-                @php
-                    $m = $matiere['matiere'];
-                    $heuresRestantes = $matiere['heures_restantes_formatted'] ?? $matiere['heures_restantes'];
-                    $volumeTotal = $matiere['volume_horaire_total_formatted'] ?? $matiere['volume_horaire_total'];
-
-                    // Label enrichi LMD vs BTS
-                    if ($isLmd) {
-                        $code = $m->code ?: '';
-                        $ue = $m->uniteEnseignement ?? null;
-                        $ueLabel = '';
-                        if ($ue) {
-                            $type = $ue->type_ue?->label() ?? 'UE';
-                            $ueLabel = '  ·  ' . $type . ' · ' . ($ue->code ?? $ue->name);
-                        }
-                        $optLabel = ($code ? $code . ' — ' : '') . $m->name . $ueLabel . '   (' . $heuresRestantes . '/' . $volumeTotal . ')';
-                    } else {
+    @if($isLmd)
+        {{-- Custom picker premium avec recherche + groupement UE --}}
+        <x-sce-ecue-picker
+            name="matiere_id"
+            :matieres="$matieres"
+            :value="old('matiere_id')"
+            :required="true"
+            placeholder="Rechercher une ECUE par code, nom ou UE…"
+            onchange-js="updateTeachersForSubject();" />
+    @else
+        {{-- Mode BTS : select natif stylé --}}
+        <div class="sce-select-wrap">
+            <i class="fas fa-graduation-cap sce-select-icon"></i>
+            <select name="matiere_id" id="matiere_id"
+                    class="sce-matiere-select @error('matiere_id') is-invalid @enderror"
+                    onchange="updateTeachersForSubject()"
+                    required>
+                <option value="">Sélectionner une matière...</option>
+                @foreach($matieres as $matiere)
+                    @php
+                        $m = $matiere['matiere'];
+                        $heuresRestantes = $matiere['heures_restantes_formatted'] ?? $matiere['heures_restantes'];
+                        $volumeTotal = $matiere['volume_horaire_total_formatted'] ?? $matiere['volume_horaire_total'];
                         $optLabel = $m->name . '   (' . $heuresRestantes . ' restantes / ' . $volumeTotal . ')';
-                    }
-                @endphp
-                <option value="{{ $m->id }}"
-                        data-heures-restantes="{{ $matiere['heures_restantes'] }}"
-                        data-heures-restantes-formatted="{{ $matiere['heures_restantes_formatted'] ?? $matiere['heures_restantes'] }}"
-                        data-volume-total="{{ $matiere['volume_horaire_total'] }}"
-                        data-volume-total-formatted="{{ $matiere['volume_horaire_total_formatted'] ?? $matiere['volume_horaire_total'] }}"
-                        data-enseignants="{{ ($matiere['enseignants_selectables'] ?? collect())->pluck('id')->toJson() }}"
-                        data-planification-id="{{ $matiere['planification_id'] ?? '' }}"
-                        {{ old('matiere_id') == $m->id ? 'selected' : '' }}>
-                    {{ $optLabel }}
-                </option>
-            @endforeach
-        </select>
-        <i class="fas fa-chevron-down sce-select-caret"></i>
-    </div>
+                    @endphp
+                    <option value="{{ $m->id }}"
+                            data-heures-restantes="{{ $matiere['heures_restantes'] }}"
+                            data-heures-restantes-formatted="{{ $matiere['heures_restantes_formatted'] ?? $matiere['heures_restantes'] }}"
+                            data-volume-total="{{ $matiere['volume_horaire_total'] }}"
+                            data-volume-total-formatted="{{ $matiere['volume_horaire_total_formatted'] ?? $matiere['volume_horaire_total'] }}"
+                            data-enseignants="{{ ($matiere['enseignants_selectables'] ?? collect())->pluck('id')->toJson() }}"
+                            data-planification-id="{{ $matiere['planification_id'] ?? '' }}"
+                            {{ old('matiere_id') == $m->id ? 'selected' : '' }}>
+                        {{ $optLabel }}
+                    </option>
+                @endforeach
+            </select>
+            <i class="fas fa-chevron-down sce-select-caret"></i>
+        </div>
+    @endif
 
     <div id="matiere-info" class="sce-form-info" style="display: none;">
         <i class="fas fa-clock"></i>


### PR DESCRIPTION
## Summary

Hotfix UX visual-check Marcel sur EDT B3 COM Licence 2 LMD :

- **A. Picker ECUE premium** avec recherche + groupement par UE (composant `<x-sce-ecue-picker>`)
- **B. Warning explicite** si classe LMD sans parcours_id configuré
- **C. Boutons "Créer/Gérer enseignants"** masqués en LMD (lien vers Planning LMD)
- **D. Detection LMD inclusive** unifiée (fix doublon types CM/TD/TP + Cours/Devoir affichés simultanément)
- **E. Bonus** : section "Suivi par matière" collapsable sur bulk-edit