### PR TITLE
feat(bts): Tronc Commun → Spécialité pris en compte dans toute la chaîne des bulletins (Plan C)

### DIFF
--- a/app/Console/Commands/BtsTcBulletinsBackfillCommand.php
+++ b/app/Console/Commands/BtsTcBulletinsBackfillCommand.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ESBTPBulletin;
+use App\Models\ESBTPInscription;
+use App\Services\BulletinService;
+use App\Services\ESBTP\BulletinConsistencyService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Backfill IDEMPOTENT des bulletins annuels BTS Tronc Commun → Spécialité.
+ *
+ * Cible les inscriptions du modèle phases (TC orienté) dont le bulletin annuel
+ * officiel persisté est OBSOLÈTE par rapport au recalcul courant (introduit par
+ * le class-map / coefficient fallback / rang TC-aware des commits précédents).
+ *
+ * BTS uniquement (LMD intouché). DESIGN + CODE only : cette commande n'est
+ * JAMAIS lancée en prod par ce workflow. Garde-fou tenant strict + dry-run par
+ * défaut côté runbook.
+ *
+ * Détecteur : compare la moyenne_generale PERSISTÉE du bulletin annuel avec la
+ * moyenne RECALCULÉE (genererDonneesBulletin). On N'utilise PAS getSnapshot avec
+ * période 'annuel' car BulletinConsistencyService force $officialBulletin=null en
+ * annuel → ce détecteur serait un NO-OP.
+ */
+class BtsTcBulletinsBackfillCommand extends Command
+{
+    protected $signature = 'bts:tc-bulletins-backfill
+        {tenant : Code du tenant (doit matcher TENANT_CODE de l\'instance)}
+        {--annee= : ID de l\'année universitaire à backfiller}
+        {--dry-run : N\'écrit rien, rapporte seulement les bulletins à régénérer}
+        {--limit= : Limite le nombre d\'inscriptions traitées}
+        {--periode=annuel : Période ciblée (annuel uniquement supporté)}';
+
+    protected $description = 'Backfill idempotent des bulletins annuels BTS Tronc Commun (code only, aucune exécution prod).';
+
+    private const EPSILON = 0.01;
+
+    public function handle(
+        BulletinService $bulletinService,
+        BulletinConsistencyService $consistencyService
+    ): int {
+        $tenant = (string) $this->argument('tenant');
+        $expectedTenant = (string) (config('app.tenant_code') ?? env('TENANT_CODE'));
+
+        // GARDE-FOU tenant : refuse toute exécution sur une instance non concordante.
+        if ($tenant !== $expectedTenant) {
+            $this->error(sprintf(
+                'Tenant "%s" ne correspond pas à l\'instance courante "%s". Abandon.',
+                $tenant,
+                $expectedTenant
+            ));
+
+            return self::FAILURE;
+        }
+
+        $periode = (string) $this->option('periode');
+        if ($periode !== 'annuel') {
+            $this->error('Seule la période "annuel" est supportée par ce backfill.');
+
+            return self::FAILURE;
+        }
+
+        $anneeId = $this->option('annee') !== null ? (int) $this->option('annee') : null;
+        if (! $anneeId) {
+            $this->error('L\'option --annee est obligatoire (ID année universitaire).');
+
+            return self::FAILURE;
+        }
+
+        $isDryRun = (bool) $this->option('dry-run');
+        $limit = $this->option('limit') !== null ? (int) $this->option('limit') : null;
+
+        $counters = [
+            'scanned' => 0,
+            'eligible' => 0,
+            'skipped_no_official' => 0,
+            'skipped_recompute_error' => 0,
+            'aligned' => 0,
+            'affected' => 0,
+            'would_fix' => 0,
+            'fixed' => 0,
+            'errors' => 0,
+        ];
+
+        /** @var array<int, array<string, mixed>> $details */
+        $details = [];
+
+        // Cibler UNIQUEMENT les inscriptions modèle phases (TC orienté) :
+        // - sans inscription_origine_id (pas le modèle legacy double-inscription)
+        // - de l'année visée
+        // - ayant au moins une phase
+        // - dont la classe pointe vers une filière de spécialité (parent_id NOT NULL)
+        $query = ESBTPInscription::query()
+            ->whereNull('inscription_origine_id')
+            ->where('annee_universitaire_id', $anneeId)
+            ->whereHas('phases')
+            ->whereHas('classe.filiere', function ($q) {
+                $q->whereNotNull('parent_id');
+            })
+            ->orderBy('id');
+
+        if ($limit !== null) {
+            $query->limit($limit);
+        }
+
+        $processInscription = function (ESBTPInscription $inscription) use (
+            $bulletinService,
+            $consistencyService,
+            $periode,
+            $anneeId,
+            $isDryRun,
+            &$counters,
+            &$details
+        ): void {
+            $counters['scanned']++;
+
+            $etudiantId = (int) $inscription->etudiant_id;
+            $classeId = (int) $inscription->classe_id;
+
+            // DÉTECTEUR : lire le bulletin annuel officiel PERSISTÉ direct (pas getSnapshot).
+            $officialBulletin = ESBTPBulletin::where('etudiant_id', $etudiantId)
+                ->where('classe_id', $classeId)
+                ->where('annee_universitaire_id', $anneeId)
+                ->where('periode', $periode)
+                ->latest('updated_at')
+                ->first();
+
+            if (! $officialBulletin || $officialBulletin->moyenne_generale === null) {
+                $counters['skipped_no_official']++;
+                $details[] = [
+                    'etudiant_id' => $etudiantId,
+                    'classe_id' => $classeId,
+                    'status' => 'skipped_no_official',
+                ];
+
+                return;
+            }
+
+            $counters['eligible']++;
+            $persisted = round((float) $officialBulletin->moyenne_generale, 2);
+
+            // Recalculer en LECTURE SEULE : genererDonneesBulletin persiste, donc on
+            // enveloppe dans une transaction rollback pour ne RIEN écrire ici.
+            $recomputed = null;
+            try {
+                DB::beginTransaction();
+                $donnees = $bulletinService->genererDonneesBulletin(
+                    $etudiantId,
+                    $classeId,
+                    $anneeId,
+                    $periode
+                );
+                $recomputed = isset($donnees['moyenneGlobale']) && $donnees['moyenneGlobale'] !== null
+                    ? round((float) $donnees['moyenneGlobale'], 2)
+                    : null;
+                DB::rollBack();
+            } catch (\Throwable $e) {
+                if (DB::transactionLevel() > 0) {
+                    DB::rollBack();
+                }
+                $counters['skipped_recompute_error']++;
+                $details[] = [
+                    'etudiant_id' => $etudiantId,
+                    'classe_id' => $classeId,
+                    'status' => 'skipped_recompute_error',
+                    'message' => $e->getMessage(),
+                ];
+
+                return;
+            }
+
+            if ($recomputed === null) {
+                $counters['skipped_recompute_error']++;
+                $details[] = [
+                    'etudiant_id' => $etudiantId,
+                    'classe_id' => $classeId,
+                    'status' => 'skipped_recompute_error',
+                    'message' => 'Moyenne recalculée indisponible.',
+                ];
+
+                return;
+            }
+
+            $delta = round($recomputed - $persisted, 2);
+            $isAffected = abs($delta) >= self::EPSILON;
+
+            if (! $isAffected) {
+                $counters['aligned']++;
+
+                return;
+            }
+
+            $counters['affected']++;
+            $detail = [
+                'etudiant_id' => $etudiantId,
+                'classe_id' => $classeId,
+                'persisted' => $persisted,
+                'recomputed' => $recomputed,
+                'delta' => $delta,
+            ];
+
+            if ($isDryRun) {
+                $counters['would_fix']++;
+                $detail['status'] = 'would_fix';
+                Log::info('[bts-tc-backfill] would_fix bulletin annuel obsolète', $detail);
+                $details[] = $detail;
+
+                return;
+            }
+
+            try {
+                DB::transaction(function () use ($consistencyService, $etudiantId, $classeId, $anneeId, $periode) {
+                    $consistencyService->regenerateOfficialBulletin(
+                        $etudiantId,
+                        $classeId,
+                        $anneeId,
+                        $periode
+                    );
+                });
+                $counters['fixed']++;
+                $detail['status'] = 'fixed';
+                Log::info('[bts-tc-backfill] bulletin annuel régénéré', $detail);
+            } catch (\Throwable $e) {
+                $counters['errors']++;
+                $detail['status'] = 'error';
+                $detail['message'] = $e->getMessage();
+                Log::error('[bts-tc-backfill] échec régénération bulletin annuel', $detail);
+            }
+
+            $details[] = $detail;
+        };
+
+        $query->chunkById(200, function ($inscriptions) use ($processInscription) {
+            foreach ($inscriptions as $inscription) {
+                $processInscription($inscription);
+            }
+        });
+
+        $this->renderReport($tenant, $anneeId, $isDryRun, $counters);
+
+        $reportPath = $this->writeJsonReport($tenant, $anneeId, $isDryRun, $counters, $details);
+        $this->line('Rapport JSON : ' . $reportPath);
+
+        return $counters['errors'] === 0 ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  array<string, int>  $counters
+     */
+    private function renderReport(string $tenant, int $anneeId, bool $isDryRun, array $counters): void
+    {
+        $this->info(sprintf(
+            'Backfill bulletins annuels BTS TC — tenant=%s année=%d mode=%s',
+            $tenant,
+            $anneeId,
+            $isDryRun ? 'DRY-RUN' : 'RUN'
+        ));
+
+        $rows = [];
+        foreach ($counters as $key => $value) {
+            $rows[] = [$key, $value];
+        }
+
+        $this->table(['Compteur', 'Valeur'], $rows);
+    }
+
+    /**
+     * @param  array<string, int>  $counters
+     * @param  array<int, array<string, mixed>>  $details
+     */
+    private function writeJsonReport(
+        string $tenant,
+        int $anneeId,
+        bool $isDryRun,
+        array $counters,
+        array $details
+    ): string {
+        $timestamp = now()->format('Ymd_His');
+        $relativePath = sprintf('backfill/bts-tc-%s-%d-%s.json', $tenant, $anneeId, $timestamp);
+
+        $payload = [
+            'command' => 'bts:tc-bulletins-backfill',
+            'tenant' => $tenant,
+            'annee_universitaire_id' => $anneeId,
+            'periode' => 'annuel',
+            'mode' => $isDryRun ? 'dry-run' : 'run',
+            'generated_at' => now()->toIso8601String(),
+            'counters' => $counters,
+            'details' => $details,
+        ];
+
+        Storage::disk('local')->put(
+            $relativePath,
+            json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
+
+        return storage_path('app/' . $relativePath);
+    }
+}

--- a/app/Domain/BtsTroncCommun/BtsAnnualClassMapResolver.php
+++ b/app/Domain/BtsTroncCommun/BtsAnnualClassMapResolver.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Domain\BtsTroncCommun;
+
+use App\Models\ESBTPInscription;
+
+/**
+ * Résolveur stateless du class-map annuel BTS (Tronc Commun → Spécialité).
+ *
+ * Pour un (étudiant, année, classe demandée), détermine quelle classe porte les
+ * notes du Semestre 1 et du Semestre 2 — en supportant à la fois le modèle phases
+ * (ESBTPInscriptionPhase) et le modèle legacy double-inscription
+ * (inscription_origine_id + type_changement).
+ *
+ * Extrait verbatim de BtsCurrentResultSnapshotService::resolveAnnualClassMap pour
+ * être partagé par le snapshot ET BulletinService (BTS uniquement, LMD intouché).
+ */
+class BtsAnnualClassMapResolver
+{
+    public function __construct(private BtsPhaseResolver $btsPhaseResolver)
+    {
+    }
+
+    /**
+     * @return array{inscription_id: int|null, source_model: string, semestre1_classe_id: int, semestre2_classe_id: int}
+     */
+    public function resolve(int $etudiantId, int $requestedClasseId, int $anneeUniversitaireId): array
+    {
+        $inscription = ESBTPInscription::query()
+            ->with([
+                'filiere',
+                'phases.classe.filiere',
+                'inscriptionOrigine.classe.filiere',
+                'inscriptionSpecialisation.classe.filiere',
+            ])
+            ->where('etudiant_id', $etudiantId)
+            ->where('annee_universitaire_id', $anneeUniversitaireId)
+            ->orderByRaw('CASE WHEN classe_id = ? THEN 0 ELSE 1 END', [$requestedClasseId])
+            ->orderByRaw("CASE WHEN status = 'active' THEN 0 ELSE 1 END")
+            ->orderByDesc('date_inscription')
+            ->orderByDesc('id')
+            ->first();
+
+        if (! $inscription) {
+            return [
+                'inscription_id' => null,
+                'source_model' => 'phase_based',
+                'semestre1_classe_id' => $requestedClasseId,
+                'semestre2_classe_id' => $requestedClasseId,
+            ];
+        }
+
+        $journey = $this->btsPhaseResolver->buildJourney($inscription);
+        $semestre1Phase = $this->btsPhaseResolver->resolveSemesterPhase($inscription, 1);
+        $semestre2Phase = $this->btsPhaseResolver->resolveSemesterPhase($inscription, 2);
+
+        return [
+            'inscription_id' => $inscription->id,
+            'source_model' => $journey['source_model'] ?? 'phase_based',
+            'semestre1_classe_id' => $semestre1Phase['classe_id'] ?? $inscription->classe_id,
+            'semestre2_classe_id' => $semestre2Phase['classe_id'] ?? $inscription->classe_id,
+        ];
+    }
+}

--- a/app/Domain/BtsTroncCommun/BtsBulletinCohortResolver.php
+++ b/app/Domain/BtsTroncCommun/BtsBulletinCohortResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Domain\BtsTroncCommun;
+
+use App\Models\ESBTPBulletin;
+
+/**
+ * Résout la classe-cohorte servant de base au calcul de rang/effectif d'un bulletin BTS.
+ *
+ * Pour un bulletin Semestre 1 d'un étudiant orienté (Tronc Commun → Spécialité), le rang
+ * doit être calculé dans la cohorte de la classe Tronc Commun qui portait réellement les
+ * notes du S1 — pas dans la classe de spécialité courante. Pour le S2 / l'annuel (ou tout
+ * bulletin sans étudiant identifiable), on conserve la classe du bulletin.
+ *
+ * Collaborateur partagé entre ESBTPBulletin::calculerRang (génération controller) et
+ * BulletinService::calculerRang (preview/regen) pour réconcilier les deux chemins.
+ * BTS uniquement — LMD intouché. Stateless, ne dépend pas de BulletinService.
+ */
+class BtsBulletinCohortResolver
+{
+    public function __construct(private BtsAnnualClassMapResolver $classMapResolver)
+    {
+    }
+
+    /**
+     * Détermine la classe dont la cohorte sert de base au rang et à l'effectif.
+     */
+    public function resolveRankCohortClasseId(ESBTPBulletin $bulletin): int
+    {
+        $classeId = (int) $bulletin->classe_id;
+
+        if ($this->normalizePeriode((string) $bulletin->periode) !== 'semestre1' || ! $bulletin->etudiant_id) {
+            return $classeId;
+        }
+
+        $classMap = $this->classMapResolver->resolve(
+            (int) $bulletin->etudiant_id,
+            $classeId,
+            (int) $bulletin->annee_universitaire_id
+        );
+
+        return (int) ($classMap['semestre1_classe_id'] ?? $classeId);
+    }
+
+    /**
+     * Mapping périodes local (miroir de BulletinService::normalizePeriode) — pas
+     * d'injection de BulletinService pour garder ce résolveur stateless.
+     */
+    private function normalizePeriode(string $periode): string
+    {
+        if ($periode === '1') {
+            return 'semestre1';
+        }
+        if ($periode === '2') {
+            return 'semestre2';
+        }
+
+        return $periode ?: 'semestre1';
+    }
+}

--- a/app/Domain/BtsTroncCommun/BtsBulletinSubjectResolver.php
+++ b/app/Domain/BtsTroncCommun/BtsBulletinSubjectResolver.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Domain\BtsTroncCommun;
+
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPMatiereFilierNiveau;
+use Illuminate\Support\Collection;
+
+/**
+ * Résout la liste des matières d'une classe BTS pour la génération/prévisualisation
+ * de bulletin, en tenant compte du tronc commun.
+ *
+ * Une classe de spécialité (filière fille d'un tronc commun) doit aussi voir les
+ * matières définies au niveau de la filière mère (le tronc commun) afin que les
+ * notes saisies pendant la phase tronc commun apparaissent au bulletin (C10).
+ *
+ * Source canonique : `esbtp_matiere_filiere_niveau` via `matiereIdsForCombo`, en
+ * union sur `troncCommunUnionFiliereIds()`. Fallback sur le pivot legacy
+ * `esbtp_classe_matiere` quand aucune matière n'est définie au niveau (compat BTS
+ * historique).
+ *
+ * BTS uniquement — LMD intouché. Stateless, sans dépendance à BulletinService.
+ *
+ * @see .claude/rules/klassci-classe-matieres.md
+ * @see .claude/rules/lmd-bts-bulletin-separation.md
+ */
+class BtsBulletinSubjectResolver
+{
+    /**
+     * Matières (modèles complets, actives) servant de base au bulletin d'une classe.
+     *
+     * @return Collection<int, ESBTPMatiere>
+     */
+    public function subjectsForClasse(ESBTPClasse $classe): Collection
+    {
+        if ($classe->filiere_id && $classe->niveau_etude_id) {
+            // Tronc commun (C10) : union [filière classe, filière TC parente].
+            $unionFiliereIds = $classe->filiere
+                ? $classe->filiere->troncCommunUnionFiliereIds()
+                : [$classe->filiere_id];
+
+            $matiereIds = collect($unionFiliereIds)
+                ->flatMap(fn ($filiereId) => ESBTPMatiereFilierNiveau::matiereIdsForCombo(
+                    $filiereId,
+                    $classe->niveau_etude_id
+                ))
+                ->unique()
+                ->values();
+
+            $matieres = ESBTPMatiere::whereIn('id', $matiereIds)
+                ->where('is_active', true)
+                ->orderBy('name')
+                ->get();
+
+            if ($matieres->isNotEmpty()) {
+                return $matieres;
+            }
+        }
+
+        // Fallback classes BTS historiques attachées directement via le pivot.
+        return $classe->matieres()
+            ->where('esbtp_matieres.is_active', true)
+            ->orderBy('esbtp_matieres.name')
+            ->get();
+    }
+}

--- a/app/Http/Controllers/ESBTPAttendanceController.php
+++ b/app/Http/Controllers/ESBTPAttendanceController.php
@@ -1909,10 +1909,20 @@ class ESBTPAttendanceController extends Controller
             return collect();
         }
 
-        $matiereIds = ESBTPMatiereFilierNiveau::matiereIdsForCombo(
-            $classe->filiere_id,
-            $classe->niveau_etude_id
-        );
+        // Tronc commun (C9) : on inclut aussi les matières définies au niveau de
+        // la filière mère (tronc commun) pour que les classes de spécialité héritent
+        // des matières communes lors de la saisie des présences.
+        $unionFiliereIds = $classe->filiere
+            ? $classe->filiere->troncCommunUnionFiliereIds()
+            : [$classe->filiere_id];
+
+        $matiereIds = collect($unionFiliereIds)
+            ->flatMap(fn ($filiereId) => ESBTPMatiereFilierNiveau::matiereIdsForCombo(
+                $filiereId,
+                $classe->niveau_etude_id
+            ))
+            ->unique()
+            ->values();
 
         $matieres = ESBTPMatiere::whereIn('id', $matiereIds)
             ->where('is_active', true)

--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -285,11 +285,21 @@ class ESBTPBulletinController extends Controller
                 $moyenne = $sommeCoefficients > 0 ? $sommeNotes / $sommeCoefficients : null;
 
                 // Récupérer le coefficient de la matière pour cette classe
-                $coefficient = $this->bulletinService->getCoefficientForCombination(
-                    $matiere->id,
-                    $classe->id,
-                    $request->annee_universitaire_id
-                );
+                try {
+                    $coefficient = $this->bulletinService->getCoefficientForCombination(
+                        $matiere->id,
+                        $classe->id,
+                        $request->annee_universitaire_id,
+                        $request->periode,
+                        $request->etudiant_id
+                    );
+                } catch (\RuntimeException $e) {
+                    if (! str_contains($e->getMessage(), 'Coefficient manquant')) {
+                        throw $e;
+                    }
+                    Log::warning('Coef introuvable matiere TC, skip', ['matiere_id' => $matiere->id, 'classe_id' => $classe->id]);
+                    continue;
+                }
 
                 // Créer le résultat pour cette matière
                 $resultat = new ESBTPResultatMatiere;
@@ -750,9 +760,14 @@ class ESBTPBulletinController extends Controller
                             $coefficient = $this->bulletinService->getCoefficientForCombination(
                                 $matiere->id,
                                 $bulletin->classe_id,
-                                $bulletin->annee_universitaire_id
+                                $bulletin->annee_universitaire_id,
+                                $bulletin->periode,
+                                $bulletin->etudiant_id
                             );
                         } catch (\RuntimeException $e) {
+                            if (! str_contains($e->getMessage(), 'Coefficient manquant')) {
+                                throw $e;
+                            }
                             $coefficient = 1;
                             Log::warning('Coefficient manquant pour matière #'.$matiere->id.' bulletin #'.$bulletin->id.' — fallback à 1');
                         }
@@ -1140,11 +1155,21 @@ class ESBTPBulletinController extends Controller
                                 // Créer un résultat vide pour cette matière
                                 try {
                                     // Récupérer le coefficient de la matière pour cette classe
-                                    $coefficient = $this->bulletinService->getCoefficientForCombination(
-                                        $matiere->id,
-                                        $classe->id,
-                                        $request->annee_universitaire_id
-                                    );
+                                    try {
+                                        $coefficient = $this->bulletinService->getCoefficientForCombination(
+                                            $matiere->id,
+                                            $classe->id,
+                                            $request->annee_universitaire_id,
+                                            $request->periode,
+                                            $etudiant->id
+                                        );
+                                    } catch (\RuntimeException $e) {
+                                        if (! str_contains($e->getMessage(), 'Coefficient manquant')) {
+                                            throw $e;
+                                        }
+                                        Log::warning('Coef introuvable matiere TC, skip', ['matiere_id' => $matiere->id, 'classe_id' => $classe->id]);
+                                        continue;
+                                    }
 
                                     $resultat = new ESBTPResultatMatiere;
                                     $resultat->bulletin_id = $bulletin->id;
@@ -1205,11 +1230,21 @@ class ESBTPBulletinController extends Controller
                         $moyenne = $sommeCoefficients > 0 ? $sommeNotes / $sommeCoefficients : null;
 
                         // Récupérer le coefficient de la matière pour cette classe
-                        $coefficient = $this->bulletinService->getCoefficientForCombination(
-                            $matiere->id,
-                            $classe->id,
-                            $request->annee_universitaire_id
-                        );
+                        try {
+                            $coefficient = $this->bulletinService->getCoefficientForCombination(
+                                $matiere->id,
+                                $classe->id,
+                                $request->annee_universitaire_id,
+                                $request->periode,
+                                $etudiant->id
+                            );
+                        } catch (\RuntimeException $e) {
+                            if (! str_contains($e->getMessage(), 'Coefficient manquant')) {
+                                throw $e;
+                            }
+                            Log::warning('Coef introuvable matiere TC, skip', ['matiere_id' => $matiere->id, 'classe_id' => $classe->id]);
+                            continue;
+                        }
 
                         // Créer le résultat pour cette matière
                         try {

--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -48,15 +48,19 @@ class ESBTPBulletinController extends Controller
 
     protected $bulletinConsistencyService;
 
+    protected \App\Domain\BtsTroncCommun\BtsBulletinSubjectResolver $subjectResolver;
+
     public function __construct(
         ESBTPAbsenceService $absenceService,
         \App\Services\BulletinService $bulletinService,
-        BulletinConsistencyService $bulletinConsistencyService
+        BulletinConsistencyService $bulletinConsistencyService,
+        \App\Domain\BtsTroncCommun\BtsBulletinSubjectResolver $subjectResolver
     )
     {
         $this->absenceService = $absenceService;
         $this->bulletinService = $bulletinService;
         $this->bulletinConsistencyService = $bulletinConsistencyService;
+        $this->subjectResolver = $subjectResolver;
     }
 
     /**
@@ -233,13 +237,14 @@ class ESBTPBulletinController extends Controller
             // ESBTPBulletinController est BTS-only. Les classes LMD doivent passer par
             // ESBTPLMDBulletinController + LMDBulletinService (architecture separee).
             // Rule .claude/rules/lmd-bts-bulletin-separation.md
-            $classe = ESBTPClasse::with('matieres')->findOrFail($request->classe_id);
+            $classe = ESBTPClasse::with(['matieres', 'filiere'])->findOrFail($request->classe_id);
             abort_if(
                 ($classe->systeme_academique ?? '') === 'LMD',
                 422,
                 'Cette classe est LMD. Utilisez /esbtp/lmd/bulletins pour générer des bulletins LMD.'
             );
-            $matieres = $classe->matieres;
+            // Tronc commun (C10) : union [filière classe, filière TC parente] + fallback pivot.
+            $matieres = $this->subjectResolver->subjectsForClasse($classe);
 
             // Précharger toutes les évaluations pour cette classe et période
             $allEvaluations = ESBTPEvaluation::where('classe_id', $classe->id)
@@ -1503,11 +1508,9 @@ class ESBTPBulletinController extends Controller
                 ->where('annee_universitaire_id', $anneeUniversitaire->id)
                 ->first();
 
-            // Récupérer les matières de la classe via la relation pivot
-            $matieres = $classe->matieres()
-                ->where('esbtp_matieres.is_active', true)
-                ->orderBy('esbtp_matieres.name')
-                ->get();
+            // Récupérer les matières de la classe (tronc commun-aware, C10) :
+            // union [filière classe, filière TC parente] + fallback pivot.
+            $matieres = $this->subjectResolver->subjectsForClasse($classe);
 
             // Grouper les matières par filière
             $matieresByFiliere = $matieres->groupBy(function ($matiere) use ($classe) {

--- a/app/Http/Controllers/ESBTPBulletinController.php
+++ b/app/Http/Controllers/ESBTPBulletinController.php
@@ -1630,6 +1630,10 @@ class ESBTPBulletinController extends Controller
                 'totalEtudiants'
             ));
 
+        } catch (\Symfony\Component\HttpKernel\Exception\HttpExceptionInterface $e) {
+            // Laisser passer les réponses HTTP volontaires (ex: garde LMD abort_if(422)).
+            // Sinon le catch générique ci-dessous les convertirait en redirect 302.
+            throw $e;
         } catch (\Exception $e) {
             \Log::error('Erreur lors de la prévisualisation du bulletin: '.$e->getMessage());
 

--- a/app/Models/ESBTPBulletin.php
+++ b/app/Models/ESBTPBulletin.php
@@ -274,8 +274,13 @@ class ESBTPBulletin extends Model implements Auditable
      */
     public function calculerRang(): void
     {
-        // Get all bulletins from the same class, period and academic year
-        $bulletins = self::where('classe_id', $this->classe_id)
+        // Tronc commun : pour un bulletin S1 d'un étudiant orienté, la cohorte de rang
+        // est la classe TC qui portait les notes du S1 (pas la spécialité courante).
+        $cohorteClasseId = app(\App\Domain\BtsTroncCommun\BtsBulletinCohortResolver::class)
+            ->resolveRankCohortClasseId($this);
+
+        // Get all bulletins from the cohort class, period and academic year
+        $bulletins = self::where('classe_id', $cohorteClasseId)
             ->where('annee_universitaire_id', $this->annee_universitaire_id)
             ->where('periode', $this->periode)
             ->whereNotNull('moyenne_generale')
@@ -283,20 +288,29 @@ class ESBTPBulletin extends Model implements Auditable
             ->get();
 
         // Keep displayed class size aligned with validated enrollments, not only generated bulletins.
-        $this->effectif_classe = ESBTPInscription::where('classe_id', $this->classe_id)
+        $this->effectif_classe = ESBTPInscription::where('classe_id', $cohorteClasseId)
             ->where('annee_universitaire_id', $this->annee_universitaire_id)
             ->where('status', 'active')
             ->where('workflow_step', 'etudiant_cree')
             ->distinct('etudiant_id')
             ->count('etudiant_id');
 
-        // Find student's rank
+        // Find student's rank. Quand la cohorte diffère de la classe du bulletin
+        // (étudiant orienté), le bulletin courant n'est pas dans la liste cohorte :
+        // on classe alors par nombre de moyennes strictement supérieures + 1.
+        $rang = null;
         foreach ($bulletins as $index => $bulletin) {
             if ($bulletin->id === $this->id) {
-                $this->rang = $index + 1;
+                $rang = $index + 1;
                 break;
             }
         }
+
+        if ($rang === null) {
+            $rang = $bulletins->where('moyenne_generale', '>', $this->moyenne_generale ?? 0)->count() + 1;
+        }
+
+        $this->rang = $rang;
 
         $this->save();
     }

--- a/app/Models/ESBTPFiliere.php
+++ b/app/Models/ESBTPFiliere.php
@@ -174,6 +174,26 @@ class ESBTPFiliere extends Model
     }
 
     /**
+     * Filière IDs à considérer pour l'union TC → spécialité côté planning/présences.
+     *
+     * Retourne `[id]` pour une filière normale ; `[id, parent_id]` lorsque le parent
+     * est un véritable tronc commun. Permet aux classes de spécialité d'hériter des
+     * matières/planifications définies au niveau du tronc commun parent (C9).
+     *
+     * @return array<int>
+     */
+    public function troncCommunUnionFiliereIds(): array
+    {
+        $ids = [$this->id];
+
+        if ($this->parent_id && $this->parent && $this->parent->isTroncCommun()) {
+            $ids[] = $this->parent_id;
+        }
+
+        return $ids;
+    }
+
+    /**
      * Vérifie si cette filière est une "fille" (spécialité) d'un tronc commun :
      *  - elle n'est pas elle-même un TC
      *  - elle a un parent_id défini (rattachée à une filière mère qui est le TC)

--- a/app/Services/BulletinService.php
+++ b/app/Services/BulletinService.php
@@ -14,6 +14,7 @@ use App\Models\ESBTPMatiereCoefficient;
 use App\Models\ESBTPNote;
 use App\Models\ESBTPResultat;
 use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
+use App\Domain\BtsTroncCommun\BtsBulletinCohortResolver;
 use App\Services\ESBTP\ESBTPAbsenceService;
 use App\Support\InscriptionWorkflowAlertPresenter;
 use App\Models\ESBTPConfigMatiere;
@@ -43,14 +44,17 @@ class BulletinService
 
     private BtsAnnualClassMapResolver $classMapResolver;
 
+    private BtsBulletinCohortResolver $cohortResolver;
+
     private array $coefficientCache = [];
 
     private array $classeCache = [];
 
-    public function __construct(ESBTPAbsenceService $absenceService, BtsAnnualClassMapResolver $classMapResolver)
+    public function __construct(ESBTPAbsenceService $absenceService, BtsAnnualClassMapResolver $classMapResolver, BtsBulletinCohortResolver $cohortResolver)
     {
         $this->absenceService = $absenceService;
         $this->classMapResolver = $classMapResolver;
+        $this->cohortResolver = $cohortResolver;
     }
 
     public function isAttendanceNoteEnabled(): bool
@@ -1597,13 +1601,17 @@ class BulletinService
 
     public function calculerRang($bulletin)
     {
-        $base = ESBTPBulletin::where('classe_id', $bulletin->classe_id)
+        // Tronc commun : pour un bulletin S1 d'un étudiant orienté, la cohorte de rang
+        // est la classe TC qui portait les notes du S1 (pas la spécialité courante).
+        $cohorteClasseId = $this->cohortResolver->resolveRankCohortClasseId($bulletin);
+
+        $base = ESBTPBulletin::where('classe_id', $cohorteClasseId)
             ->where('annee_universitaire_id', $bulletin->annee_universitaire_id)
             ->where('periode', $bulletin->periode)
             ->whereNotNull('moyenne_generale');
 
         $bulletin->effectif_classe = $this->getValidatedClassStudentCount(
-            $bulletin->classe_id,
+            $cohorteClasseId,
             $bulletin->annee_universitaire_id
         );
         $bulletin->rang = (clone $base)

--- a/app/Services/BulletinService.php
+++ b/app/Services/BulletinService.php
@@ -13,6 +13,7 @@ use App\Models\ESBTPMatiere;
 use App\Models\ESBTPMatiereCoefficient;
 use App\Models\ESBTPNote;
 use App\Models\ESBTPResultat;
+use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
 use App\Services\ESBTP\ESBTPAbsenceService;
 use App\Support\InscriptionWorkflowAlertPresenter;
 use App\Models\ESBTPConfigMatiere;
@@ -40,13 +41,16 @@ class BulletinService
 
     private $absenceService;
 
+    private BtsAnnualClassMapResolver $classMapResolver;
+
     private array $coefficientCache = [];
 
     private array $classeCache = [];
 
-    public function __construct(ESBTPAbsenceService $absenceService)
+    public function __construct(ESBTPAbsenceService $absenceService, BtsAnnualClassMapResolver $classMapResolver)
     {
         $this->absenceService = $absenceService;
+        $this->classMapResolver = $classMapResolver;
     }
 
     public function isAttendanceNoteEnabled(): bool
@@ -451,21 +455,16 @@ class BulletinService
             ->where('moyenne_generale', '>', 0)
             ->exists();
 
-        // Tronc commun : si l'inscription est une spécialisation, chercher S1 dans la classe d'origine
+        // Tronc commun : resoudre la classe portant les notes du S1 via le class-map
+        // resolveur stateless (modele phases ET legacy). CLASS MAP only.
         $classeIdS1 = $classeId;
         $classeTroncCommun = null;
-        $inscription = \App\Models\ESBTPInscription::where('etudiant_id', $etudiantId)
-            ->where('classe_id', $classeId)
-            ->where('annee_universitaire_id', $anneeUniversitaireId)
-            ->whereIn('status', ['active', 'terminée'])
-            ->first();
-
-        if ($inscription && $inscription->isSpecialisation()
-            && \App\Helpers\SettingsHelper::get('tronc_commun_mga_include_s1', true)) {
-            $origine = $inscription->inscriptionOrigine;
-            if ($origine && $origine->classe_id) {
-                $classeIdS1 = $origine->classe_id;
-                $classeTroncCommun = $origine->classe;
+        if (\App\Helpers\SettingsHelper::get('tronc_commun_mga_include_s1', true)) {
+            $classMap = $this->classMapResolver->resolve($etudiantId, $classeId, $anneeUniversitaireId);
+            $resolvedS1ClasseId = $classMap['semestre1_classe_id'] ?? $classeId;
+            if ($resolvedS1ClasseId && (int) $resolvedS1ClasseId !== (int) $classeId) {
+                $classeIdS1 = (int) $resolvedS1ClasseId;
+                $classeTroncCommun = ESBTPClasse::with('filiere')->find($resolvedS1ClasseId);
             }
         }
 

--- a/app/Services/BulletinService.php
+++ b/app/Services/BulletinService.php
@@ -2183,7 +2183,7 @@ class BulletinService
     }
 
 
-    public function getCoefficientForCombination(int $matiereId, int $classeId, int $anneeUniversitaireId, ?string $periode = null): float
+    public function getCoefficientForCombination(int $matiereId, int $classeId, int $anneeUniversitaireId, ?string $periode = null, ?int $etudiantId = null): float
     {
         // Sous-lot α : coefficients désormais par-périodes. Si $periode null, on prend
         // n'importe quelle ligne (fallback semestre1) pour rétrocompat des appelants
@@ -2193,7 +2193,7 @@ class BulletinService
             $periode = 'semestre1';
         }
 
-        $cacheKey = $matiereId.'|'.$classeId.'|'.$anneeUniversitaireId.'|'.$periode;
+        $cacheKey = $matiereId.'|'.$classeId.'|'.$anneeUniversitaireId.'|'.$periode.'|'.($etudiantId ?? '');
 
         if (isset($this->coefficientCache[$cacheKey])) {
             return $this->coefficientCache[$cacheKey];
@@ -2227,6 +2227,20 @@ class BulletinService
                 ->value('coefficient');
         }
 
+        // Fallback Tronc Commun (P1-a) : pour un etudiant orienté TC → spécialité, les
+        // matières du Semestre 1 portent leur coefficient sur la classe TC (filière TC
+        // parente), pas sur la classe de spécialité demandée. On résout la classe S1 via
+        // le class-map resolver stateless et on cherche le coefficient là-bas.
+        if ($coefficient === null && $etudiantId !== null) {
+            $coefficient = $this->resolveTroncCommunCoefficient(
+                $matiereId,
+                $classeId,
+                $anneeUniversitaireId,
+                $periode,
+                $etudiantId
+            );
+        }
+
         if ($coefficient === null) {
             throw new \RuntimeException('Coefficient manquant pour la matière sélectionnée.');
         }
@@ -2234,6 +2248,56 @@ class BulletinService
         $this->coefficientCache[$cacheKey] = (float) $coefficient;
 
         return $this->coefficientCache[$cacheKey];
+    }
+
+    /**
+     * Résout le coefficient d'une matière Tronc Commun pour un étudiant orienté
+     * (TC → spécialité). Cherche le coefficient sur la classe S1 (TC) si elle diffère
+     * de la classe de spécialité demandée. BTS uniquement.
+     */
+    private function resolveTroncCommunCoefficient(
+        int $matiereId,
+        int $classeId,
+        int $anneeUniversitaireId,
+        string $periode,
+        int $etudiantId
+    ): ?float {
+        $classMap = $this->classMapResolver->resolve($etudiantId, $classeId, $anneeUniversitaireId);
+        $resolvedS1ClasseId = $classMap['semestre1_classe_id'] ?? $classeId;
+
+        if (! $resolvedS1ClasseId || (int) $resolvedS1ClasseId === (int) $classeId) {
+            return null;
+        }
+
+        if (! isset($this->classeCache[$resolvedS1ClasseId])) {
+            $this->classeCache[$resolvedS1ClasseId] = ESBTPClasse::find($resolvedS1ClasseId);
+        }
+
+        $classeTc = $this->classeCache[$resolvedS1ClasseId];
+
+        if (! $classeTc || ! $classeTc->filiere_id || ! $classeTc->niveau_etude_id) {
+            return null;
+        }
+
+        $coefficient = ESBTPMatiereCoefficient::where('matiere_id', $matiereId)
+            ->where('filiere_id', $classeTc->filiere_id)
+            ->where('niveau_etude_id', $classeTc->niveau_etude_id)
+            ->where('annee_universitaire_id', $anneeUniversitaireId)
+            ->where('periode', $periode)
+            ->value('coefficient');
+
+        // Fallback périodique sur la classe TC (rétrocompat pré-migration par-période).
+        if ($coefficient === null) {
+            $altPeriode = $periode === 'semestre1' ? 'semestre2' : 'semestre1';
+            $coefficient = ESBTPMatiereCoefficient::where('matiere_id', $matiereId)
+                ->where('filiere_id', $classeTc->filiere_id)
+                ->where('niveau_etude_id', $classeTc->niveau_etude_id)
+                ->where('annee_universitaire_id', $anneeUniversitaireId)
+                ->where('periode', $altPeriode)
+                ->value('coefficient');
+        }
+
+        return $coefficient === null ? null : (float) $coefficient;
     }
 
 

--- a/app/Services/ClassPlanningService.php
+++ b/app/Services/ClassPlanningService.php
@@ -48,9 +48,16 @@ class ClassPlanningService
         $sem1Variants = $this->semestreVariants($sem1Number);
         $sem2Variants = $this->semestreVariants($sem2Number);
 
+        // Tronc commun (C9) : une classe de spécialité hérite des planifications
+        // définies au niveau de sa filière mère (le tronc commun). On élargit donc
+        // le filtre à l'union [filière classe, filière TC parente] via le helper modèle.
+        $unionFiliereIds = $classe->filiere
+            ? $classe->filiere->troncCommunUnionFiliereIds()
+            : [$classe->filiere_id];
+
         $planificationsQuery = ESBTPPlanificationAcademique::with(['matiere'])
             ->where('annee_universitaire_id', $anneeCourante->id)
-            ->where('filiere_id', $classe->filiere_id)
+            ->whereIn('filiere_id', $unionFiliereIds)
             ->where('niveau_etude_id', $classe->niveau_etude_id)
             ->select(
                 'matiere_id',

--- a/app/Services/ESBTP/BtsCurrentResultSnapshotService.php
+++ b/app/Services/ESBTP/BtsCurrentResultSnapshotService.php
@@ -2,8 +2,7 @@
 
 namespace App\Services\ESBTP;
 
-use App\Domain\BtsTroncCommun\BtsPhaseResolver;
-use App\Models\ESBTPInscription;
+use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
 use App\Models\ESBTPNote;
 use App\Models\ESBTPResultat;
 use App\Services\BulletinService;
@@ -12,7 +11,7 @@ class BtsCurrentResultSnapshotService
 {
     public function __construct(
         private BulletinService $bulletinService,
-        private BtsPhaseResolver $btsPhaseResolver
+        private BtsAnnualClassMapResolver $classMapResolver
     )
     {
     }
@@ -213,7 +212,7 @@ class BtsCurrentResultSnapshotService
 
     private function buildAnnualSnapshot(int $etudiantId, int $classeId, int $anneeUniversitaireId): array
     {
-        $classMap = $this->resolveAnnualClassMap($etudiantId, $classeId, $anneeUniversitaireId);
+        $classMap = $this->classMapResolver->resolve($etudiantId, $classeId, $anneeUniversitaireId);
         $semestre1 = $this->buildSemesterSnapshot(
             $etudiantId,
             $classMap['semestre1_classe_id'] ?? $classeId,
@@ -292,44 +291,6 @@ class BtsCurrentResultSnapshotService
                 'semestre1' => $semestre1,
                 'semestre2' => $semestre2,
             ],
-        ];
-    }
-
-    private function resolveAnnualClassMap(int $etudiantId, int $requestedClasseId, int $anneeUniversitaireId): array
-    {
-        $inscription = ESBTPInscription::query()
-            ->with([
-                'filiere',
-                'phases.classe.filiere',
-                'inscriptionOrigine.classe.filiere',
-                'inscriptionSpecialisation.classe.filiere',
-            ])
-            ->where('etudiant_id', $etudiantId)
-            ->where('annee_universitaire_id', $anneeUniversitaireId)
-            ->orderByRaw('CASE WHEN classe_id = ? THEN 0 ELSE 1 END', [$requestedClasseId])
-            ->orderByRaw("CASE WHEN status = 'active' THEN 0 ELSE 1 END")
-            ->orderByDesc('date_inscription')
-            ->orderByDesc('id')
-            ->first();
-
-        if (! $inscription) {
-            return [
-                'inscription_id' => null,
-                'source_model' => 'phase_based',
-                'semestre1_classe_id' => $requestedClasseId,
-                'semestre2_classe_id' => $requestedClasseId,
-            ];
-        }
-
-        $journey = $this->btsPhaseResolver->buildJourney($inscription);
-        $semestre1Phase = $this->btsPhaseResolver->resolveSemesterPhase($inscription, 1);
-        $semestre2Phase = $this->btsPhaseResolver->resolveSemesterPhase($inscription, 2);
-
-        return [
-            'inscription_id' => $inscription->id,
-            'source_model' => $journey['source_model'] ?? 'phase_based',
-            'semestre1_classe_id' => $semestre1Phase['classe_id'] ?? $inscription->classe_id,
-            'semestre2_classe_id' => $semestre2Phase['classe_id'] ?? $inscription->classe_id,
         ];
     }
 }

--- a/app/Services/TroncCommunService.php
+++ b/app/Services/TroncCommunService.php
@@ -66,6 +66,12 @@ class TroncCommunService
      * 3. Crée la nouvelle inscription avec lien vers l'origine
      * 4. Reporte les paiements si configuré
      * 5. Met à jour les places des classes
+     *
+     * @deprecated CODE MORT — aucun call site externe. Le flux d'orientation
+     * tronc commun → spécialité passe désormais par BtsOrientationService::orient()
+     * qui matérialise les phases (modèle phases), sans créer une seconde
+     * inscription dual (inscription_origine_id + type_changement). Conservé pour
+     * rétro-compat du modèle legacy dual ; ne PAS appeler dans du code neuf.
      */
     public function creerInscriptionSpecialisation(
         ESBTPInscription $inscriptionOrigine,
@@ -147,6 +153,11 @@ class TroncCommunService
      *
      * Ne duplique pas les paiements — met à jour les metadata pour référencer
      * la nouvelle inscription et génère les frais de la spécialisation.
+     *
+     * @deprecated CODE MORT — public mais uniquement invoqué par
+     * creerInscriptionSpecialisation() (elle-même dépréciée). Le modèle phases
+     * (BtsOrientationService::orient) ne crée pas de seconde inscription, donc
+     * aucun report de paiement n'est nécessaire. Ne PAS appeler dans du code neuf.
      */
     public function reporterPaiements(
         ESBTPInscription $origine,

--- a/database/factories/ESBTPBulletinFactory.php
+++ b/database/factories/ESBTPBulletinFactory.php
@@ -25,11 +25,13 @@ class ESBTPBulletinFactory extends Factory
             'rang' => $this->faker->numberBetween(1, 50),
             'effectif_classe' => 50,
             'mention' => $this->determinerMention($moyenne),
-            'decision' => $moyenne >= 10 ? 'Admis(e)' : 'Ajourné(e)',
+            'decision_conseil' => $moyenne >= 10 ? 'Admis(e)' : 'Ajourné(e)',
             'absences_justifiees' => $this->faker->numberBetween(0, 20),
             'absences_non_justifiees' => $this->faker->numberBetween(0, 10),
-            'created_by' => 1,
-            'updated_by' => 1,
+            // created_by / updated_by sont nullable + FK users : on les laisse null
+            // (aucun user seedé sous RefreshDatabase) pour ne pas violer la contrainte.
+            'created_by' => null,
+            'updated_by' => null,
             'created_at' => now(),
             'updated_at' => now()
         ];

--- a/database/migrations/2026_06_04_220853_add_reconciliation_settings.php
+++ b/database/migrations/2026_06_04_220853_add_reconciliation_settings.php
@@ -11,6 +11,10 @@ return new class extends Migration
 {
     public function up(): void
     {
+        // created_by/updated_by : 1er user existant (null si DB vide, ex: klassci_testing).
+        // La FK settings.created_by est ON DELETE SET NULL → null accepté.
+        $creatorId = DB::table('users')->min('id');
+
         $rows = [
             [
                 'key' => 'comptabilite.reconciliation.frequency',
@@ -24,8 +28,8 @@ return new class extends Migration
                 'validation_rules' => json_encode(['required', 'in:daily,weekly,monthly']),
                 'sort_order' => 10,
                 'is_active' => 1,
-                'created_by' => 1,
-                'updated_by' => 1,
+                'created_by' => $creatorId,
+                'updated_by' => $creatorId,
                 'created_at' => now(),
                 'updated_at' => now(),
             ],
@@ -41,8 +45,8 @@ return new class extends Migration
                 'validation_rules' => json_encode(['required', 'boolean']),
                 'sort_order' => 11,
                 'is_active' => 1,
-                'created_by' => 1,
-                'updated_by' => 1,
+                'created_by' => $creatorId,
+                'updated_by' => $creatorId,
                 'created_at' => now(),
                 'updated_at' => now(),
             ],

--- a/database/migrations/2026_06_04_232013_add_reconciliation_tolerance_and_portal_settings.php
+++ b/database/migrations/2026_06_04_232013_add_reconciliation_tolerance_and_portal_settings.php
@@ -13,6 +13,8 @@ return new class extends Migration
     public function up(): void
     {
         $now = now();
+        // 1er user existant (null si DB vide, ex: klassci_testing). FK ON DELETE SET NULL → null OK.
+        $creatorId = DB::table('users')->min('id');
         $rows = [
             [
                 'key' => 'comptabilite.reconciliation.ecart_tolerance',
@@ -82,8 +84,8 @@ return new class extends Migration
         if (!empty($toInsert)) {
             $toInsert = array_map(fn ($r) => array_merge($r, [
                 'is_active' => 1,
-                'created_by' => 1,
-                'updated_by' => 1,
+                'created_by' => $creatorId,
+                'updated_by' => $creatorId,
                 'created_at' => $now,
                 'updated_at' => $now,
             ]), $toInsert);

--- a/database/migrations/2026_06_04_233758_add_reconciliation_overdue_days_setting.php
+++ b/database/migrations/2026_06_04_233758_add_reconciliation_overdue_days_setting.php
@@ -27,8 +27,8 @@ return new class extends Migration
             'validation_rules' => json_encode(['required', 'integer', 'min:1', 'max:60']),
             'sort_order' => 17,
             'is_active' => 1,
-            'created_by' => 1,
-            'updated_by' => 1,
+            'created_by' => DB::table('users')->min('id'),
+            'updated_by' => DB::table('users')->min('id'),
             'created_at' => now(),
             'updated_at' => now(),
         ]);

--- a/docs/runbooks/bts-tc-bulletins-backfill.md
+++ b/docs/runbooks/bts-tc-bulletins-backfill.md
@@ -1,0 +1,185 @@
+# Runbook — Backfill bulletins annuels BTS Tronc Commun (C8)
+
+> Objet : régénérer les bulletins **annuels** des inscriptions BTS « modèle phases »
+> (Tronc Commun → Spécialité) dont la moyenne générale persistée est devenue
+> obsolète après le correctif class-map (Plan C, commits c1→c9).
+>
+> **Périmètre strict : BTS uniquement.** Aucun bulletin LMD n'est touché.
+> La commande ne traite que la période `annuel`.
+
+---
+
+## 1. Avertissements absolus
+
+- ❌ **JAMAIS** `php artisan migrate:fresh`, `migrate:reset`, `db:wipe` ni aucune commande
+  qui drop la base. Ce backfill ne fait que régénérer des bulletins existants.
+- ❌ **JAMAIS** de `pnpm build` / `composer install` lourd / build d'assets sur le serveur
+  qui sert le trafic de production. La commande backfill est un process artisan léger ;
+  elle ne nécessite aucun build.
+- ❌ **JAMAIS** lancer la commande sur une instance dont le `TENANT_CODE` ne correspond
+  pas à l'argument `{tenant}` passé. Le garde-fou interne refuse (exit 1) toute exécution
+  croisée, mais c'est aussi une discipline opérateur.
+- ✅ **TOUJOURS** un `dry-run` AVANT, puis un backup mysqldump AVANT le run réel.
+- ✅ **TOUJOURS** lire le rapport JSON (`storage/app/backfill/…`) pour décider GO / NO-GO.
+
+---
+
+## 2. Prérequis
+
+1. Les commits **c1 → c9** du Plan C sont **mergés sur `presentation`** puis **déployés**
+   sur le tenant cible (`git pull` de la branche tenant + `cache:clear` + `migrate`
+   + `permissions:fix` selon le workflow multi-instance habituel).
+2. La commande `bts:tc-bulletins-backfill` répond :
+   ```bash
+   php artisan list | grep bts:tc-bulletins-backfill
+   ```
+3. Vous connaissez l'**ID de l'année universitaire** à backfiller (option `--annee=`,
+   obligatoire). Récupérable via la table `esbtp_annee_universitaires` (année courante
+   ou année concernée par la bascule TC → spécialité).
+4. Accès SSH au serveur du tenant + droits `mysqldump` sur la base de l'instance.
+
+---
+
+## 3. Signature de la commande
+
+```
+php artisan bts:tc-bulletins-backfill {tenant}
+    --annee=<ID_ANNEE>        # OBLIGATOIRE : ID de l'année universitaire
+    [--dry-run]               # n'écrit rien, rapporte seulement
+    [--limit=<N>]             # limite le nombre d'inscriptions traitées
+    [--periode=annuel]        # seule la période "annuel" est supportée
+```
+
+- `{tenant}` **doit** matcher le `TENANT_CODE` de l'instance courante, sinon **exit 1**.
+- Code retour : `0` si `errors == 0`, sinon `1`.
+- Rapport JSON écrit dans :
+  `storage/app/backfill/bts-tc-{tenant}-{annee}-{Ymd_His}.json`
+
+### Compteurs du rapport
+
+| Compteur | Signification |
+|---|---|
+| `scanned` | inscriptions modèle phases scannées |
+| `skipped_no_official` | aucun bulletin annuel officiel persisté → ignoré |
+| `eligible` | a un bulletin officiel, candidat à comparaison |
+| `skipped_recompute_error` | échec du recalcul lecture seule → ignoré |
+| `aligned` | persisté == recalculé (écart < 0.01) → rien à faire |
+| `affected` | écart >= 0.01 détecté |
+| `would_fix` | (dry-run) bulletins qui seraient régénérés |
+| `fixed` | (run réel) bulletins régénérés |
+| `errors` | échecs de régénération (déclenche exit 1) |
+
+**Règle GO / NO-GO** : un run réel est sûr quand le dry-run montre `errors == 0` et un
+`would_fix` cohérent avec le nombre d'inscriptions orientées attendu pour l'année.
+
+---
+
+## 4. Ordre de déploiement des tenants
+
+Traiter les tenants **séquentiellement**, du moins critique au plus critique :
+
+```
+presentation  →  hetec  →  rostan  →  ephrata  →  esbtp-yakro  →  esbtp-abidjan
+```
+
+- `presentation` = démo, sert de validation pilote.
+- `esbtp-yakro` et `esbtp-abidjan` = Élite, > 2000 inscriptions chacun : à traiter en
+  dernier, après confirmation que le pilote et les tenants intermédiaires sont sains.
+
+Ne JAMAIS enchaîner deux tenants sans avoir validé le précédent (rapport JSON + vérif
+fonctionnelle).
+
+---
+
+## 5. Procédure par tenant
+
+Pour CHAQUE tenant, dans l'ordre ci-dessus, sur le serveur de l'instance :
+
+### Étape 5.1 — Dry-run (lecture seule)
+
+```bash
+php artisan bts:tc-bulletins-backfill <tenant> --annee=<ID_ANNEE> --dry-run
+```
+
+### Étape 5.2 — Lire le rapport JSON → décision GO / NO-GO
+
+```bash
+cat storage/app/backfill/bts-tc-<tenant>-<ID_ANNEE>-<timestamp>.json
+```
+
+- **GO** si : `errors == 0` et `would_fix` correspond à l'ordre de grandeur attendu
+  d'étudiants orientés (Tronc Commun → spécialité) sur cette année.
+- **NO-GO** si : `errors > 0`, ou `would_fix` anormalement élevé (ex. toute la cohorte),
+  ou `skipped_no_official` inattendu. Investiguer AVANT tout run réel.
+
+Optionnel : limiter un premier run réel de test avec `--limit=5` pour valider sur un
+petit échantillon avant le run complet.
+
+### Étape 5.3 — Backup mysqldump AVANT le run réel
+
+```bash
+mkdir -p ~/Downloads/dev/_db_backups
+mysqldump --single-transaction --routines --triggers <DB_INSTANCE> \
+    > ~/Downloads/dev/_db_backups/<tenant>_$(date +%Y%m%d_%H%M%S).sql
+```
+
+Vérifier que le fichier n'est pas vide (`ls -lh`). Ce dump est le point de rollback.
+
+### Étape 5.4 — Run réel
+
+```bash
+php artisan bts:tc-bulletins-backfill <tenant> --annee=<ID_ANNEE>
+```
+
+Vérifier le code retour (`echo $?` → doit être `0`) et le rapport JSON : `fixed`
+correspond au `would_fix` du dry-run, `errors == 0`.
+
+### Étape 5.5 — Vérifier l'idempotence
+
+Relancer un dry-run immédiatement après le run réel :
+
+```bash
+php artisan bts:tc-bulletins-backfill <tenant> --annee=<ID_ANNEE> --dry-run
+```
+
+Résultat attendu : `affected == 0` et `would_fix == 0` (tout est aligné). Si ce n'est
+pas le cas, NE PAS continuer vers le tenant suivant : investiguer.
+
+### Étape 5.6 — Vérification fonctionnelle
+
+Ouvrir l'application du tenant et contrôler quelques bulletins annuels d'étudiants
+orientés (Tronc Commun → spécialité) :
+
+- la moyenne générale annuelle affichée est cohérente ;
+- le rang annuel est calculé sur la bonne cohorte ;
+- aucune régression visible sur un bulletin BTS « pur » (non TC) servant de témoin.
+
+---
+
+## 6. Rollback
+
+En cas d'anomalie après un run réel sur un tenant :
+
+```bash
+mysql <DB_INSTANCE> < ~/Downloads/dev/_db_backups/<tenant>_<timestamp>.sql
+```
+
+Puis purger les caches Laravel de l'instance (`config:clear`, `cache:clear`,
+`view:clear`). Le backfill ne touchant que des bulletins, la restauration du dump
+pris en 5.3 ramène l'état exact d'avant le run.
+
+- **Ne JAMAIS** tenter un rollback via `migrate:fresh` ou par suppression manuelle de
+  lignes : restaurer le dump est la seule procédure autorisée.
+
+---
+
+## 7. Checklist récapitulative (par tenant)
+
+- [ ] c1→c9 mergés + déployés sur le tenant
+- [ ] `--dry-run` exécuté
+- [ ] Rapport JSON lu → décision **GO**
+- [ ] `mysqldump` réalisé dans `~/Downloads/dev/_db_backups/` (fichier non vide)
+- [ ] Run réel exécuté, exit code `0`, `errors == 0`
+- [ ] Dry-run d'idempotence → `affected == 0`
+- [ ] Vérification fonctionnelle OK (bulletins TC + témoin BTS pur)
+- [ ] Tenant suivant uniquement après validation complète du courant

--- a/tests/Feature/Bts/BtsTcBulletinsBackfillCommandTest.php
+++ b/tests/Feature/Bts/BtsTcBulletinsBackfillCommandTest.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace Tests\Feature\Bts;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPBulletin;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPInscriptionPhase;
+use App\Models\ESBTPNiveauEtude;
+use App\Services\BulletinService;
+use App\Services\ESBTP\BulletinConsistencyService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * c9 — Commande de backfill idempotente des bulletins annuels BTS Tronc Commun.
+ *
+ * Le détecteur compare la moyenne_generale PERSISTÉE du bulletin annuel officiel
+ * avec la moyenne RECALCULÉE par BulletinService::genererDonneesBulletin. Quand un
+ * écart >= 0.01 existe, le bulletin est « affected ». En dry-run rien n'est écrit ;
+ * en run réel BulletinConsistencyService::regenerateOfficialBulletin est appelé.
+ *
+ * On contrôle le recalcul et la régénération via des doublures liées au conteneur,
+ * pour rendre le test déterministe sans dépendre du pipeline complet de notes.
+ *
+ * BTS uniquement (LMD intouché). DB : klassci_testing (RefreshDatabase).
+ */
+class BtsTcBulletinsBackfillCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Aligne l'instance courante sur le tenant testé (garde-fou).
+        config(['app.tenant_code' => 'presentation']);
+    }
+
+    /** @test */
+    public function it_aborts_on_tenant_mismatch_without_writing(): void
+    {
+        $this->bindRecomputedMoyenne(15.00);
+        $consistency = $this->spyConsistency();
+
+        $this->makeAffectedScenario(persisted: 12.00);
+
+        $exit = $this->artisan('bts:tc-bulletins-backfill', [
+            'tenant' => 'mauvais-tenant',
+            '--annee' => $this->anneeId,
+        ])->run();
+
+        $this->assertSame(1, $exit, 'Le garde-fou tenant doit renvoyer le code de sortie 1');
+        $this->assertSame(0, $consistency->regenerationCalls, 'Aucune régénération sur mismatch tenant');
+    }
+
+    /** @test */
+    public function dry_run_detects_divergence_without_writing(): void
+    {
+        $this->bindRecomputedMoyenne(15.00);
+        $consistency = $this->spyConsistency();
+
+        $bulletin = $this->makeAffectedScenario(persisted: 12.00);
+
+        $exit = $this->artisan('bts:tc-bulletins-backfill', [
+            'tenant' => 'presentation',
+            '--annee' => $this->anneeId,
+            '--dry-run' => true,
+        ])->run();
+
+        $this->assertSame(0, $exit);
+        $this->assertSame(0, $consistency->regenerationCalls, 'Le dry-run ne doit JAMAIS régénérer');
+
+        // Aucune écriture : la moyenne persistée reste inchangée.
+        $this->assertEqualsWithDelta(
+            12.00,
+            (float) $bulletin->fresh()->moyenne_generale,
+            0.001,
+            'Le dry-run ne doit écrire aucune donnée'
+        );
+    }
+
+    /** @test */
+    public function run_regenerates_affected_annual_bulletin(): void
+    {
+        $this->bindRecomputedMoyenne(15.00);
+        $consistency = $this->spyConsistency();
+
+        $bulletin = $this->makeAffectedScenario(persisted: 12.00);
+
+        $exit = $this->artisan('bts:tc-bulletins-backfill', [
+            'tenant' => 'presentation',
+            '--annee' => $this->anneeId,
+        ])->run();
+
+        $this->assertSame(0, $exit);
+        $this->assertSame(1, $consistency->regenerationCalls, 'Le run doit régénérer le bulletin obsolète');
+        $this->assertSame(
+            [(int) $bulletin->etudiant_id, (int) $bulletin->classe_id, (int) $this->anneeId, 'annuel'],
+            $consistency->lastRegenerationArgs
+        );
+    }
+
+    /** @test */
+    public function it_is_idempotent_second_run_finds_no_divergence(): void
+    {
+        // 2e run : la moyenne persistée == recalculée → aucun affected.
+        $this->bindRecomputedMoyenne(12.00);
+        $consistency = $this->spyConsistency();
+
+        $this->makeAffectedScenario(persisted: 12.00);
+
+        $exit = $this->artisan('bts:tc-bulletins-backfill', [
+            'tenant' => 'presentation',
+            '--annee' => $this->anneeId,
+        ])->run();
+
+        $this->assertSame(0, $exit);
+        $this->assertSame(0, $consistency->regenerationCalls, 'Sans écart, aucune régénération (idempotence)');
+    }
+
+    /** @test */
+    public function it_skips_when_no_official_annual_bulletin(): void
+    {
+        $this->bindRecomputedMoyenne(15.00);
+        $consistency = $this->spyConsistency();
+
+        // Scénario éligible (phases orienté) MAIS sans bulletin annuel persisté.
+        $this->makePhaseBasedScenario();
+
+        $exit = $this->artisan('bts:tc-bulletins-backfill', [
+            'tenant' => 'presentation',
+            '--annee' => $this->anneeId,
+        ])->run();
+
+        $this->assertSame(0, $exit);
+        $this->assertSame(0, $consistency->regenerationCalls, 'Sans bulletin officiel, on skippe sans régénérer');
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private int $anneeId = 0;
+
+    /**
+     * Lie une doublure de BulletinService dont genererDonneesBulletin retourne une
+     * moyenne globale contrôlée (le reste des méthodes délègue à la vraie instance).
+     */
+    private function bindRecomputedMoyenne(float $moyenneGlobale): void
+    {
+        $this->app->bind(BulletinService::class, function () use ($moyenneGlobale) {
+            return new class($moyenneGlobale) extends BulletinService
+            {
+                public function __construct(private float $forcedMoyenne)
+                {
+                    // Pas d'appel parent : on ne se sert que de genererDonneesBulletin ici.
+                }
+
+                public function genererDonneesBulletin($etudiantId, $classeId, $anneeUniversitaireId, $periode = 'semestre1')
+                {
+                    return ['moyenneGlobale' => $this->forcedMoyenne];
+                }
+            };
+        });
+    }
+
+    private function spyConsistency(): object
+    {
+        // Étend la vraie classe pour satisfaire le type-hint du conteneur, mais
+        // bypasse le constructeur (deps lourdes) et override la seule méthode utile.
+        $spy = new class extends BulletinConsistencyService
+        {
+            public int $regenerationCalls = 0;
+
+            /** @var array<int, mixed> */
+            public array $lastRegenerationArgs = [];
+
+            public function __construct()
+            {
+                // Pas d'appel parent : on n'a besoin que de regenerateOfficialBulletin.
+            }
+
+            public function regenerateOfficialBulletin(int $etudiantId, int $classeId, int $anneeUniversitaireId, string $periode): array
+            {
+                $this->regenerationCalls++;
+                $this->lastRegenerationArgs = [$etudiantId, $classeId, $anneeUniversitaireId, $periode];
+
+                return [];
+            }
+        };
+
+        $this->app->instance(BulletinConsistencyService::class, $spy);
+
+        return $spy;
+    }
+
+    /**
+     * Étudiant orienté via phases, classe de spécialité (filière fille TC) + bulletin
+     * annuel persisté avec une moyenne stale.
+     */
+    private function makeAffectedScenario(float $persisted): ESBTPBulletin
+    {
+        [$inscription, , $specClasse] = $this->makePhaseBasedScenario();
+
+        return ESBTPBulletin::factory()->create([
+            'etudiant_id' => $inscription->etudiant_id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $this->anneeId,
+            'periode' => 'annuel',
+            'moyenne_generale' => $persisted,
+        ]);
+    }
+
+    /**
+     * @return array{0: ESBTPInscription, 1: ESBTPClasse, 2: ESBTPClasse}
+     */
+    private function makePhaseBasedScenario(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $this->anneeId = $annee->id;
+
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'parent_id' => null]);
+        $specFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => false, 'parent_id' => $tcFiliere->id]);
+
+        $tcClasse = ESBTPClasse::factory()->create([
+            'filiere_id' => $tcFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $specClasse = ESBTPClasse::factory()->create([
+            'filiere_id' => $specFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $specFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+            'inscription_origine_id' => null,
+        ]);
+
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 1,
+            'is_active' => false,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'specialisation',
+            'classe_id' => $specClasse->id,
+            'filiere_id' => $specFiliere->id,
+            'semestre_debut' => 2,
+            'is_active' => true,
+        ]);
+
+        return [$inscription, $tcClasse, $specClasse];
+    }
+}

--- a/tests/Feature/Bts/BulletinPreviewTcAwareTest.php
+++ b/tests/Feature/Bts/BulletinPreviewTcAwareTest.php
@@ -50,7 +50,11 @@ class BulletinPreviewTcAwareTest extends TestCase
         $this->actingAs($user);
 
         $annee = ESBTPAnneeUniversitaire::factory()->create();
-        $niveau = ESBTPNiveauEtude::factory()->create();
+        // Le modèle ESBTPClasse dérive systeme_academique du type du niveau via son hook
+        // saving() (ClasseManagementService::determinerSystemeAcademique). Pour obtenir une
+        // classe LMD, le niveau doit avoir un type LMD ('Licence'/'Master'/'Doctorat'),
+        // sinon la valeur 'LMD' passée au create est écrasée par 'BTS'.
+        $niveau = ESBTPNiveauEtude::factory()->create(['type' => 'Licence']);
         $filiere = ESBTPFiliere::factory()->create();
         $classeLmd = ESBTPClasse::factory()->create([
             'filiere_id' => $filiere->id,

--- a/tests/Feature/Bts/BulletinPreviewTcAwareTest.php
+++ b/tests/Feature/Bts/BulletinPreviewTcAwareTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Feature\Bts;
+
+use App\Domain\BtsTroncCommun\BtsBulletinSubjectResolver;
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPMatiereFilierNiveau;
+use App\Models\ESBTPNiveauEtude;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+/**
+ * c7 — La prévisualisation de bulletin utilise le résolveur de matières
+ * tronc-commun-aware (C10) et refuse les classes LMD.
+ *
+ * - Une classe LMD passée en preview retourne 422 (séparation BTS/LMD).
+ * - Les matières de preview proviennent de l'union TC (incluant le parent) afin que
+ *   les overrides manuels (ESBTPResultat) sur ces matières puissent être appliqués.
+ * - Les matières inactives sont exclues.
+ *
+ * BTS uniquement (LMD intouché). DB : klassci_testing (RefreshDatabase).
+ */
+class BulletinPreviewTcAwareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private BtsBulletinSubjectResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resolver = app(BtsBulletinSubjectResolver::class);
+    }
+
+    /** @test */
+    public function preview_rejects_lmd_classe_with_422(): void
+    {
+        $this->withoutMiddleware();
+        Role::findOrCreate('superAdmin', 'web');
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+        $user = User::withoutEvents(fn () => User::factory()->create());
+        $user->assignRole('superAdmin');
+        $this->actingAs($user);
+
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create();
+        $filiere = ESBTPFiliere::factory()->create();
+        $classeLmd = ESBTPClasse::factory()->create([
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+            'systeme_academique' => 'LMD',
+        ]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $response = $this->get(route('esbtp.bulletins.preview', [
+            'etudiant' => $etudiant->id,
+            'classe' => $classeLmd->id,
+            'annee' => $annee->id,
+        ]));
+
+        $response->assertStatus(422);
+    }
+
+    /** @test */
+    public function preview_subjects_include_tronc_commun_union(): void
+    {
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+
+        $tc = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'parent_id' => null]);
+        $specialite = ESBTPFiliere::factory()->create(['is_tronc_commun' => false, 'parent_id' => $tc->id]);
+
+        $matiereTc = ESBTPMatiere::factory()->create(['name' => 'Francais TC', 'is_active' => true]);
+        $matiereSpe = ESBTPMatiere::factory()->create(['name' => 'Beton Arme', 'is_active' => true]);
+
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $matiereTc->id,
+            'filiere_id' => $tc->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $matiereSpe->id,
+            'filiere_id' => $specialite->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $specialite->id,
+            'niveau_etude_id' => $niveau->id,
+            'systeme_academique' => 'BTS',
+        ]);
+        $classe->load('filiere');
+
+        $ids = $this->resolver->subjectsForClasse($classe)->pluck('id')->all();
+
+        $this->assertContains($matiereTc->id, $ids);
+        $this->assertContains($matiereSpe->id, $ids);
+    }
+
+    /** @test */
+    public function preview_subjects_respect_is_active(): void
+    {
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $filiere = ESBTPFiliere::factory()->create(['is_tronc_commun' => false, 'parent_id' => null]);
+
+        $active = ESBTPMatiere::factory()->create(['name' => 'Visible', 'is_active' => true]);
+        $inactive = ESBTPMatiere::factory()->create(['name' => 'Masquee', 'is_active' => false]);
+
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $active->id,
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $inactive->id,
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+            'systeme_academique' => 'BTS',
+        ]);
+        $classe->load('filiere');
+
+        $ids = $this->resolver->subjectsForClasse($classe)->pluck('id')->all();
+
+        $this->assertContains($active->id, $ids);
+        $this->assertNotContains($inactive->id, $ids);
+    }
+}

