### PR TITLE
fix(paie): export PDF période (clé estimation déplacée au mois + colonne Mois)

### DIFF
--- a/app/Exports/PaiePayrollExport.php
+++ b/app/Exports/PaiePayrollExport.php
@@ -32,7 +32,7 @@ class PaiePayrollExport implements FromCollection, WithHeadings, WithMapping, Wi
 
     public function headings(): array
     {
-        return ['Enseignant', 'Heures réalisées', 'Base (FCFA)', 'Retenues (FCFA)', 'Net à payer (FCFA)', 'Statut'];
+        return ['Enseignant', 'Mois', 'Heures réalisées', 'Base (FCFA)', 'Retenues (FCFA)', 'Net à payer (FCFA)', 'Statut'];
     }
 
     /** @param array $row */
@@ -40,6 +40,7 @@ class PaiePayrollExport implements FromCollection, WithHeadings, WithMapping, Wi
     {
         return [
             $row['name'] ?? '',
+            (int) ($row['nb_mois'] ?? 1),
             (float) ($row['heures'] ?? 0),
             (float) ($row['base'] ?? 0),
             (float) ($row['retenues'] ?? 0),

--- a/resources/views/esbtp/comptabilite/salaires/pdf.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/pdf.blade.php
@@ -21,6 +21,7 @@
         <thead>
             <tr>
                 <th>Enseignant</th>
+                <th class="pp-num">Mois</th>
                 <th class="pp-num">Heures réalisées</th>
                 <th class="pp-num">Base</th>
                 <th class="pp-num">Retenues</th>
@@ -30,17 +31,20 @@
         </thead>
         <tbody>
             @foreach($rows as $r)
+                @php $estime = ($r['nb_a_preparer'] ?? 0) > 0; @endphp
                 <tr>
                     <td>{{ $r['name'] }}</td>
+                    <td class="pp-num">{{ $r['nb_mois'] ?? 1 }}</td>
                     <td class="pp-num">{{ $fmtH($r['heures']) }}</td>
                     <td class="pp-num">{{ $fmt($r['base']) }}</td>
                     <td class="pp-num">− {{ $fmt($r['retenues']) }}</td>
-                    <td class="pp-num pp-net">{{ $fmt($r['net']) }}@if($r['estimation'])<br><span class="pp-est">estimé</span>@endif</td>
+                    <td class="pp-num pp-net">{{ $fmt($r['net']) }}@if($estime)<br><span class="pp-est">estimé</span>@endif</td>
                     <td>{{ $statutLabels[$r['statut']] ?? $r['statut'] }}</td>
                 </tr>
             @endforeach
             <tr class="pp-total">
                 <td>TOTAL ({{ count($rows) }} enseignant{{ count($rows) > 1 ? 's' : '' }})</td>
+                <td class="pp-num"></td>
                 <td class="pp-num"></td>
                 <td class="pp-num">{{ $fmt($totalBase) }}</td>
                 <td class="pp-num">− {{ $fmt($totalRet) }}</td>


### PR DESCRIPTION
Le PDF d'état de paie référençait `$row['estimation']` (clé désormais portée par chaque mois, plus au niveau ligne) → 500. Corrigé : drapeau estimé dérivé de nb_a_preparer, ajout colonne Mois (nb_mois) au PDF et à l'Excel.