### PR TITLE
fix(routes): corrige le 404 sur /esbtp/attendances/justifications (doublon attendances.show)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -2519,7 +2519,11 @@ Route::middleware(['auth', 'permission:admin.access'])->prefix('esbtp')->name('e
     // Routes pour les présences (attendances)
     Route::get('/attendances', [\App\Http\Controllers\ESBTPAttendanceController::class, 'index'])->name('attendances.index')
         ->middleware('permission:attendances.view');
+    // NB: doublon de esbtp.attendances.show (def. canonique ~ligne 876). Même méthode+URI ⇒
+    // écrase la route canonique dans la collection : DOIT garder whereNumber sinon /attendances/justifications
+    // est capturé comme {attendance} (404). Voir feedback_duplicate_route_definitions.
     Route::get('/attendances/{attendance}', [\App\Http\Controllers\ESBTPAttendanceController::class, 'show'])->name('attendances.show')
+        ->whereNumber('attendance')
         ->middleware('permission:attendances.view');
 
     // Routes pour le planning général coordinateur


### PR DESCRIPTION
Suite e2e : le 404 persistait malgre le whereNumber precedent. Cause racine = un **doublon** de la route GET /attendances/{attendance} (name attendances.show, ~ligne 2525) sans whereNumber, qui ecrasait la route canonique contrainte (ligne 876) dans la RouteCollection (meme methode+URI, derniere ecrase la position de la premiere) et capturait 'justifications' comme parametre => 404. whereNumber ajoute sur le doublon. Verifie en e2e authentifie (superAdmin).