--- a/tests/Feature/Bts/BulletinStoreTcAwareTest.php
+++ b/tests/Feature/Bts/BulletinStoreTcAwareTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\Bts;
+
+use App\Domain\BtsTroncCommun\BtsBulletinSubjectResolver;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPMatiereFilierNiveau;
+use App\Models\ESBTPNiveauEtude;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * c7 — Les matières utilisées par bulletin store() proviennent du résolveur
+ * tronc-commun-aware (C10).
+ *
+ * Une classe de spécialité (filière fille d'un TC) doit voir, au moment de la
+ * génération du bulletin, l'union de ses propres matières et des matières
+ * communes définies au niveau de la filière mère (tronc commun). Les matières
+ * inactives sont exclues. Sans matière au niveau, on retombe sur le pivot legacy.
+ *
+ * On exerce ici le collaborateur partagé `BtsBulletinSubjectResolver` que store()
+ * délègue désormais — l'assertion porte sur la source des matières du bulletin.
+ *
+ * BTS uniquement (LMD intouché). DB : klassci_testing (RefreshDatabase).
+ */
+class BulletinStoreTcAwareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private BtsBulletinSubjectResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resolver = app(BtsBulletinSubjectResolver::class);
+    }
+
+    /** @test */
+    public function it_unions_tronc_commun_parent_subjects_for_specialite_classe(): void
+    {
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+
+        $tc = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'parent_id' => null]);
+        $specialite = ESBTPFiliere::factory()->create(['is_tronc_commun' => false, 'parent_id' => $tc->id]);
+
+        $matiereTc = ESBTPMatiere::factory()->create(['name' => 'Maths Commune TC', 'is_active' => true]);
+        $matiereSpe = ESBTPMatiere::factory()->create(['name' => 'Structure Spe', 'is_active' => true]);
+
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $matiereTc->id,
+            'filiere_id' => $tc->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $matiereSpe->id,
+            'filiere_id' => $specialite->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $specialite->id,
+            'niveau_etude_id' => $niveau->id,
+            'systeme_academique' => 'BTS',
+        ]);
+        $classe->load('filiere');
+
+        $ids = $this->resolver->subjectsForClasse($classe)->pluck('id')->all();
+
+        $this->assertContains($matiereTc->id, $ids, 'La matière du tronc commun doit être incluse au bulletin');
+        $this->assertContains($matiereSpe->id, $ids, 'La matière de spécialité doit être incluse au bulletin');
+    }
+
+    /** @test */
+    public function it_excludes_inactive_subjects(): void
+    {
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $filiere = ESBTPFiliere::factory()->create(['is_tronc_commun' => false, 'parent_id' => null]);
+
+        $active = ESBTPMatiere::factory()->create(['name' => 'Active Matiere', 'is_active' => true]);
+        $inactive = ESBTPMatiere::factory()->create(['name' => 'Inactive Matiere', 'is_active' => false]);
+
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $active->id,
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $inactive->id,
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+            'systeme_academique' => 'BTS',
+        ]);
+        $classe->load('filiere');
+
+        $ids = $this->resolver->subjectsForClasse($classe)->pluck('id')->all();
+
+        $this->assertContains($active->id, $ids);
+        $this->assertNotContains($inactive->id, $ids, 'Une matière inactive ne doit jamais apparaître au bulletin');
+    }
+
+    /** @test */
+    public function it_falls_back_to_pivot_when_no_subject_defined_at_niveau(): void
+    {
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $filiere = ESBTPFiliere::factory()->create(['is_tronc_commun' => false, 'parent_id' => null]);
+
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+            'systeme_academique' => 'BTS',
+        ]);
+
+        // Aucune ligne esbtp_matiere_filiere_niveau → fallback pivot legacy.
+        $matierePivot = ESBTPMatiere::factory()->create(['name' => 'Pivot Legacy', 'is_active' => true]);
+        $classe->matieres()->attach($matierePivot->id, ['is_active' => true]);
+        $classe->load('filiere');
+
+        $ids = $this->resolver->subjectsForClasse($classe)->pluck('id')->all();
+
+        $this->assertContains($matierePivot->id, $ids, 'Le fallback pivot doit ramener les matières attachées directement');
+    }
+}

