### PR TITLE
fix(cli): students:show colonnes matiere/filiere/niveau nom->name

### DIFF
--- a/.claude/rules/klassci-debugging-discipline.md
+++ b/.claude/rules/klassci-debugging-discipline.md
@@ -212,6 +212,8 @@ grep -n "nom_colonne" app/Models/LeModele.php  # idéalement dans $fillable/cast
 ```
 Si la colonne est un concept d'une autre entité (ex: rattrapage LMD vs note BTS), ne PAS la sélectionner sur la table voisine.
 
+**Variante `nom` vs `name` (récurrente dans `CLIStudentController`)** : `esbtp_etudiants` utilise bien `nom` (français, nom de famille), MAIS `esbtp_matieres` / `esbtp_filieres` / `esbtp_niveaux_etudes` utilisent `name`. Les eager-loads `->with('matiere:id,nom')` / `->with('filiere:id,nom')` lèvent `Unknown column 'nom'`. Toujours vérifier le `$fillable` de CHAQUE modèle ciblé : `grep "'nom'\|'name'" app/Models/ESBTPXxx.php`. Bugs corrigés en série (commit `6f18f30b` filiere/niveau, puis juin 2026 matiere) — vérifier les 3 d'un coup quand on touche un eager-load de ce controller.
+
 **Diagnostic** : un endpoint API qui 500 mais dont le code « semble bon » → reproduire avec le CLI (`klassci <cmd> <tenant>`) qui RENVOIE le message SQL exact, bien plus parlant que le 500 web générique. Le CLI est un excellent révélateur de schema/colonnes.
 
 ---

--- a/app/Http/Controllers/API/CLI/CLIStudentController.php
+++ b/app/Http/Controllers/API/CLI/CLIStudentController.php
@@ -155,7 +155,7 @@ class CLIStudentController extends BaseApiController
                     $q->where('annee_universitaire_id', $annee->id);
                 })
                 ->with('evaluation:id,titre,type')
-                ->with('matiere:id,nom')
+                ->with('matiere:id,name')
                 ->limit(20)
                 ->get(['id', 'matiere_id', 'evaluation_id', 'note', 'is_absent'])
             : collect();
@@ -175,8 +175,8 @@ class CLIStudentController extends BaseApiController
                 'status' => $inscription->status,
                 'workflow_step' => $inscription->workflow_step,
                 'classe' => $inscription->classe?->name,
-                'filiere' => $inscription->filiere?->nom,
-                'niveau' => $inscription->niveau?->nom,
+                'filiere' => $inscription->filiere?->name,
+                'niveau' => $inscription->niveau?->name,
                 'date_inscription' => $inscription->date_inscription?->format('Y-m-d'),
             ] : null,
             'paiements' => $paiements->map(fn ($p) => [
@@ -189,7 +189,7 @@ class CLIStudentController extends BaseApiController
             ]),
             'notes' => $notes->map(fn ($n) => [
                 'id' => $n->id,
-                'matiere' => $n->matiere?->nom,
+                'matiere' => $n->matiere?->name,
                 'evaluation' => $n->evaluation?->titre,
                 'type' => $n->evaluation?->type,
                 'note' => $n->note,


### PR DESCRIPTION
Hotfix suite PR #431. Apres retrait de note_rattrapage, `klassci students:show` 500ait sur `Unknown column 'nom' in esbtp_matieres` (`->with('matiere:id,nom')`). Les tables esbtp_matieres/filieres/niveaux_etudes utilisent `name` (seul esbtp_etudiants a `nom`). Corrige les 3 eager-loads/access + documente la variante nom/name dans la rule debugging (piege #12).