### PR TITLE
feat(paie): bulletin individuel PDF (x-pdf-document) + mode paiement select

### DIFF
--- a/app/Http/Controllers/ESBTPSalaireController.php
+++ b/app/Http/Controllers/ESBTPSalaireController.php
@@ -16,6 +16,8 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
+use PDF;
 
 /**
  * Paie enseignants (comptabilité). Page dédiée, séparée de la pédagogie.
@@ -527,12 +529,67 @@ class ESBTPSalaireController extends Controller
         $user = auth()->user();
 
         return view('esbtp.comptabilite.salaires.show', [
-            'salaire'      => $salaire,
-            'gains'        => $salaire->details->where('categorie', 'gain')->values(),
-            'retenues'     => $salaire->details->where('categorie', 'retenue')->values(),
-            'moisLabel'    => self::MOIS_FR[$salaire->mois] ?? $salaire->mois,
-            'canValidate'  => $user->can('comptabilite.salaires.validate') || $user->can('comptabilite.salaires.validate_own'),
-            'canPay'       => $user->can('comptabilite.salaires.pay'),
+            'salaire'       => $salaire,
+            'gains'         => $salaire->details->where('categorie', 'gain')->values(),
+            'retenues'      => $salaire->details->where('categorie', 'retenue')->values(),
+            'moisLabel'     => self::MOIS_FR[$salaire->mois] ?? $salaire->mois,
+            'modesPaiement' => $this->modesPaiementOptions(),
+            'modeLabel'     => $this->modeLabel($salaire->mode_paiement),
+            'canValidate'   => $user->can('comptabilite.salaires.validate') || $user->can('comptabilite.salaires.validate_own'),
+            'canPay'        => $user->can('comptabilite.salaires.pay'),
+        ]);
+    }
+
+    /** Options du select mode de paiement : code canonique → libellé FR (config payment_modes). */
+    private function modesPaiementOptions(): array
+    {
+        return collect(config('payment_modes.labels', []))->map(fn ($m) => $m['label'])->toArray();
+    }
+
+    /** Libellé lisible d'un mode_paiement stocké (code canonique OU libellé legacy). */
+    private function modeLabel(?string $mode): ?string
+    {
+        if (empty($mode)) {
+            return null;
+        }
+        $labels = config('payment_modes.labels', []);
+        if (isset($labels[$mode])) {
+            return $labels[$mode]['label'];
+        }
+        $alias = config('payment_modes.aliases', [])[\Illuminate\Support\Str::slug($mode, '_')] ?? null;
+        return $alias && isset($labels[$alias]) ? $labels[$alias]['label'] : $mode;
+    }
+
+    // ── Bulletin de paie individuel (PDF via <x-pdf-document>) ──
+    /** @return array{0:\Barryvdh\DomPDF\PDF,1:string} */
+    private function buildPayslipPdf(ESBTPSalaire $salaire): array
+    {
+        $salaire->load(['details', 'teacher.user', 'preparePar', 'validePar', 'payePar', 'anneeUniversitaire']);
+        $teacherName = $salaire->teacher->user->name ?? $salaire->teacher->name ?? 'Enseignant';
+        $pdf = PDF::loadView('esbtp.comptabilite.salaires.payslip-pdf', [
+            'salaire'   => $salaire,
+            'gains'     => $salaire->details->where('categorie', 'gain')->values(),
+            'retenues'  => $salaire->details->where('categorie', 'retenue')->values(),
+            'moisLabel' => self::MOIS_FR[$salaire->mois] ?? $salaire->mois,
+            'modeLabel' => $this->modeLabel($salaire->mode_paiement),
+        ])->setPaper('a4', 'portrait');
+
+        $slug = \Illuminate\Support\Str::slug($teacherName);
+        return [$pdf, "bulletin_paie_{$slug}_{$salaire->mois}_{$salaire->annee}.pdf"];
+    }
+
+    public function payslipPdf(ESBTPSalaire $salaire)
+    {
+        [$pdf, $filename] = $this->buildPayslipPdf($salaire);
+        return $pdf->download($filename);
+    }
+
+    public function payslipPdfPreview(ESBTPSalaire $salaire)
+    {
+        [$pdf, $filename] = $this->buildPayslipPdf($salaire);
+        return new \Illuminate\Http\Response($pdf->output(), 200, [
+            'Content-Type'        => 'application/pdf',
+            'Content-Disposition' => 'inline; filename="' . $filename . '"',
         ]);
     }
 