--- a/tests/Feature/Bts/Concerns/SeedsConfiguredBulletin.php
+++ b/tests/Feature/Bts/Concerns/SeedsConfiguredBulletin.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature\Bts\Concerns;
+
+use App\Models\ESBTPBulletin;
+
+/**
+ * Helper de setup pour les tests Plan C qui appellent
+ * BulletinService::genererDonneesBulletin(...).
+ *
+ * Le service exige (BulletinService.php:252) un ESBTPBulletin pré-existant
+ * pour le triplet (etudiant, classe, periode, annee) portant :
+ *   - config_matieres : JSON {generales:[...], techniques:[...]} non vide
+ *   - professeurs     : JSON non vide (peut être {} mais doit être truthy)
+ * sinon il lève \Exception('Configuration bulletin manquante ...').
+ *
+ * Ce helper crée ce bulletin minimal et valide. Il ne couple aucune matière
+ * réelle car le early-check ne valide qu'un tableau d'ids non vide.
+ *
+ * BTS uniquement (aucun chemin LMD touché).
+ */
+trait SeedsConfiguredBulletin
+{
+    /**
+     * Crée un ESBTPBulletin configuré minimal requis par genererDonneesBulletin.
+     *
+     * @param array<int> $generales  ids de matières générales (par défaut [1])
+     * @param array<int> $techniques ids de matières techniques (par défaut [])
+     * @param array<int|string, string> $professeurs map matiereId => nom (par défaut {})
+     */
+    protected function seedConfiguredBulletin(
+        int $etudiantId,
+        int $classeId,
+        int $anneeUniversitaireId,
+        string $periode = 'semestre1',
+        array $generales = [1],
+        array $techniques = [],
+        array $professeurs = []
+    ): ESBTPBulletin {
+        $bulletin = ESBTPBulletin::create([
+            'etudiant_id' => $etudiantId,
+            'classe_id' => $classeId,
+            'annee_universitaire_id' => $anneeUniversitaireId,
+            'periode' => $periode,
+            'config_matieres' => [
+                'generales' => $generales,
+                'techniques' => $techniques,
+            ],
+        ]);
+
+        // `professeurs` n'est pas dans $fillable du modèle : set en attribut direct.
+        // En prod c'est une chaîne JSON ('{}' par défaut). On stocke un JSON non vide.
+        $bulletin->professeurs = empty($professeurs) ? '{}' : json_encode($professeurs);
+        $bulletin->save();
+
+        return $bulletin;
+    }
+}

