### PR TITLE
feat(paie): vue période flexible (mois → année + plage libre)

### DIFF
--- a/app/Http/Controllers/ESBTPSalaireController.php
+++ b/app/Http/Controllers/ESBTPSalaireController.php
@@ -43,6 +43,7 @@ class ESBTPSalaireController extends Controller
 
         $recap = $this->buildRecap($filtres);
         $kpis = $this->recapKpis($recap);
+        $periodLabel = $this->periodLabel($this->resolvePeriode($filtres)[2]);
 
         $teachers = ESBTPTeacher::with('user:id,name')->get()
             ->map(fn ($t) => ['id' => $t->id, 'name' => $t->user->name ?? $t->name ?? 'Enseignant'])
@@ -52,6 +53,8 @@ class ESBTPSalaireController extends Controller
             'recap'       => $recap,
             'kpis'        => $kpis,
             'filtres'     => $filtres,
+            'periodLabel' => $periodLabel,
+            'presets'     => ['month' => 'Mois', 'quarter' => 'Trimestre', 'semester' => 'Semestre', 'year' => 'Année', 'custom' => 'Plage'],
             'annee'       => $annee,
             'teachers'    => $teachers,
             'moisOptions' => self::MOIS_FR,
@@ -78,18 +81,102 @@ class ESBTPSalaireController extends Controller
                 'canCreate'    => auth()->user()->can('comptabilite.salaires.create'),
             ])->render(),
             'kpis_html' => view('esbtp.comptabilite.salaires.partials._kpis', ['kpis' => $kpis])->render(),
-            'period_label' => (self::MOIS_FR[$filtres['mois']] ?? '') . ' ' . $filtres['annee'],
+            'period_label' => $this->periodLabel($this->resolvePeriode($filtres)[2]),
         ]);
     }
 
     private function filtres(Request $request): array
     {
         return [
-            'mois'   => (int) $request->get('mois', now()->month),
-            'annee'  => (int) $request->get('annee', now()->year),
+            'preset' => in_array($request->get('preset'), ['month', 'quarter', 'semester', 'year', 'custom'], true)
+                ? $request->get('preset') : 'month',
+            'mois'   => (int) $request->get('mois', now()->month),   // mois d'ancrage
+            'annee'  => (int) $request->get('annee', now()->year),   // année d'ancrage
+            'from'   => $request->get('from'),                       // plage perso (mois)
+            'to'     => $request->get('to'),
             'statut' => $request->get('statut'),
             'q'      => trim((string) $request->get('q', '')),
         ];
+    }
+
+    /**
+     * Résout la période (préset ou plage) en [from, to, mois[]].
+     * Les bulletins étant MENSUELS, on décompose toujours en mois calendaires
+     * (l'ITS est progressif PAR MOIS : impossible de l'appliquer sur un total trimestriel).
+     *
+     * @return array{0: Carbon, 1: Carbon, 2: array<int, array{mois:int, annee:int}>}
+     */
+    private function resolvePeriode(array $f): array
+    {
+        if ($f['preset'] === 'custom' && !empty($f['from']) && !empty($f['to'])) {
+            $from = Carbon::parse($f['from'])->startOfMonth();
+            $to   = Carbon::parse($f['to'])->endOfMonth();
+            if ($to->lt($from)) {
+                [$from, $to] = [$to->copy()->startOfMonth(), $from->copy()->endOfMonth()];
+            }
+        } else {
+            $anchor = Carbon::create($f['annee'], max(1, min(12, $f['mois'])), 1);
+            switch ($f['preset']) {
+                case 'quarter':
+                    $from = $anchor->copy()->subMonths(2)->startOfMonth();
+                    $to   = $anchor->copy()->endOfMonth();
+                    break;
+                case 'semester':
+                    $from = $anchor->copy()->subMonths(5)->startOfMonth();
+                    $to   = $anchor->copy()->endOfMonth();
+                    break;
+                case 'year':
+                    $au = ESBTPAnneeUniversitaire::where('is_current', true)->first();
+                    if ($au && $au->date_debut && $au->date_fin) {
+                        $from = Carbon::parse($au->date_debut)->startOfMonth();
+                        $to   = Carbon::parse($au->date_fin)->endOfMonth();
+                    } else {
+                        $from = $anchor->copy()->subMonths(11)->startOfMonth();
+                        $to   = $anchor->copy()->endOfMonth();
+                    }
+                    break;
+                default: // month
+                    $from = $anchor->copy()->startOfMonth();
+                    $to   = $anchor->copy()->endOfMonth();
+            }
+        }
+
+        return [$from, $to, $this->listMonths($from, $to)];
+    }
+
+    /** Liste des mois calendaires [from, to], plafonnée au mois courant (pas de futur sans heures). */
+    private function listMonths(Carbon $from, Carbon $to): array
+    {
+        $months = [];
+        $cursor = $from->copy()->startOfMonth();
+        $end    = $to->copy()->startOfMonth();
+        $now    = Carbon::now()->startOfMonth();
+        while ($cursor->lte($end) && count($months) < 24) {
+            if ($cursor->lte($now)) {
+                $months[] = ['mois' => (int) $cursor->month, 'annee' => (int) $cursor->year];
+            }
+            $cursor->addMonth();
+        }
+        if (empty($months)) {
+            $months[] = ['mois' => (int) $end->month, 'annee' => (int) $end->year];
+        }
+        return $months;
+    }
+
+    /** Libellé période lisible (« Mai 2026 » ou « Mars – Juin 2026 »). */
+    private function periodLabel(array $months): string
+    {
+        if (empty($months)) {
+            return '';
+        }
+        $first = $months[0];
+        $last  = $months[count($months) - 1];
+        if (count($months) === 1) {
+            return (self::MOIS_FR[$first['mois']] ?? '') . ' ' . $first['annee'];
+        }
+        $a = self::MOIS_FR[$first['mois']] ?? '';
+        $b = (self::MOIS_FR[$last['mois']] ?? '') . ' ' . $last['annee'];
+        return $first['annee'] === $last['annee'] ? "$a – $b" : "$a {$first['annee']} – $b";
     }
 
     /** Libellés statut incluant le pseudo-statut « à préparer ». */
