### PR TITLE
fix(paie): type_seance legacy 'cours' casse le rapport heures (500)

### DIFF
--- a/app/Http/Controllers/ESBTP/TeacherAttendanceController.php
+++ b/app/Http/Controllers/ESBTP/TeacherAttendanceController.php
@@ -530,9 +530,8 @@ class TeacherAttendanceController extends Controller
 
         return $seances->map(function ($seance) use ($hours, $today) {
             $statut = $this->resolveAttendanceStatus($seance, $today);
-            $type = $seance->type_seance instanceof TypeSeance
-                ? $seance->type_seance
-                : TypeSeance::fromLegacy($seance->type_seance);
+            // Valeur brute : le cast enum lève une ValueError sur les valeurs legacy ('cours').
+            $type = TypeSeance::fromLegacy($seance->getRawOriginal('type_seance'));
             $estPassee = $seance->date_seance && Carbon::parse($seance->date_seance)->endOfDay()->isPast();
 
             // Séance encore à venir (date future, ou aujourd'hui avant la fin) → pas d'action.

--- a/app/Services/TeacherHoursService.php
+++ b/app/Services/TeacherHoursService.php
@@ -133,9 +133,9 @@ class TeacherHoursService
         $warnings = [];
 
         foreach ($seances as $seance) {
-            $type = $seance->type_seance instanceof TypeSeance
-                ? $seance->type_seance
-                : TypeSeance::fromLegacy($seance->type_seance);
+            // ⚠️ Lire la valeur BRUTE : le cast enum du modèle lève une ValueError sur
+            // les valeurs legacy (ex 'cours') stockées en DB. fromLegacy les normalise.
+            $type = TypeSeance::fromLegacy($seance->getRawOriginal('type_seance'));
             $key = $type->value;
 
             if (!isset($parType[$key])) {


### PR DESCRIPTION
Les séances BTS legacy ont `type_seance='cours'` ; le cast enum lève une ValueError à l'accès → 500 sur préset Année/Plage. Fix : lecture brute via `getRawOriginal` + `TypeSeance::fromLegacy`.