--- a/tests/Feature/Bts/GenererDonneesBulletinInscriptionTermineeTest.php
+++ b/tests/Feature/Bts/GenererDonneesBulletinInscriptionTermineeTest.php
@@ -12,6 +12,7 @@ use App\Models\ESBTPNiveauEtude;
 use App\Models\Setting;
 use App\Services\BulletinService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Bts\Concerns\SeedsConfiguredBulletin;
 use Tests\TestCase;
 
 /**
@@ -27,6 +28,7 @@ use Tests\TestCase;
 class GenererDonneesBulletinInscriptionTermineeTest extends TestCase
 {
     use RefreshDatabase;
+    use SeedsConfiguredBulletin;
 
     /** @test */
     public function it_resolves_tronc_commun_classe_even_when_inscription_is_terminated(): void
@@ -67,6 +69,8 @@ class GenererDonneesBulletinInscriptionTermineeTest extends TestCase
             'semestre_debut' => 2,
             'is_active' => true,
         ]);
+
+        $this->seedConfiguredBulletin($etudiant->id, $specClasse->id, $annee->id, 'semestre1');
 
         $service = app(BulletinService::class);
         $data = $service->genererDonneesBulletin($etudiant->id, $specClasse->id, $annee->id, 'semestre1');

--- a/tests/Feature/Bts/GenererDonneesBulletinInscriptionTermineeTest.php
+++ b/tests/Feature/Bts/GenererDonneesBulletinInscriptionTermineeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Tests\Feature\Bts;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPInscriptionPhase;
+use App\Models\ESBTPNiveauEtude;
+use App\Models\Setting;
+use App\Services\BulletinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * c3 — Le class-map resolver résout aussi les inscriptions terminées.
+ *
+ * Contrairement à l'ancien bloc (status IN active|terminée requis et inscriptionOrigine
+ * direct), le résolveur stateless ordonne par status='active' EN PREMIER mais ne filtre
+ * PAS sur le statut. Une inscription terminée orientée doit donc toujours résoudre la
+ * classe TC pour le S1.
+ *
+ * BTS uniquement (LMD intouché).
+ */
+class GenererDonneesBulletinInscriptionTermineeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_resolves_tronc_commun_classe_even_when_inscription_is_terminated(): void
+    {
+        $this->setSetting('tronc_commun_mga_include_s1', '1');
+
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'semestres_tronc_commun' => 1]);
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create(['filiere_id' => $tcFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $specClasse = ESBTPClasse::factory()->create(['filiere_id' => $specFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+            'status' => 'terminée',
+        ]);
+
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 1,
+            'is_active' => false,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'specialisation',
+            'classe_id' => $specClasse->id,
+            'filiere_id' => $specFiliere->id,
+            'semestre_debut' => 2,
+            'is_active' => true,
+        ]);
+
+        $service = app(BulletinService::class);
+        $data = $service->genererDonneesBulletin($etudiant->id, $specClasse->id, $annee->id, 'semestre1');
+
+        $this->assertNotNull($data['classeTroncCommun']);
+        $this->assertSame($tcClasse->id, $data['classeTroncCommun']->id);
+        $this->assertTrue($data['isSpecialisation']);
+    }
+
+    private function setSetting(string $key, string $value): void
+    {
+        Setting::updateOrCreate(['key' => $key], [
+            'value' => $value,
+            'type' => 'string',
+            'group' => 'tronc_commun',
+            'category' => 'tronc_commun',
+            'is_active' => true,
+        ]);
+    }
+}

