### PR TITLE
fix(lmd-reconciliation): preview gere l'echec dry-run

### DIFF
--- a/resources/views/esbtp/lmd/reconciliation/index.blade.php
+++ b/resources/views/esbtp/lmd/reconciliation/index.blade.php
@@ -460,8 +460,16 @@ function recManager() {
                 typeLabel: (type === 'ue' ? 'Unité d\'enseignement' : 'ECUE') + ' — ' + this.prettyName(group.normalized_name),
                 report: null, force: false,
             };
-            const report = await this.callMerge(type, canonicalId, absorbed, true, false);
-            this.modal.report = report;
+            try {
+                const report = await this.callMerge(type, canonicalId, absorbed, true, false);
+                if (!report || typeof report !== 'object') {
+                    throw new Error('Aperçu indisponible (réponse vide).');
+                }
+                this.modal.report = report;
+            } catch (err) {
+                this.toast('error', err.message || 'Aperçu impossible — réessayez.');
+                this.closeModal();
+            }
         },
 
         async confirmMerge() {


### PR DESCRIPTION
preview() catche l'echec du dry-run (toast + fermeture) au lieu de laisser le modal en 'Apercu en cours' avec Fusionner bloque. Decouvert en repro live (modal.report null).