@@ -107,62 +194,77 @@ class ESBTPSalaireController extends Controller
      */
     private function buildRecap(array $filtres): array
     {
-        [$from, $to] = $this->moisRange($filtres['mois'], $filtres['annee']);
-        $report = $this->hours->report($from, $to);
+        [, , $months] = $this->resolvePeriode($filtres);
 
         $teachers = ESBTPTeacher::with(['tauxSeances', 'user:id,name'])->get()->keyBy('id');
-        $bulletins = ESBTPSalaire::where('mois', $filtres['mois'])
-            ->where('annee', $filtres['annee'])->get()->keyBy('teacher_id');
+
+        // Tous les bulletins des mois de la période, indexés teacher-mois-annee.
+        $bulletins = ESBTPSalaire::where(function ($q) use ($months) {
+            foreach ($months as $m) {
+                $q->orWhere(fn ($w) => $w->where('mois', $m['mois'])->where('annee', $m['annee']));
+            }
+        })->get()->keyBy(fn ($b) => $b->teacher_id . '-' . $b->mois . '-' . $b->annee);
 
         $cnpsTaux = $this->payroll->tauxCnps();
-        $rows = [];
-        $seen = [];
+        $agg = []; // teacher_id => agrégat période (avec cellules mensuelles)
 
-        foreach ($report['enseignants'] as $ens) {
-            $teacher = $teachers->get($ens['teacher_id']);
-            if (!$teacher) {
-                continue;
-            }
-            $base = 0.0;
-            $heures = 0.0;
-            $types = [];
-            foreach ($ens['par_type'] as $pt) {
-                if (!$pt['facturable'] || $pt['heures_realisees'] <= 0) {
+        // Pour chaque mois : calculer les heures réelles → estimation, OU lire le bulletin existant.
+        foreach ($months as $m) {
+            [$mFrom, $mTo] = $this->moisRange($m['mois'], $m['annee']);
+            $report = $this->hours->report($mFrom, $mTo);
+            $withHours = [];
+
+            foreach ($report['enseignants'] as $ens) {
+                $teacher = $teachers->get($ens['teacher_id']);
+                if (!$teacher) {
                     continue;
                 }
-                $taux = $teacher->tauxPour($pt['type']);
-                $base += $pt['heures_realisees'] * $taux;
-                $heures += $pt['heures_realisees'];
-                $types[] = [
-                    'type' => $pt['type'], 'icon' => $pt['icon'], 'style' => $pt['style'],
-                    'heures' => $pt['heures_realisees'], 'taux' => $taux,
-                ];
+                $withHours[$ens['teacher_id']] = true;
+                $base = 0.0;
+                $heures = 0.0;
+                $byType = [];
+                foreach ($ens['par_type'] as $pt) {
+                    if (!$pt['facturable'] || $pt['heures_realisees'] <= 0) {
+                        continue;
+                    }
+                    $taux = $teacher->tauxPour($pt['type']);
+                    $base += $pt['heures_realisees'] * $taux;
+                    $heures += $pt['heures_realisees'];
+                    $byType[$pt['type']] = [
+                        'type' => $pt['type'], 'icon' => $pt['icon'], 'style' => $pt['style'],
+                        'heures' => $pt['heures_realisees'], 'taux' => $taux,
+                    ];
+                }
+                $base = round($base, 2);
+                $bulletin = $bulletins->get($ens['teacher_id'] . '-' . $m['mois'] . '-' . $m['annee']);
+                if ($base <= 0 && !$bulletin) {
+                    continue;
+                }
+                $its = $this->payroll->computeIts($base);
+                $cnps = round($base * $cnpsTaux / 100, 2);
+                $this->accumulateMonth($agg, $teacher, $ens['name'], $m, $heures, $byType, $base, $its, $cnps, $bulletin);
             }
-            $base = round($base, 2);
-            $bulletin = $bulletins->get($ens['teacher_id']);
-            if ($base <= 0 && !$bulletin) {
-                continue;
-            }
-            $its = $this->payroll->computeIts($base);
-            $cnps = round($base * $cnpsTaux / 100, 2);
 
-            $rows[] = $this->recapRow($ens['teacher_id'], $ens['name'], $heures, $types, $base, $its, $cnps, $bulletin);
-            $seen[$ens['teacher_id']] = true;
+            // Bulletins du mois sans heures dans le report (ex: saisie manuelle).
+            foreach ($bulletins as $key => $bulletin) {
+                if ((int) $bulletin->mois !== $m['mois'] || (int) $bulletin->annee !== $m['annee']) {
+                    continue;
+                }
+                if (isset($withHours[$bulletin->teacher_id])) {
+                    continue;
+                }
+                $teacher = $teachers->get($bulletin->teacher_id);
+                $name = $teacher?->user?->name ?? $teacher?->name ?? 'Enseignant';
+                $this->accumulateMonth($agg, $teacher, $name, $m, (float) $bulletin->heures_total, [], (float) $bulletin->salaire_base, (float) $bulletin->impot_its, (float) $bulletin->cnps, $bulletin);
+            }
         }
 
-        // Bulletins dont l'enseignant n'a pas d'heures dans le report (ex: saisie manuelle).
-        foreach ($bulletins as $tid => $bulletin) {
-            if (isset($seen[$tid])) {
-                continue;
-            }
-            $teacher = $teachers->get($tid);
-            $name = $teacher?->user?->name ?? $teacher?->name ?? 'Enseignant';
-            $rows[] = $this->recapRow($tid, $name, (float) $bulletin->heures_total, [], (float) $bulletin->salaire_base, (float) $bulletin->impot_its, (float) $bulletin->cnps, $bulletin);
-        }
+        $rows = array_map(fn ($a) => $this->finalizeRow($a), array_values($agg));
 
-        // Filtres statut + recherche.
+        // Filtre statut : la ligne matche si son statut global OU une de ses cellules matche.
         if (!empty($filtres['statut'])) {
-            $rows = array_values(array_filter($rows, fn ($r) => $r['statut'] === $filtres['statut']));
+            $rows = array_values(array_filter($rows, fn ($r) => $r['statut'] === $filtres['statut']
+                || in_array($filtres['statut'], array_column($r['months'], 'statut'), true)));
         }
         if ($filtres['q'] !== '') {
             $q = mb_strtolower($filtres['q']);
@@ -174,24 +276,65 @@ class ESBTPSalaireController extends Controller
         return $rows;
     }
 
-    /** Construit une ligne de récap (statut = bulletin ou « à préparer »). */
-    private function recapRow($teacherId, string $name, float $heures, array $types, float $base, float $its, float $cnps, ?ESBTPSalaire $bulletin): array
+    /** Accumule une cellule mensuelle (estimation ou bulletin) dans l'agrégat période d'un enseignant. */
+    private function accumulateMonth(array &$agg, $teacher, string $name, array $m, float $heures, array $byType, float $base, float $its, float $cnps, ?ESBTPSalaire $bulletin): void
     {
-        $netEstime = round($base - $its - $cnps, 2);
+        $tid = $teacher?->id;
+        if ($tid === null) {
+            return;
+        }
+        if (!isset($agg[$tid])) {
+            $agg[$tid] = ['teacher_id' => (int) $tid, 'name' => $name, 'heures' => 0.0, 'types' => [],
+                'base' => 0.0, 'retenues' => 0.0, 'net' => 0.0, 'months' => []];
+        }
+        $monthNet = $bulletin ? (float) $bulletin->net_a_payer : round($base - $its - $cnps, 2);
+        $monthRet = $bulletin ? (float) $bulletin->retenues : round($its + $cnps, 2);
 
-        return [
-            'teacher_id'  => (int) $teacherId,
-            'name'        => $name,
-            'heures'      => round($heures, 2),
-            'types'       => $types,
-            'base'        => $base,
-            'retenues'    => $bulletin ? (float) $bulletin->retenues : round($its + $cnps, 2),
-            'net'         => $bulletin ? (float) $bulletin->net_a_payer : $netEstime,
-            'estimation'  => !$bulletin,
-            'has_bulletin'=> (bool) $bulletin,
-            'bulletin_id' => $bulletin?->id,
-            'statut'      => $bulletin ? $bulletin->workflow_status : 'a_preparer',
+        $agg[$tid]['heures'] += $heures;
+        $agg[$tid]['base'] += $base;
+        $agg[$tid]['retenues'] += $monthRet;
+        $agg[$tid]['net'] += $monthNet;
+        foreach ($byType as $type => $t) {
+            if (!isset($agg[$tid]['types'][$type])) {
+                $agg[$tid]['types'][$type] = $t;
+            } else {
+                $agg[$tid]['types'][$type]['heures'] += $t['heures'];
+            }
+        }
+        $agg[$tid]['months'][] = [
+            'mois' => $m['mois'], 'annee' => $m['annee'],
+            'label' => self::MOIS_FR[$m['mois']] ?? (string) $m['mois'],
+            'short' => mb_substr(self::MOIS_FR[$m['mois']] ?? '', 0, 4, 'UTF-8'),
+            'net' => $monthNet, 'base' => round($base, 2), 'retenues' => $monthRet, 'heures' => round($heures, 2),
+            'statut' => $bulletin ? $bulletin->workflow_status : 'a_preparer',
+            'has_bulletin' => (bool) $bulletin, 'bulletin_id' => $bulletin?->id, 'estimation' => !$bulletin,
         ];
+    }
+
+    /** Finalise une ligne : tri chrono des mois + statut global + arrondis. */
+    private function finalizeRow(array $a): array
+    {
+        usort($a['months'], fn ($x, $y) => [$x['annee'], $x['mois']] <=> [$y['annee'], $y['mois']]);
+        $statuts = array_column($a['months'], 'statut');
+        $overall = 'paye';
+        if (in_array('a_preparer', $statuts, true)) {
+            $overall = 'a_preparer';
+        } elseif (in_array('brouillon', $statuts, true)) {
+            $overall = 'brouillon';
+        } elseif (in_array('valide', $statuts, true)) {
+            $overall = 'valide';
+        } elseif (array_unique($statuts) === ['annule']) {
+            $overall = 'annule';
+        }
+        $a['types'] = array_values($a['types']);
+        $a['base'] = round($a['base'], 2);
+        $a['retenues'] = round($a['retenues'], 2);
+        $a['net'] = round($a['net'], 2);
+        $a['heures'] = round($a['heures'], 2);
+        $a['statut'] = $overall;
+        $a['nb_mois'] = count($a['months']);
+        $a['nb_a_preparer'] = count(array_filter($a['months'], fn ($mm) => $mm['statut'] === 'a_preparer'));
+        return $a;
     }
 
     /**
@@ -202,18 +345,26 @@ class ESBTPSalaireController extends Controller
      */
     private function recapKpis(array $recap): array
     {
-        $sum = fn ($pred) => array_sum(array_map(fn ($r) => $r['net'], array_filter($recap, $pred)));
-        $count = fn ($pred) => count(array_filter($recap, $pred));
+        // Cellules = (enseignant × mois) — un bulletin est mensuel, on compte les cellules.
+        $cells = [];
+        foreach ($recap as $r) {
+            foreach ($r['months'] as $m) {
+                $cells[] = $m;
+            }
+        }
+        $sum = fn ($pred) => round(array_sum(array_map(fn ($c) => $c['net'], array_filter($cells, $pred))), 2);
+        $count = fn ($pred) => count(array_filter($cells, $pred));
 
         return [
-            'total_net'    => round(array_sum(array_column($recap, 'net')), 2),
-            'nb_total'     => count($recap),
-            'nb_a_preparer'=> $count(fn ($r) => $r['statut'] === 'a_preparer'),
-            'nb_brouillon' => $count(fn ($r) => $r['statut'] === ESBTPSalaire::ST_BROUILLON),
-            'nb_valide'    => $count(fn ($r) => $r['statut'] === ESBTPSalaire::ST_VALIDE),
-            'nb_paye'      => $count(fn ($r) => $r['statut'] === ESBTPSalaire::ST_PAYE),
-            'net_paye'     => round($sum(fn ($r) => $r['statut'] === ESBTPSalaire::ST_PAYE), 2),
-            'net_a_preparer' => round($sum(fn ($r) => $r['statut'] === 'a_preparer'), 2),
+            'total_net'      => round(array_sum(array_column($recap, 'net')), 2),
+            'nb_total'       => count($recap),
+            'nb_mois'        => count(array_unique(array_map(fn ($c) => $c['annee'] . '-' . $c['mois'], $cells))),
+            'nb_a_preparer'  => $count(fn ($c) => $c['statut'] === 'a_preparer'),
+            'net_a_preparer' => $sum(fn ($c) => $c['statut'] === 'a_preparer'),
+            'nb_brouillon'   => $count(fn ($c) => $c['statut'] === ESBTPSalaire::ST_BROUILLON),
+            'nb_valide'      => $count(fn ($c) => $c['statut'] === ESBTPSalaire::ST_VALIDE),
+            'nb_paye'        => $count(fn ($c) => $c['statut'] === ESBTPSalaire::ST_PAYE),
+            'net_paye'       => $sum(fn ($c) => $c['statut'] === ESBTPSalaire::ST_PAYE),
         ];
     }
 
@@ -223,7 +374,7 @@ class ESBTPSalaireController extends Controller
         $filtres = $this->filtres($request);
         $recap = $this->buildRecap($filtres);
         $kpis = $this->recapKpis($recap);
-        $periodLabel = (self::MOIS_FR[$filtres['mois']] ?? '') . ' ' . $filtres['annee'];
+        $periodLabel = $this->periodLabel($this->resolvePeriode($filtres)[2]);
 
         return new PaiePayrollReport($recap, $kpis, [
             'Période' => $periodLabel,

--- a/resources/views/esbtp/comptabilite/salaires/index.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/index.blade.php
@@ -90,6 +90,45 @@
         .pay-rrow-end { width: 100%; flex-direction: row; justify-content: space-between; padding-left: 54px; }
     }
 
+    /* ── Sélecteur de période (présets segmentés) ─────────── */
+    .pay-presets { display: inline-flex; background: #f1f5f9; border-radius: 10px; padding: .22rem; gap: .15rem; flex-wrap: wrap; }
+    .pay-preset { border: none; background: transparent; color: #475569; font-size: .76rem; font-weight: 700; padding: .42rem .8rem; border-radius: 8px; cursor: pointer; transition: background .15s, color .15s, box-shadow .15s; }
+    .pay-preset--on { background: #fff; color: #0453cb; box-shadow: 0 1px 3px rgba(15,23,42,.1); }
+    .pay-preset:hover:not(.pay-preset--on) { color: #0453cb; }
+    .pay-field--anchor { min-width: 130px; }
+
+    /* ── Bandeau mensuel cliquable (récap période) ────────── */
+    .pay-rrow-id { flex: 1 1 210px; }
+    .pay-rrow-months { display: flex; flex-wrap: wrap; gap: .4rem; flex: 2 1 300px; align-content: center; }
+    .pay-mchip { display: inline-flex; flex-direction: column; align-items: stretch; min-width: 60px; border-radius: 9px; padding: .3rem .5rem; text-decoration: none; border: 1px solid transparent; cursor: pointer; font-family: inherit; transition: box-shadow .12s, filter .12s; }
+    .pay-mchip:hover { box-shadow: 0 4px 12px rgba(15,23,42,.12); filter: brightness(1.02); }
+    .pay-mchip-top { display: flex; align-items: center; justify-content: space-between; gap: .3rem; }
+    .pay-mchip-m { font-size: .63rem; font-weight: 800; text-transform: uppercase; letter-spacing: .3px; }
+    .pay-mchip-top i { font-size: .58rem; opacity: .75; }
+    .pay-mchip-net { font-size: .78rem; font-weight: 800; margin-top: .12rem; white-space: nowrap; }
+    .pay-mchip--a_preparer { background: rgba(245,158,11,.1); border-color: rgba(245,158,11,.32); color: #b45309; }
+    .pay-mchip--a_preparer:hover { background: rgba(245,158,11,.18); }
+    .pay-mchip--brouillon { background: rgba(100,116,139,.1); border-color: rgba(100,116,139,.26); color: #475569; }
+    .pay-mchip--valide { background: rgba(4,83,203,.1); border-color: rgba(4,83,203,.3); color: #0453cb; }
+    .pay-mchip--paye { background: rgba(16,185,129,.12); border-color: rgba(16,185,129,.32); color: #065f46; }
+    .pay-mchip--annule { background: rgba(220,38,38,.1); border-color: rgba(220,38,38,.3); color: #b91c1c; }
+    .pay-mchip--annule .pay-mchip-net { text-decoration: line-through; }
+
+    .pay-rrow-netcol { flex-shrink: 0; min-width: 132px; display: flex; flex-direction: column; align-items: flex-end; gap: .25rem; }
+    .pay-rrow-net-lbl { font-size: .57rem; color: #94a3b8; text-transform: uppercase; letter-spacing: .3px; font-weight: 700; }
+    .pay-rrow-net-val { font-size: 1.15rem; font-weight: 800; color: #0453cb; }
+    .pay-rrow-net-val small { font-size: .58rem; color: #94a3b8; font-weight: 700; }
+    .pay-rrow-statusline { display: flex; align-items: center; gap: .4rem; flex-wrap: wrap; justify-content: flex-end; }
+    .pay-rrow-hint { font-size: .62rem; color: #b45309; font-weight: 700; white-space: nowrap; }
+
+    .pay-legend { display: flex; flex-wrap: wrap; gap: .8rem; padding: .5rem 1.25rem .7rem; border-bottom: 1px solid #f1f5f9; }
+    .pay-legend-item { display: inline-flex; align-items: center; gap: .35rem; font-size: .66rem; color: #64748b; font-weight: 600; }
+    .pay-legend-dot { width: 10px; height: 10px; border-radius: 3px; }
+    @media (max-width: 860px) {
+        .pay-rrow-months { flex-basis: 100%; padding-left: 54px; }
+        .pay-rrow-netcol { width: 100%; flex-direction: row; justify-content: space-between; align-items: center; padding-left: 54px; }
+    }
+
     /* Modals */
     .pay-modal-overlay { position: fixed; inset: 0; background: rgba(15,23,42,.5); backdrop-filter: blur(2px); display: flex; align-items: flex-start; justify-content: center; padding: 3rem 1rem; z-index: 1080; overflow-y: auto; }
     .pay-modal { background: #fff; border-radius: 16px; width: 100%; max-width: 760px; box-shadow: 0 24px 60px rgba(15,23,42,.25); }
@@ -172,17 +211,38 @@
         </div>
     </div>
 
-    {{-- Filtres --}}
+    {{-- Filtres période --}}
     <div class="pay-filters">
         <div class="pay-field">
-            <span class="pay-field-lbl">Mois</span>
+            <span class="pay-field-lbl">Période</span>
+            <div class="pay-presets">
+                @foreach($presets as $key => $lbl)
+                    <button type="button" class="pay-preset" :class="filters.preset==='{{ $key }}' ? 'pay-preset--on' : ''" @click="setPreset('{{ $key }}')">{{ $lbl }}</button>
+                @endforeach
+            </div>
+        </div>
+
+        {{-- Ancrage mois/année (présets relatifs : la période se termine à ce mois) --}}
+        <div class="pay-field pay-field--anchor" x-show="['month','quarter','semester'].includes(filters.preset)">
+            <span class="pay-field-lbl" x-text="filters.preset==='month' ? 'Mois' : 'Jusqu’au mois'">Mois</span>
             <x-au-select name="mois_filter" :value="(string) $filtres['mois']" :options="$moisOptions" icon="fa-calendar" />
         </div>
-        <div class="pay-field">
+        <div class="pay-field pay-field--anchor" x-show="['month','quarter','semester'].includes(filters.preset)">
             <span class="pay-field-lbl">Année</span>
             <x-au-select name="annee_filter" :value="(string) $filtres['annee']"
                 :options="collect(range(now()->year - 3, now()->year + 1))->mapWithKeys(fn($y) => [$y => (string) $y])->toArray()" icon="fa-calendar-days" />
         </div>
+
+        {{-- Plage libre --}}
+        <div class="pay-field pay-field--anchor" x-show="filters.preset==='custom'" x-cloak>
+            <span class="pay-field-lbl">Du (mois)</span>
+            <input type="month" class="pay-input" x-model="filters.from" @change="filters.preset==='custom' && filters.from && filters.to && applyFilters()">
+        </div>
+        <div class="pay-field pay-field--anchor" x-show="filters.preset==='custom'" x-cloak>
+            <span class="pay-field-lbl">Au (mois)</span>
+            <input type="month" class="pay-input" x-model="filters.to" @change="filters.preset==='custom' && filters.from && filters.to && applyFilters()">
+        </div>
+
         <div class="pay-field">
             <span class="pay-field-lbl">Statut</span>
             <x-au-select name="statut_filter" :value="$filtres['statut'] ?? ''" placeholder="Tous statuts" icon="fa-filter" :options="$statutLabels" />
@@ -202,9 +262,15 @@
         <div class="pay-recap-head">
             <div class="pay-recap-head-ico"><i class="fas fa-list-check"></i></div>
             <div>
-                <div class="pay-recap-head-title">Enseignants à payer — <span x-text="periodLabel">{{ $moisOptions[$filtres['mois']] ?? '' }} {{ $filtres['annee'] }}</span></div>
-                <div class="pay-recap-head-sub">Heures réalisées × taux par type · montant estimé tant que le bulletin n'est pas préparé</div>
+                <div class="pay-recap-head-title">Enseignants à payer — <span x-text="periodLabel">{{ $periodLabel }}</span></div>
+                <div class="pay-recap-head-sub">Heures réalisées × taux par type · chaque mois est cliquable (préparer ou voir le bulletin)</div>
             </div>
+        </div>
+        <div class="pay-legend">
+            <span class="pay-legend-item"><span class="pay-legend-dot" style="background:#f59e0b;"></span> À préparer (estimé)</span>
+            <span class="pay-legend-item"><span class="pay-legend-dot" style="background:#64748b;"></span> Brouillon</span>
+            <span class="pay-legend-item"><span class="pay-legend-dot" style="background:#0453cb;"></span> Validé</span>
+            <span class="pay-legend-item"><span class="pay-legend-dot" style="background:#10b981;"></span> Payé</span>
         </div>
         <div class="pay-panel-body" id="payList">
             @include('esbtp.comptabilite.salaires.partials._recap', ['recap' => $recap, 'statutLabels' => $statutLabels, 'canCreate' => $canCreate])
@@ -383,8 +449,8 @@ function salairesPage() {
     return {
         urls: {},
         loading: false,
-        filters: { mois: @json((string) $filtres['mois']), annee: @json((string) $filtres['annee']), statut: @json($filtres['statut'] ?? ''), q: '' },
-        periodLabel: @json(($moisOptions[$filtres['mois']] ?? '') . ' ' . $filtres['annee']),
+        filters: { preset: @json($filtres['preset']), mois: @json((string) $filtres['mois']), annee: @json((string) $filtres['annee']), from: @json($filtres['from'] ?? ''), to: @json($filtres['to'] ?? ''), statut: @json($filtres['statut'] ?? ''), q: '' },
+        periodLabel: @json($periodLabel),
         showPrepare: false, showConfig: false,
         calculating: false, saving: false, savingConfig: false,
         preview: null, exists: false, locked: false,
@@ -394,14 +460,19 @@ function salairesPage() {
         init() {
             const d = this.$root.dataset;
             this.urls = { data: d.urlData, prepare: d.urlPrepare, store: d.urlStore, config: d.urlConfig };
-            this.$watch('filters.mois', () => this.applyFilters());
-            this.$watch('filters.annee', () => this.applyFilters());
+            this.$watch('filters.mois', () => { if (this.filters.preset !== 'custom') this.applyFilters(); });
+            this.$watch('filters.annee', () => { if (this.filters.preset !== 'custom') this.applyFilters(); });
             this.$watch('filters.statut', () => this.applyFilters());
             this.bindFilterSelects();
-            // Bouton « Préparer » sur une ligne du récap → ouvre le modal pré-rempli.
-            window.addEventListener('paie:prepare-teacher', (ev) => this.preparePour(ev.detail.id));
+            // Mois cliquable sur une ligne du récap → ouvre le modal pré-rempli sur CE mois.
+            window.addEventListener('paie:prepare-teacher', (ev) => this.preparePour(ev.detail.id, ev.detail.mois, ev.detail.annee));
             // Filtres repris par les exports PDF/Excel.
-            window.exportFilters = () => ({ mois: this.filters.mois, annee: this.filters.annee, statut: this.filters.statut, q: this.filters.q });
+            window.exportFilters = () => ({ preset: this.filters.preset, mois: this.filters.mois, annee: this.filters.annee, from: this.filters.from, to: this.filters.to, statut: this.filters.statut, q: this.filters.q });
+        },
+
+        setPreset(p) {
+            this.filters.preset = p;
+            if (p !== 'custom' || (this.filters.from && this.filters.to)) this.applyFilters();
         },
 
         bindFilterSelects() {
@@ -429,15 +500,20 @@ function salairesPage() {
             } catch (e) { this.toast('error', e.message); } finally { this.loading = false; }
         },
 
-        // Ouvre le modal de préparation pré-rempli pour un enseignant donné (récap → « Préparer »).
-        preparePour(teacherId) {
+        // Ouvre le modal de préparation pré-rempli pour un enseignant + un mois précis (clic sur la pastille mensuelle).
+        preparePour(teacherId, mois, annee) {
             this.preview = null; this.exists = false; this.locked = false;
-            this.prep = { teacher_id: String(teacherId), mois: this.filters.mois, annee: this.filters.annee, impot_its: '', cnps: '', primes: [], retenues: [] };
+            this.prep = { teacher_id: String(teacherId), mois: String(mois || this.filters.mois), annee: String(annee || this.filters.annee), impot_its: '', cnps: '', primes: [], retenues: [] };
             this.showPrepare = true;
-            // pré-sélectionne l'enseignant dans le picker du modal + calcule.
+            // pré-sélectionne enseignant + mois + année dans les pickers du modal, puis calcule.
             this.$nextTick(() => {
-                const sel = document.querySelector('select[name="prep_teacher"]');
-                if (sel) { sel.value = String(teacherId); sel.dispatchEvent(new Event('change', { bubbles: true })); }
+                const setSel = (name, val) => {
+                    const sel = document.querySelector('select[name="' + name + '"]');
+                    if (sel) { sel.value = String(val); sel.dispatchEvent(new Event('change', { bubbles: true })); }
+                };
+                setSel('prep_teacher', teacherId);
+                setSel('prep_mois', this.prep.mois);
+                setSel('prep_annee', this.prep.annee);
                 this.calculate();
             });
         },

--- a/resources/views/esbtp/comptabilite/salaires/partials/_recap.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/partials/_recap.blade.php
@@ -1,4 +1,5 @@
-{{-- Récap paie : tous les enseignants à payer ce mois. Reçoit $recap, $statutLabels, $canCreate. --}}
+{{-- Récap paie période. Reçoit $recap, $statutLabels, $canCreate.
+     Chaque ligne = 1 enseignant ; chaque pastille = 1 mois (cliquable : préparer ou voir). --}}
 @php
     $fmt = fn($v) => number_format($v, 0, ',', ' ');
     $fmtH = function ($v) { $h=(int)floor($v); $m=(int)round(($v-$h)*60); return $h.'h'.($m>0?sprintf('%02d',$m):''); };
@@ -9,9 +10,16 @@
         'paye'       => ['bg' => 'rgba(16,185,129,.12)',  'color' => '#065f46'],
         'annule'     => ['bg' => 'rgba(220,38,38,.1)',    'color' => '#b91c1c'],
     ];
+    $stIcon = [
+        'a_preparer' => 'fa-wand-magic-sparkles', 'brouillon' => 'fa-pen',
+        'valide' => 'fa-check', 'paye' => 'fa-circle-check', 'annule' => 'fa-ban',
+    ];
 @endphp
 @forelse($recap as $row)
-    @php $st = $badge[$row['statut']] ?? $badge['a_preparer']; @endphp
+    @php
+        $st = $badge[$row['statut']] ?? $badge['a_preparer'];
+        $hasEstim = collect($row['months'])->contains('estimation', true);
+    @endphp
     <div class="pay-rrow">
         <div class="pay-rrow-avatar">{{ \Illuminate\Support\Str::substr($row['name'], 0, 1) }}</div>
         <div class="pay-rrow-id">
@@ -25,22 +33,46 @@
                 @endforeach
             </div>
         </div>
-        <div class="pay-rrow-amounts">
-            <div class="pay-rrow-amt"><span class="pay-rrow-amt-lbl">Base</span>{{ $fmt($row['base']) }}</div>
-            <div class="pay-rrow-amt pay-rrow-amt--neg"><span class="pay-rrow-amt-lbl">Retenues</span>− {{ $fmt($row['retenues']) }}</div>
-            <div class="pay-rrow-amt pay-rrow-amt--net">
-                <span class="pay-rrow-amt-lbl">Net{{ $row['estimation'] ? ' estimé' : '' }}</span>
-                <strong>{{ $fmt($row['net']) }}</strong>
-            </div>
+
+        {{-- Bandeau mensuel cliquable --}}
+        <div class="pay-rrow-months">
+            @foreach($row['months'] as $m)
+                @php
+                    $icon = $stIcon[$m['statut']] ?? 'fa-circle';
+                    $stLabel = $statutLabels[$m['statut']] ?? $m['statut'];
+                    $tip = $m['label'].' '.$m['annee'].' — '.($m['estimation'] ? 'Estimé ' : 'Net ').$fmt($m['net']).' FCFA — '.$stLabel;
+                @endphp
+                @if($m['has_bulletin'])
+                    <a href="{{ route('esbtp.comptabilite.salaires.show', $m['bulletin_id']) }}"
+                       class="pay-mchip pay-mchip--{{ $m['statut'] }}" title="{{ $tip }} · voir le bulletin">
+                        <span class="pay-mchip-top"><span class="pay-mchip-m">{{ $m['short'] }}</span><i class="fas {{ $icon }}"></i></span>
+                        <span class="pay-mchip-net">{{ $fmt($m['net']) }}</span>
+                    </a>
+                @elseif($canCreate)
+                    <button type="button" class="pay-mchip pay-mchip--a_preparer" title="{{ $tip }} · cliquer pour préparer"
+                            onclick="window.dispatchEvent(new CustomEvent('paie:prepare-teacher',{detail:{id:{{ $row['teacher_id'] }},mois:{{ $m['mois'] }},annee:{{ $m['annee'] }}}}))">
+                        <span class="pay-mchip-top"><span class="pay-mchip-m">{{ $m['short'] }}</span><i class="fas {{ $icon }}"></i></span>
+                        <span class="pay-mchip-net">~{{ $fmt($m['net']) }}</span>
+                    </button>
+                @else
+                    <span class="pay-mchip pay-mchip--{{ $m['statut'] }}" title="{{ $tip }}">
+                        <span class="pay-mchip-top"><span class="pay-mchip-m">{{ $m['short'] }}</span><i class="fas {{ $icon }}"></i></span>
+                        <span class="pay-mchip-net">{{ $fmt($m['net']) }}</span>
+                    </span>
+                @endif
+            @endforeach
         </div>
-        <div class="pay-rrow-end">
-            <span class="pay-rrow-badge" style="background:{{ $st['bg'] }};color:{{ $st['color'] }};">{{ $statutLabels[$row['statut']] ?? $row['statut'] }}</span>
-            @if($row['has_bulletin'])
-                <a href="{{ route('esbtp.comptabilite.salaires.show', $row['bulletin_id']) }}" class="pay-rrow-btn pay-rrow-btn--view"><i class="fas fa-eye"></i> Voir</a>
-            @elseif($canCreate)
-                <button type="button" class="pay-rrow-btn pay-rrow-btn--prep"
-                        onclick="window.dispatchEvent(new CustomEvent('paie:prepare-teacher',{detail:{id:{{ $row['teacher_id'] }}}}))"><i class="fas fa-calculator"></i> Préparer</button>
-            @endif
+
+        {{-- Net total période + statut global --}}
+        <div class="pay-rrow-netcol">
+            <span class="pay-rrow-net-lbl">Net{{ $hasEstim ? ' estimé' : '' }} · {{ $row['nb_mois'] }} mois</span>
+            <strong class="pay-rrow-net-val">{{ $fmt($row['net']) }} <small>FCFA</small></strong>
+            <div class="pay-rrow-statusline">
+                <span class="pay-rrow-badge" style="background:{{ $st['bg'] }};color:{{ $st['color'] }};">{{ $statutLabels[$row['statut']] ?? $row['statut'] }}</span>
+                @if($row['nb_a_preparer'] > 0)
+                    <span class="pay-rrow-hint"><i class="fas fa-pen-ruler"></i> {{ $row['nb_a_preparer'] }} à préparer</span>
+                @endif
+            </div>
         </div>
     </div>
 @empty


### PR DESCRIPTION
La page Paie était bloquée au mois. Ajout de présets Mois / Trimestre / Semestre / Année / Plage libre. Les bulletins restent mensuels (ITS progressif par mois) : la période est décomposée en mois, chaque cellule enseignant×mois = bulletin existant OU estimation. Bandeau de pastilles mensuelles cliquables (préparer/voir), colorées par statut. KPIs + exports suivent la période.