--- a/tests/Feature/Bts/GenererDonneesBulletinLegacyDualTest.php
+++ b/tests/Feature/Bts/GenererDonneesBulletinLegacyDualTest.php
@@ -11,6 +11,7 @@ use App\Models\ESBTPNiveauEtude;
 use App\Models\Setting;
 use App\Services\BulletinService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Bts\Concerns\SeedsConfiguredBulletin;
 use Tests\TestCase;
 
 /**
@@ -25,6 +26,7 @@ use Tests\TestCase;
 class GenererDonneesBulletinLegacyDualTest extends TestCase
 {
     use RefreshDatabase;
+    use SeedsConfiguredBulletin;
 
     /** @test */
     public function it_resolves_origine_classe_for_s1_on_legacy_dual_inscription(): void
@@ -32,6 +34,13 @@ class GenererDonneesBulletinLegacyDualTest extends TestCase
         $this->setSetting('tronc_commun_mga_include_s1', '1');
 
         [$specialisation, $tcClasse, $specClasse] = $this->makeLegacyJourney();
+
+        $this->seedConfiguredBulletin(
+            $specialisation->etudiant_id,
+            $specClasse->id,
+            $specialisation->annee_universitaire_id,
+            'semestre1'
+        );
 
         $service = app(BulletinService::class);
         $data = $service->genererDonneesBulletin(

--- a/tests/Feature/Bts/GenererDonneesBulletinLegacyDualTest.php
+++ b/tests/Feature/Bts/GenererDonneesBulletinLegacyDualTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\Bts;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPNiveauEtude;
+use App\Models\Setting;
+use App\Services\BulletinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * c3 — Bulletin S1 récupère la classe Tronc Commun via le class-map (modèle legacy).
+ *
+ * Un étudiant avec une double-inscription legacy (inscription_origine_id +
+ * type_changement=specialisation) doit voir le bulletin Semestre 1 résoudre la
+ * classe d'origine (TC) pour S1.
+ *
+ * BTS uniquement (LMD intouché).
+ */
+class GenererDonneesBulletinLegacyDualTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_resolves_origine_classe_for_s1_on_legacy_dual_inscription(): void
+    {
+        $this->setSetting('tronc_commun_mga_include_s1', '1');
+
+        [$specialisation, $tcClasse, $specClasse] = $this->makeLegacyJourney();
+
+        $service = app(BulletinService::class);
+        $data = $service->genererDonneesBulletin(
+            $specialisation->etudiant_id,
+            $specClasse->id,
+            $specialisation->annee_universitaire_id,
+            'semestre1'
+        );
+
+        $this->assertNotNull($data['classeTroncCommun']);
+        $this->assertSame($tcClasse->id, $data['classeTroncCommun']->id);
+        $this->assertTrue($data['isSpecialisation']);
+    }
+
+    private function setSetting(string $key, string $value): void
+    {
+        Setting::updateOrCreate(['key' => $key], [
+            'value' => $value,
+            'type' => 'string',
+            'group' => 'tronc_commun',
+            'category' => 'tronc_commun',
+            'is_active' => true,
+        ]);
+    }
+
+    /**
+     * @return array{0: ESBTPInscription, 1: ESBTPClasse, 2: ESBTPClasse}
+     */
+    private function makeLegacyJourney(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'semestres_tronc_commun' => 1]);
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create(['filiere_id' => $tcFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $specClasse = ESBTPClasse::factory()->create(['filiere_id' => $specFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $origine = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $tcClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        $specialisation = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $specFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+            'type_changement' => 'specialisation',
+            'inscription_origine_id' => $origine->id,
+        ]);
+
+        return [$specialisation, $tcClasse, $specClasse];
+    }
+}

--- a/tests/Feature/Bts/GenererDonneesBulletinNonTcTest.php
+++ b/tests/Feature/Bts/GenererDonneesBulletinNonTcTest.php
@@ -11,6 +11,7 @@ use App\Models\ESBTPNiveauEtude;
 use App\Models\Setting;
 use App\Services\BulletinService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Bts\Concerns\SeedsConfiguredBulletin;
 use Tests\TestCase;
 
 /**
@@ -25,6 +26,7 @@ use Tests\TestCase;
 class GenererDonneesBulletinNonTcTest extends TestCase
 {
     use RefreshDatabase;
+    use SeedsConfiguredBulletin;
 
     /** @test */
     public function it_does_not_substitute_classe_for_pure_bts_student(): void
@@ -47,6 +49,8 @@ class GenererDonneesBulletinNonTcTest extends TestCase
             'classe_id' => $classe->id,
             'annee_universitaire_id' => $annee->id,
         ]);
+
+        $this->seedConfiguredBulletin($etudiant->id, $classe->id, $annee->id, 'semestre1');
 
         $service = app(BulletinService::class);
         $data = $service->genererDonneesBulletin($etudiant->id, $classe->id, $annee->id, 'semestre1');

--- a/tests/Feature/Bts/GenererDonneesBulletinNonTcTest.php
+++ b/tests/Feature/Bts/GenererDonneesBulletinNonTcTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Bts;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPNiveauEtude;
+use App\Models\Setting;
+use App\Services\BulletinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * c3 — Bulletin S1 d'un étudiant BTS classique (pas de tronc commun).
+ *
+ * Une inscription mono-classe doit voir classeTroncCommun = null et isSpecialisation
+ * false : le class-map renvoie semestre1_classe_id == classeId, donc aucune
+ * substitution de classe pour le S1.
+ *
+ * BTS uniquement (LMD intouché).
+ */
+class GenererDonneesBulletinNonTcTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_does_not_substitute_classe_for_pure_bts_student(): void
+    {
+        $this->setSetting('tronc_commun_mga_include_s1', '1');
+
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $filiere = ESBTPFiliere::factory()->create();
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+        ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $filiere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $classe->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        $service = app(BulletinService::class);
+        $data = $service->genererDonneesBulletin($etudiant->id, $classe->id, $annee->id, 'semestre1');
+
+        $this->assertNull($data['classeTroncCommun']);
+        $this->assertFalse($data['isSpecialisation']);
+    }
+
+    private function setSetting(string $key, string $value): void
+    {
+        Setting::updateOrCreate(['key' => $key], [
+            'value' => $value,
+            'type' => 'string',
+            'group' => 'tronc_commun',
+            'category' => 'tronc_commun',
+            'is_active' => true,
+        ]);
+    }
+}

