### PR TITLE
fix(paie): 500 audit auditable_id NULL sur la liste des salaires

### DIFF
--- a/app/Http/Controllers/ESBTPSalaireController.php
+++ b/app/Http/Controllers/ESBTPSalaireController.php
@@ -320,7 +320,11 @@ class ESBTPSalaireController extends Controller
     {
         $base = ESBTPSalaire::where('mois', $filtres['mois'])->where('annee', $filtres['annee']);
 
-        $byStatut = (clone $base)->select('workflow_status', DB::raw('count(*) as n'), DB::raw('sum(net_a_payer) as net'))
+        // ⚠️ toBase() : requête d'agrégat SANS hydrater de modèles ESBTPSalaire.
+        // Sinon des modèles sans `id` (colonnes id non sélectionnées) déclenchent
+        // l'audit OwenIt « retrieved » → insert audits.auditable_id NULL → 500.
+        $byStatut = (clone $base)->toBase()
+            ->select('workflow_status', DB::raw('count(*) as n'), DB::raw('sum(net_a_payer) as net'))
             ->groupBy('workflow_status')->get()->keyBy('workflow_status');
 
         return [

--- a/app/Models/ESBTPSalaire.php
+++ b/app/Models/ESBTPSalaire.php
@@ -33,6 +33,12 @@ class ESBTPSalaire extends Model implements Auditable
         'date_paiement', 'mode_paiement', 'reference_paiement',
     ];
 
+    /**
+     * Pas d'audit « retrieved » (spam à chaque chargement de liste + casse les
+     * agrégats sans id). On audite uniquement les mutations significatives.
+     */
+    protected $auditEvents = ['created', 'updated', 'deleted'];
+
     protected $fillable = [
         'user_id', 'teacher_id', 'annee_universitaire_id', 'mois', 'annee',
         'period_start', 'period_end',


### PR DESCRIPTION
kpis() hydratait des ESBTPSalaire sans id (SELECT agrégat) → audit OwenIt 'retrieved' avec auditable_id NULL → 500 dès qu'un bulletin existe. Fix : toBase() sur l'agrégat + $auditEvents sans 'retrieved'.