### PR TITLE
fix(attendance,navbar): corrige 5 erreurs runtime presentation (colonnes renommees, closure, route 404)

### DIFF
--- a/app/Http/Controllers/CoordinateurDashboardController.php
+++ b/app/Http/Controllers/CoordinateurDashboardController.php
@@ -407,8 +407,8 @@ class CoordinateurDashboardController extends Controller
             }
 
             // Alerte : Enseignants présents mais workflow incomplet (séance non clôturée)
-            $enseignantsNonClotures = \App\Models\ESBTPSessionWorkflow::whereDate('attendance_signed_at', $date)
-                ->where('attendance_signed', true)
+            $enseignantsNonClotures = \App\Models\ESBTPSessionWorkflow::whereDate('attendance_start_signed_at', $date)
+                ->where('attendance_start_signed', true)
                 ->where('current_step', 'closed_incomplete')
                 ->with(['seanceCours.teacher.user', 'seanceCours.matiere', 'seanceCours.classe'])
                 ->get();

--- a/app/Http/Controllers/ESBTPAttendanceController.php
+++ b/app/Http/Controllers/ESBTPAttendanceController.php
@@ -1328,7 +1328,7 @@ class ESBTPAttendanceController extends Controller
 
         // Current academic year + inscription
         $anneeCourante = \App\Models\ESBTPAnneeUniversitaire::where('is_current', true)->first();
-        $anneesUniversitaires = \App\Models\ESBTPAnneeUniversitaire::orderByDesc('date_debut')->get();
+        $anneesUniversitaires = \App\Models\ESBTPAnneeUniversitaire::orderByDesc('start_date')->get();
         $inscription = null;
 
         if ($anneeCourante) {
@@ -1846,9 +1846,15 @@ class ESBTPAttendanceController extends Controller
             // 3. Retards détectés
             $stats['delays_today'] = max(0, $stats['scheduled_courses_today'] - $stats['teacher_attendances_today']);
 
-            // 4. Cours clôturés
+            // 4. Cours clôturés (émargement début + fin + appels effectués)
             $stats['courses_closed_today'] = ESBTPSeanceCours::whereDate('date_seance', $date)
-                ->where('status', 'completed')
+                ->whereHas('teacherAttendances', function ($q) use ($date) {
+                    $q->whereDate('date', $date)->where('type', 'start');
+                })
+                ->whereHas('teacherAttendances', function ($q) use ($date) {
+                    $q->whereDate('date', $date)->where('type', 'end');
+                })
+                ->whereHas('attendances')
                 ->count();
 
             // 5. Classes avec forte absentéisme (plus de 30% d'absences)

--- a/app/Http/Controllers/NavbarController.php
+++ b/app/Http/Controllers/NavbarController.php
@@ -305,7 +305,7 @@ class NavbarController extends Controller
             $classeId = $etudiant ? $etudiant->inscriptions()->anneeEnCours()->latest()->value('classe_id') : null;
 
             $messages = ESBTPAnnonce::with(['createdBy', 'classes', 'etudiants']) // Charger les relations nécessaires
-                ->where(function ($query) use ($etudiant) {
+                ->where(function ($query) use ($etudiant, $classeId) {
                     // Annonces générales pour tous les étudiants
                     $query->where('type', 'general');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -870,20 +870,25 @@ Route::middleware(['auth', 'installed', 'force.password.change'])->group(functio
                     ->name('manual.destroy')
                     ->middleware('permission:attendances.create');
 
-                // Then parameter routes
+                // Then parameter routes (numeric only, so static paths like
+                // /attendances/justifications are not captured as {attendance})
                 Route::get('/attendances/{attendance}', [ESBTPAttendanceController::class, 'show'])
+                    ->whereNumber('attendance')
                     ->name('show')
                     ->middleware('permission:attendances.view');
 
                 Route::get('/attendances/{attendance}/edit', [ESBTPAttendanceController::class, 'edit'])
+                    ->whereNumber('attendance')
                     ->name('edit')
                     ->middleware('permission:attendances.edit');
 
                 Route::put('/attendances/{attendance}', [ESBTPAttendanceController::class, 'update'])
+                    ->whereNumber('attendance')
                     ->name('update')
                     ->middleware('permission:attendances.edit');
 
                 Route::delete('/attendances/{attendance}', [ESBTPAttendanceController::class, 'destroy'])
+                    ->whereNumber('attendance')
                     ->name('destroy')
                     ->middleware('permission:attendances.delete');
 


### PR DESCRIPTION
## Contexte
Erreurs recensees aujourd'hui (2026-06-18) sur le tenant `presentation` via `/api/cli/logs?level=error`, plus un 404 signale par l'utilisateur. Toutes sont des references a des noms de colonnes/routes obsoletes (schema drift). **Aucune migration** : le schema est deja correct, c'est le code qui etait perime.

## Corrections
| # | Symptome | Fix |
|---|---|---|
| 1 | `Undefined variable $classeId` (x6) — NavbarController:308 | Capture `$classeId` dans le `use(...)` de la closure |
| 2 | `Unknown column 'date_debut' in ORDER BY` — ESBTPAttendanceController:1331 | `date_debut` -> `start_date` (vraie colonne ; accesseur PHP ne s'applique pas au SQL) |
| 3 | `Unknown column 'status'` sur esbtp_seance_cours — ESBTPAttendanceController:1851 | `courses_closed_today` calcule via emargements debut+fin+appels (definition canonique du projet) |
| 4 | `Unknown column 'attendance_signed_at'` — CoordinateurDashboardController:410 | `attendance_signed[_at]` -> `attendance_start_signed[_at]` (colonnes renommees par migration 2025_10_17) |
| 5 | **404** `/esbtp/attendances/justifications` | `whereNumber('attendance')` sur les routes wildcard pour ne plus capturer le chemin statique |

## Verification
- `php -l` OK sur les 4 fichiers
- Colonnes verifiees contre migrations + modeles (start_date confirme par le create migration + le `ORDER BY start_date` de la migration 2025_07_20)

## Acceptance
- [ ] Plus d'erreur `level=error` sur ces 5 motifs apres deploiement
- [ ] `/esbtp/attendances/justifications` repond (plus de 404)