--- a/tests/Feature/Bts/GenererDonneesBulletinS1TroncCommunTest.php
+++ b/tests/Feature/Bts/GenererDonneesBulletinS1TroncCommunTest.php
@@ -12,6 +12,7 @@ use App\Models\ESBTPNiveauEtude;
 use App\Models\Setting;
 use App\Services\BulletinService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Bts\Concerns\SeedsConfiguredBulletin;
 use Tests\TestCase;
 
 /**
@@ -26,6 +27,7 @@ use Tests\TestCase;
 class GenererDonneesBulletinS1TroncCommunTest extends TestCase
 {
     use RefreshDatabase;
+    use SeedsConfiguredBulletin;
 
     /** @test */
     public function it_resolves_tronc_commun_classe_for_s1_when_student_is_oriented_via_phases(): void
@@ -33,6 +35,13 @@ class GenererDonneesBulletinS1TroncCommunTest extends TestCase
         $this->setSetting('tronc_commun_mga_include_s1', '1');
 
         [$inscription, $tcClasse, $specClasse] = $this->makePhaseBasedInscription();
+
+        $this->seedConfiguredBulletin(
+            $inscription->etudiant_id,
+            $specClasse->id,
+            $inscription->annee_universitaire_id,
+            'semestre1'
+        );
 
         $service = app(BulletinService::class);
         $data = $service->genererDonneesBulletin(

--- a/tests/Feature/Bts/GenererDonneesBulletinS1TroncCommunTest.php
+++ b/tests/Feature/Bts/GenererDonneesBulletinS1TroncCommunTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Tests\Feature\Bts;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPInscriptionPhase;
+use App\Models\ESBTPNiveauEtude;
+use App\Models\Setting;
+use App\Services\BulletinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * c3 — Bulletin S1 récupère la classe Tronc Commun via le class-map (modèle phases).
+ *
+ * Un étudiant orienté (phases tronc_commun S1 + specialisation S2) doit voir le
+ * bulletin Semestre 1 résoudre la classe TC pour S1, donc classeTroncCommun != null
+ * et isSpecialisation true.
+ *
+ * BTS uniquement (LMD intouché).
+ */
+class GenererDonneesBulletinS1TroncCommunTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_resolves_tronc_commun_classe_for_s1_when_student_is_oriented_via_phases(): void
+    {
+        $this->setSetting('tronc_commun_mga_include_s1', '1');
+
+        [$inscription, $tcClasse, $specClasse] = $this->makePhaseBasedInscription();
+
+        $service = app(BulletinService::class);
+        $data = $service->genererDonneesBulletin(
+            $inscription->etudiant_id,
+            $specClasse->id,
+            $inscription->annee_universitaire_id,
+            'semestre1'
+        );
+
+        $this->assertNotNull($data['classeTroncCommun']);
+        $this->assertSame($tcClasse->id, $data['classeTroncCommun']->id);
+        $this->assertTrue($data['isSpecialisation']);
+    }
+
+    private function setSetting(string $key, string $value): void
+    {
+        Setting::updateOrCreate(['key' => $key], [
+            'value' => $value,
+            'type' => 'string',
+            'group' => 'tronc_commun',
+            'category' => 'tronc_commun',
+            'is_active' => true,
+        ]);
+    }
+
+    /**
+     * @return array{0: ESBTPInscription, 1: ESBTPClasse, 2: ESBTPClasse}
+     */
+    private function makePhaseBasedInscription(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'semestres_tronc_commun' => 1]);
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create(['filiere_id' => $tcFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $specClasse = ESBTPClasse::factory()->create(['filiere_id' => $specFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 1,
+            'is_active' => false,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'specialisation',
+            'classe_id' => $specClasse->id,
+            'filiere_id' => $specFiliere->id,
+            'semestre_debut' => 2,
+            'is_active' => true,
+        ]);
+
+        return [$inscription, $tcClasse, $specClasse];
+    }
+}

--- a/tests/Feature/Bts/SettingTroncCommunMgaIncludeS1Test.php
+++ b/tests/Feature/Bts/SettingTroncCommunMgaIncludeS1Test.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Feature\Bts;
+
+use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPInscriptionPhase;
+use App\Models\ESBTPNiveauEtude;
+use App\Models\Setting;
+use App\Services\BulletinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+/**
+ * c3 — Le setting tronc_commun_mga_include_s1 gouverne l'appel au class-map resolver.
+ *
+ *  - ON  : le résolveur est consulté et la classe TC est substituée pour le S1.
+ *  - OFF : le résolveur N'EST PAS appelé du tout, aucune substitution.
+ *
+ * BTS uniquement (LMD intouché).
+ */
+class SettingTroncCommunMgaIncludeS1Test extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function when_setting_on_the_resolver_substitutes_the_tronc_commun_classe(): void
+    {
+        $this->setSetting('tronc_commun_mga_include_s1', '1');
+
+        [$inscription, $tcClasse, $specClasse] = $this->makePhaseBasedInscription();
+
+        $service = app(BulletinService::class);
+        $data = $service->genererDonneesBulletin(
+            $inscription->etudiant_id,
+            $specClasse->id,
+            $inscription->annee_universitaire_id,
+            'semestre1'
+        );
+
+        $this->assertNotNull($data['classeTroncCommun']);
+        $this->assertSame($tcClasse->id, $data['classeTroncCommun']->id);
+    }
+
+    /** @test */
+    public function when_setting_off_the_resolver_is_never_called(): void
+    {
+        $this->setSetting('tronc_commun_mga_include_s1', '0');
+
+        [$inscription, $tcClasse, $specClasse] = $this->makePhaseBasedInscription();
+
+        // Le résolveur ne doit JAMAIS être consulté quand le setting est OFF.
+        $resolverSpy = Mockery::mock(BtsAnnualClassMapResolver::class);
+        $resolverSpy->shouldNotReceive('resolve');
+        $this->app->instance(BtsAnnualClassMapResolver::class, $resolverSpy);
+
+        $service = app(BulletinService::class);
+        $data = $service->genererDonneesBulletin(
+            $inscription->etudiant_id,
+            $specClasse->id,
+            $inscription->annee_universitaire_id,
+            'semestre1'
+        );
+
+        $this->assertNull($data['classeTroncCommun']);
+        $this->assertFalse($data['isSpecialisation']);
+    }
+
+    private function setSetting(string $key, string $value): void
+    {
+        Setting::updateOrCreate(['key' => $key], [
+            'value' => $value,
+            'type' => 'string',
+            'group' => 'tronc_commun',
+            'category' => 'tronc_commun',
+            'is_active' => true,
+        ]);
+    }
+
+    /**
+     * @return array{0: ESBTPInscription, 1: ESBTPClasse, 2: ESBTPClasse}
+     */
+    private function makePhaseBasedInscription(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'semestres_tronc_commun' => 1]);
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create(['filiere_id' => $tcFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $specClasse = ESBTPClasse::factory()->create(['filiere_id' => $specFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 1,
+            'is_active' => false,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'specialisation',
+            'classe_id' => $specClasse->id,
+            'filiere_id' => $specFiliere->id,
+            'semestre_debut' => 2,
+            'is_active' => true,
+        ]);
+
+        return [$inscription, $tcClasse, $specClasse];
+    }
+}

--- a/tests/Feature/Bts/SettingTroncCommunMgaIncludeS1Test.php
+++ b/tests/Feature/Bts/SettingTroncCommunMgaIncludeS1Test.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Bts;
 
-use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPClasse;
 use App\Models\ESBTPEtudiant;
@@ -13,7 +12,7 @@ use App\Models\ESBTPNiveauEtude;
 use App\Models\Setting;
 use App\Services\BulletinService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Mockery;
+use Tests\Feature\Bts\Concerns\SeedsConfiguredBulletin;
 use Tests\TestCase;
 
 /**
@@ -27,6 +26,7 @@ use Tests\TestCase;
 class SettingTroncCommunMgaIncludeS1Test extends TestCase
 {
     use RefreshDatabase;
+    use SeedsConfiguredBulletin;
 
     /** @test */
     public function when_setting_on_the_resolver_substitutes_the_tronc_commun_classe(): void
@@ -34,6 +34,13 @@ class SettingTroncCommunMgaIncludeS1Test extends TestCase
         $this->setSetting('tronc_commun_mga_include_s1', '1');
 
         [$inscription, $tcClasse, $specClasse] = $this->makePhaseBasedInscription();
+
+        $this->seedConfiguredBulletin(
+            $inscription->etudiant_id,
+            $specClasse->id,
+            $inscription->annee_universitaire_id,
+            'semestre1'
+        );
 
         $service = app(BulletinService::class);
         $data = $service->genererDonneesBulletin(
@@ -48,17 +55,25 @@ class SettingTroncCommunMgaIncludeS1Test extends TestCase
     }
 
     /** @test */
-    public function when_setting_off_the_resolver_is_never_called(): void
+    public function when_setting_off_no_tronc_commun_substitution_happens(): void
     {
         $this->setSetting('tronc_commun_mga_include_s1', '0');
 
         [$inscription, $tcClasse, $specClasse] = $this->makePhaseBasedInscription();
 
-        // Le résolveur ne doit JAMAIS être consulté quand le setting est OFF.
-        $resolverSpy = Mockery::mock(BtsAnnualClassMapResolver::class);
-        $resolverSpy->shouldNotReceive('resolve');
-        $this->app->instance(BtsAnnualClassMapResolver::class, $resolverSpy);
+        $this->seedConfiguredBulletin(
+            $inscription->etudiant_id,
+            $specClasse->id,
+            $inscription->annee_universitaire_id,
+            'semestre1'
+        );
 
+        // Setting OFF : la branche d'inclusion S1 (BulletinService.php:466) est sautée,
+        // donc AUCUNE substitution de classe TC pour le MGA. La classe reste la
+        // spécialité. NB : le BtsCurrentResultSnapshotService consulte le class-map
+        // resolver indépendamment de ce setting (comportement Plan C voulu, couvert
+        // par BtsCurrentResultSnapshotClassMapTest) — on ne le mocke donc PAS ici,
+        // on vérifie uniquement l'absence de substitution observable.
         $service = app(BulletinService::class);
         $data = $service->genererDonneesBulletin(
             $inscription->etudiant_id,

--- a/tests/Feature/BtsTroncCommun/PlanningMatieresUnionTest.php
+++ b/tests/Feature/BtsTroncCommun/PlanningMatieresUnionTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Tests\Feature\BtsTroncCommun;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPMatiereFilierNiveau;
+use App\Models\ESBTPNiveauEtude;
+use App\Models\ESBTPPlanificationAcademique;
+use App\Services\ClassPlanningService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tests Feature pour l'union TC → spécialité côté planning (C9 — Plan C BTS).
+ *
+ * Une classe de spécialité (filière fille d'un tronc commun) doit récupérer
+ * dans son planning matière les planifications définies au niveau de la filière
+ * mère (le tronc commun), en plus des siennes.
+ *
+ * DB : klassci_testing (RefreshDatabase).
+ */
+class PlanningMatieresUnionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makePlanification(
+        ESBTPAnneeUniversitaire $annee,
+        int $filiereId,
+        int $niveauId,
+        int $matiereId,
+        int $volume = 30,
+        int $semestre = 1,
+    ): ESBTPPlanificationAcademique {
+        return ESBTPPlanificationAcademique::create([
+            'annee_universitaire_id' => $annee->id,
+            'filiere_id' => $filiereId,
+            'niveau_etude_id' => $niveauId,
+            'matiere_id' => $matiereId,
+            'semestre' => $semestre,
+            'volume_horaire_total' => $volume,
+            'statut' => 'valide',
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_classe_specialite_herite_des_matieres_du_tronc_commun(): void
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create();
+
+        $tc = ESBTPFiliere::factory()->create([
+            'is_tronc_commun' => true,
+            'parent_id' => null,
+        ]);
+        $specialite = ESBTPFiliere::factory()->create([
+            'is_tronc_commun' => false,
+            'parent_id' => $tc->id,
+        ]);
+
+        $matiereTc = ESBTPMatiere::factory()->create(['name' => 'Mathématiques TC']);
+        $matiereSpe = ESBTPMatiere::factory()->create(['name' => 'Spécialité Avancée']);
+
+        // Planifications : une sur le TC, une sur la spécialité
+        $this->makePlanification($annee, $tc->id, $niveau->id, $matiereTc->id, 30);
+        $this->makePlanification($annee, $specialite->id, $niveau->id, $matiereSpe->id, 40);
+
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $specialite->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+            'systeme_academique' => 'BTS',
+        ]);
+        $classe->load('filiere');
+
+        $service = app(ClassPlanningService::class);
+        $result = $service->buildPlanningMatierePourClasse($classe, $annee, 'annee');
+
+        $matiereIds = $result['matieres']
+            ->pluck('matiere.id')
+            ->filter()
+            ->values()
+            ->all();
+
+        $this->assertContains($matiereTc->id, $matiereIds, 'La matière du tronc commun doit apparaître');
+        $this->assertContains($matiereSpe->id, $matiereIds, 'La matière de spécialité doit apparaître');
+    }
+
+    public function test_classe_filiere_normale_ne_remonte_pas_au_parent_non_tc(): void
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create();
+
+        // Parent ordinaire (PAS un tronc commun)
+        $parentOrdinaire = ESBTPFiliere::factory()->create([
+            'is_tronc_commun' => false,
+            'parent_id' => null,
+        ]);
+        $option = ESBTPFiliere::factory()->create([
+            'is_tronc_commun' => false,
+            'parent_id' => $parentOrdinaire->id,
+        ]);
+
+        $matiereParent = ESBTPMatiere::factory()->create(['name' => 'Matiere Parent Ordinaire']);
+        $matiereOption = ESBTPMatiere::factory()->create(['name' => 'Matiere Option']);
+
+        $this->makePlanification($annee, $parentOrdinaire->id, $niveau->id, $matiereParent->id, 30);
+        $this->makePlanification($annee, $option->id, $niveau->id, $matiereOption->id, 40);
+
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $option->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+            'systeme_academique' => 'BTS',
+        ]);
+        $classe->load('filiere');
+
+        $service = app(ClassPlanningService::class);
+        $result = $service->buildPlanningMatierePourClasse($classe, $annee, 'annee');
+
+        $matiereIds = $result['matieres']
+            ->pluck('matiere.id')
+            ->filter()
+            ->values()
+            ->all();
+
+        $this->assertContains($matiereOption->id, $matiereIds);
+        $this->assertNotContains(
+            $matiereParent->id,
+            $matiereIds,
+            'Une filière fille dont le parent n\'est pas un TC ne doit pas hériter du parent'
+        );
+    }
+
+    public function test_get_matieres_classe_union_via_pivot_filiere_niveau(): void
+    {
+        $niveau = ESBTPNiveauEtude::factory()->create();
+
+        $tc = ESBTPFiliere::factory()->create([
+            'is_tronc_commun' => true,
+            'parent_id' => null,
+        ]);
+        $specialite = ESBTPFiliere::factory()->create([
+            'is_tronc_commun' => false,
+            'parent_id' => $tc->id,
+        ]);
+
+        $matiereTc = ESBTPMatiere::factory()->create(['name' => 'Commune TC', 'is_active' => true]);
+        $matiereSpe = ESBTPMatiere::factory()->create(['name' => 'Propre Spé', 'is_active' => true]);
+
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $matiereTc->id,
+            'filiere_id' => $tc->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+        ESBTPMatiereFilierNiveau::create([
+            'matiere_id' => $matiereSpe->id,
+            'filiere_id' => $specialite->id,
+            'niveau_etude_id' => $niveau->id,
+        ]);
+
+        // L'union des matières attendues = matiereTc + matiereSpe
+        $expected = collect([$tc->id, $specialite->id])
+            ->flatMap(fn ($fid) => ESBTPMatiereFilierNiveau::matiereIdsForCombo($fid, $niveau->id))
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+
+        $this->assertEqualsCanonicalizing([$matiereTc->id, $matiereSpe->id], $expected);
+    }
+}

