### PR TITLE
feat(paie): récap tous enseignants + export PDF/Excel + séances dans l'emploi du temps courant

### DIFF
--- a/app/Console/Commands/PaieSeedDemoCommand.php
+++ b/app/Console/Commands/PaieSeedDemoCommand.php
@@ -109,7 +109,8 @@ class PaieSeedDemoCommand extends Command
                 ESBTPTeacherAttendance::whereIn('course_id', $oldSeances)->delete();
                 ESBTPSeanceCours::whereIn('id', $oldSeances)->forceDelete();
             }
-            ESBTPEmploiTemps::where('titre', 'like', self::ET_PREFIX . '%')->forceDelete();
+            // On NE supprime PAS l'emploi du temps démo (réutilisé) : sinon, après
+            // setAsCurrent, la classe se retrouverait sans emploi du temps courant.
 
             $teacherCursor = 0;
 
@@ -120,16 +121,21 @@ class PaieSeedDemoCommand extends Command
                 }
                 $semestre = (int) ($planifs->first()->semestre ?? 1);
 
-                $emploi = ESBTPEmploiTemps::create([
+                // Réutilise l'emploi du temps démo s'il existe (idempotent), sinon le crée.
+                $emploi = ESBTPEmploiTemps::firstOrNew([
                     'titre' => self::ET_PREFIX . $classe->name,
                     'classe_id' => $classe->id,
                     'annee_universitaire_id' => $annee->id,
+                ]);
+                $emploi->fill([
                     'semestre' => $semestre,
                     'date_debut' => Carbon::now()->subWeeks($weeks + 1)->startOfWeek()->toDateString(),
                     'date_fin' => Carbon::now()->addWeeks(3)->toDateString(),
                     'is_active' => true,
-                    'is_current' => false,
-                ]);
+                ])->save();
+                // En faire l'emploi du temps COURANT de la classe (sinon les séances
+                // ne sont pas visibles : la page classe affiche l'emploi du temps courant).
+                ESBTPEmploiTemps::setAsCurrent($emploi->id);
                 $stats['emplois']++;
 
                 foreach ($planifs as $mIdx => $planif) {

--- a/app/Domain/Exports/Reports/PaiePayrollReport.php
+++ b/app/Domain/Exports/Reports/PaiePayrollReport.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Domain\Exports\Reports;
+
+use App\Domain\Exports\ExportableReport;
+use App\Exports\PaiePayrollExport;
+use Maatwebsite\Excel\Concerns\FromCollection;
+
+/**
+ * État de paie des enseignants pour une période — récap « ce qu'on doit verser ».
+ * Consommé par ESBTPSalaireController pour preview/PDF/Excel via ExportRenderer.
+ */
+class PaiePayrollReport extends ExportableReport
+{
+    public function __construct(
+        private readonly array $rows,
+        private readonly array $kpis = [],
+        private readonly array $appliedFilters = [],
+        private readonly string $periodLabel = '',
+        private readonly array $statutLabels = [],
+    ) {}
+
+    public function title(): string
+    {
+        return 'État de paie des enseignants';
+    }
+
+    public function subtitle(): ?string
+    {
+        return 'Période : ' . $this->periodLabel;
+    }
+
+    public function pdfView(): string
+    {
+        return 'esbtp.comptabilite.salaires.pdf';
+    }
+
+    public function viewData(): array
+    {
+        return [
+            'rows'         => $this->rows,
+            'kpis'         => $this->kpis,
+            'periodLabel'  => $this->periodLabel,
+            'statutLabels' => $this->statutLabels,
+        ];
+    }
+
+    public function excelExport(): FromCollection
+    {
+        return new PaiePayrollExport($this->rows, $this->statutLabels, $this->appliedFilters);
+    }
+
+    public function filters(): array
+    {
+        return $this->appliedFilters;
+    }
+
+    public function orientation(): string
+    {
+        return 'landscape';
+    }
+
+    public function filename(): string
+    {
+        return 'etat_paie_' . now()->format('Ymd_His');
+    }
+}

--- a/app/Exports/PaiePayrollExport.php
+++ b/app/Exports/PaiePayrollExport.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Exports;
+
+use Illuminate\Support\Collection;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+use Maatwebsite\Excel\Concerns\WithMapping;
+use Maatwebsite\Excel\Concerns\WithTitle;
+
+/**
+ * Export Excel de l'état de paie des enseignants. Colonnes alignées avec le PDF.
+ */
+class PaiePayrollExport implements FromCollection, WithHeadings, WithMapping, WithTitle, ShouldAutoSize
+{
+    /**
+     * @param  array<int, array>  $rows
+     * @param  array<string, string>  $statutLabels
+     * @param  array<string, mixed>  $filters
+     */
+    public function __construct(
+        private readonly array $rows,
+        private readonly array $statutLabels = [],
+        private readonly array $filters = [],
+    ) {}
+
+    public function collection(): Collection
+    {
+        return collect($this->rows);
+    }
+
+    public function headings(): array
+    {
+        return ['Enseignant', 'Heures réalisées', 'Base (FCFA)', 'Retenues (FCFA)', 'Net à payer (FCFA)', 'Statut'];
+    }
+
+    /** @param array $row */
+    public function map($row): array
+    {
+        return [
+            $row['name'] ?? '',
+            (float) ($row['heures'] ?? 0),
+            (float) ($row['base'] ?? 0),
+            (float) ($row['retenues'] ?? 0),
+            (float) ($row['net'] ?? 0),
+            $this->statutLabels[$row['statut'] ?? ''] ?? ($row['statut'] ?? ''),
+        ];
+    }
+
+    public function title(): string
+    {
+        return 'Paie enseignants';
+    }
+}

--- a/app/Http/Controllers/ESBTPSalaireController.php
+++ b/app/Http/Controllers/ESBTPSalaireController.php
@@ -3,11 +3,15 @@
 namespace App\Http\Controllers;
 
 use App\Domain\Comptabilite\Paie\PayrollComputationService;
+use App\Domain\Exports\Reports\PaiePayrollReport;
+use App\Enums\TypeSeance;
+use App\Services\ExportRenderer;
 use App\Helpers\SettingsHelper;
 use App\Models\ESBTPAnneeUniversitaire;
 use App\Models\ESBTPSalaire;
 use App\Models\ESBTPSalaireDetail;
 use App\Models\ESBTPTeacher;
+use App\Services\TeacherHoursService;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -21,8 +25,10 @@ use Illuminate\Support\Facades\Log;
  */
 class ESBTPSalaireController extends Controller
 {
-    public function __construct(private PayrollComputationService $payroll)
-    {
+    public function __construct(
+        private PayrollComputationService $payroll,
+        private TeacherHoursService $hours,
+    ) {
     }
 
     private const MOIS_FR = [
@@ -33,54 +39,211 @@ class ESBTPSalaireController extends Controller
     public function index(Request $request)
     {
         $annee = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+        $filtres = $this->filtres($request);
 
-        $filtres = [
-            'mois'    => (int) $request->get('mois', now()->month),
-            'annee'   => (int) $request->get('annee', now()->year),
-            'statut'  => $request->get('statut'),
-        ];
-
-        $bulletins = $this->bulletinsQuery($filtres)->get();
-        $kpis = $this->kpis($filtres);
+        $recap = $this->buildRecap($filtres);
+        $kpis = $this->recapKpis($recap);
 
         $teachers = ESBTPTeacher::with('user:id,name')->get()
             ->map(fn ($t) => ['id' => $t->id, 'name' => $t->user->name ?? $t->name ?? 'Enseignant'])
             ->sortBy('name')->values();
 
         return view('esbtp.comptabilite.salaires.index', [
-            'bulletins'   => $bulletins,
+            'recap'       => $recap,
             'kpis'        => $kpis,
             'filtres'     => $filtres,
             'annee'       => $annee,
             'teachers'    => $teachers,
             'moisOptions' => self::MOIS_FR,
-            'statutLabels'=> ESBTPSalaire::statutLabels(),
+            'statutLabels'=> $this->statutLabels(),
             'canCreate'   => auth()->user()->can('comptabilite.salaires.create'),
             'canConfigure'=> auth()->user()->can('comptabilite.salaires.configure'),
+            'canExport'   => auth()->user()->can('comptabilite.salaires.export'),
             'cnpsTaux'    => $this->payroll->tauxCnps(),
             'bareme'      => $this->payroll->baremeIts(),
         ]);
     }
 
-    /** AJAX : liste filtrée + KPIs (no-reload). */
+    /** AJAX : récap filtré + KPIs (no-reload). */
     public function data(Request $request)
     {
-        $filtres = [
+        $filtres = $this->filtres($request);
+        $recap = $this->buildRecap($filtres);
+        $kpis = $this->recapKpis($recap);
+
+        return response()->json([
+            'list_html' => view('esbtp.comptabilite.salaires.partials._recap', [
+                'recap'        => $recap,
+                'statutLabels' => $this->statutLabels(),
+                'canCreate'    => auth()->user()->can('comptabilite.salaires.create'),
+            ])->render(),
+            'kpis_html' => view('esbtp.comptabilite.salaires.partials._kpis', ['kpis' => $kpis])->render(),
+            'period_label' => (self::MOIS_FR[$filtres['mois']] ?? '') . ' ' . $filtres['annee'],
+        ]);
+    }
+
+    private function filtres(Request $request): array
+    {
+        return [
             'mois'   => (int) $request->get('mois', now()->month),
             'annee'  => (int) $request->get('annee', now()->year),
             'statut' => $request->get('statut'),
+            'q'      => trim((string) $request->get('q', '')),
         ];
+    }
 
-        $bulletins = $this->bulletinsQuery($filtres)->get();
-        $kpis = $this->kpis($filtres);
+    /** Libellés statut incluant le pseudo-statut « à préparer ». */
+    private function statutLabels(): array
+    {
+        return ['a_preparer' => 'À préparer'] + ESBTPSalaire::statutLabels();
+    }
 
-        return response()->json([
-            'list_html' => view('esbtp.comptabilite.salaires.partials._list', [
-                'bulletins'    => $bulletins,
-                'statutLabels' => ESBTPSalaire::statutLabels(),
-            ])->render(),
-            'kpis_html' => view('esbtp.comptabilite.salaires.partials._kpis', ['kpis' => $kpis])->render(),
-        ]);
+    /**
+     * Récapitulatif paie : TOUS les enseignants avec heures facturables ce mois,
+     * leur montant estimé (heures × taux − ITS/CNPS), fusionné avec les bulletins
+     * déjà préparés (statut + net réel). C'est la vue « ce qu'on doit verser ».
+     *
+     * @return array<int, array<string,mixed>>
+     */
+    private function buildRecap(array $filtres): array
+    {
+        [$from, $to] = $this->moisRange($filtres['mois'], $filtres['annee']);
+        $report = $this->hours->report($from, $to);
+
+        $teachers = ESBTPTeacher::with(['tauxSeances', 'user:id,name'])->get()->keyBy('id');
+        $bulletins = ESBTPSalaire::where('mois', $filtres['mois'])
+            ->where('annee', $filtres['annee'])->get()->keyBy('teacher_id');
+
+        $cnpsTaux = $this->payroll->tauxCnps();
+        $rows = [];
+        $seen = [];
+
+        foreach ($report['enseignants'] as $ens) {
+            $teacher = $teachers->get($ens['teacher_id']);
+            if (!$teacher) {
+                continue;
+            }
+            $base = 0.0;
+            $heures = 0.0;
+            $types = [];
+            foreach ($ens['par_type'] as $pt) {
+                if (!$pt['facturable'] || $pt['heures_realisees'] <= 0) {
+                    continue;
+                }
+                $taux = $teacher->tauxPour($pt['type']);
+                $base += $pt['heures_realisees'] * $taux;
+                $heures += $pt['heures_realisees'];
+                $types[] = [
+                    'type' => $pt['type'], 'icon' => $pt['icon'], 'style' => $pt['style'],
+                    'heures' => $pt['heures_realisees'], 'taux' => $taux,
+                ];
+            }
+            $base = round($base, 2);
+            $bulletin = $bulletins->get($ens['teacher_id']);
+            if ($base <= 0 && !$bulletin) {
+                continue;
+            }
+            $its = $this->payroll->computeIts($base);
+            $cnps = round($base * $cnpsTaux / 100, 2);
+
+            $rows[] = $this->recapRow($ens['teacher_id'], $ens['name'], $heures, $types, $base, $its, $cnps, $bulletin);
+            $seen[$ens['teacher_id']] = true;
+        }
+
+        // Bulletins dont l'enseignant n'a pas d'heures dans le report (ex: saisie manuelle).
+        foreach ($bulletins as $tid => $bulletin) {
+            if (isset($seen[$tid])) {
+                continue;
+            }
+            $teacher = $teachers->get($tid);
+            $name = $teacher?->user?->name ?? $teacher?->name ?? 'Enseignant';
+            $rows[] = $this->recapRow($tid, $name, (float) $bulletin->heures_total, [], (float) $bulletin->salaire_base, (float) $bulletin->impot_its, (float) $bulletin->cnps, $bulletin);
+        }
+
+        // Filtres statut + recherche.
+        if (!empty($filtres['statut'])) {
+            $rows = array_values(array_filter($rows, fn ($r) => $r['statut'] === $filtres['statut']));
+        }
+        if ($filtres['q'] !== '') {
+            $q = mb_strtolower($filtres['q']);
+            $rows = array_values(array_filter($rows, fn ($r) => str_contains(mb_strtolower($r['name']), $q)));
+        }
+
+        usort($rows, fn ($a, $b) => $b['net'] <=> $a['net']);
+
+        return $rows;
+    }
+
+    /** Construit une ligne de récap (statut = bulletin ou « à préparer »). */
+    private function recapRow($teacherId, string $name, float $heures, array $types, float $base, float $its, float $cnps, ?ESBTPSalaire $bulletin): array
+    {
+        $netEstime = round($base - $its - $cnps, 2);
+
+        return [
+            'teacher_id'  => (int) $teacherId,
+            'name'        => $name,
+            'heures'      => round($heures, 2),
+            'types'       => $types,
+            'base'        => $base,
+            'retenues'    => $bulletin ? (float) $bulletin->retenues : round($its + $cnps, 2),
+            'net'         => $bulletin ? (float) $bulletin->net_a_payer : $netEstime,
+            'estimation'  => !$bulletin,
+            'has_bulletin'=> (bool) $bulletin,
+            'bulletin_id' => $bulletin?->id,
+            'statut'      => $bulletin ? $bulletin->workflow_status : 'a_preparer',
+        ];
+    }
+
+    /**
+     * KPIs depuis le récap.
+     *
+     * @param  array<int, array<string,mixed>>  $recap
+     * @return array<string, float|int>
+     */
+    private function recapKpis(array $recap): array
+    {
+        $sum = fn ($pred) => array_sum(array_map(fn ($r) => $r['net'], array_filter($recap, $pred)));
+        $count = fn ($pred) => count(array_filter($recap, $pred));
+
+        return [
+            'total_net'    => round(array_sum(array_column($recap, 'net')), 2),
+            'nb_total'     => count($recap),
+            'nb_a_preparer'=> $count(fn ($r) => $r['statut'] === 'a_preparer'),
+            'nb_brouillon' => $count(fn ($r) => $r['statut'] === ESBTPSalaire::ST_BROUILLON),
+            'nb_valide'    => $count(fn ($r) => $r['statut'] === ESBTPSalaire::ST_VALIDE),
+            'nb_paye'      => $count(fn ($r) => $r['statut'] === ESBTPSalaire::ST_PAYE),
+            'net_paye'     => round($sum(fn ($r) => $r['statut'] === ESBTPSalaire::ST_PAYE), 2),
+            'net_a_preparer' => round($sum(fn ($r) => $r['statut'] === 'a_preparer'), 2),
+        ];
+    }
+
+    // ── Exports (PDF / Excel) ───────────────────────────────
+    private function buildReport(Request $request): PaiePayrollReport
+    {
+        $filtres = $this->filtres($request);
+        $recap = $this->buildRecap($filtres);
+        $kpis = $this->recapKpis($recap);
+        $periodLabel = (self::MOIS_FR[$filtres['mois']] ?? '') . ' ' . $filtres['annee'];
+
+        return new PaiePayrollReport($recap, $kpis, [
+            'Période' => $periodLabel,
+            'Statut'  => $filtres['statut'] ? ($this->statutLabels()[$filtres['statut']] ?? $filtres['statut']) : 'Tous',
+        ], $periodLabel, $this->statutLabels());
+    }
+
+    public function previewPdf(Request $request, ExportRenderer $renderer)
+    {
+        return $renderer->pdfPreview($this->buildReport($request));
+    }
+
+    public function exportPdf(Request $request, ExportRenderer $renderer)
+    {
+        return $renderer->pdfDownload($this->buildReport($request));
+    }
+
+    public function exportExcel(Request $request, ExportRenderer $renderer)
+    {
+        return $renderer->excelDownload($this->buildReport($request));
     }
 
     /** AJAX : calcule un aperçu de bulletin (sans persistance). */
@@ -303,39 +466,6 @@ class ESBTPSalaireController extends Controller
     }
 
     // ── Helpers ─────────────────────────────────────────────
-    private function bulletinsQuery(array $filtres)
-    {
-        $q = ESBTPSalaire::with('teacher.user:id,name')
-            ->where('mois', $filtres['mois'])
-            ->where('annee', $filtres['annee']);
-
-        if (!empty($filtres['statut'])) {
-            $q->where('workflow_status', $filtres['statut']);
-        }
-
-        return $q->orderByDesc('updated_at');
-    }
-
-    private function kpis(array $filtres): array
-    {
-        $base = ESBTPSalaire::where('mois', $filtres['mois'])->where('annee', $filtres['annee']);
-
-        // ⚠️ toBase() : requête d'agrégat SANS hydrater de modèles ESBTPSalaire.
-        // Sinon des modèles sans `id` (colonnes id non sélectionnées) déclenchent
-        // l'audit OwenIt « retrieved » → insert audits.auditable_id NULL → 500.
-        $byStatut = (clone $base)->toBase()
-            ->select('workflow_status', DB::raw('count(*) as n'), DB::raw('sum(net_a_payer) as net'))
-            ->groupBy('workflow_status')->get()->keyBy('workflow_status');
-
-        return [
-            'total_net'   => (float) (clone $base)->sum('net_a_payer'),
-            'nb_total'    => (clone $base)->count(),
-            'nb_brouillon'=> (int) ($byStatut[ESBTPSalaire::ST_BROUILLON]->n ?? 0),
-            'nb_valide'   => (int) ($byStatut[ESBTPSalaire::ST_VALIDE]->n ?? 0),
-            'nb_paye'     => (int) ($byStatut[ESBTPSalaire::ST_PAYE]->n ?? 0),
-            'net_paye'    => (float) ($byStatut[ESBTPSalaire::ST_PAYE]->net ?? 0),
-        ];
-    }
 
     /** @return array{0:Carbon,1:Carbon} */
     private function moisRange(int $mois, int $annee): array

--- a/resources/views/esbtp/comptabilite/salaires/index.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/index.blade.php
@@ -52,6 +52,44 @@
     .pay-empty { text-align: center; padding: 2.5rem 1rem; color: #94a3b8; }
     .pay-empty i { font-size: 2rem; display: block; margin-bottom: .6rem; color: #cbd5e1; }
 
+    /* ── Récap enseignants à payer ─────────────────────────── */
+    .pay-field--grow { flex: 1; min-width: 200px; }
+    .pay-search { position: relative; display: flex; align-items: center; }
+    .pay-search > i { position: absolute; left: .7rem; color: #94a3b8; font-size: .8rem; }
+    .pay-search .pay-input { padding-left: 2rem; }
+    .pay-recap-head { display: flex; align-items: center; gap: .65rem; padding: 1rem 1.25rem; border-bottom: 1px solid #f1f5f9; }
+    .pay-recap-head-ico { width: 36px; height: 36px; border-radius: 10px; background: linear-gradient(135deg, #0453cb, #3b7ddb); color: #fff; display: flex; align-items: center; justify-content: center; font-size: .85rem; flex-shrink: 0; }
+    .pay-recap-head-title { font-size: .95rem; font-weight: 700; color: #1e293b; }
+    .pay-recap-head-sub { font-size: .73rem; color: #94a3b8; }
+
+    .pay-rrow { display: flex; align-items: center; gap: 1rem; padding: .9rem .4rem; border-bottom: 1px solid #f1f5f9; }
+    .pay-rrow:last-child { border-bottom: none; }
+    .pay-rrow:hover { background: rgba(4,83,203,.025); }
+    .pay-rrow-avatar { width: 42px; height: 42px; border-radius: 50%; flex-shrink: 0; background: linear-gradient(135deg, #0453cb, #5e91de); color: #fff; display: flex; align-items: center; justify-content: center; font-weight: 700; }
+    .pay-rrow-id { flex: 1; min-width: 0; }
+    .pay-rrow-name { font-size: .9rem; font-weight: 700; color: #1e293b; }
+    .pay-rrow-types { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: .3rem; align-items: center; }
+    .pay-rrow-h { font-size: .72rem; font-weight: 700; color: #334155; }
+    .pay-rrow-h i { color: #94a3b8; margin-right: .15rem; }
+    .pay-rrow-chip { display: inline-flex; align-items: center; gap: .25rem; font-size: .66rem; font-weight: 700; padding: .12rem .4rem; border-radius: 6px; }
+    .pay-rrow-amounts { display: flex; gap: 1.25rem; flex-shrink: 0; }
+    .pay-rrow-amt { text-align: right; font-size: .9rem; font-weight: 700; color: #334155; }
+    .pay-rrow-amt-lbl { display: block; font-size: .58rem; color: #94a3b8; text-transform: uppercase; letter-spacing: .3px; font-weight: 600; margin-bottom: .1rem; }
+    .pay-rrow-amt--neg { color: #b91c1c; }
+    .pay-rrow-amt--net strong { font-size: 1.1rem; font-weight: 800; color: #0453cb; }
+    .pay-rrow-end { display: flex; flex-direction: column; align-items: flex-end; gap: .4rem; flex-shrink: 0; min-width: 110px; }
+    .pay-rrow-badge { font-size: .66rem; font-weight: 700; padding: .2rem .55rem; border-radius: 6px; white-space: nowrap; }
+    .pay-rrow-btn { display: inline-flex; align-items: center; gap: .35rem; border: 1px solid #e2e8f0; background: #fff; cursor: pointer; border-radius: 8px; padding: .35rem .7rem; font-size: .74rem; font-weight: 700; text-decoration: none; transition: all .15s; }
+    .pay-rrow-btn--prep { color: #0453cb; border-color: rgba(4,83,203,.3); }
+    .pay-rrow-btn--prep:hover { background: #0453cb; color: #fff; }
+    .pay-rrow-btn--view { color: #475569; }
+    .pay-rrow-btn--view:hover { border-color: #0453cb; color: #0453cb; }
+    @media (max-width: 860px) {
+        .pay-rrow { flex-wrap: wrap; }
+        .pay-rrow-amounts { gap: .9rem; width: 100%; justify-content: space-between; padding-left: 54px; }
+        .pay-rrow-end { width: 100%; flex-direction: row; justify-content: space-between; padding-left: 54px; }
+    }
+
     /* Modals */
     .pay-modal-overlay { position: fixed; inset: 0; background: rgba(15,23,42,.5); backdrop-filter: blur(2px); display: flex; align-items: flex-start; justify-content: center; padding: 3rem 1rem; z-index: 1080; overflow-y: auto; }
     .pay-modal { background: #fff; border-radius: 16px; width: 100%; max-width: 760px; box-shadow: 0 24px 60px rgba(15,23,42,.25); }
@@ -114,6 +152,13 @@
                 </div>
             </div>
             <div class="pay-hero-actions">
+                @if($canExport)
+                    <x-export-modal
+                        :preview-url="route('esbtp.comptabilite.salaires.export.preview-pdf')"
+                        :pdf-url="route('esbtp.comptabilite.salaires.export.pdf')"
+                        :excel-url="route('esbtp.comptabilite.salaires.export.excel')"
+                        button-class="pay-btn pay-btn--glass" />
+                @endif
                 @if($canConfigure)
                     <button type="button" class="pay-btn pay-btn--glass" @click="openConfig()"><i class="fas fa-sliders"></i> Paramètres</button>
                 @endif
@@ -142,13 +187,27 @@
             <span class="pay-field-lbl">Statut</span>
             <x-au-select name="statut_filter" :value="$filtres['statut'] ?? ''" placeholder="Tous statuts" icon="fa-filter" :options="$statutLabels" />
         </div>
+        <div class="pay-field pay-field--grow">
+            <span class="pay-field-lbl">Rechercher un enseignant</span>
+            <div class="pay-search">
+                <i class="fas fa-search"></i>
+                <input type="text" class="pay-input" placeholder="Nom de l'enseignant…" x-model="filters.q" @input.debounce.400ms="applyFilters()">
+            </div>
+        </div>
         <span class="pay-spin" :class="loading ? 'show' : ''"><i class="fas fa-circle-notch fa-spin"></i> Mise à jour…</span>
     </div>
 
-    {{-- Liste --}}
+    {{-- Récap : tous les enseignants à payer ce mois --}}
     <div class="pay-panel">
+        <div class="pay-recap-head">
+            <div class="pay-recap-head-ico"><i class="fas fa-list-check"></i></div>
+            <div>
+                <div class="pay-recap-head-title">Enseignants à payer — <span x-text="periodLabel">{{ $moisOptions[$filtres['mois']] ?? '' }} {{ $filtres['annee'] }}</span></div>
+                <div class="pay-recap-head-sub">Heures réalisées × taux par type · montant estimé tant que le bulletin n'est pas préparé</div>
+            </div>
+        </div>
         <div class="pay-panel-body" id="payList">
-            @include('esbtp.comptabilite.salaires.partials._list', ['bulletins' => $bulletins, 'statutLabels' => $statutLabels])
+            @include('esbtp.comptabilite.salaires.partials._recap', ['recap' => $recap, 'statutLabels' => $statutLabels, 'canCreate' => $canCreate])
         </div>
     </div>
 
@@ -324,7 +383,8 @@ function salairesPage() {
     return {
         urls: {},
         loading: false,
-        filters: { mois: @json((string) $filtres['mois']), annee: @json((string) $filtres['annee']), statut: @json($filtres['statut'] ?? '') },
+        filters: { mois: @json((string) $filtres['mois']), annee: @json((string) $filtres['annee']), statut: @json($filtres['statut'] ?? ''), q: '' },
+        periodLabel: @json(($moisOptions[$filtres['mois']] ?? '') . ' ' . $filtres['annee']),
         showPrepare: false, showConfig: false,
         calculating: false, saving: false, savingConfig: false,
         preview: null, exists: false, locked: false,
@@ -334,8 +394,14 @@ function salairesPage() {
         init() {
             const d = this.$root.dataset;
             this.urls = { data: d.urlData, prepare: d.urlPrepare, store: d.urlStore, config: d.urlConfig };
-            this.$watch('filters', () => this.applyFilters());
+            this.$watch('filters.mois', () => this.applyFilters());
+            this.$watch('filters.annee', () => this.applyFilters());
+            this.$watch('filters.statut', () => this.applyFilters());
             this.bindFilterSelects();
+            // Bouton « Préparer » sur une ligne du récap → ouvre le modal pré-rempli.
+            window.addEventListener('paie:prepare-teacher', (ev) => this.preparePour(ev.detail.id));
+            // Filtres repris par les exports PDF/Excel.
+            window.exportFilters = () => ({ mois: this.filters.mois, annee: this.filters.annee, statut: this.filters.statut, q: this.filters.q });
         },
 
         bindFilterSelects() {
@@ -359,7 +425,21 @@ function salairesPage() {
                 const d = await res.json();
                 document.getElementById('payList').innerHTML = d.list_html;
                 document.getElementById('payKpis').innerHTML = d.kpis_html;
+                if (d.period_label) this.periodLabel = d.period_label;
             } catch (e) { this.toast('error', e.message); } finally { this.loading = false; }
+        },
+
+        // Ouvre le modal de préparation pré-rempli pour un enseignant donné (récap → « Préparer »).
+        preparePour(teacherId) {
+            this.preview = null; this.exists = false; this.locked = false;
+            this.prep = { teacher_id: String(teacherId), mois: this.filters.mois, annee: this.filters.annee, impot_its: '', cnps: '', primes: [], retenues: [] };
+            this.showPrepare = true;
+            // pré-sélectionne l'enseignant dans le picker du modal + calcule.
+            this.$nextTick(() => {
+                const sel = document.querySelector('select[name="prep_teacher"]');
+                if (sel) { sel.value = String(teacherId); sel.dispatchEvent(new Event('change', { bubbles: true })); }
+                this.calculate();
+            });
         },
 
         openPrepare() {

--- a/resources/views/esbtp/comptabilite/salaires/partials/_kpis.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/partials/_kpis.blade.php
@@ -1,31 +1,31 @@
-{{-- KPIs paie du mois. Reçoit $kpis. --}}
+{{-- KPIs paie du mois (récap). Reçoit $kpis. --}}
 @php $fmt = fn($v) => number_format($v, 0, ',', ' '); @endphp
 <div class="pay-kpi">
     <div class="pay-kpi-ico"><i class="fas fa-sack-dollar"></i></div>
     <div>
         <div class="pay-kpi-val">{{ $fmt($kpis['total_net']) }}<span class="pay-kpi-cur">FCFA</span></div>
-        <div class="pay-kpi-lbl">Net total du mois</div>
+        <div class="pay-kpi-lbl">Net total à verser</div>
     </div>
 </div>
 <div class="pay-kpi">
-    <div class="pay-kpi-ico"><i class="fas fa-file-invoice"></i></div>
+    <div class="pay-kpi-ico"><i class="fas fa-user-group"></i></div>
     <div>
         <div class="pay-kpi-val">{{ $kpis['nb_total'] }}</div>
-        <div class="pay-kpi-lbl">Bulletins</div>
+        <div class="pay-kpi-lbl">Enseignants à payer</div>
     </div>
 </div>
-<div class="pay-kpi">
-    <div class="pay-kpi-ico" style="background:rgba(255,255,255,.16);"><i class="fas fa-pen-ruler"></i></div>
+<div class="pay-kpi pay-kpi--warn">
+    <div class="pay-kpi-ico" style="background:rgba(245,158,11,.28);"><i class="fas fa-pen-ruler"></i></div>
     <div>
-        <div class="pay-kpi-val">{{ $kpis['nb_brouillon'] }}</div>
-        <div class="pay-kpi-lbl">Brouillons</div>
+        <div class="pay-kpi-val">{{ $kpis['nb_a_preparer'] }}</div>
+        <div class="pay-kpi-lbl">À préparer · {{ $fmt($kpis['net_a_preparer']) }} FCFA</div>
     </div>
 </div>
 <div class="pay-kpi">
     <div class="pay-kpi-ico" style="background:rgba(255,255,255,.16);"><i class="fas fa-check-double"></i></div>
     <div>
-        <div class="pay-kpi-val">{{ $kpis['nb_valide'] }}</div>
-        <div class="pay-kpi-lbl">Validés</div>
+        <div class="pay-kpi-val">{{ $kpis['nb_brouillon'] + $kpis['nb_valide'] }}</div>
+        <div class="pay-kpi-lbl">{{ $kpis['nb_brouillon'] }} brouillon(s) · {{ $kpis['nb_valide'] }} validé(s)</div>
     </div>
 </div>
 <div class="pay-kpi pay-kpi--ok">

--- a/resources/views/esbtp/comptabilite/salaires/partials/_recap.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/partials/_recap.blade.php
@@ -1,0 +1,51 @@
+{{-- Récap paie : tous les enseignants à payer ce mois. Reçoit $recap, $statutLabels, $canCreate. --}}
+@php
+    $fmt = fn($v) => number_format($v, 0, ',', ' ');
+    $fmtH = function ($v) { $h=(int)floor($v); $m=(int)round(($v-$h)*60); return $h.'h'.($m>0?sprintf('%02d',$m):''); };
+    $badge = [
+        'a_preparer' => ['bg' => 'rgba(245,158,11,.12)', 'color' => '#b45309'],
+        'brouillon'  => ['bg' => 'rgba(100,116,139,.12)', 'color' => '#475569'],
+        'valide'     => ['bg' => 'rgba(4,83,203,.1)',     'color' => '#0453cb'],
+        'paye'       => ['bg' => 'rgba(16,185,129,.12)',  'color' => '#065f46'],
+        'annule'     => ['bg' => 'rgba(220,38,38,.1)',    'color' => '#b91c1c'],
+    ];
+@endphp
+@forelse($recap as $row)
+    @php $st = $badge[$row['statut']] ?? $badge['a_preparer']; @endphp
+    <div class="pay-rrow">
+        <div class="pay-rrow-avatar">{{ \Illuminate\Support\Str::substr($row['name'], 0, 1) }}</div>
+        <div class="pay-rrow-id">
+            <div class="pay-rrow-name">{{ $row['name'] }}</div>
+            <div class="pay-rrow-types">
+                <span class="pay-rrow-h"><i class="fas fa-hourglass-half"></i> {{ $fmtH($row['heures']) }}</span>
+                @foreach($row['types'] as $t)
+                    <span class="pay-rrow-chip" style="{{ $t['style'] }}" title="{{ $t['type'] }} — {{ $fmtH($t['heures']) }} × {{ $fmt($t['taux']) }} FCFA">
+                        <i class="fas {{ $t['icon'] }}"></i> {{ $t['type'] }} {{ $fmtH($t['heures']) }}
+                    </span>
+                @endforeach
+            </div>
+        </div>
+        <div class="pay-rrow-amounts">
+            <div class="pay-rrow-amt"><span class="pay-rrow-amt-lbl">Base</span>{{ $fmt($row['base']) }}</div>
+            <div class="pay-rrow-amt pay-rrow-amt--neg"><span class="pay-rrow-amt-lbl">Retenues</span>− {{ $fmt($row['retenues']) }}</div>
+            <div class="pay-rrow-amt pay-rrow-amt--net">
+                <span class="pay-rrow-amt-lbl">Net{{ $row['estimation'] ? ' estimé' : '' }}</span>
+                <strong>{{ $fmt($row['net']) }}</strong>
+            </div>
+        </div>
+        <div class="pay-rrow-end">
+            <span class="pay-rrow-badge" style="background:{{ $st['bg'] }};color:{{ $st['color'] }};">{{ $statutLabels[$row['statut']] ?? $row['statut'] }}</span>
+            @if($row['has_bulletin'])
+                <a href="{{ route('esbtp.comptabilite.salaires.show', $row['bulletin_id']) }}" class="pay-rrow-btn pay-rrow-btn--view"><i class="fas fa-eye"></i> Voir</a>
+            @elseif($canCreate)
+                <button type="button" class="pay-rrow-btn pay-rrow-btn--prep"
+                        onclick="window.dispatchEvent(new CustomEvent('paie:prepare-teacher',{detail:{id:{{ $row['teacher_id'] }}}}))"><i class="fas fa-calculator"></i> Préparer</button>
+            @endif
+        </div>
+    </div>
+@empty
+    <div class="pay-empty">
+        <i class="fas fa-user-clock"></i>
+        <p>Aucun enseignant avec des heures facturables sur cette période.</p>
+    </div>
+@endforelse

--- a/resources/views/esbtp/comptabilite/salaires/pdf.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/pdf.blade.php
@@ -1,0 +1,52 @@
+@php
+    $fmt = fn($v) => number_format((float) $v, 0, ',', ' ');
+    $fmtH = function ($v) { $h=(int)floor($v); $m=(int)round(($v-$h)*60); return $h.'h'.($m>0?sprintf('%02d',$m):''); };
+    $totalBase = array_sum(array_map(fn($r) => (float) $r['base'], $rows));
+    $totalRet  = array_sum(array_map(fn($r) => (float) $r['retenues'], $rows));
+    $totalNet  = array_sum(array_map(fn($r) => (float) $r['net'], $rows));
+@endphp
+<x-pdf-document :title="$reportTitle" :subtitle="$reportSubtitle" :filters="$reportFilters" orientation="landscape">
+    <style>
+        .pp-table { width: 100%; border-collapse: collapse; font-size: 10px; }
+        .pp-table th { background: #0453cb; color: #fff; text-align: left; padding: 6px 8px; font-size: 9px; text-transform: uppercase; letter-spacing: .3px; }
+        .pp-table td { padding: 5px 8px; border-bottom: 1px solid #e5e7eb; }
+        .pp-table tr:nth-child(even) td { background: #f8fafc; }
+        .pp-num { text-align: right; white-space: nowrap; }
+        .pp-net { font-weight: 700; color: #0453cb; }
+        .pp-badge { font-size: 8px; font-weight: 700; padding: 1px 5px; border-radius: 3px; }
+        .pp-total td { border-top: 2px solid #0453cb; font-weight: 700; background: #eff6ff !important; }
+        .pp-est { color: #b45309; font-size: 8px; }
+    </style>
+    <table class="pp-table">
+        <thead>
+            <tr>
+                <th>Enseignant</th>
+                <th class="pp-num">Heures réalisées</th>
+                <th class="pp-num">Base</th>
+                <th class="pp-num">Retenues</th>
+                <th class="pp-num">Net à payer</th>
+                <th>Statut</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($rows as $r)
+                <tr>
+                    <td>{{ $r['name'] }}</td>
+                    <td class="pp-num">{{ $fmtH($r['heures']) }}</td>
+                    <td class="pp-num">{{ $fmt($r['base']) }}</td>
+                    <td class="pp-num">− {{ $fmt($r['retenues']) }}</td>
+                    <td class="pp-num pp-net">{{ $fmt($r['net']) }}@if($r['estimation'])<br><span class="pp-est">estimé</span>@endif</td>
+                    <td>{{ $statutLabels[$r['statut']] ?? $r['statut'] }}</td>
+                </tr>
+            @endforeach
+            <tr class="pp-total">
+                <td>TOTAL ({{ count($rows) }} enseignant{{ count($rows) > 1 ? 's' : '' }})</td>
+                <td class="pp-num"></td>
+                <td class="pp-num">{{ $fmt($totalBase) }}</td>
+                <td class="pp-num">− {{ $fmt($totalRet) }}</td>
+                <td class="pp-num pp-net">{{ $fmt($totalNet) }} FCFA</td>
+                <td></td>
+            </tr>
+        </tbody>
+    </table>
+</x-pdf-document>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1793,6 +1793,13 @@ Route::middleware(['auth', 'comptabilite.access'])->prefix('esbtp/comptabilite')
             ->name('index')->middleware('permission:comptabilite.salaires.view');
         Route::get('/data', [\App\Http\Controllers\ESBTPSalaireController::class, 'data'])
             ->name('data')->middleware(['permission:comptabilite.salaires.view', 'throttle:120,1']);
+        // Exports état de paie (avant /{salaire} pour ne pas être capturés comme param)
+        Route::get('/export/preview-pdf', [\App\Http\Controllers\ESBTPSalaireController::class, 'previewPdf'])
+            ->name('export.preview-pdf')->middleware(['permission:comptabilite.salaires.export', 'throttle:60,1']);
+        Route::get('/export/pdf', [\App\Http\Controllers\ESBTPSalaireController::class, 'exportPdf'])
+            ->name('export.pdf')->middleware(['permission:comptabilite.salaires.export', 'throttle:10,1']);
+        Route::get('/export/excel', [\App\Http\Controllers\ESBTPSalaireController::class, 'exportExcel'])
+            ->name('export.excel')->middleware(['permission:comptabilite.salaires.export', 'throttle:10,1']);
         Route::post('/prepare', [\App\Http\Controllers\ESBTPSalaireController::class, 'prepare'])
             ->name('prepare')->middleware(['permission:comptabilite.salaires.create', 'throttle:60,1']);
         Route::post('/', [\App\Http\Controllers\ESBTPSalaireController::class, 'store'])


### PR DESCRIPTION
Page Paie devient un vrai centre de commande : récap de tous les enseignants avec heures + montant dû (estimé tant que non préparé), recherche, KPIs total à verser/à préparer, action Préparer (modal pré-rempli)/Voir, export PDF+Excel. Seeder : l'emploi du temps démo devient le courant de la classe (setAsCurrent) + réutilisé — les séances sont désormais visibles dans l'emploi du temps de la classe.