### PR TITLE
feat(paie): seeder démo (taux + séances suivant le planning) + doc rule au-select

### DIFF
--- a/.claude/rules/premium-selects.md
+++ b/.claude/rules/premium-selects.md
@@ -179,6 +179,54 @@ Règles à respecter pour un nouveau composant picker :
 </form>
 ```
 
+## ⚠ Piège largeur : `<x-au-select>` rétréci hors d'un parent flex/grid (modals)
+
+Le wrapper `.au-select` est `display: inline-flex; flex: 1 1 0%`. Le `flex: 1` ne
+s'applique **que si le parent est lui-même un conteneur flex/grid**. Dans les pages
+de filtres ça marche car le composant est dans `.au-filters-row` (flex) ou `.xx-field`
+(flex-column → `align-items: stretch` étire la largeur). **Mais dans une cellule de
+modal en `<div>` nu, l'`inline-flex` rétrécit à son contenu** → le trigger fait ~150px,
+le menu `.au-select-menu` (`left:8px; right:8px` du wrapper) devient minuscule, et les
+libellés longs (noms d'enseignants, intitulés) sont **tronqués**.
+
+### ❌ INTERDIT (cellule de modal sans parent flex)
+
+```blade
+<div class="pay-grid3">       {{-- grid OK, mais la cellule enfant est un <div> nu --}}
+    <div>
+        <span class="field-lbl">Enseignant</span>
+        <x-au-select name="teacher_id" :searchable="true" :options="$teachers" />
+    </div>  {{-- ← au-select rétréci → menu étroit → noms tronqués --}}
+</div>
+```
+
+### ✅ CORRECT — conteneur flex-column + largeur explicite
+
+```blade
+{{-- Liste longue (enseignants) : pleine largeur sur sa propre ligne --}}
+<div class="xx-field">  {{-- .xx-field = display:flex; flex-direction:column --}}
+    <span class="field-lbl">Enseignant</span>
+    <x-au-select class="xx-au-full" name="teacher_id" :searchable="true" :options="$teachers" />
+</div>
+```
+
+```css
+/* Force le picker à remplir sa colonne même hors d'un parent flex */
+.xx-au-full { display: flex !important; width: 100%; }
+.xx-au-full .au-select-trigger { width: 100%; }
+```
+
+**Règles** :
+1. Toujours placer `<x-au-select>` dans un parent **flex/grid** (idéalement `flex-direction: column`
+   pour les formulaires) — jamais dans un `<div>` nu.
+2. Pour les **listes longues** (enseignants, étudiants, matières), donner au picker
+   une **ligne pleine largeur** (pas une colonne 1/3) pour que le menu ait la place
+   d'afficher les libellés complets.
+3. En cas de doute, ajouter une classe `width:100%; display:flex` sur le composant.
+
+Incident fondateur : modal « Préparer un bulletin de paie » (juin 2026) — picker
+enseignant tronqué (« BEDE ABE… », « GUESSA… ») car cellules de modal en `<div>` nu.
+
 ## Anti-patterns à BLOQUER en review
 
 1. ❌ `<select class="form-select">` ou `<select class="form-control">` direct dans une page premium — utiliser `<x-au-select>`.

--- a/app/Console/Commands/PaieSeedDemoCommand.php
+++ b/app/Console/Commands/PaieSeedDemoCommand.php
@@ -1,0 +1,268 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\TypeSeance;
+use App\Models\ESBTPAnneeUniversitaire;
+use App\Models\ESBTPClasse;
+use App\Models\ESBTPEmploiTemps;
+use App\Models\ESBTPEnseignantTauxSeance;
+use App\Models\ESBTPPlanificationAcademique;
+use App\Models\ESBTPSeanceCours;
+use App\Models\ESBTPTeacher;
+use App\Models\ESBTPTeacherAttendance;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Données démo testables pour la PAIE ENSEIGNANTS, en symbiose avec l'UI :
+ *  - taux horaires des enseignants existants : esbtp_enseignant_taux_seance (+ taux_horaire)
+ *  - séances dans de NOUVEAUX emplois du temps, EN SUIVANT LE PLANNING HORAIRE
+ *    (esbtp_planifications_academiques : volumes CM/TD/TP par matière + enseignant
+ *    principal assigné), classes BTS ET LMD.
+ *
+ * On NE crée PAS de données de paie (aucun bulletin/salaire). L'utilisateur génère
+ * lui-même le bulletin. Les séances passées sont émargées (présent/retard) pour que
+ * le calcul ait des heures réalisées ; les plus récentes restent à émarger (test UI).
+ *
+ * Idempotent : les emplois du temps démo (titre préfixé) et leurs séances/émargements
+ * sont purgés avant chaque exécution. --dry-run pour investiguer sans écrire.
+ */
+class PaieSeedDemoCommand extends Command
+{
+    protected $signature = 'paie:seed-demo
+        {--weeks=6 : Nombre de semaines passées de séances à générer}
+        {--max-matieres=5 : Nombre max de matières (planifications) par classe}
+        {--dry-run : Ne rien écrire, juste rapporter ce qui serait fait}';
+
+    protected $description = 'Seed démo paie : taux profs + séances suivant le planning horaire (BTS + LMD)';
+
+    private const ET_PREFIX = 'Démo paie — ';
+    private const MARKER = 'DEMO_PAIE_SEED';
+
+    /** Profils de taux variés (FCFA/h). */
+    private const TAUX_PROFILES = [
+        ['CM' => 8000, 'TD' => 6000, 'TP' => 5000, 'def' => 5000],
+        ['CM' => 10000, 'TD' => 7500, 'TP' => 6000, 'def' => 6000],
+        ['CM' => 7000, 'TD' => 5500, 'TP' => 4500, 'def' => 4500],
+        ['CM' => 12000, 'TD' => 9000, 'TP' => 7000, 'def' => 7000],
+    ];
+
+    public function handle(): int
+    {
+        $dry = (bool) $this->option('dry-run');
+        $weeks = max(1, (int) $this->option('weeks'));
+        $maxMat = max(1, (int) $this->option('max-matieres'));
+
+        $annee = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+        if (!$annee) {
+            $this->error('Aucune année universitaire courante.');
+            return self::FAILURE;
+        }
+        $this->info("Année : {$annee->name} (#{$annee->id})");
+
+        // Classes cibles : 1 LMD + 1 BTS qui ont des planifications (planning horaire).
+        $lmd = $this->classeAvecPlanif($annee, 'LMD');
+        $bts = $this->classeAvecPlanif($annee, 'BTS');
+        $cibles = collect([$lmd, $bts])->filter()->values();
+
+        if ($cibles->isEmpty()) {
+            $this->error('Aucune classe avec planification trouvée (esbtp_planifications_academiques).');
+            return self::FAILURE;
+        }
+
+        // Pool d'enseignants pour fallback (planif sans enseignant principal).
+        $pool = ESBTPTeacher::with('user')->whereHas('user')->orderBy('id')->get();
+        if ($pool->isEmpty()) {
+            $this->error('Aucun enseignant (esbtp_teachers avec user).');
+            return self::FAILURE;
+        }
+
+        $durations = [60, 90, 120, 180]; // durées VARIÉES (séances pas toutes 1h)
+        $startHours = ['08:00', '10:00', '13:30', '15:00'];
+
+        $usedTeachers = collect();
+        $report = [];
+
+        foreach ($cibles as $classe) {
+            $planifs = $this->planifsDeClasse($annee, $classe)->take($maxMat);
+            $report[] = "Classe {$classe->name} ({$classe->systeme_academique}) → " . $planifs->count() . ' matière(s) planifiée(s)';
+        }
+
+        if ($dry) {
+            foreach ($report as $r) {
+                $this->line('  ' . $r);
+            }
+            $this->warn('[DRY-RUN] Aucune écriture. Lancez sans --dry-run pour générer.');
+            return self::SUCCESS;
+        }
+
+        $stats = ['emplois' => 0, 'seances' => 0, 'emargements' => 0, 'taux' => 0];
+
+        DB::transaction(function () use (
+            $cibles, $annee, $pool, $weeks, $maxMat, $durations, $startHours, &$usedTeachers, &$stats
+        ) {
+            // Purge démo précédente (idempotence).
+            $oldSeances = ESBTPSeanceCours::where('description', self::MARKER)->pluck('id');
+            if ($oldSeances->isNotEmpty()) {
+                ESBTPTeacherAttendance::whereIn('course_id', $oldSeances)->delete();
+                ESBTPSeanceCours::whereIn('id', $oldSeances)->forceDelete();
+            }
+            ESBTPEmploiTemps::where('titre', 'like', self::ET_PREFIX . '%')->forceDelete();
+
+            $teacherCursor = 0;
+
+            foreach ($cibles as $classe) {
+                $planifs = $this->planifsDeClasse($annee, $classe)->take($maxMat);
+                if ($planifs->isEmpty()) {
+                    continue;
+                }
+                $semestre = (int) ($planifs->first()->semestre ?? 1);
+
+                $emploi = ESBTPEmploiTemps::create([
+                    'titre' => self::ET_PREFIX . $classe->name,
+                    'classe_id' => $classe->id,
+                    'annee_universitaire_id' => $annee->id,
+                    'semestre' => $semestre,
+                    'date_debut' => Carbon::now()->subWeeks($weeks + 1)->startOfWeek()->toDateString(),
+                    'date_fin' => Carbon::now()->addWeeks(3)->toDateString(),
+                    'is_active' => true,
+                    'is_current' => false,
+                ]);
+                $stats['emplois']++;
+
+                foreach ($planifs as $mIdx => $planif) {
+                    // Enseignant : principal assigné, sinon round-robin du pool.
+                    $teacher = $planif->enseignant_principal_id
+                        ? $pool->firstWhere('user_id', $planif->enseignant_principal_id)
+                        : null;
+                    if (!$teacher) {
+                        $teacher = $pool[$teacherCursor % $pool->count()];
+                        $teacherCursor++;
+                    }
+                    $usedTeachers->put($teacher->id, $teacher);
+
+                    // Types présents dans le planning de cette matière.
+                    $types = [];
+                    if (($planif->volume_horaire_cm ?? 0) > 0) $types[] = TypeSeance::CM;
+                    if (($planif->volume_horaire_td ?? 0) > 0) $types[] = TypeSeance::TD;
+                    if (($planif->volume_horaire_tp ?? 0) > 0) $types[] = TypeSeance::TP;
+                    if (empty($types)) {
+                        $types[] = TypeSeance::CM; // matière planifiée sans détail → CM par défaut
+                    }
+
+                    foreach ($types as $tIdx => $type) {
+                        // 1 séance / semaine sur la fenêtre.
+                        for ($w = 0; $w < $weeks; $w++) {
+                            $date = Carbon::now()->subWeeks($w)->startOfWeek()
+                                ->addDays(($mIdx + $tIdx) % 5); // lundi..vendredi
+                            if ($date->isFuture()) {
+                                continue;
+                            }
+                            $startStr = $startHours[($mIdx + $tIdx + $w) % count($startHours)];
+                            $duration = $durations[($w + $tIdx) % count($durations)];
+                            $debut = Carbon::parse($date->toDateString() . ' ' . $startStr);
+                            $fin = (clone $debut)->addMinutes($duration);
+
+                            $seance = ESBTPSeanceCours::create([
+                                'emploi_temps_id' => $emploi->id,
+                                'classe_id' => $classe->id,
+                                'matiere_id' => $planif->matiere_id,
+                                'teacher_id' => $teacher->id,
+                                'jour' => (int) $date->dayOfWeekIso,
+                                'heure_debut' => $debut->format('H:i:s'),
+                                'heure_fin' => $fin->format('H:i:s'),
+                                'salle' => 'DEMO-' . $type->value,
+                                'description' => self::MARKER,
+                                'type' => ESBTPSeanceCours::TYPE_COURSE,
+                                'type_seance' => $type->value,
+                                'is_active' => true,
+                                'date_seance' => $date->toDateString(),
+                                'annee_universitaire_id' => $annee->id,
+                            ]);
+                            $stats['seances']++;
+
+                            // Émargement des séances de + de 2 semaines (passées/faites) ~75%.
+                            $est2sPlus = $date->lt(Carbon::now()->subWeeks(2));
+                            if ($est2sPlus && (($w + $mIdx + $tIdx) % 4 !== 0)) {
+                                $status = (($w + $mIdx) % 6 === 0) ? 'late' : 'present';
+                                ESBTPTeacherAttendance::create([
+                                    'teacher_id' => $teacher->user_id,
+                                    'course_id' => $seance->id,
+                                    'date' => $date->toDateString(),
+                                    'status' => $status,
+                                    'type' => 'start',
+                                    'attempts' => 1,
+                                    'validated_at' => (clone $debut),
+                                ]);
+                                ESBTPTeacherAttendance::create([
+                                    'teacher_id' => $teacher->user_id,
+                                    'course_id' => $seance->id,
+                                    'date' => $date->toDateString(),
+                                    'status' => 'present',
+                                    'type' => 'end',
+                                    'attempts' => 1,
+                                    'validated_at' => (clone $fin),
+                                ]);
+                                $stats['emargements'] += 2;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Taux horaires des enseignants utilisés (table esbtp_enseignant_taux_seance + défaut).
+            foreach ($usedTeachers->values() as $i => $teacher) {
+                $profile = self::TAUX_PROFILES[$i % count(self::TAUX_PROFILES)];
+                $teacher->update(['taux_horaire' => $profile['def']]);
+                foreach (['CM', 'TD', 'TP'] as $tp) {
+                    ESBTPEnseignantTauxSeance::updateOrCreate(
+                        ['teacher_id' => $teacher->id, 'type_seance' => $tp],
+                        ['taux_horaire' => $profile[$tp]]
+                    );
+                    $stats['taux']++;
+                }
+            }
+        });
+
+        $this->info("✓ Emplois du temps démo : {$stats['emplois']}");
+        $this->info("✓ Séances (suivant le planning) : {$stats['seances']}");
+        $this->info("✓ Émargements (séances passées) : {$stats['emargements']}");
+        $this->info("✓ Taux par type définis : {$stats['taux']} (sur " . $usedTeachers->count() . ' enseignants)');
+        $this->newLine();
+        $this->info('Enseignants dotés de taux :');
+        foreach ($usedTeachers->values() as $teacher) {
+            $this->line('  - ' . ($teacher->user->name ?? ('#' . $teacher->id)));
+        }
+        $this->newLine();
+        $this->info('Testez : /esbtp/teacher-attendance/report (marquez les séances récentes) puis');
+        $this->info('         /esbtp/comptabilite/salaires → Préparer un bulletin sur un de ces enseignants.');
+
+        return self::SUCCESS;
+    }
+
+    /** Première classe d'un système (LMD/BTS) qui possède des planifications. */
+    private function classeAvecPlanif(ESBTPAnneeUniversitaire $annee, string $systeme): ?ESBTPClasse
+    {
+        return ESBTPClasse::query()
+            ->where('systeme_academique', $systeme)
+            ->whereNotNull('filiere_id')
+            ->whereNotNull('niveau_etude_id')
+            ->get()
+            ->first(fn ($c) => $this->planifsDeClasse($annee, $c)->isNotEmpty());
+    }
+
+    /** Planifications (planning horaire) d'une classe pour l'année. */
+    private function planifsDeClasse(ESBTPAnneeUniversitaire $annee, ESBTPClasse $classe)
+    {
+        return ESBTPPlanificationAcademique::query()
+            ->where('annee_universitaire_id', $annee->id)
+            ->where('filiere_id', $classe->filiere_id)
+            ->where('niveau_etude_id', $classe->niveau_etude_id)
+            ->where('is_active', true)
+            ->with('matiere:id,name')
+            ->orderByDesc(DB::raw('(COALESCE(volume_horaire_cm,0)+COALESCE(volume_horaire_td,0)+COALESCE(volume_horaire_tp,0))'))
+            ->get();
+    }
+}

--- a/app/Http/Controllers/API/CLI/CLIPaieController.php
+++ b/app/Http/Controllers/API/CLI/CLIPaieController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\API\CLI;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+
+/**
+ * Endpoints CLI pour la paie enseignants (seed démo distant).
+ */
+class CLIPaieController extends Controller
+{
+    /**
+     * Déclenche la commande paie:seed-demo (taux profs + séances suivant le planning).
+     * POST /api/cli/paie/seed-demo
+     */
+    public function seedDemo(Request $request)
+    {
+        $params = array_filter([
+            '--weeks' => $request->integer('weeks') ?: null,
+            '--max-matieres' => $request->integer('max_matieres') ?: null,
+            '--dry-run' => $request->boolean('dry_run') ?: null,
+        ], fn ($v) => $v !== null);
+
+        $code = Artisan::call('paie:seed-demo', $params);
+        $output = Artisan::output();
+
+        return response()->json([
+            'success' => $code === 0,
+            'exit_code' => $code,
+            'output' => $output,
+        ], $code === 0 ? 200 : 500);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -278,6 +278,9 @@ Route::middleware(['auth:sanctum', 'throttle:60,1'])->prefix('cli')->name('api.c
     // Read endpoints — Users
     Route::get('/users', [App\Http\Controllers\API\CLI\CLIUserController::class, 'users'])->name('users');
 
+    // Paie enseignants — seed démo (taux profs + séances suivant le planning horaire)
+    Route::post('/paie/seed-demo', [App\Http\Controllers\API\CLI\CLIPaieController::class, 'seedDemo'])->name('paie.seed-demo');
+
     // Write endpoints
     Route::post('/inscriptions/{id}/validate', [App\Http\Controllers\API\CLI\CLIStudentController::class, 'validateInscription'])->name('inscriptions.validate');
     Route::post('/inscriptions/move', [App\Http\Controllers\API\CLI\CLIStudentController::class, 'moveStudents'])->name('inscriptions.move');


### PR DESCRIPTION
Commande paie:seed-demo + endpoint /api/cli/paie/seed-demo : taux par type sur enseignants existants + séances dans de nouveaux emplois du temps suivant le planning horaire (planifications CM/TD/TP + enseignant principal), BTS et LMD. Émarge les séances passées. Aucune donnée de paie générée. + doc piège au-select inline-flex dans la rule.