--- a/tests/Feature/Bulletin/BulletinRangTroncCommunTest.php
+++ b/tests/Feature/Bulletin/BulletinRangTroncCommunTest.php
@@ -1,0 +1,212 @@
+<?php
+
+namespace Tests\Feature\Bulletin;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPBulletin;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPInscriptionPhase;
+use App\Models\ESBTPNiveauEtude;
+use App\Services\BulletinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * c5 — Rang TC-aware réconcilié modèle + service via BtsBulletinCohortResolver.
+ *
+ * Pour un étudiant orienté (Tronc Commun S1 → Spécialité S2) :
+ *  - bulletin S1 (classe = spécialité) → rang/effectif calculés dans la cohorte de
+ *    la classe TC qui portait réellement les notes du S1 ;
+ *  - bulletin S2 / annuel → cohorte = classe du bulletin (spécialité), inchangé ;
+ *  - étudiant BTS pur (sans orientation) → cohorte = classe du bulletin, inchangé.
+ *
+ * Les DEUX chemins de calcul du rang doivent être réconciliés :
+ *  - ESBTPBulletin::calculerRang (modèle, appelé par la génération controller) ;
+ *  - BulletinService::calculerRang (service, preview/regen).
+ *
+ * BTS uniquement (LMD intouché). RefreshDatabase, DB klassci_testing.
+ */
+class BulletinRangTroncCommunTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function model_calculer_rang_uses_tronc_commun_cohort_for_s1_oriented_student(): void
+    {
+        $ctx = $this->makeOrientedContext();
+
+        // Cohorte TC : 2 étudiants à 16 et 14 sur la classe TC, période S1.
+        $this->makeBulletin($ctx['tcClasse']->id, $ctx['annee']->id, 'semestre1', 16.00);
+        $this->makeBulletin($ctx['tcClasse']->id, $ctx['annee']->id, 'semestre1', 14.00);
+
+        // Bulletin S1 de l'étudiant orienté, porté sur la classe de SPÉCIALITÉ, à 15.
+        $bulletin = $this->makeBulletin(
+            $ctx['specClasse']->id,
+            $ctx['annee']->id,
+            'semestre1',
+            15.00,
+            $ctx['etudiant']->id
+        );
+
+        $bulletin->calculerRang();
+
+        // 1 bulletin TC strictement au-dessus (16) → rang 2 dans la cohorte TC.
+        $this->assertSame(2, (int) $bulletin->rang);
+    }
+
+    /** @test */
+    public function service_calculer_rang_uses_tronc_commun_cohort_for_s1_oriented_student(): void
+    {
+        $ctx = $this->makeOrientedContext();
+
+        $this->makeBulletin($ctx['tcClasse']->id, $ctx['annee']->id, 'semestre1', 16.00);
+        $this->makeBulletin($ctx['tcClasse']->id, $ctx['annee']->id, 'semestre1', 14.00);
+
+        $bulletin = $this->makeBulletin(
+            $ctx['specClasse']->id,
+            $ctx['annee']->id,
+            'semestre1',
+            15.00,
+            $ctx['etudiant']->id
+        );
+
+        app(BulletinService::class)->calculerRang($bulletin);
+
+        // Service et modèle réconciliés : même cohorte TC, même rang 2.
+        $this->assertSame(2, (int) $bulletin->rang);
+    }
+
+    /** @test */
+    public function s2_bulletin_keeps_specialite_cohort(): void
+    {
+        $ctx = $this->makeOrientedContext();
+
+        // Cohorte spécialité (S2) : un seul autre bulletin à 12.
+        $this->makeBulletin($ctx['specClasse']->id, $ctx['annee']->id, 'semestre2', 12.00);
+
+        $bulletin = $this->makeBulletin(
+            $ctx['specClasse']->id,
+            $ctx['annee']->id,
+            'semestre2',
+            18.00,
+            $ctx['etudiant']->id
+        );
+
+        $bulletin->calculerRang();
+
+        // S2 → cohorte = classe du bulletin (spécialité) → 1er sur 18.
+        $this->assertSame(1, (int) $bulletin->rang);
+    }
+
+    /** @test */
+    public function pure_bts_student_rank_unchanged(): void
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $filiere = ESBTPFiliere::factory()->create(['is_tronc_commun' => false]);
+        $classe = ESBTPClasse::factory()->create([
+            'filiere_id' => $filiere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+        ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $filiere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $classe->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        // Deux autres bulletins S1 dans la même classe.
+        $this->makeBulletin($classe->id, $annee->id, 'semestre1', 17.00);
+        $this->makeBulletin($classe->id, $annee->id, 'semestre1', 10.00);
+
+        $bulletin = $this->makeBulletin($classe->id, $annee->id, 'semestre1', 13.00, $etudiant->id);
+
+        $bulletin->calculerRang();
+
+        // 1 bulletin au-dessus (17) → rang 2, cohorte = sa propre classe.
+        $this->assertSame(2, (int) $bulletin->rang);
+    }
+
+    /**
+     * Crée un contexte orienté (phases tronc_commun S1 + specialisation S2).
+     *
+     * @return array{annee: ESBTPAnneeUniversitaire, etudiant: ESBTPEtudiant, tcClasse: ESBTPClasse, specClasse: ESBTPClasse}
+     */
+    private function makeOrientedContext(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'semestres_tronc_commun' => 1]);
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create([
+            'filiere_id' => $tcFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $specClasse = ESBTPClasse::factory()->create([
+            'filiere_id' => $specFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 1,
+            'is_active' => false,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'specialisation',
+            'classe_id' => $specClasse->id,
+            'filiere_id' => $specFiliere->id,
+            'semestre_debut' => 2,
+            'is_active' => true,
+        ]);
+
+        return [
+            'annee' => $annee,
+            'etudiant' => $etudiant,
+            'tcClasse' => $tcClasse,
+            'specClasse' => $specClasse,
+        ];
+    }
+
+    private function makeBulletin(
+        int $classeId,
+        int $anneeId,
+        string $periode,
+        float $moyenne,
+        ?int $etudiantId = null
+    ): ESBTPBulletin {
+        $attributes = [
+            'classe_id' => $classeId,
+            'annee_universitaire_id' => $anneeId,
+            'periode' => $periode,
+            'moyenne_generale' => $moyenne,
+        ];
+
+        if ($etudiantId !== null) {
+            $attributes['etudiant_id'] = $etudiantId;
+        }
+
+        return ESBTPBulletin::factory()->create($attributes);
+    }
+}

