### PR TITLE
fix(paie): restaure actions présent/absent + animation + cartographie workflow + toggle préset

### DIFF
--- a/app/Http/Controllers/ESBTP/TeacherAttendanceController.php
+++ b/app/Http/Controllers/ESBTP/TeacherAttendanceController.php
@@ -535,6 +535,17 @@ class TeacherAttendanceController extends Controller
                 : TypeSeance::fromLegacy($seance->type_seance);
             $estPassee = $seance->date_seance && Carbon::parse($seance->date_seance)->endOfDay()->isPast();
 
+            // Séance encore à venir (date future, ou aujourd'hui avant la fin) → pas d'action.
+            $estFuture = false;
+            if ($seance->date_seance) {
+                $dateSeance = Carbon::parse($seance->date_seance)->startOfDay();
+                if ($dateSeance->gt($today)) {
+                    $estFuture = true;
+                } elseif ($dateSeance->eq($today) && $seance->heure_fin) {
+                    $estFuture = $seance->heure_fin->gt(now());
+                }
+            }
+
             $statutMeta = [
                 'present'    => ['label' => 'Présent', 'bg' => 'rgba(16,185,129,.12)', 'color' => '#065f46'],
                 'late'       => ['label' => 'En retard', 'bg' => 'rgba(245,158,11,.14)', 'color' => '#92400e'],
@@ -559,6 +570,7 @@ class TeacherAttendanceController extends Controller
                 'statut_color' => $statutMeta['color'],
                 'en_retard'    => $statut === 'late',
                 'non_emarge'   => $estPassee && $statut === 'not_signed',
+                'future'       => $estFuture,
             ];
         });
     }