@@ -579,7 +636,7 @@ class ESBTPSalaireController extends Controller
         }
 
         $data = $request->validate([
-            'mode_paiement'      => 'required|string|max:50',
+            'mode_paiement'      => ['required', Rule::in(array_keys(config('payment_modes.labels', [])))],
             'reference_paiement' => 'nullable|string|max:100',
             'date_paiement'      => 'nullable|date',
         ]);

--- a/resources/views/esbtp/comptabilite/salaires/payslip-pdf.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/payslip-pdf.blade.php
@@ -1,0 +1,108 @@
+@php
+    $fmt = fn($v) => number_format((float) $v, 0, ',', ' ');
+    $fmtH = function ($v) { $h=(int)floor($v); $m=(int)round(($v-$h)*60); return $h.'h'.($m>0?sprintf('%02d',$m):''); };
+    $teacherName = $salaire->teacher->user->name ?? $salaire->teacher->name ?? 'Enseignant';
+    $brut = (float) $salaire->salaire_base + (float) $salaire->primes;
+@endphp
+<x-pdf-document
+    title="Bulletin de paie"
+    :subtitle="$teacherName . ' — ' . $moisLabel . ' ' . $salaire->annee"
+    :filters="['Enseignant' => $teacherName, 'Période' => $moisLabel . ' ' . $salaire->annee, 'Statut' => $salaire->statutLabel()]"
+    orientation="portrait">
+
+    <style>
+        .bp-meta { width: 100%; border-collapse: collapse; margin-bottom: 12px; font-size: 10px; }
+        .bp-meta td { padding: 4px 8px; border: 1px solid #e5e7eb; }
+        .bp-meta .bp-k { color: #64748b; width: 22%; background: #f8fafc; }
+        .bp-meta .bp-v { font-weight: 700; color: #1e293b; }
+        .bp-sec-title { font-size: 11px; font-weight: 700; color: #0453cb; text-transform: uppercase; letter-spacing: .3px; margin: 14px 0 5px; padding-bottom: 3px; border-bottom: 2px solid #0453cb; }
+        .bp-table { width: 100%; border-collapse: collapse; font-size: 10px; }
+        .bp-table th { background: #0453cb; color: #fff; text-align: left; padding: 5px 8px; font-size: 9px; text-transform: uppercase; }
+        .bp-table th.bp-num, .bp-table td.bp-num { text-align: right; white-space: nowrap; }
+        .bp-table td { padding: 5px 8px; border-bottom: 1px solid #eef2f7; }
+        .bp-table tr:nth-child(even) td { background: #f8fafc; }
+        .bp-detail { color: #94a3b8; font-size: 8px; }
+        .bp-sub td { border-top: 2px solid #cbd5e1; font-weight: 700; background: #eff6ff !important; }
+        .bp-sub--neg td { background: #fef2f2 !important; color: #b91c1c; }
+        .bp-net { width: 100%; border-collapse: collapse; margin-top: 12px; }
+        .bp-net td { padding: 10px 12px; background: linear-gradient(135deg, #0a3d8f, #0453cb); color: #fff; }
+        .bp-net .bp-net-lbl { font-size: 11px; font-weight: 700; }
+        .bp-net .bp-net-val { font-size: 18px; font-weight: 800; text-align: right; }
+        .bp-pay { margin-top: 12px; font-size: 10px; }
+        .bp-sign { width: 100%; border-collapse: collapse; margin-top: 26px; }
+        .bp-sign td { width: 50%; padding: 6px 10px; font-size: 9px; color: #64748b; vertical-align: top; }
+        .bp-sign-line { border-top: 1px solid #94a3b8; margin-top: 38px; padding-top: 4px; color: #1e293b; font-weight: 700; }
+    </style>
+
+    {{-- Identité --}}
+    <table class="bp-meta">
+        <tr>
+            <td class="bp-k">Enseignant</td><td class="bp-v">{{ $teacherName }}</td>
+            <td class="bp-k">Période</td><td class="bp-v">{{ $moisLabel }} {{ $salaire->annee }}</td>
+        </tr>
+        <tr>
+            <td class="bp-k">Heures réalisées</td><td class="bp-v">{{ $fmtH($salaire->heures_total) }}</td>
+            <td class="bp-k">Statut</td><td class="bp-v">{{ $salaire->statutLabel() }}</td>
+        </tr>
+    </table>
+
+    {{-- Gains --}}
+    <div class="bp-sec-title">Gains — heures réalisées × taux</div>
+    <table class="bp-table">
+        <thead>
+            <tr><th>Désignation</th><th class="bp-num">Base</th><th class="bp-num">Montant</th></tr>
+        </thead>
+        <tbody>
+            @foreach($gains as $g)
+                <tr>
+                    <td>{{ $g->libelle }}</td>
+                    <td class="bp-num">@if($g->heures){{ $fmtH($g->heures) }} × {{ $fmt($g->taux) }}@else—@endif</td>
+                    <td class="bp-num">{{ $fmt($g->montant) }}</td>
+                </tr>
+            @endforeach
+            <tr class="bp-sub"><td>Brut</td><td class="bp-num"></td><td class="bp-num">{{ $fmt($brut) }} FCFA</td></tr>
+        </tbody>
+    </table>
+
+    {{-- Retenues --}}
+    <div class="bp-sec-title">Retenues</div>
+    <table class="bp-table">
+        <thead>
+            <tr><th>Désignation</th><th class="bp-num">Montant</th></tr>
+        </thead>
+        <tbody>
+            @forelse($retenues as $r)
+                <tr><td>{{ $r->libelle }}</td><td class="bp-num">− {{ $fmt($r->montant) }}</td></tr>
+            @empty
+                <tr><td colspan="2" style="color:#94a3b8;">Aucune retenue</td></tr>
+            @endforelse
+            <tr class="bp-sub bp-sub--neg"><td>Total retenues</td><td class="bp-num">− {{ $fmt($salaire->retenues) }} FCFA</td></tr>
+        </tbody>
+    </table>
+
+    {{-- Net --}}
+    <table class="bp-net">
+        <tr>
+            <td class="bp-net-lbl">NET À PAYER</td>
+            <td class="bp-net-val">{{ $fmt($salaire->net_a_payer) }} FCFA</td>
+        </tr>
+    </table>
+
+    {{-- Règlement --}}
+    @if($salaire->isPaye())
+        <div class="bp-pay">
+            <strong>Règlement :</strong>
+            {{ $modeLabel ?? '—' }}
+            @if($salaire->date_paiement) · le {{ \Carbon\Carbon::parse($salaire->date_paiement)->format('d/m/Y') }} @endif
+            @if($salaire->reference_paiement) · réf. {{ $salaire->reference_paiement }} @endif
+        </div>
+    @endif
+
+    {{-- Signatures --}}
+    <table class="bp-sign">
+        <tr>
+            <td>Pour l'établissement<div class="bp-sign-line">Le Directeur / La Comptabilité</div></td>
+            <td>Reçu par l'enseignant<div class="bp-sign-line">{{ $teacherName }}</div></td>
+        </tr>
+    </table>
+</x-pdf-document>

--- a/resources/views/esbtp/comptabilite/salaires/show.blade.php
+++ b/resources/views/esbtp/comptabilite/salaires/show.blade.php
@@ -54,6 +54,9 @@
     .pys-modal-foot { padding: 1rem 1.4rem; border-top: 1px solid #f1f5f9; display: flex; justify-content: flex-end; gap: .6rem; }
     .pys-input { border: 1px solid #e2e8f0; border-radius: 9px; padding: .55rem .7rem; font-size: .85rem; width: 100%; }
     .pys-field-lbl { font-size: .68rem; font-weight: 700; color: #64748b; text-transform: uppercase; letter-spacing: .4px; display: block; margin-bottom: .25rem; }
+    /* Force le picker premium à remplir la cellule du modal (sinon inline-flex rétrécit). */
+    .pys-au-full { display: flex !important; width: 100%; }
+    .pys-au-full .au-select-trigger { width: 100%; }
     [x-cloak] { display: none !important; }
 
     @media (max-width: 992px) { .pys-grid { grid-template-columns: 1fr; } }
@@ -175,7 +178,7 @@
                         <div class="pys-meta-row">
                             <div class="pys-meta-ico"><i class="fas fa-money-bill-transfer"></i></div>
                             <span class="pys-meta-lbl">Mode</span>
-                            <span class="pys-meta-val">{{ $salaire->mode_paiement ?? '—' }}</span>
+                            <span class="pys-meta-val">{{ $modeLabel ?? '—' }}</span>
                         </div>
                     @endif
                 </div>
@@ -200,6 +203,14 @@
                         @if($salaire->isBrouillon() && !$canValidate)
                             <div class="pys-locked" style="color:#475569;background:rgba(100,116,139,.08);border-color:rgba(100,116,139,.2);">En attente de validation.</div>
                         @endif
+
+                        {{-- Bulletin de paie individuel (aperçu + téléchargement) --}}
+                        <div style="border-top:1px solid #f1f5f9;margin-top:.4rem;padding-top:.8rem;">
+                            <span class="pys-field-lbl" style="margin-bottom:.5rem;">Bulletin de paie</span>
+                            <x-pdf-actions
+                                :preview-url="route('esbtp.comptabilite.salaires.payslip.preview', $salaire->id)"
+                                :download-url="route('esbtp.comptabilite.salaires.payslip', $salaire->id)" />
+                        </div>
                     </div>
                 </div>
             </div>
@@ -217,7 +228,8 @@
                 <div class="pys-modal-body">
                     <div>
                         <label class="pys-field-lbl">Mode de paiement</label>
-                        <input type="text" name="mode_paiement" class="pys-input" placeholder="Espèces, Virement, Mobile Money…" required>
+                        <x-au-select name="mode_paiement" class="pys-au-full" :options="$modesPaiement"
+                            placeholder="Choisir un mode…" icon="fa-money-bill-transfer" :searchable="true" />
                     </div>
                     <div>
                         <label class="pys-field-lbl">Référence (optionnel)</label>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1813,6 +1813,11 @@ Route::middleware(['auth', 'comptabilite.access'])->prefix('esbtp/comptabilite')
             ->name('validate');
         Route::post('/{salaire}/pay', [\App\Http\Controllers\ESBTPSalaireController::class, 'pay'])
             ->name('pay')->middleware('permission:comptabilite.salaires.pay');
+        // Bulletin de paie individuel (PDF) — aperçu inline + téléchargement
+        Route::get('/{salaire}/payslip', [\App\Http\Controllers\ESBTPSalaireController::class, 'payslipPdf'])
+            ->name('payslip')->middleware(['permission:comptabilite.salaires.view', 'throttle:20,1']);
+        Route::get('/{salaire}/payslip/preview', [\App\Http\Controllers\ESBTPSalaireController::class, 'payslipPdfPreview'])
+            ->name('payslip.preview')->middleware(['permission:comptabilite.salaires.view', 'throttle:60,1']);
     });
 
     // Analytics Prédictifs (Phase 3 + Phase 4)


### PR DESCRIPTION
Bulletin de paie individuel par enseignant en PDF via le composant réutilisable `<x-pdf-document>` (aperçu + téléchargement via `<x-pdf-actions>`). Mode de paiement passé en `<x-au-select>` premium alimenté par `config/payment_modes.php`, validation `Rule::in` des codes canoniques.