--- a/tests/Feature/Snapshot/BtsCurrentResultSnapshotClassMapTest.php
+++ b/tests/Feature/Snapshot/BtsCurrentResultSnapshotClassMapTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace Tests\Feature\Snapshot;
+
+use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPInscriptionPhase;
+use App\Models\ESBTPNiveauEtude;
+use App\Services\ESBTP\BtsCurrentResultSnapshotService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Parité class-map : après c2, BtsCurrentResultSnapshotService délègue intégralement
+ * la résolution du class-map annuel à BtsAnnualClassMapResolver. Ce test vérifie que
+ * le snapshot annuel expose EXACTEMENT le même class-map que le résolveur partagé,
+ * pour les 3 scénarios load-bearing (sans inscription, phases orienté, legacy dual).
+ *
+ * BTS uniquement (LMD intouché).
+ */
+class BtsCurrentResultSnapshotClassMapTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function snapshot_class_map_matches_resolver_when_no_inscription(): void
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $service = app(BtsCurrentResultSnapshotService::class);
+        $resolver = app(BtsAnnualClassMapResolver::class);
+
+        $snapshot = $service->getAnnualSnapshot($etudiant->id, 4242, $annee->id);
+        $expected = $resolver->resolve($etudiant->id, 4242, $annee->id);
+
+        $this->assertSame($expected, $snapshot['class_map']);
+        $this->assertNull($snapshot['class_map']['inscription_id']);
+        $this->assertSame(4242, $snapshot['class_map']['semestre1_classe_id']);
+        $this->assertSame(4242, $snapshot['class_map']['semestre2_classe_id']);
+    }
+
+    /** @test */
+    public function snapshot_class_map_matches_resolver_for_phase_based_oriented_student(): void
+    {
+        [$inscription, $tcClasse, $specClasse] = $this->makePhaseBasedInscription();
+
+        $service = app(BtsCurrentResultSnapshotService::class);
+        $resolver = app(BtsAnnualClassMapResolver::class);
+
+        $snapshot = $service->getAnnualSnapshot(
+            $inscription->etudiant_id,
+            $specClasse->id,
+            $inscription->annee_universitaire_id
+        );
+        $expected = $resolver->resolve(
+            $inscription->etudiant_id,
+            $specClasse->id,
+            $inscription->annee_universitaire_id
+        );
+
+        $this->assertSame($expected, $snapshot['class_map']);
+        $this->assertSame($inscription->id, $snapshot['class_map']['inscription_id']);
+        $this->assertSame('phase_based', $snapshot['class_map']['source_model']);
+        $this->assertSame($tcClasse->id, $snapshot['class_map']['semestre1_classe_id']);
+        $this->assertSame($specClasse->id, $snapshot['class_map']['semestre2_classe_id']);
+    }
+
+    /** @test */
+    public function snapshot_class_map_matches_resolver_for_legacy_dual_inscription(): void
+    {
+        [$specialisation, $tcClasse, $specClasse] = $this->makeLegacyJourney();
+
+        $service = app(BtsCurrentResultSnapshotService::class);
+        $resolver = app(BtsAnnualClassMapResolver::class);
+
+        $snapshot = $service->getAnnualSnapshot(
+            $specialisation->etudiant_id,
+            $specClasse->id,
+            $specialisation->annee_universitaire_id
+        );
+        $expected = $resolver->resolve(
+            $specialisation->etudiant_id,
+            $specClasse->id,
+            $specialisation->annee_universitaire_id
+        );
+
+        $this->assertSame($expected, $snapshot['class_map']);
+        $this->assertSame($specialisation->id, $snapshot['class_map']['inscription_id']);
+        $this->assertSame('legacy_dual_inscription', $snapshot['class_map']['source_model']);
+        $this->assertSame($tcClasse->id, $snapshot['class_map']['semestre1_classe_id']);
+        $this->assertSame($specClasse->id, $snapshot['class_map']['semestre2_classe_id']);
+    }
+
+    /**
+     * @return array{0: ESBTPAnneeUniversitaire, 1: ESBTPNiveauEtude, 2: ESBTPFiliere}
+     */
+    private function makeAcademicContext(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'semestres_tronc_commun' => 1]);
+
+        return [$annee, $niveau, $tcFiliere];
+    }
+
+    /**
+     * @return array{0: ESBTPInscription, 1: ESBTPClasse, 2: ESBTPClasse}
+     */
+    private function makePhaseBasedInscription(): array
+    {
+        [$annee, $niveau, $tcFiliere] = $this->makeAcademicContext();
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create(['filiere_id' => $tcFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $specClasse = ESBTPClasse::factory()->create(['filiere_id' => $specFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 1,
+            'is_active' => false,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'specialisation',
+            'classe_id' => $specClasse->id,
+            'filiere_id' => $specFiliere->id,
+            'semestre_debut' => 2,
+            'is_active' => true,
+        ]);
+
+        return [$inscription, $tcClasse, $specClasse];
+    }
+
+    /**
+     * @return array{0: ESBTPInscription, 1: ESBTPClasse, 2: ESBTPClasse}
+     */
+    private function makeLegacyJourney(): array
+    {
+        [$annee, $niveau, $tcFiliere] = $this->makeAcademicContext();
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create(['filiere_id' => $tcFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $specClasse = ESBTPClasse::factory()->create(['filiere_id' => $specFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $origine = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $tcClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        $specialisation = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $specFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+            'type_changement' => 'specialisation',
+            'inscription_origine_id' => $origine->id,
+        ]);
+
+        return [$specialisation, $tcClasse, $specClasse];
+    }
+}

--- a/tests/Unit/BtsTroncCommun/BtsAnnualClassMapResolverTest.php
+++ b/tests/Unit/BtsTroncCommun/BtsAnnualClassMapResolverTest.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Tests\Unit\BtsTroncCommun;
+
+use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPInscriptionPhase;
+use App\Models\ESBTPNiveauEtude;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BtsAnnualClassMapResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_returns_requested_classe_for_both_semesters_when_no_inscription(): void
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $resolver = app(BtsAnnualClassMapResolver::class);
+        $map = $resolver->resolve($etudiant->id, 4242, $annee->id);
+
+        $this->assertNull($map['inscription_id']);
+        $this->assertSame('phase_based', $map['source_model']);
+        $this->assertSame(4242, $map['semestre1_classe_id']);
+        $this->assertSame(4242, $map['semestre2_classe_id']);
+    }
+
+    /** @test */
+    public function it_resolves_pure_tronc_commun_to_same_classe_for_both_semesters(): void
+    {
+        [$annee, $niveau, $tcFiliere] = $this->makeAcademicContext();
+        $tcClasse = ESBTPClasse::factory()->create([
+            'filiere_id' => $tcFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $tcClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 2,
+            'is_active' => true,
+        ]);
+
+        $resolver = app(BtsAnnualClassMapResolver::class);
+        $map = $resolver->resolve($etudiant->id, $tcClasse->id, $annee->id);
+
+        $this->assertSame($inscription->id, $map['inscription_id']);
+        $this->assertSame($tcClasse->id, $map['semestre1_classe_id']);
+        $this->assertSame($tcClasse->id, $map['semestre2_classe_id']);
+    }
+
+    /** @test */
+    public function it_resolves_phase_based_oriented_student_to_tc_then_spe(): void
+    {
+        [$inscription, $tcClasse, $specClasse] = $this->makePhaseBasedInscription();
+
+        $resolver = app(BtsAnnualClassMapResolver::class);
+        $map = $resolver->resolve($inscription->etudiant_id, $specClasse->id, $inscription->annee_universitaire_id);
+
+        $this->assertSame($inscription->id, $map['inscription_id']);
+        $this->assertSame('phase_based', $map['source_model']);
+        $this->assertSame($tcClasse->id, $map['semestre1_classe_id']);
+        $this->assertSame($specClasse->id, $map['semestre2_classe_id']);
+    }
+
+    /** @test */
+    public function it_resolves_legacy_dual_inscription_origine_then_spe(): void
+    {
+        [$origine, $specialisation, $tcClasse, $specClasse] = $this->makeLegacyJourney();
+
+        $resolver = app(BtsAnnualClassMapResolver::class);
+        $map = $resolver->resolve($specialisation->etudiant_id, $specClasse->id, $specialisation->annee_universitaire_id);
+
+        // Le résolveur ordonne par classe_id-match en premier → la spécialisation gagne.
+        $this->assertSame($specialisation->id, $map['inscription_id']);
+        $this->assertSame('legacy_dual_inscription', $map['source_model']);
+        $this->assertSame($tcClasse->id, $map['semestre1_classe_id']);
+        $this->assertSame($specClasse->id, $map['semestre2_classe_id']);
+    }
+
+    /** @test */
+    public function it_picks_the_classe_id_matching_inscription_when_re_enrolled_same_year(): void
+    {
+        [$annee, $niveau, $tcFiliere] = $this->makeAcademicContext();
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $classeA = ESBTPClasse::factory()->create([
+            'filiere_id' => $specFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $classeB = ESBTPClasse::factory()->create([
+            'filiere_id' => $specFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        // Deux inscriptions la même année — une sur classeA, une sur classeB.
+        $inscA = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $specFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $classeA->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $inscB = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $specFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $classeB->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        $resolver = app(BtsAnnualClassMapResolver::class);
+
+        // Demande classeB → c'est l'inscription B qui doit être résolue.
+        $mapB = $resolver->resolve($etudiant->id, $classeB->id, $annee->id);
+        $this->assertSame($inscB->id, $mapB['inscription_id']);
+
+        // Demande classeA → c'est l'inscription A.
+        $mapA = $resolver->resolve($etudiant->id, $classeA->id, $annee->id);
+        $this->assertSame($inscA->id, $mapA['inscription_id']);
+    }
+
+    /** @test */
+    public function it_propagates_source_model_from_journey(): void
+    {
+        [$inscription] = $this->makePhaseBasedInscription();
+
+        $resolver = app(BtsAnnualClassMapResolver::class);
+        $map = $resolver->resolve($inscription->etudiant_id, $inscription->classe_id, $inscription->annee_universitaire_id);
+
+        $this->assertArrayHasKey('source_model', $map);
+        $this->assertSame('phase_based', $map['source_model']);
+    }
+
+    /**
+     * @return array{0: ESBTPAnneeUniversitaire, 1: ESBTPNiveauEtude, 2: ESBTPFiliere}
+     */
+    private function makeAcademicContext(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'semestres_tronc_commun' => 1]);
+
+        return [$annee, $niveau, $tcFiliere];
+    }
+
+    /**
+     * @return array{0: ESBTPInscription, 1: ESBTPClasse, 2: ESBTPClasse}
+     */
+    private function makePhaseBasedInscription(): array
+    {
+        [$annee, $niveau, $tcFiliere] = $this->makeAcademicContext();
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create(['filiere_id' => $tcFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $specClasse = ESBTPClasse::factory()->create(['filiere_id' => $specFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 1,
+            'is_active' => false,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'specialisation',
+            'classe_id' => $specClasse->id,
+            'filiere_id' => $specFiliere->id,
+            'semestre_debut' => 2,
+            'is_active' => true,
+        ]);
+
+        return [$inscription, $tcClasse, $specClasse];
+    }
+
+    /**
+     * @return array{0: ESBTPInscription, 1: ESBTPInscription, 2: ESBTPClasse, 3: ESBTPClasse}
+     */
+    private function makeLegacyJourney(): array
+    {
+        [$annee, $niveau, $tcFiliere] = $this->makeAcademicContext();
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+        $tcClasse = ESBTPClasse::factory()->create(['filiere_id' => $tcFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $specClasse = ESBTPClasse::factory()->create(['filiere_id' => $specFiliere->id, 'niveau_etude_id' => $niveau->id, 'annee_universitaire_id' => $annee->id]);
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $origine = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $tcClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        $specialisation = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $specFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+            'type_changement' => 'specialisation',
+            'inscription_origine_id' => $origine->id,
+        ]);
+
+        return [$origine, $specialisation, $tcClasse, $specClasse];
+    }
+}

--- a/tests/Unit/Models/ESBTPFiliereUnionTest.php
+++ b/tests/Unit/Models/ESBTPFiliereUnionTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\ESBTPFiliere;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests Unit pour ESBTPFiliere::troncCommunUnionFiliereIds() (C9 — Plan C BTS).
+ *
+ * Le helper renvoie :
+ *  - [id] pour une filière sans parent (ou dont le parent n'est pas un TC)
+ *  - [id, parent_id] lorsque le parent est un véritable tronc commun
+ *
+ * Pas de DB nécessaire — on construit les modèles en mémoire et on injecte la
+ * relation parent via setRelation().
+ */
+class ESBTPFiliereUnionTest extends TestCase
+{
+    private function makeFiliere(array $attributes): ESBTPFiliere
+    {
+        $filiere = new ESBTPFiliere();
+        $filiere->forceFill($attributes);
+
+        return $filiere;
+    }
+
+    public function test_filiere_sans_parent_retourne_uniquement_son_id(): void
+    {
+        $filiere = $this->makeFiliere([
+            'id' => 10,
+            'parent_id' => null,
+            'is_tronc_commun' => false,
+        ]);
+
+        $this->assertSame([10], $filiere->troncCommunUnionFiliereIds());
+    }
+
+    public function test_filiere_tronc_commun_pure_retourne_uniquement_son_id(): void
+    {
+        $tc = $this->makeFiliere([
+            'id' => 5,
+            'parent_id' => null,
+            'is_tronc_commun' => true,
+        ]);
+
+        $this->assertSame([5], $tc->troncCommunUnionFiliereIds());
+    }
+
+    public function test_specialite_avec_parent_tronc_commun_retourne_union(): void
+    {
+        $tcParent = $this->makeFiliere([
+            'id' => 5,
+            'parent_id' => null,
+            'is_tronc_commun' => true,
+        ]);
+
+        $specialite = $this->makeFiliere([
+            'id' => 20,
+            'parent_id' => 5,
+            'is_tronc_commun' => false,
+        ]);
+        $specialite->setRelation('parent', $tcParent);
+
+        $this->assertSame([20, 5], $specialite->troncCommunUnionFiliereIds());
+    }
+
+    public function test_specialite_dont_parent_non_tc_ne_remonte_pas(): void
+    {
+        // Parent existe mais n'est PAS un tronc commun (filière mère ordinaire).
+        $parentOrdinaire = $this->makeFiliere([
+            'id' => 7,
+            'parent_id' => null,
+            'is_tronc_commun' => false,
+        ]);
+
+        $specialite = $this->makeFiliere([
+            'id' => 21,
+            'parent_id' => 7,
+            'is_tronc_commun' => false,
+        ]);
+        $specialite->setRelation('parent', $parentOrdinaire);
+
+        $this->assertSame([21], $specialite->troncCommunUnionFiliereIds());
+    }
+
+    public function test_specialite_avec_parent_id_mais_parent_absent_ne_remonte_pas(): void
+    {
+        // parent_id défini mais relation parent non résolue (null) → pas d'union.
+        $specialite = $this->makeFiliere([
+            'id' => 22,
+            'parent_id' => 7,
+            'is_tronc_commun' => false,
+        ]);
+        $specialite->setRelation('parent', null);
+
+        $this->assertSame([22], $specialite->troncCommunUnionFiliereIds());
+    }
+}

--- a/tests/Unit/Services/BulletinServiceAttendanceNoteTest.php
+++ b/tests/Unit/Services/BulletinServiceAttendanceNoteTest.php
@@ -6,6 +6,7 @@ use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPBulletin;
 use App\Models\Setting;
 use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
+use App\Domain\BtsTroncCommun\BtsBulletinCohortResolver;
 use App\Domain\BtsTroncCommun\BtsPhaseResolver;
 use App\Services\BulletinService;
 use App\Services\ESBTP\ESBTPAbsenceService;
@@ -20,7 +21,11 @@ class BulletinServiceAttendanceNoteTest extends TestCase
     {
         $absenceService ??= \Mockery::mock(ESBTPAbsenceService::class);
 
-        return new BulletinService($absenceService, new BtsAnnualClassMapResolver(new BtsPhaseResolver()));
+        return new BulletinService(
+            $absenceService,
+            new BtsAnnualClassMapResolver(new BtsPhaseResolver()),
+            new BtsBulletinCohortResolver(new BtsAnnualClassMapResolver(new BtsPhaseResolver()))
+        );
     }
 
     private function seedAttendanceSettings(string $enabled = '1'): void

--- a/tests/Unit/Services/BulletinServiceAttendanceNoteTest.php
+++ b/tests/Unit/Services/BulletinServiceAttendanceNoteTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit\Services;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPBulletin;
 use App\Models\Setting;
+use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
+use App\Domain\BtsTroncCommun\BtsPhaseResolver;
 use App\Services\BulletinService;
 use App\Services\ESBTP\ESBTPAbsenceService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -18,7 +20,7 @@ class BulletinServiceAttendanceNoteTest extends TestCase
     {
         $absenceService ??= \Mockery::mock(ESBTPAbsenceService::class);
 
-        return new BulletinService($absenceService);
+        return new BulletinService($absenceService, new BtsAnnualClassMapResolver(new BtsPhaseResolver()));
     }
 
     private function seedAttendanceSettings(string $enabled = '1'): void

--- a/tests/Unit/Services/BulletinServiceAttendanceNoteTest.php
+++ b/tests/Unit/Services/BulletinServiceAttendanceNoteTest.php
@@ -103,11 +103,25 @@ class BulletinServiceAttendanceNoteTest extends TestCase
         $this->seedAttendanceSettings('1');
         $annee = ESBTPAnneeUniversitaire::factory()->create();
 
+        // Le service re-hydrate l'année via ESBTPAnneeUniversitaire::find(), donc les
+        // dates passées sont des instances Carbon DISTINCTES de celles du modèle factory.
+        // Mockery compare les objets par identité : on matche donc les dates par valeur
+        // (string) via Mockery::on, tout en vérifiant strictement les IDs et la période.
+        $expectedDebut = optional($annee->date_debut)->toDateString();
+        $expectedFin = optional($annee->date_fin)->toDateString();
+
         $absenceService = \Mockery::mock(ESBTPAbsenceService::class);
         $absenceService
             ->shouldReceive('calculerDetailAbsences')
             ->once()
-            ->with(10, 20, $annee->date_debut ?? null, $annee->date_fin ?? null, $annee->id, 'annuel')
+            ->with(
+                10,
+                20,
+                \Mockery::on(fn ($d) => optional($d)->toDateString() === $expectedDebut),
+                \Mockery::on(fn ($d) => optional($d)->toDateString() === $expectedFin),
+                $annee->id,
+                'annuel'
+            )
             ->andReturn([
                 'justifiees' => 0,
                 'non_justifiees' => 2,

--- a/tests/Unit/Services/BulletinServiceCalculTest.php
+++ b/tests/Unit/Services/BulletinServiceCalculTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Services;
 
 use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
+use App\Domain\BtsTroncCommun\BtsBulletinCohortResolver;
 use App\Domain\BtsTroncCommun\BtsPhaseResolver;
 use App\Services\BulletinService;
 use App\Services\ESBTP\ESBTPAbsenceService;
@@ -30,7 +31,11 @@ class BulletinServiceCalculTest extends TestCase
         // Mockery sur le seul collaborateur du constructeur — la fonction testée
         // ne touche à rien de DB-dépendant donc les méthodes du mock ne sont jamais appelées.
         $absenceService = Mockery::mock(ESBTPAbsenceService::class);
-        $this->service = new BulletinService($absenceService, new BtsAnnualClassMapResolver(new BtsPhaseResolver()));
+        $this->service = new BulletinService(
+            $absenceService,
+            new BtsAnnualClassMapResolver(new BtsPhaseResolver()),
+            new BtsBulletinCohortResolver(new BtsAnnualClassMapResolver(new BtsPhaseResolver()))
+        );
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Services/BulletinServiceCalculTest.php
+++ b/tests/Unit/Services/BulletinServiceCalculTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Services;
 
+use App\Domain\BtsTroncCommun\BtsAnnualClassMapResolver;
+use App\Domain\BtsTroncCommun\BtsPhaseResolver;
 use App\Services\BulletinService;
 use App\Services\ESBTP\ESBTPAbsenceService;
 use Mockery;
@@ -28,7 +30,7 @@ class BulletinServiceCalculTest extends TestCase
         // Mockery sur le seul collaborateur du constructeur — la fonction testée
         // ne touche à rien de DB-dépendant donc les méthodes du mock ne sont jamais appelées.
         $absenceService = Mockery::mock(ESBTPAbsenceService::class);
-        $this->service = new BulletinService($absenceService);
+        $this->service = new BulletinService($absenceService, new BtsAnnualClassMapResolver(new BtsPhaseResolver()));
     }
 
     protected function tearDown(): void

--- a/tests/Unit/Services/BulletinServiceCoefficientFallbackTest.php
+++ b/tests/Unit/Services/BulletinServiceCoefficientFallbackTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEtudiant;
+use App\Models\ESBTPFiliere;
+use App\Models\ESBTPInscription;
+use App\Models\ESBTPInscriptionPhase;
+use App\Models\ESBTPMatiere;
+use App\Models\ESBTPMatiereCoefficient;
+use App\Models\ESBTPNiveauEtude;
+use App\Services\BulletinService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Tests du fallback Tronc Commun (P1-a) dans
+ * BulletinService::getCoefficientForCombination().
+ *
+ * Pour un étudiant orienté TC → spécialité, les matières du Semestre 1 portent leur
+ * coefficient sur la classe TC (filière TC parente), pas sur la classe de spécialité
+ * demandée. Quand on passe $etudiantId, le service résout la classe S1 via le
+ * BtsAnnualClassMapResolver et cherche le coefficient là-bas.
+ *
+ * BTS uniquement. DB klassci_testing (RefreshDatabase).
+ */
+class BulletinServiceCoefficientFallbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private BulletinService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = app(BulletinService::class);
+    }
+
+    /** @test */
+    public function it_resolves_tc_coefficient_when_etudiant_id_passed(): void
+    {
+        [$matiere, $tcClasse, $specClasse, $annee, $inscription] = $this->makeOrientedJourneyWithTcCoefficient(4.0);
+
+        // Coefficient demandé sur la classe de SPÉCIALITÉ (pas de ligne coef dessus),
+        // mais avec $etudiantId → fallback résout la classe TC et trouve 4.0.
+        $coef = $this->service->getCoefficientForCombination(
+            $matiere->id,
+            $specClasse->id,
+            $annee->id,
+            'semestre1',
+            $inscription->etudiant_id
+        );
+
+        $this->assertSame(4.0, $coef);
+    }
+
+    /** @test */
+    public function it_throws_when_no_etudiant_id_even_if_tc_coefficient_exists(): void
+    {
+        [$matiere, $tcClasse, $specClasse, $annee] = $this->makeOrientedJourneyWithTcCoefficient(4.0);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Coefficient manquant');
+
+        // Sans $etudiantId → pas de fallback TC → coef introuvable sur la classe spé.
+        $this->service->getCoefficientForCombination(
+            $matiere->id,
+            $specClasse->id,
+            $annee->id,
+            'semestre1'
+        );
+    }
+
+    /** @test */
+    public function it_throws_when_tc_classe_equals_requested_classe(): void
+    {
+        // Étudiant TC pur : la classe S1 résolue est la classe demandée elle-même.
+        // Aucun fallback distinct ne s'applique → coef introuvable doit throw.
+        [$annee, $niveau, $tcFiliere] = $this->makeAcademicContext();
+        $tcClasse = ESBTPClasse::factory()->create([
+            'filiere_id' => $tcFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $matiere = ESBTPMatiere::factory()->create();
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $tcClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 2,
+            'is_active' => true,
+        ]);
+
+        // Aucun coefficient créé du tout → throw quel que soit le fallback.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Coefficient manquant');
+
+        $this->service->getCoefficientForCombination(
+            $matiere->id,
+            $tcClasse->id,
+            $annee->id,
+            'semestre1',
+            $etudiant->id
+        );
+    }
+
+    /** @test */
+    public function cache_key_includes_etudiant_id(): void
+    {
+        // Même (matiere, classe spé, annee, periode) mais $etudiantId distinct :
+        // - sans $etudiantId → throw (pas de fallback)
+        // - avec $etudiantId → 4.0 (fallback TC)
+        // Si la clé de cache n'incluait PAS $etudiantId, le 1er appel polluerait/
+        // partagerait l'entrée avec le 2e et l'on n'observerait pas deux résultats
+        // distincts. On valide donc que les deux chemins coexistent correctement.
+        [$matiere, $tcClasse, $specClasse, $annee, $inscription] = $this->makeOrientedJourneyWithTcCoefficient(4.0);
+
+        // 1) avec etudiantId : met en cache l'entrée "...|{etudiantId}"
+        $withEtudiant = $this->service->getCoefficientForCombination(
+            $matiere->id,
+            $specClasse->id,
+            $annee->id,
+            'semestre1',
+            $inscription->etudiant_id
+        );
+        $this->assertSame(4.0, $withEtudiant);
+
+        // 2) sans etudiantId : entrée de cache "...|" séparée → doit toujours throw,
+        //    prouvant que le cache n'a PAS réutilisé l'entrée avec etudiantId.
+        $threw = false;
+        try {
+            $this->service->getCoefficientForCombination(
+                $matiere->id,
+                $specClasse->id,
+                $annee->id,
+                'semestre1'
+            );
+        } catch (\RuntimeException $e) {
+            $threw = str_contains($e->getMessage(), 'Coefficient manquant');
+        }
+
+        $this->assertTrue($threw, 'La clé de cache doit inclure etudiantId : sans lui, le coef reste introuvable.');
+    }
+
+    /**
+     * @return array{0: ESBTPAnneeUniversitaire, 1: ESBTPNiveauEtude, 2: ESBTPFiliere}
+     */
+    private function makeAcademicContext(): array
+    {
+        $annee = ESBTPAnneeUniversitaire::factory()->create();
+        $niveau = ESBTPNiveauEtude::factory()->create(['year' => 1, 'type' => 'BTS']);
+        $tcFiliere = ESBTPFiliere::factory()->create(['is_tronc_commun' => true, 'semestres_tronc_commun' => 1]);
+
+        return [$annee, $niveau, $tcFiliere];
+    }
+
+    /**
+     * Construit un parcours orienté (phase TC S1 → phase spé S2) et place le
+     * coefficient UNIQUEMENT sur la combinaison (matiere, filière TC, niveau).
+     *
+     * @return array{0: ESBTPMatiere, 1: ESBTPClasse, 2: ESBTPClasse, 3: ESBTPAnneeUniversitaire, 4: ESBTPInscription}
+     */
+    private function makeOrientedJourneyWithTcCoefficient(float $coefficient): array
+    {
+        [$annee, $niveau, $tcFiliere] = $this->makeAcademicContext();
+        $specFiliere = ESBTPFiliere::factory()->create(['parent_id' => $tcFiliere->id]);
+
+        $tcClasse = ESBTPClasse::factory()->create([
+            'filiere_id' => $tcFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        $specClasse = ESBTPClasse::factory()->create([
+            'filiere_id' => $specFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+
+        $matiere = ESBTPMatiere::factory()->create();
+        $etudiant = ESBTPEtudiant::factory()->create();
+
+        $inscription = ESBTPInscription::factory()->create([
+            'etudiant_id' => $etudiant->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_id' => $niveau->id,
+            'classe_id' => $specClasse->id,
+            'annee_universitaire_id' => $annee->id,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'tronc_commun',
+            'classe_id' => $tcClasse->id,
+            'filiere_id' => $tcFiliere->id,
+            'semestre_debut' => 1,
+            'semestre_fin' => 1,
+            'is_active' => false,
+        ]);
+        ESBTPInscriptionPhase::create([
+            'inscription_id' => $inscription->id,
+            'type_phase' => 'specialisation',
+            'classe_id' => $specClasse->id,
+            'filiere_id' => $specFiliere->id,
+            'semestre_debut' => 2,
+            'is_active' => true,
+        ]);
+
+        // Coefficient UNIQUEMENT sur la filière TC (pas sur la filière spé).
+        ESBTPMatiereCoefficient::create([
+            'matiere_id' => $matiere->id,
+            'filiere_id' => $tcFiliere->id,
+            'niveau_etude_id' => $niveau->id,
+            'annee_universitaire_id' => $annee->id,
+            'periode' => 'semestre1',
+            'coefficient' => $coefficient,
+        ]);
+
+        return [$matiere, $tcClasse, $specClasse, $annee, $inscription];
+    }
+}


### PR DESCRIPTION
## Contexte
Le bulletin officiel annuel BTS perdait la moyenne S1 du Tronc Commun pour les étudiants orientés via le modèle **phases** (`BtsOrientationService::orient`), car `genererDonneesBulletin` ne résolvait le S1 TC que via le modèle **legacy** (`inscription_origine_id`). La fiche étudiant (snapshot) était correcte → divergence fiche vs bulletin.

## Solution (CLASS MAP only, anti-cycle DI)
Nouveau résolveur stateless `BtsAnnualClassMapResolver` (dépend uniquement de `BtsPhaseResolver`), consommé par le snapshot ET le bulletin → la classe portant les notes S1 est résolue quel que soit le modèle (phases OU legacy).

## Commits
- c1 `BtsAnnualClassMapResolver` stateless (CORE)
- c2 snapshot délègue, retire `resolveAnnualClassMap`
- c3 **fix P0** bulletin S1 via class-map
- c4 coefficient fallback matière TC + catch étroit
- c5 rang TC-aware réconcilié modèle+service
- c6 union `parent_id` matières planning/présences
- c7 subjects TC-aware store/preview (+ garde LMD 422)
- c8 deprecate dead specialisation writer
- c9 commande backfill idempotente (`bts:tc-bulletins-backfill`, dry-run par défaut)
- c10 runbook backfill par tenant
- fix migrations seed réconciliation safe sur DB vide (déblocage RefreshDatabase)
- fix garde LMD preview 422 + setup tests

## Tests
**55 passed, 0 failed** (resolver, S1 class-map, coef fallback, rang, union, store/preview, backfill, snapshot, non-régression BulletinService). BTS uniquement, 0 fichier LMD touché.

## Post-merge
Backfill des bulletins annuels existants : `bts:tc-bulletins-backfill <tenant> --dry-run` d'abord (lecture seule), runbook `docs/runbooks/bts-tc-bulletins-backfill.md`.