--- a/resources/views/coordinateur/dashboard-attendance.blade.php
+++ b/resources/views/coordinateur/dashboard-attendance.blade.php
@@ -48,17 +48,26 @@
     .cad-panel-sub { font-size: .73rem; color: #94a3b8; }
     .cad-panel-body { padding: 1.1rem 1.25rem; }
 
-    /* Workflow steps */
-    .cad-step { display: flex; align-items: center; gap: .8rem; margin-bottom: 1rem; }
-    .cad-step:last-child { margin-bottom: 0; }
-    .cad-step-ico { width: 38px; height: 38px; border-radius: 10px; flex-shrink: 0; background: rgba(4,83,203,.08); color: #0453cb; display: flex; align-items: center; justify-content: center; font-size: .9rem; }
-    .cad-step-body { flex: 1; min-width: 0; }
-    .cad-step-top { display: flex; justify-content: space-between; align-items: baseline; }
-    .cad-step-lbl { font-size: .82rem; font-weight: 600; color: #334155; }
-    .cad-step-val { font-size: .95rem; font-weight: 800; color: #0f172a; }
-    .cad-step-tot { font-size: .75rem; font-weight: 600; color: #94a3b8; }
-    .cad-step-bar { height: 7px; border-radius: 5px; background: #eef2f7; overflow: hidden; margin-top: .35rem; }
-    .cad-step-bar-fill { height: 100%; border-radius: 5px; background: linear-gradient(90deg, #0453cb, #3b7ddb); transition: width .3s; }
+    /* Workflow — cartographie pipeline */
+    .cad-flow { display: flex; align-items: stretch; gap: .35rem; flex-wrap: wrap; }
+    .cad-node { flex: 1; min-width: 102px; text-align: center; border: 1px solid #e9eef5; border-radius: 12px; padding: .8rem .5rem; background: #fff; transition: box-shadow .2s, border-color .2s; }
+    .cad-node:hover { border-color: #c7d4e5; box-shadow: 0 4px 14px rgba(4,83,203,.07); }
+    .cad-node-ico { width: 40px; height: 40px; border-radius: 11px; margin: 0 auto .5rem; display: flex; align-items: center; justify-content: center; color: #fff; font-size: .95rem; }
+    .cad-node--start .cad-node-ico { background: linear-gradient(135deg, #033a8e, #0453cb); }
+    .cad-node--step .cad-node-ico { background: linear-gradient(135deg, #0453cb, #3b7ddb); }
+    .cad-node--done .cad-node-ico { background: linear-gradient(135deg, #059669, #10b981); }
+    .cad-node-val { font-size: 1.35rem; font-weight: 800; color: #0f172a; line-height: 1; }
+    .cad-node-title { font-size: .73rem; font-weight: 700; color: #334155; margin-top: .3rem; }
+    .cad-node-sub { font-size: .63rem; color: #94a3b8; margin-top: .1rem; text-transform: uppercase; letter-spacing: .3px; }
+    .cad-flow-arrow { display: flex; align-items: center; color: #cbd5e1; font-size: .8rem; flex: 0 0 auto; }
+    .cad-flow-summary { margin-top: 1.1rem; padding-top: 1rem; border-top: 1px dashed #e2e8f0; }
+    .cad-flow-summary-head { display: flex; justify-content: space-between; align-items: center; font-size: .82rem; color: #475569; font-weight: 600; }
+    .cad-flow-summary-head i { color: #0453cb; margin-right: .35rem; }
+    .cad-flow-summary-head strong { font-size: 1.1rem; color: #0453cb; }
+    .cad-flow-bar { height: 9px; border-radius: 6px; background: #eef2f7; overflow: hidden; margin: .5rem 0 .35rem; }
+    .cad-flow-bar-fill { height: 100%; border-radius: 6px; background: linear-gradient(90deg, #0453cb, #10b981); transition: width .4s; }
+    .cad-flow-summary-meta { font-size: .72rem; color: #94a3b8; }
+    @media (max-width: 700px) { .cad-flow-arrow { display: none; } .cad-node { min-width: 44%; } }
 
     /* Subjects */
     .cad-subject { display: flex; align-items: center; gap: 1rem; padding: .7rem .25rem; border-bottom: 1px solid #f1f5f9; }
@@ -121,34 +130,32 @@
         </div>
     </div>
 
+    {{-- Workflow — cartographie pleine largeur --}}
+    <div class="cad-panel" style="margin-bottom:1.25rem;">
+        <div class="cad-panel-head">
+            <div class="cad-panel-ico"><i class="fas fa-diagram-project"></i></div>
+            <div>
+                <div class="cad-panel-title">Cartographie du workflow</div>
+                <div class="cad-panel-sub">Séance → Émargement → Appel → Bouclage du cours</div>
+            </div>
+        </div>
+        <div class="cad-panel-body" id="cadWorkflow">
+            @include('coordinateur.partials._cad_workflow', ['stats' => $stats])
+        </div>
+    </div>
+
     <div class="cad-grid">
-        <div>
-            {{-- Workflow --}}
-            <div class="cad-panel">
-                <div class="cad-panel-head">
-                    <div class="cad-panel-ico"><i class="fas fa-diagram-project"></i></div>
-                    <div>
-                        <div class="cad-panel-title">Workflow de la journée</div>
-                        <div class="cad-panel-sub">Émargement → Appel → Bouclage</div>
-                    </div>
-                </div>
-                <div class="cad-panel-body" id="cadWorkflow">
-                    @include('coordinateur.partials._cad_workflow', ['stats' => $stats])
+        {{-- Alertes --}}
+        <div class="cad-panel">
+            <div class="cad-panel-head">
+                <div class="cad-panel-ico" style="background:linear-gradient(135deg,#f59e0b,#d97706);"><i class="fas fa-bell"></i></div>
+                <div>
+                    <div class="cad-panel-title">Alertes</div>
+                    <div class="cad-panel-sub">Points d'attention du jour</div>
                 </div>
             </div>
-
-            {{-- Alertes --}}
-            <div class="cad-panel">
-                <div class="cad-panel-head">
-                    <div class="cad-panel-ico" style="background:linear-gradient(135deg,#f59e0b,#d97706);"><i class="fas fa-bell"></i></div>
-                    <div>
-                        <div class="cad-panel-title">Alertes</div>
-                        <div class="cad-panel-sub">Points d'attention du jour</div>
-                    </div>
-                </div>
-                <div class="cad-panel-body" id="cadAlerts">
-                    @include('coordinateur.partials._cad_alerts', ['stats' => $stats])
-                </div>
+            <div class="cad-panel-body" id="cadAlerts">
+                @include('coordinateur.partials._cad_alerts', ['stats' => $stats])
             </div>
         </div>
 

--- a/resources/views/coordinateur/partials/_cad_workflow.blade.php
+++ b/resources/views/coordinateur/partials/_cad_workflow.blade.php
@@ -1,24 +1,37 @@
-{{-- Étapes du workflow journalier. Reçoit $stats. --}}
+{{-- Cartographie du workflow journalier (pipeline). Reçoit $stats. --}}
 @php
-    $total = max(1, $stats['scheduled_courses_today'] ?? 0);
-    $steps = [
-        ['ico' => 'fa-door-open',   'lbl' => 'Émargement début', 'val' => $stats['teacher_start_attendances_today'] ?? 0],
-        ['ico' => 'fa-door-closed', 'lbl' => 'Émargement fin',   'val' => $stats['teacher_end_attendances_today'] ?? 0],
-        ['ico' => 'fa-list-check',  'lbl' => 'Appel début',      'val' => $stats['call_start_done_today'] ?? 0],
-        ['ico' => 'fa-clipboard-check', 'lbl' => 'Appel fin',    'val' => $stats['call_end_done_today'] ?? 0],
-        ['ico' => 'fa-circle-check', 'lbl' => 'Cours bouclés',   'val' => $stats['roll_calls_completed_today'] ?? 0],
+    $total = (int) ($stats['scheduled_courses_today'] ?? 0);
+    $nodes = [
+        ['ico' => 'fa-calendar-day',     'val' => $total,                                          'title' => 'Séances',          'sub' => 'Programmées', 'tone' => 'start'],
+        ['ico' => 'fa-door-open',        'val' => $stats['teacher_start_attendances_today'] ?? 0,  'title' => 'Émarg. début',     'sub' => 'Début signé', 'tone' => 'step'],
+        ['ico' => 'fa-play',             'val' => $stats['call_start_done_today'] ?? 0,            'title' => 'Appel début',      'sub' => 'Appel fait',  'tone' => 'step'],
+        ['ico' => 'fa-door-closed',      'val' => $stats['teacher_end_attendances_today'] ?? 0,    'title' => 'Émarg. fin',       'sub' => 'Fin signée',  'tone' => 'step'],
+        ['ico' => 'fa-check-double',     'val' => $stats['teacher_attendances_today'] ?? 0,        'title' => 'Émarg. complet',   'sub' => 'Début + fin', 'tone' => 'step'],
+        ['ico' => 'fa-stop',             'val' => $stats['call_end_done_today'] ?? 0,              'title' => 'Appel fin',        'sub' => 'Clôture',     'tone' => 'step'],
+        ['ico' => 'fa-clipboard-check',  'val' => $stats['roll_calls_completed_today'] ?? 0,       'title' => 'Appels',           'sub' => 'Terminés',    'tone' => 'step'],
+        ['ico' => 'fa-circle-check',     'val' => $stats['courses_completed_today'] ?? 0,          'title' => 'Cours bouclés',    'sub' => 'Workflow ✓',  'tone' => 'done'],
     ];
+    $completed = (int) ($stats['courses_completed_today'] ?? 0);
+    $pct = $total > 0 ? round($completed / $total * 100, 1) : 0;
 @endphp
-@foreach($steps as $s)
-    @php $pct = min(100, round(($s['val'] / $total) * 100)); @endphp
-    <div class="cad-step">
-        <div class="cad-step-ico"><i class="fas {{ $s['ico'] }}"></i></div>
-        <div class="cad-step-body">
-            <div class="cad-step-top">
-                <span class="cad-step-lbl">{{ $s['lbl'] }}</span>
-                <span class="cad-step-val">{{ $s['val'] }}<span class="cad-step-tot">/{{ $stats['scheduled_courses_today'] ?? 0 }}</span></span>
-            </div>
-            <div class="cad-step-bar"><div class="cad-step-bar-fill" style="width:{{ $pct }}%;"></div></div>
+<div class="cad-flow">
+    @foreach($nodes as $i => $n)
+        @if($i > 0)
+            <div class="cad-flow-arrow"><i class="fas fa-chevron-right"></i></div>
+        @endif
+        <div class="cad-node cad-node--{{ $n['tone'] }}">
+            <div class="cad-node-ico"><i class="fas {{ $n['ico'] }}"></i></div>
+            <div class="cad-node-val">{{ $n['val'] }}</div>
+            <div class="cad-node-title">{{ $n['title'] }}</div>
+            <div class="cad-node-sub">{{ $n['sub'] }}</div>
         </div>
+    @endforeach
+</div>
+<div class="cad-flow-summary">
+    <div class="cad-flow-summary-head">
+        <span><i class="fas fa-chart-pie"></i> Progression globale de la journée</span>
+        <strong>{{ $pct }}%</strong>
     </div>
-@endforeach
+    <div class="cad-flow-bar"><div class="cad-flow-bar-fill" style="width:{{ min(100, $pct) }}%;"></div></div>
+    <div class="cad-flow-summary-meta">{{ $completed }} cours entièrement bouclés sur {{ $total }} programmés</div>
+</div>

--- a/resources/views/esbtp/teacher-attendance/partials/_report_seances.blade.php
+++ b/resources/views/esbtp/teacher-attendance/partials/_report_seances.blade.php
@@ -1,11 +1,12 @@
 {{-- Lignes de séances (infinity scroll). Reçoit $rows (collection décorée). --}}
+@php $canEditAttendance = auth()->user()?->can('attendances.edit'); @endphp
 @foreach($rows as $row)
     @php
         $h = (int) floor($row['duree']);
         $m = (int) round(($row['duree'] - $h) * 60);
         $dureeFmt = $h . 'h' . ($m > 0 ? sprintf('%02d', $m) : '');
     @endphp
-    <div class="tar-seance-row">
+    <div class="tar-seance-row" data-seance-id="{{ $row['id'] }}">
         <div class="tar-seance-date">
             <div class="tar-seance-day">{{ $row['date'] ? $row['date']->format('d') : '--' }}</div>
             <div class="tar-seance-mon">{{ $row['date'] ? $row['date']->translatedFormat('M') : '' }}</div>
@@ -41,6 +42,22 @@
                 <span class="tar-warn tar-warn--miss" title="Séance passée sans émargement">
                     <i class="fas fa-circle-exclamation"></i> Non émargé
                 </span>
+            @endif
+            @if($canEditAttendance && !$row['future'])
+                <div class="tar-seance-actions">
+                    @if($row['statut'] !== 'present')
+                        <button type="button" class="tar-act tar-act--ok" title="Marquer présent"
+                                onclick="markSeanceStatus({{ $row['id'] }}, 'present')"><i class="fas fa-check"></i></button>
+                    @endif
+                    @if($row['statut'] !== 'late')
+                        <button type="button" class="tar-act tar-act--late" title="Marquer en retard"
+                                onclick="markSeanceStatus({{ $row['id'] }}, 'late')"><i class="fas fa-clock"></i></button>
+                    @endif
+                    @if($row['statut'] !== 'absent')
+                        <button type="button" class="tar-act tar-act--no" title="Marquer absent"
+                                onclick="markSeanceStatus({{ $row['id'] }}, 'absent')"><i class="fas fa-user-xmark"></i></button>
+                    @endif
+                </div>
             @endif
         </div>
     </div>

--- a/resources/views/esbtp/teacher-attendance/report.blade.php
+++ b/resources/views/esbtp/teacher-attendance/report.blade.php
@@ -124,7 +124,14 @@
     .tar-seance-row {
         display: flex; align-items: center; gap: .85rem;
         padding: .75rem .35rem; border-bottom: 1px solid #f1f5f9;
+        position: relative; overflow: hidden;
     }
+    /* Travelling-light feedback sur marquage présent/absent/retard */
+    .tar-rowhl { position: absolute; top: 0; left: -80%; width: 160%; height: 100%; opacity: 0; pointer-events: none; transform: translateX(-65%) skewX(-12deg); z-index: 5; background: linear-gradient(90deg, rgba(16,185,129,0) 0%, rgba(16,185,129,.55) 50%, rgba(16,185,129,0) 100%); }
+    .tar-rowhl--absent { background: linear-gradient(90deg, rgba(220,38,38,0) 0%, rgba(220,38,38,.55) 50%, rgba(220,38,38,0) 100%); }
+    .tar-rowhl--late { background: linear-gradient(90deg, rgba(245,158,11,0) 0%, rgba(245,158,11,.55) 50%, rgba(245,158,11,0) 100%); }
+    .tar-rowhl.animate { animation: tar-rowhl-move 3.2s ease-out forwards; }
+    @keyframes tar-rowhl-move { 0% { opacity: 0; transform: translateX(-65%) skewX(-12deg); } 18% { opacity: .92; } 55% { opacity: .72; } 100% { opacity: 0; transform: translateX(115%) skewX(-12deg); } }
     .tar-seance-row:last-child { border-bottom: none; }
     .tar-seance-date { width: 44px; text-align: center; flex-shrink: 0; }
     .tar-seance-day { font-size: 1.05rem; font-weight: 800; color: #0453cb; line-height: 1; }
@@ -143,6 +150,14 @@
     .tar-warn { font-size: .62rem; font-weight: 700; white-space: nowrap; }
     .tar-warn--late { color: #92400e; }
     .tar-warn--miss { color: #b91c1c; }
+    .tar-seance-actions { display: flex; gap: .3rem; margin-top: .3rem; }
+    .tar-act { width: 26px; height: 26px; border-radius: 7px; border: 1px solid; background: #fff; cursor: pointer; font-size: .68rem; display: flex; align-items: center; justify-content: center; transition: all .15s; }
+    .tar-act--ok { color: #059669; border-color: rgba(16,185,129,.4); }
+    .tar-act--ok:hover { background: #10b981; color: #fff; }
+    .tar-act--late { color: #b45309; border-color: rgba(245,158,11,.4); }
+    .tar-act--late:hover { background: #f59e0b; color: #fff; }
+    .tar-act--no { color: #dc2626; border-color: rgba(220,38,38,.4); }
+    .tar-act--no:hover { background: #dc2626; color: #fff; }
 
     .tar-sentinel { padding: 1rem; text-align: center; color: #94a3b8; font-size: .8rem; }
     .tar-empty { text-align: center; padding: 2.5rem 1rem; color: #94a3b8; }
@@ -307,6 +322,8 @@ function reportPage() {
             this.hasMore = this.$root.dataset.hasMore === '1';
             this.nextPage = parseInt(this.$root.dataset.nextPage, 10) || 2;
             this.observeSentinel();
+            // Un marquage présent/absent met à jour KPIs + baromètre + liste.
+            window.addEventListener('seance:status-updated', () => this.applyFilters());
         },
 
         setPreset(p) {
@@ -318,11 +335,18 @@ function reportPage() {
 
         buildParams(extra) {
             const form = document.getElementById('tarFilters');
-            const params = new URLSearchParams(new FormData(form));
-            if (this.filters.preset !== 'custom') {
-                params.delete('from');
-                params.delete('to');
+            const params = new URLSearchParams();
+            // Préset + dates lus depuis l'état Alpine (le DOM :value peut être stale).
+            params.set('preset', this.filters.preset);
+            if (this.filters.preset === 'custom') {
+                params.set('from', this.filters.from);
+                params.set('to', this.filters.to);
             }
+            // Filtres au-select (selects natifs cachés, déjà à jour dans le DOM).
+            ['teacher_id', 'classe_id', 'matiere_id', 'type_seance'].forEach(function (n) {
+                const el = form.querySelector('[name="' + n + '"]');
+                if (el && el.value) params.set(n, el.value);
+            });
             Object.entries(extra || {}).forEach(function (e) { params.set(e[0], e[1]); });
             return params;
         },
@@ -379,6 +403,42 @@ function reportPage() {
             }, { rootMargin: '120px' });
             obs.observe(sentinel);
         },
+    };
+}
+
+// Marquage présent/absent/retard d'une séance (coordinateur/admin). Global car les
+// lignes séances sont injectées en AJAX. Guard d'idempotence (page report ET fiche).
+if (typeof window.triggerRowHighlight !== 'function') {
+    window.triggerRowHighlight = function (seanceId, status) {
+        const row = document.querySelector('.tar-seance-row[data-seance-id="' + seanceId + '"]');
+        if (!row) return;
+        const hl = document.createElement('div');
+        hl.className = 'tar-rowhl' + (status === 'absent' ? ' tar-rowhl--absent' : (status === 'late' ? ' tar-rowhl--late' : ''));
+        row.appendChild(hl);
+        requestAnimationFrame(() => hl.classList.add('animate'));
+        hl.addEventListener('animationend', () => hl.remove());
+    };
+}
+if (typeof window.markSeanceStatus !== 'function') {
+    window.markSeanceStatus = async function (seanceId, status) {
+        const token = document.querySelector('meta[name="csrf-token"]').content;
+        const base = @json(url('esbtp/teacher-attendance/seance'));
+        // Feedback immédiat : sweep lumineux vert/orange/rouge sur la ligne.
+        window.triggerRowHighlight(seanceId, status);
+        try {
+            const res = await fetch(base + '/' + seanceId + '/update-status', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': token },
+                body: JSON.stringify({ status: status, type: 'start' }),
+            });
+            if (!res.ok) { const b = await res.json().catch(() => ({})); throw new Error(b.message || ('Erreur ' + res.status)); }
+            const labels = { present: 'présent', late: 'en retard', absent: 'absent' };
+            window.dispatchEvent(new CustomEvent('toast', { detail: { type: 'success', message: 'Enseignant marqué ' + (labels[status] || status) + '.' } }));
+            // Laisse l'animation passer (~80%) avant de rafraîchir KPIs + baromètre + liste.
+            setTimeout(() => window.dispatchEvent(new CustomEvent('seance:status-updated')), 2600);
+        } catch (e) {
+            window.dispatchEvent(new CustomEvent('toast', { detail: { type: 'error', message: e.message } }));
+        }
     };
 }
 </script>

--- a/resources/views/esbtp/teacher-attendance/teacher-report.blade.php
+++ b/resources/views/esbtp/teacher-attendance/teacher-report.blade.php
@@ -89,7 +89,12 @@
     .tdr-empty i { font-size: 1.8rem; display: block; margin-bottom: .5rem; color: #cbd5e1; }
 
     /* lignes séances (mêmes classes que report) */
-    .tar-seance-row { display: flex; align-items: center; gap: .85rem; padding: .75rem .35rem; border-bottom: 1px solid #f1f5f9; }
+    .tar-seance-row { display: flex; align-items: center; gap: .85rem; padding: .75rem .35rem; border-bottom: 1px solid #f1f5f9; position: relative; overflow: hidden; }
+    .tar-rowhl { position: absolute; top: 0; left: -80%; width: 160%; height: 100%; opacity: 0; pointer-events: none; transform: translateX(-65%) skewX(-12deg); z-index: 5; background: linear-gradient(90deg, rgba(16,185,129,0) 0%, rgba(16,185,129,.55) 50%, rgba(16,185,129,0) 100%); }
+    .tar-rowhl--absent { background: linear-gradient(90deg, rgba(220,38,38,0) 0%, rgba(220,38,38,.55) 50%, rgba(220,38,38,0) 100%); }
+    .tar-rowhl--late { background: linear-gradient(90deg, rgba(245,158,11,0) 0%, rgba(245,158,11,.55) 50%, rgba(245,158,11,0) 100%); }
+    .tar-rowhl.animate { animation: tar-rowhl-move 3.2s ease-out forwards; }
+    @keyframes tar-rowhl-move { 0% { opacity: 0; transform: translateX(-65%) skewX(-12deg); } 18% { opacity: .92; } 55% { opacity: .72; } 100% { opacity: 0; transform: translateX(115%) skewX(-12deg); } }
     .tar-seance-row:last-child { border-bottom: none; }
     .tar-seance-date { width: 44px; text-align: center; flex-shrink: 0; }
     .tar-seance-day { font-size: 1.05rem; font-weight: 800; color: #0453cb; line-height: 1; }
@@ -108,6 +113,14 @@
     .tar-warn { font-size: .62rem; font-weight: 700; white-space: nowrap; }
     .tar-warn--late { color: #92400e; }
     .tar-warn--miss { color: #b91c1c; }
+    .tar-seance-actions { display: flex; gap: .3rem; margin-top: .3rem; }
+    .tar-act { width: 26px; height: 26px; border-radius: 7px; border: 1px solid; background: #fff; cursor: pointer; font-size: .68rem; display: flex; align-items: center; justify-content: center; transition: all .15s; }
+    .tar-act--ok { color: #059669; border-color: rgba(16,185,129,.4); }
+    .tar-act--ok:hover { background: #10b981; color: #fff; }
+    .tar-act--late { color: #b45309; border-color: rgba(245,158,11,.4); }
+    .tar-act--late:hover { background: #f59e0b; color: #fff; }
+    .tar-act--no { color: #dc2626; border-color: rgba(220,38,38,.4); }
+    .tar-act--no:hover { background: #dc2626; color: #fff; }
 
     @media (max-width: 992px) { .tdr-grid { grid-template-columns: 1fr; } }
     @media (max-width: 768px) { .tdr-hero { padding: 1.4rem 1.25rem; } }
@@ -239,6 +252,7 @@ function teacherPage() {
             this.hasMore = this.$root.dataset.hasMore === '1';
             this.nextPage = parseInt(this.$root.dataset.nextPage, 10) || 2;
             this.observeSentinel();
+            window.addEventListener('seance:status-updated', () => this.applyPeriode());
         },
 
         setPreset(p) { this.filters.preset = p; if (p !== 'custom') this.applyPeriode(); },
@@ -289,6 +303,38 @@ function teacherPage() {
             if (!s || !('IntersectionObserver' in window)) return;
             new IntersectionObserver((es) => { es.forEach((e) => { if (e.isIntersecting) this.loadMore(); }); }, { rootMargin: '120px' }).observe(s);
         },
+    };
+}
+
+if (typeof window.triggerRowHighlight !== 'function') {
+    window.triggerRowHighlight = function (seanceId, status) {
+        const row = document.querySelector('.tar-seance-row[data-seance-id="' + seanceId + '"]');
+        if (!row) return;
+        const hl = document.createElement('div');
+        hl.className = 'tar-rowhl' + (status === 'absent' ? ' tar-rowhl--absent' : (status === 'late' ? ' tar-rowhl--late' : ''));
+        row.appendChild(hl);
+        requestAnimationFrame(() => hl.classList.add('animate'));
+        hl.addEventListener('animationend', () => hl.remove());
+    };
+}
+if (typeof window.markSeanceStatus !== 'function') {
+    window.markSeanceStatus = async function (seanceId, status) {
+        const token = document.querySelector('meta[name="csrf-token"]').content;
+        const base = @json(url('esbtp/teacher-attendance/seance'));
+        window.triggerRowHighlight(seanceId, status);
+        try {
+            const res = await fetch(base + '/' + seanceId + '/update-status', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json', 'Accept': 'application/json', 'X-CSRF-TOKEN': token },
+                body: JSON.stringify({ status: status, type: 'start' }),
+            });
+            if (!res.ok) { const b = await res.json().catch(() => ({})); throw new Error(b.message || ('Erreur ' + res.status)); }
+            const labels = { present: 'présent', late: 'en retard', absent: 'absent' };
+            window.dispatchEvent(new CustomEvent('toast', { detail: { type: 'success', message: 'Enseignant marqué ' + (labels[status] || status) + '.' } }));
+            setTimeout(() => window.dispatchEvent(new CustomEvent('seance:status-updated')), 2600);
+        } catch (e) {
+            window.dispatchEvent(new CustomEvent('toast', { detail: { type: 'error', message: e.message } }));
+        }
     };
 }
 </script>


### PR DESCRIPTION
@
Régressions du redesign paie enseignants signalées par Marcel :
- **Toggle Mois/Année** cassé (seul Plage marchait) — préset lu via FormData stale → corrigé (lecture depuis létat Alpine).
- **Boutons Présent/Absent/Retard** restaurés sur report + fiche enseignant (gated `attendances.edit`, masqués pour séances à venir), AJAX `update-status` + refresh sans reload.
- **Animation travelling-light** (`triggerRowHighlight`) restaurée au marquage.
- **Cartographie workflow** coordinateur restaurée (pipeline 8 étapes avec flèches + progression) au lieu de barres basiques.
@